### PR TITLE
feat(UI): Align rule-card toggle row, generalize Responses toggle, add rule sort

### DIFF
--- a/frontend/src/components/ModelRequestHeader.tsx
+++ b/frontend/src/components/ModelRequestHeader.tsx
@@ -26,6 +26,12 @@ import { fontMono } from '@/theme/fonts';
 // Styled components - compact for graph use
 const HEADER_PADDING_X = 40;
 const HEADER_PADDING_Y = 6;
+// Reserves a consistent slot for "name + edit icon" so the toggles that
+// follow (1M, Responses, …) line up at the same x-position across every
+// rule card, regardless of how long each rule's model name happens to be.
+// Names longer than this simply overflow it — no truncation — so it never
+// hides information, it only stops short names from misaligning the row.
+const NAME_SLOT_MIN_WIDTH = 200;
 
 const HeaderContainer = styled(Box, {
     shouldForwardProp: (prop) => prop !== 'collapsible',
@@ -86,10 +92,11 @@ export interface ModelRequestHeaderProps {
     // 1M context window props
     context1M?: boolean;
     onContext1MToggle?: () => void;
-    // Native OpenAI Responses API toggle (Codex-scenario rules only). Provided
-    // only when the rule's primary provider is OpenAI-style — same gating
-    // pattern as context1M. responsesProbing shows a spinner while the
-    // pre-flight connectivity check runs before the flag is actually set.
+    // Native OpenAI Responses API toggle. Provided only when the rule's
+    // primary provider is OpenAI-style — same gating pattern as context1M.
+    // Not Codex-specific: any OpenAI-style rule can opt in, the pre-flight
+    // probe is what actually gates support. responsesProbing shows a spinner
+    // while that check runs before the flag is actually set.
     responsesEnabled?: boolean;
     responsesProbing?: boolean;
     onResponsesToggle?: () => void;
@@ -206,63 +213,65 @@ export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
 
         return (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }} onClick={(e) => e.stopPropagation()}>
-                <Tooltip
-                    title={modelName
-                        ? `The model name that clients use to make requests. This will be matched against incoming API calls. Supports wildcards (* or [any]) for matching any model. (click to copy)`
-                        : 'No model specified'}
-                    placement="top"
-                >
-                    {isWildcard ? (
-                        <Chip
-                            label={
-                                <Typography variant="body2" sx={{ fontWeight: 600, fontSize: '0.8rem' }}>
-                                    {modelName}
-                                </Typography>
-                            }
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: NAME_SLOT_MIN_WIDTH, flexShrink: 0 }}>
+                    <Tooltip
+                        title={modelName
+                            ? `The model name that clients use to make requests. This will be matched against incoming API calls. Supports wildcards (* or [any]) for matching any model. (click to copy)`
+                            : 'No model specified'}
+                        placement="top"
+                    >
+                        {isWildcard ? (
+                            <Chip
+                                label={
+                                    <Typography variant="body2" sx={{ fontWeight: 600, fontSize: '0.8rem' }}>
+                                        {modelName}
+                                    </Typography>
+                                }
+                                size="small"
+                                variant="outlined"
+                                onClick={(e) => { e.stopPropagation(); handleCopy(); }}
+                                sx={{
+                                    '& .MuiChip-label': { fontWeight: 600 },
+                                    height: 22,
+                                    cursor: 'pointer',
+                                    '&:hover': {
+                                        backgroundColor: 'action.hover',
+                                    },
+                                }}
+                            />
+                        ) : (
+                            <ModelNameText
+                                onClick={(e) => { e.stopPropagation(); handleCopy(); }}
+                                sx={{
+                                    cursor: modelName ? 'pointer' : 'default',
+                                    '&:hover': modelName ? {
+                                        textDecoration: 'underline',
+                                        textDecorationStyle: 'dotted',
+                                        textDecorationColor: 'text.secondary',
+                                        color: 'primary.main',
+                                    } : {},
+                                }}
+                            >
+                                {modelName}
+                            </ModelNameText>
+                        )}
+                    </Tooltip>
+                    <Tooltip title="Edit model name">
+                        <IconButton
                             size="small"
-                            variant="outlined"
-                            onClick={(e) => { e.stopPropagation(); handleCopy(); }}
+                            onClick={(e) => { e.stopPropagation(); setEditMode(true); }}
                             sx={{
-                                '& .MuiChip-label': { fontWeight: 600 },
-                                height: 22,
-                                cursor: 'pointer',
-                                '&:hover': {
-                                    backgroundColor: 'action.hover',
-                                },
-                            }}
-                        />
-                    ) : (
-                        <ModelNameText
-                            onClick={(e) => { e.stopPropagation(); handleCopy(); }}
-                            sx={{
-                                cursor: modelName ? 'pointer' : 'default',
-                                '&:hover': modelName ? {
-                                    textDecoration: 'underline',
-                                    textDecorationStyle: 'dotted',
-                                    textDecorationColor: 'text.secondary',
-                                    color: 'primary.main',
-                                } : {},
+                                opacity: editable ? 0.6 : 0,
+                                p: 0.5,
+                                ml: 0.25,
+                                pointerEvents: editable ? 'auto' : 'none',
+                                '&:hover': { opacity: 1 }
                             }}
                         >
-                            {modelName}
-                        </ModelNameText>
-                    )}
-                </Tooltip>
-                <Tooltip title="Edit model name">
-                    <IconButton
-                        size="small"
-                        onClick={(e) => { e.stopPropagation(); setEditMode(true); }}
-                        sx={{
-                            opacity: editable ? 0.6 : 0,
-                            p: 0.5,
-                            ml: 0.25,
-                            pointerEvents: editable ? 'auto' : 'none',
-                            '&:hover': { opacity: 1 }
-                        }}
-                    >
-                        <EditIcon sx={{ fontSize: '0.95rem' }} />
-                    </IconButton>
-                </Tooltip>
+                            <EditIcon sx={{ fontSize: '0.95rem' }} />
+                        </IconButton>
+                    </Tooltip>
+                </Box>
 
                 {/* 1M Context Toggle */}
                 {onContext1MToggle && (
@@ -300,7 +309,7 @@ export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
                     </Tooltip>
                 )}
 
-                {/* Native OpenAI Responses API Toggle (Codex scenario) */}
+                {/* Native OpenAI Responses API Toggle */}
                 {onResponsesToggle && (
                     <Tooltip title={
                         responsesProbing

--- a/frontend/src/components/ModelRequestHeader.tsx
+++ b/frontend/src/components/ModelRequestHeader.tsx
@@ -26,12 +26,13 @@ import { fontMono } from '@/theme/fonts';
 // Styled components - compact for graph use
 const HEADER_PADDING_X = 40;
 const HEADER_PADDING_Y = 6;
-// Reserves a consistent slot for "name + edit icon" so the toggles that
-// follow (1M, Responses, …) line up at the same x-position across every
-// rule card, regardless of how long each rule's model name happens to be.
-// Names longer than this simply overflow it — no truncation — so it never
-// hides information, it only stops short names from misaligning the row.
-const NAME_SLOT_MIN_WIDTH = 200;
+// Fixed (not just minimum) width for the "name + edit icon" slot, so the
+// toggles that follow (1M, Responses, …) line up at the same x-position
+// across every rule card. Names that don't fit truncate with an ellipsis —
+// the existing hover tooltip still shows the full name, and click-to-copy
+// still copies it in full — so a long name never re-breaks the alignment
+// this exists to guarantee.
+const NAME_SLOT_WIDTH = 170;
 
 const HeaderContainer = styled(Box, {
     shouldForwardProp: (prop) => prop !== 'collapsible',
@@ -213,7 +214,7 @@ export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
 
         return (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }} onClick={(e) => e.stopPropagation()}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: NAME_SLOT_MIN_WIDTH, flexShrink: 0 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, width: NAME_SLOT_WIDTH, flexShrink: 0 }}>
                     <Tooltip
                         title={modelName
                             ? `The model name that clients use to make requests. This will be matched against incoming API calls. Supports wildcards (* or [any]) for matching any model. (click to copy)`
@@ -231,8 +232,10 @@ export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
                                 variant="outlined"
                                 onClick={(e) => { e.stopPropagation(); handleCopy(); }}
                                 sx={{
-                                    '& .MuiChip-label': { fontWeight: 600 },
+                                    '& .MuiChip-label': { fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis' },
                                     height: 22,
+                                    minWidth: 0,
+                                    flex: '0 1 auto',
                                     cursor: 'pointer',
                                     '&:hover': {
                                         backgroundColor: 'action.hover',
@@ -243,6 +246,11 @@ export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
                             <ModelNameText
                                 onClick={(e) => { e.stopPropagation(); handleCopy(); }}
                                 sx={{
+                                    minWidth: 0,
+                                    flex: '0 1 auto',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
                                     cursor: modelName ? 'pointer' : 'default',
                                     '&:hover': modelName ? {
                                         textDecoration: 'underline',
@@ -264,6 +272,7 @@ export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
                                 opacity: editable ? 0.6 : 0,
                                 p: 0.5,
                                 ml: 0.25,
+                                flexShrink: 0,
                                 pointerEvents: editable ? 'auto' : 'none',
                                 '&:hover': { opacity: 1 }
                             }}

--- a/frontend/src/components/UnifiedRoutingGraph.tsx
+++ b/frontend/src/components/UnifiedRoutingGraph.tsx
@@ -24,7 +24,7 @@ import {TierGuideDialog} from '@/components/tier/TierGuideDialog';
 import {EntryGuideDialog} from '@/components/tier/EntryGuideDialog';
 import type {Provider} from '../types/provider';
 import type {ConfigRecord} from './RoutingGraphTypes';
-import {useCodexResponsesToggle} from '@/hooks/useCodexResponsesToggle';
+import {useResponsesToggle} from '@/hooks/useResponsesToggle';
 
 // Routing mode controls display behavior
 export type RoutingMode = 'smart' | 'direct' | 'auto';
@@ -264,20 +264,21 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
         return [...list].sort((a, b) => (a.tier ?? 0) - (b.tier ?? 0));
     }, [record.providers]);
 
-    // Native OpenAI Responses API toggle (Codex-scenario rules only). Codex is
-    // a special-cased page, not a generic capability: deliberately scoped to
-    // record.scenario === 'codex' rather than every OpenAI-style rule,
-    // matching how the feature was scoped end to end. Logic lives in
-    // useCodexResponsesToggle (pre-flight probe + mid-session revalidation).
+    // Native OpenAI Responses API toggle. The underlying `openaiEndpointOverride`
+    // rule flag is per-rule and provider-agnostic by design (see
+    // .design/openai-endpoint-routing.md §3, Layer 2) — it isn't a Codex-only
+    // capability, so the toggle shows for any rule whose primary provider is
+    // OpenAI-style. useResponsesToggle runs the pre-flight probe against the
+    // real upstream before trusting a provider/model with it, and gates the
+    // rest: unsupported providers simply fail the probe and stay off.
     const primaryService = sortedDefaultProviders.find((p) => p.active !== false) || sortedDefaultProviders[0];
-    const showResponsesToggle = record.scenario === 'codex'
-        && !!primaryService
+    const showResponsesToggle = !!primaryService
         && getApiStyle(primaryService.provider) === 'openai';
     const {
         enabled: responsesEnabled,
         probing: responsesProbing,
         onToggle: handleResponsesToggle,
-    } = useCodexResponsesToggle({record, primaryService, onUpdateRecord});
+    } = useResponsesToggle({record, primaryService, onUpdateRecord});
 
     // Group already-sorted providers into tiers (single pass — order preserved from sortedDefaultProviders)
     const tierGroups = React.useMemo(() => {

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -144,6 +144,8 @@ import {
     IconBell,
     IconZoomIn,
     IconCloud,
+    IconArrowsSort,
+    IconSortAZ,
 } from '@tabler/icons-react';
 import { tablerMui } from './tablerMui';
 
@@ -190,6 +192,8 @@ export const Link = tablerMui(IconLink);
 export const PlayArrow = tablerMui(IconPlayerPlay);
 export const Filter = tablerMui(IconFilter);
 export const FilterOff = tablerMui(IconFilterOff);
+export const Sort = tablerMui(IconArrowsSort);
+export const SortByAlpha = tablerMui(IconSortAZ);
 
 // --- Status / feedback -------------------------------------------------------
 export const Info = tablerMui(IconInfoCircle);

--- a/frontend/src/hooks/useResponsesToggle.test.ts
+++ b/frontend/src/hooks/useResponsesToggle.test.ts
@@ -1,7 +1,7 @@
 import {act, renderHook, waitFor} from '@testing-library/react';
 import {vi} from 'vitest';
 import type {Mock} from 'vitest';
-import {useCodexResponsesToggle} from './useCodexResponsesToggle';
+import {useResponsesToggle} from './useResponsesToggle';
 import {runProbe} from '@/components/probe/runProbe';
 import {notify} from '@/utils/notify';
 import type {ConfigProvider, ConfigRecord} from '@/components/RoutingGraphTypes';
@@ -30,14 +30,14 @@ beforeEach(() => {
     (notify.error as Mock).mockReset();
 });
 
-describe('useCodexResponsesToggle', () => {
+describe('useResponsesToggle', () => {
     it('enables the flag after a successful probe', async () => {
         mockRunProbe.mockResolvedValue({success: true});
         const onUpdateRecord = vi.fn();
         const record = makeRecord();
         const service = makeService();
 
-        const {result} = renderHook(() => useCodexResponsesToggle({record, primaryService: service, onUpdateRecord}));
+        const {result} = renderHook(() => useResponsesToggle({record, primaryService: service, onUpdateRecord}));
         expect(result.current.enabled).toBe(false);
 
         await act(async () => {
@@ -60,7 +60,7 @@ describe('useCodexResponsesToggle', () => {
         const onUpdateRecord = vi.fn();
         const record = makeRecord();
 
-        const {result} = renderHook(() => useCodexResponsesToggle({record, primaryService: makeService(), onUpdateRecord}));
+        const {result} = renderHook(() => useResponsesToggle({record, primaryService: makeService(), onUpdateRecord}));
 
         await act(async () => {
             await result.current.onToggle();
@@ -74,7 +74,7 @@ describe('useCodexResponsesToggle', () => {
         const onUpdateRecord = vi.fn();
         const record = makeRecord({openaiEndpointOverride: 'responses'});
 
-        const {result} = renderHook(() => useCodexResponsesToggle({record, primaryService: makeService(), onUpdateRecord}));
+        const {result} = renderHook(() => useResponsesToggle({record, primaryService: makeService(), onUpdateRecord}));
         expect(result.current.enabled).toBe(true);
 
         await act(async () => {
@@ -91,7 +91,7 @@ describe('useCodexResponsesToggle', () => {
         const record = makeRecord({openaiEndpointOverride: 'responses'});
 
         const {result, rerender} = renderHook(
-            ({service}) => useCodexResponsesToggle({record, primaryService: service, onUpdateRecord}),
+            ({service}) => useResponsesToggle({record, primaryService: service, onUpdateRecord}),
             {initialProps: {service: makeService({model: 'gpt-5'})}},
         );
 
@@ -112,7 +112,7 @@ describe('useCodexResponsesToggle', () => {
         const record = makeRecord(); // openaiEndpointOverride unset
 
         const {rerender} = renderHook(
-            ({service}) => useCodexResponsesToggle({record, primaryService: service, onUpdateRecord}),
+            ({service}) => useResponsesToggle({record, primaryService: service, onUpdateRecord}),
             {initialProps: {service: makeService({model: 'gpt-5'})}},
         );
 

--- a/frontend/src/hooks/useResponsesToggle.ts
+++ b/frontend/src/hooks/useResponsesToggle.ts
@@ -3,14 +3,14 @@ import {runProbe} from '@/components/probe/runProbe';
 import {notify} from '@/utils/notify';
 import type {ConfigProvider, ConfigRecord} from '@/components/RoutingGraphTypes';
 
-export interface UseCodexResponsesToggleOptions {
+export interface UseResponsesToggleOptions {
     record: ConfigRecord;
     /** The rule's highest-priority active service, or undefined if it has none. */
     primaryService: ConfigProvider | undefined;
     onUpdateRecord?: (field: keyof ConfigRecord, value: any) => void;
 }
 
-export interface UseCodexResponsesToggleResult {
+export interface UseResponsesToggleResult {
     enabled: boolean;
     probing: boolean;
     onToggle: () => void;
@@ -31,15 +31,18 @@ async function probeResponsesSupport(service: ConfigProvider) {
     });
 }
 
-// useCodexResponsesToggle owns the "native OpenAI Responses API" switch shown
-// on Codex-scenario rule cards: a pre-flight probe against the real upstream
-// before the flag is set, and automatic re-validation if the rule's bound
+// useResponsesToggle owns the "native OpenAI Responses API" switch shown on
+// any rule card whose primary provider is OpenAI-style — it's the rule-level
+// `openaiEndpointOverride` flag (see .design/openai-endpoint-routing.md §3,
+// Layer 2), which is per-rule and provider-agnostic by design, not a
+// Codex-only feature. A pre-flight probe against the real upstream gates the
+// flag before it's set, and the hook auto-revalidates if the rule's bound
 // provider/model changes mid-session.
-export function useCodexResponsesToggle({
+export function useResponsesToggle({
     record,
     primaryService,
     onUpdateRecord,
-}: UseCodexResponsesToggleOptions): UseCodexResponsesToggleResult {
+}: UseResponsesToggleOptions): UseResponsesToggleResult {
     const [probing, setProbing] = useState(false);
     const enabled = record.flags?.openaiEndpointOverride === 'responses';
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -386,7 +386,11 @@ export default {
     "connectAI": "Connect AI",
     "newRule": "New Rule",
     "createNewRule": "Create new routing rule",
-    "howRoutingWorks": "How routing works"
+    "howRoutingWorks": "How routing works",
+    "sortOriginal": "Original order",
+    "sortByName": "Name (A→Z)",
+    "sortTooltipToName": "Showing original order — click to sort by name",
+    "sortTooltipToOriginal": "Showing by name — click to restore original order"
   },
   "probe": {
     "quickTest": "Quick test (stream)",
@@ -958,8 +962,8 @@ export default {
     "profile": {
       "renameProfile": "Rename profile",
       "deleteProfile": "Delete profile",
-      "quickStart": "Quick Start",
-      "settingsFile": "Settings File",
+      "quickStart": "Start",
+      "settingsFile": "Settings",
       "settingsFileWarning": "Generated runtime settings. Manual edits are overwritten by Profile Overrides and Model Rules.",
       "resolvingSettingsFile": "Resolving generated settings path…",
       "settingsGenerated": "Generated",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -388,7 +388,11 @@ export default {
     "connectAI": "连接 AI",
     "newRule": "新建规则",
     "createNewRule": "创建新的路由规则",
-    "howRoutingWorks": "路由原理"
+    "howRoutingWorks": "路由原理",
+    "sortOriginal": "原始顺序",
+    "sortByName": "按名称（A→Z）",
+    "sortTooltipToName": "当前按原始顺序显示 — 点击按名称排序",
+    "sortTooltipToOriginal": "当前按名称排序 — 点击恢复原始顺序"
   },
   "probe": {
     "quickTest": "快速测试（流式）",
@@ -960,8 +964,8 @@ export default {
     "profile": {
       "renameProfile": "重命名配置文件",
       "deleteProfile": "删除配置文件",
-      "quickStart": "快速开始",
-      "settingsFile": "设置文件",
+      "quickStart": "启动",
+      "settingsFile": "设置",
       "settingsFileWarning": "这是生成的运行配置；手动修改会被 Profile 覆盖和模型规则重新生成。",
       "resolvingSettingsFile": "正在计算生成文件位置…",
       "settingsGenerated": "已生成",

--- a/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
+++ b/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
@@ -71,6 +71,10 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
     // global command available as an explicit alternative for those who have.
     const [commandMode, setCommandMode] = useState<'npx' | 'global'>('npx');
     const [settingsArtifact, setSettingsArtifact] = useState<ClaudeCodeProfileSettingsArtifact | null>(null);
+    // Quick Start / Settings File share one ConfigRow (like Base URL | API Key
+    // elsewhere) instead of two separate always-expanded rows — same info,
+    // less vertical space, one at a time.
+    const [profileConfigTab, setProfileConfigTab] = useState<'quickstart' | 'settings-file'>('quickstart');
 
     // Update unified mode when profile changes
     useEffect(() => {
@@ -185,7 +189,7 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
                         </Stack>
                     }
                 >
-                    <Box sx={{ px: 2, pb: 0.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                    <Box sx={{ px: 2, pb: 0.5 }}>
                         <ConfigRow
                             tabs={[
                                 {
@@ -264,12 +268,6 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
                                         </>
                                     ),
                                 },
-                            ]}
-                            activeTab="quickstart"
-                            onTabChange={() => {}}
-                        />
-                        <ConfigRow
-                            tabs={[
                                 {
                                     key: 'settings-file',
                                     label: t('claudeCode.profile.settingsFile'),
@@ -336,8 +334,8 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
                                     ),
                                 },
                             ]}
-                            activeTab="settings-file"
-                            onTabChange={() => {}}
+                            activeTab={profileConfigTab}
+                            onTabChange={(key) => setProfileConfigTab(key as 'quickstart' | 'settings-file')}
                         />
                     </Box>
                     <ProviderConfigCard

--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -14,6 +14,7 @@ import type {TemplatePageProps} from './TemplatePage.types';
 import {TemplatePageActions} from './TemplatePageActions';
 import {TitleIconButtons} from './TitleIconButtons';
 import {useTemplatePageRules} from '@/pages/scenario/hooks/useTemplatePageRules';
+import {useRuleSort} from '@/pages/scenario/hooks/useRuleSort';
 import {useScrollToNewRule} from '@/components/hooks/useScrollToNewRule';
 import {useModelSelectDialog} from '@/hooks/useModelSelectDialog';
 import {useProviderDialog} from '@/hooks/useProviderDialog';
@@ -125,6 +126,11 @@ const TemplatePage: React.FC<TemplatePageProps> = (props) => {
         newRuleUuid,
         setNewRuleUuid,
     } = useScrollToNewRule({rules});
+
+    // Display-only ordering for the Model Rules list — doesn't touch `rules`
+    // itself, so match priority (if any) and the scroll-to-new-rule logic
+    // above stay anchored to the real, backend-ordered array.
+    const {sortMode, toggleSortMode, sortedRules} = useRuleSort(rules);
 
     // Routed through a ref so onCreateFromModel doesn't capture a stale createRule.
     const createRuleRef = useRef(createRule);
@@ -349,6 +355,8 @@ const TemplatePage: React.FC<TemplatePageProps> = (props) => {
                         onToggleExpandAll={handleToggleExpandAll}
                         showExpandCollapseButton={showExpandCollapseButton}
                         onShowGuide={() => setShowGuide(true)}
+                        sortMode={rules.length > 1 ? sortMode : undefined}
+                        onToggleSort={rules.length > 1 ? toggleSortMode : undefined}
                     />
                 }
                 rightAction={rightAction}
@@ -365,9 +373,13 @@ const TemplatePage: React.FC<TemplatePageProps> = (props) => {
                             {t('templatePage.noRules')}
                         </Box>
                     ) : (
-                        rules.map((rule, index) => {
+                        sortedRules.map((rule, index) => {
                             const isNewRule = rule.uuid === newRuleUuid;
-                            const isLastRule = index === rules.length - 1;
+                            // "Last rule" for the auto-scroll-to-new-rule anchor is
+                            // meaningless once the list is name-sorted — that ref is
+                            // only a fallback for the initial mount scroll position,
+                            // so only attach it in the original, insertion-ordered view.
+                            const isLastRule = sortMode === 'original' && index === sortedRules.length - 1;
                             const shouldAttachRef = isNewRule || (isLastRule && !newRuleUuid);
 
                             return (

--- a/frontend/src/pages/scenario/components/TitleIconButtons.tsx
+++ b/frontend/src/pages/scenario/components/TitleIconButtons.tsx
@@ -4,8 +4,11 @@ import {
     FoldUp as FoldUpIcon,
     FoldDown as FoldDownIcon,
     HelpOutline as HelpOutlineIcon,
+    Sort as SortIcon,
+    SortByAlpha as SortByAlphaIcon,
 } from '@/components/icons';
 import { IconButton, Stack, Tooltip } from '@mui/material';
+import type { RuleSortMode } from '@/pages/scenario/hooks/useRuleSort';
 
 export interface TitleIconButtonsProps {
     collapsible: boolean;
@@ -13,6 +16,10 @@ export interface TitleIconButtonsProps {
     onToggleExpandAll: () => void;
     showExpandCollapseButton?: boolean;
     onShowGuide?: () => void;
+    // Rule-list display order — purely a view concern, doesn't touch the
+    // rules' actual stored/routing order. Omit both to hide the control.
+    sortMode?: RuleSortMode;
+    onToggleSort?: () => void;
 }
 
 export const TitleIconButtons: React.FC<TitleIconButtonsProps> = ({
@@ -21,11 +28,14 @@ export const TitleIconButtons: React.FC<TitleIconButtonsProps> = ({
     onToggleExpandAll,
     showExpandCollapseButton = true,
     onShowGuide,
+    sortMode,
+    onToggleSort,
 }) => {
     const { t } = useTranslation();
+    const showSort = !!onToggleSort && !!sortMode;
 
     // Don't render if no icon buttons to show
-    if (!showExpandCollapseButton || !collapsible) {
+    if ((!showExpandCollapseButton || !collapsible) && !showSort) {
         if (!onShowGuide) return null;
     }
 
@@ -33,6 +43,13 @@ export const TitleIconButtons: React.FC<TitleIconButtonsProps> = ({
         <Stack direction="row" spacing={0.5} sx={{
             alignItems: "center"
         }}>
+            {showSort && (
+                <Tooltip title={sortMode === 'original' ? t('templateActions.sortTooltipToName') : t('templateActions.sortTooltipToOriginal')}>
+                    <IconButton size="small" onClick={onToggleSort} aria-label={sortMode === 'original' ? t('templateActions.sortByName') : t('templateActions.sortOriginal')}>
+                        {sortMode === 'original' ? <SortIcon fontSize="small" /> : <SortByAlphaIcon fontSize="small" color="primary" />}
+                    </IconButton>
+                </Tooltip>
+            )}
             {showExpandCollapseButton && collapsible && (
                 <Tooltip title={allExpanded ? t('templateActions.collapseAllRules') : t('templateActions.expandAllRules')}>
                     <IconButton size="small" onClick={onToggleExpandAll}>

--- a/frontend/src/pages/scenario/hooks/useRuleSort.ts
+++ b/frontend/src/pages/scenario/hooks/useRuleSort.ts
@@ -1,0 +1,32 @@
+import { useMemo, useState } from 'react';
+import type { Rule } from '@/components/RoutingGraphTypes.ts';
+
+export type RuleSortMode = 'original' | 'name';
+
+export interface UseRuleSortReturn {
+    sortMode: RuleSortMode;
+    toggleSortMode: () => void;
+    sortedRules: Rule[];
+}
+
+/**
+ * Purely a display concern: reorders the Model Rules list for viewing only.
+ * The rules array's actual order (which the backend may use for match
+ * priority) is never mutated — 'original' just renders `rules` as given.
+ */
+export function useRuleSort(rules: Rule[]): UseRuleSortReturn {
+    const [sortMode, setSortMode] = useState<RuleSortMode>('original');
+
+    const toggleSortMode = () => {
+        setSortMode((prev) => (prev === 'original' ? 'name' : 'original'));
+    };
+
+    const sortedRules = useMemo(() => {
+        if (sortMode === 'original') return rules;
+        return [...rules].sort((a, b) =>
+            (a.request_model || '').localeCompare(b.request_model || '', undefined, { sensitivity: 'base' }),
+        );
+    }, [rules, sortMode]);
+
+    return { sortMode, toggleSortMode, sortedRules };
+}


### PR DESCRIPTION
## Summary

**Model Rules layout**
- `ModelRequestHeader`: the model-name + edit-icon area now sits in a fixed 170px slot with ellipsis truncation (was an unbounded, name-length-dependent width), so the 1M / Responses toggles line up at the same x-position across every rule card regardless of model name length. Long names still show in full via the existing hover tooltip and click-to-copy.
- Added a sort toggle (original insertion order ↔ name A→Z) next to the "Model Rules" title, via a new `useRuleSort` hook. Display-only — it never mutates the underlying `rules` array or any backend match-priority it encodes. The scroll-to-new-rule anchor only applies in original order, where "last rule" is still meaningful.

**Responses toggle generalization**
- The native OpenAI Responses API toggle was gated to `record.scenario === 'codex'`, but the underlying `openaiEndpointOverride` rule flag is per-rule and provider-agnostic by design (`.design/openai-endpoint-routing.md` §3, Layer 2) — the pre-flight probe already validates support before the flag is set. Dropped the scenario check so any rule whose primary provider is OpenAI-style can use it.
- Renamed `useCodexResponsesToggle` → `useResponsesToggle` to match.

**Claude Code profile page**
- Merged the separate "Quick Start" and "Settings File" rows into a single toggleable `ConfigRow` (`Start | Settings`), matching the existing `Base URL | API Key` pattern directly below it — one row instead of two, same information, switched in place.

## Test plan

- [x] `pnpm test` — 49/49 passing (including renamed/updated `useResponsesToggle.test.ts`)
- [x] `pnpm typecheck` — no new errors introduced (pre-existing unrelated errors in `modelUtils.ts` are non-blocking per repo convention)
- [x] Verified visually via headless Chrome screenshots (mock mode):
  - Toggle alignment across rows of varying model-name length (`team`, `openai`, `codex` scenarios)
  - Responses toggle now appears on non-Codex OpenAI-style rules (Qwen, DeepSeek, Z.ai) and stays hidden on Anthropic-routed rules
  - Sort toggle reorders the list alphabetically and back, with correct tooltip/icon state
  - Merged `Start | Settings` row renders correctly and switches tabs at both desktop and mobile widths, no overlap with content

---
_Generated by [Claude Code](https://claude.ai/code/session_01AroWvzJN6vFpJEfedWjgDq)_