### PR TITLE
feat(UI): Widen rule-name slot, swap name/edit tooltip roles, abbreviate VModel nav label

### DIFF
--- a/frontend/src/components/ModelRequestHeader.tsx
+++ b/frontend/src/components/ModelRequestHeader.tsx
@@ -28,11 +28,12 @@ const HEADER_PADDING_X = 40;
 const HEADER_PADDING_Y = 6;
 // Fixed (not just minimum) width for the "name + edit icon" slot, so the
 // toggles that follow (1M, Responses, …) line up at the same x-position
-// across every rule card. Names that don't fit truncate with an ellipsis —
-// the existing hover tooltip still shows the full name, and click-to-copy
-// still copies it in full — so a long name never re-breaks the alignment
-// this exists to guarantee.
-const NAME_SLOT_WIDTH = 170;
+// across every rule card. Sized to fit common model names in full (e.g.
+// "deepseek-v4-flash" measures ~140px in this font) with some headroom;
+// names that still don't fit truncate with an ellipsis — the hover tooltip
+// shows the full name and click-to-copy still copies it in full, so an
+// outlier-long name never re-breaks the alignment this exists to guarantee.
+const NAME_SLOT_WIDTH = 190;
 
 const HeaderContainer = styled(Box, {
     shouldForwardProp: (prop) => prop !== 'collapsible',
@@ -216,9 +217,7 @@ export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }} onClick={(e) => e.stopPropagation()}>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, width: NAME_SLOT_WIDTH, flexShrink: 0 }}>
                     <Tooltip
-                        title={modelName
-                            ? `The model name that clients use to make requests. This will be matched against incoming API calls. Supports wildcards (* or [any]) for matching any model. (click to copy)`
-                            : 'No model specified'}
+                        title={modelName ? `${modelName} (click to copy)` : 'No model specified'}
                         placement="top"
                     >
                         {isWildcard ? (
@@ -264,7 +263,7 @@ export const ModelRequestHeader: React.FC<ModelRequestHeaderProps> = ({
                             </ModelNameText>
                         )}
                     </Tooltip>
-                    <Tooltip title="Edit model name">
+                    <Tooltip title="Edit model name — this is what's matched against incoming API calls. Supports wildcards (* or [any]) to match any model.">
                         <IconButton
                             size="small"
                             onClick={(e) => { e.stopPropagation(); setEditMode(true); }}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -117,6 +117,7 @@ export default {
     "tinglyBox": "Sharing",
     "tinglyBoxTooltip": "Distribute model access without sharing your provider credentials. Each share token tracks usage independently and can be revoked at any time without affecting the others.",
     "virtualModels": "Virtual Models",
+    "virtualModelsNavLabel": "VModel",
     "virtualModelsTooltip": "Built-in synthetic model providers for onboarding, demos, and dry-runs. They respond locally without contacting any upstream.",
     "accessControl": "Access Control",
     "status": "Status",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -119,6 +119,7 @@ export default {
     "tinglyBox": "共享分发",
     "tinglyBoxTooltip": "不暴露你的 Provider 凭据即可分发模型访问。每个分发令牌独立计量，可以随时单独吊销而不影响其他令牌。",
     "virtualModels": "虚拟模型",
+    "virtualModelsNavLabel": "VModel",
     "virtualModelsTooltip": "内置的合成模型 Provider，用于上手演示与本地试跑——无需联网即在进程内返回响应。",
     "accessControl": "访问控制",
     "status": "状态",

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -227,7 +227,10 @@ export function useActivityItems(): ActivityItem[] {
                     },
                     {
                         path: '/credentials/virtual-models',
-                        label: t('layout.virtualModels', { defaultValue: 'Virtual Models' }),
+                        // Abbreviated here only — the sidebar is the tight spot;
+                        // the page itself (VirtualModelsPage) keeps the full
+                        // "Virtual Models" title via the shared layout.virtualModels key.
+                        label: t('layout.virtualModelsNavLabel', { defaultValue: 'VModel' }),
                         icon: <IconFlask sx={{ fontSize: 20 }} />,
                         tooltip: t('layout.virtualModelsTooltip', {
                             defaultValue: 'Built-in synthetic model providers for onboarding and dry-runs.',


### PR DESCRIPTION
## Summary

Follow-up to #1514, addressing feedback on the merged rule-card alignment work plus one unrelated nav tweak:

- **`ModelRequestHeader`**: widen the fixed name+edit-icon slot from 170px to 190px so common model names (e.g. `deepseek-v4-flash`, measured ~140px in the header font) render in full instead of truncating, while every card's 1M/Responses toggle row stays aligned.
- **Tooltip roles swapped**: hovering the model name now shows the full name (`modelname (click to copy)`) instead of the generic wildcard-matching explanation — useful now that outlier-long names can still truncate. That explanation moved to the edit icon's hover instead, where it's more relevant ("Edit model name — this is what's matched against incoming API calls. Supports wildcards (\* or [any]) to match any model.").
- **Sidebar nav**: abbreviated "Virtual Models" to "VModel" in the Credential section only (tight sidebar column), via a new `layout.virtualModelsNavLabel` i18n key. The page title and hover tooltip both keep the full "Virtual Models" name — this is a nav-label-only abbreviation, not a rename.

## Test plan

- [x] `pnpm test` — 49/49 passing
- [x] `pnpm typecheck` — no new errors in changed files
- [x] Verified visually via headless Chrome screenshots (mock mode):
  - `deepseek-v4-pro`/`deepseek-v4-flash`-length names render in full, toggle row still aligned across rows of varying name length
  - Hovering the model name shows the full name + copy hint; hovering the edit icon shows the wildcard-matching explanation
  - Sidebar Credential section shows "VModel"; the Virtual Models page itself still titles as "Virtual Models"

---
_Generated by [Claude Code](https://claude.ai/code/session_01AroWvzJN6vFpJEfedWjgDq)_