### PR TITLE
fix(quota): return ErrUsageNotFound unwrapped so handlers can skip it

### DIFF
--- a/ai/quota/manager.go
+++ b/ai/quota/manager.go
@@ -130,12 +130,15 @@ func (m *Manager) RefreshProvider(ctx context.Context, providerUUID string) (*Pr
 }
 
 // GetQuota returns cached quota data and refreshes it when expired.
+//
+// A not-found store lookup returns ErrUsageNotFound UNWRAPPED — callers
+// (e.g. the provider-quota HTTP handlers) compare against that sentinel
+// with == to treat "no data yet" as a skip rather than an error; wrapping it
+// here (as this used to do, via fmt.Errorf) silently broke that comparison
+// and turned every "no quota data" provider into a hard error upstream.
 func (m *Manager) GetQuota(ctx context.Context, providerUUID string) (*ProviderUsage, error) {
 	usage, err := m.store.Get(ctx, providerUUID)
 	if err != nil {
-		if err == ErrUsageNotFound {
-			return nil, fmt.Errorf("quota not found for provider: %s", providerUUID)
-		}
 		return nil, err
 	}
 
@@ -149,15 +152,9 @@ func (m *Manager) GetQuota(ctx context.Context, providerUUID string) (*ProviderU
 }
 
 // GetQuotaNoCache returns the latest quota data stored in the database.
+// See GetQuota above for why ErrUsageNotFound must reach the caller unwrapped.
 func (m *Manager) GetQuotaNoCache(ctx context.Context, providerUUID string) (*ProviderUsage, error) {
-	usage, err := m.store.Get(ctx, providerUUID)
-	if err != nil {
-		if err == ErrUsageNotFound {
-			return nil, fmt.Errorf("quota not found for provider: %s", providerUUID)
-		}
-		return nil, err
-	}
-	return usage, nil
+	return m.store.Get(ctx, providerUUID)
 }
 
 // ListQuota returns quota data for all providers.

--- a/ai/quota/manager_test.go
+++ b/ai/quota/manager_test.go
@@ -57,6 +57,25 @@ func (f *concurrencyTestFetcher) Fetch(_ context.Context, provider *typ.Provider
 	return &ProviderUsage{ProviderUUID: provider.UUID}, nil
 }
 
+// TestGetQuota_NotFoundIsUnwrapped locks in that GetQuota (and
+// GetQuotaNoCache) return ErrUsageNotFound identically to what the store
+// returned — not a re-wrapped error. Callers such as the provider-quota
+// batch handler compare with == against this sentinel to skip providers
+// with no quota data instead of failing the whole request; a wrapped error
+// silently breaks that comparison (this was a real bug: BatchGetQuota 500'd
+// for any provider with no quota data, e.g. a vmodel/local provider, instead
+// of just omitting it from the result).
+func TestGetQuota_NotFoundIsUnwrapped(t *testing.T) {
+	manager := NewManager(DefaultConfig(), managerTestStore{}, managerTestProviderManager{}, logrus.New())
+
+	if _, err := manager.GetQuota(context.Background(), "missing"); err != ErrUsageNotFound {
+		t.Fatalf("GetQuota() error = %v, want ErrUsageNotFound (identity, via ==)", err)
+	}
+	if _, err := manager.GetQuotaNoCache(context.Background(), "missing"); err != ErrUsageNotFound {
+		t.Fatalf("GetQuotaNoCache() error = %v, want ErrUsageNotFound (identity, via ==)", err)
+	}
+}
+
 func TestRefreshBoundsConcurrency(t *testing.T) {
 	providers := make([]*typ.Provider, 20)
 	for i := range providers {

--- a/internal/server/module/providerquota/handler_test.go
+++ b/internal/server/module/providerquota/handler_test.go
@@ -1,0 +1,158 @@
+package providerquota
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/ai/quota"
+)
+
+// fakeManager lets each test configure exactly what GetQuota returns per
+// provider UUID, without a real store/fetcher.
+type fakeManager struct {
+	quotas map[string]*quota.ProviderUsage
+	errs   map[string]error
+}
+
+func (f *fakeManager) GetQuota(_ context.Context, providerUUID string) (*quota.ProviderUsage, error) {
+	if err, ok := f.errs[providerUUID]; ok {
+		return nil, err
+	}
+	if u, ok := f.quotas[providerUUID]; ok {
+		return u, nil
+	}
+	return nil, quota.ErrUsageNotFound
+}
+func (f *fakeManager) GetQuotaNoCache(ctx context.Context, providerUUID string) (*quota.ProviderUsage, error) {
+	return f.GetQuota(ctx, providerUUID)
+}
+func (f *fakeManager) ListQuota(context.Context) ([]*quota.ProviderUsage, error) { return nil, nil }
+func (f *fakeManager) Refresh(context.Context) ([]*quota.ProviderUsage, error)   { return nil, nil }
+func (f *fakeManager) RefreshProvider(context.Context, string) (*quota.ProviderUsage, error) {
+	return nil, nil
+}
+func (f *fakeManager) Summary(context.Context) (*quota.Summary, error) { return nil, nil }
+func (f *fakeManager) IsProviderSupported(string) bool                 { return true }
+func (f *fakeManager) StartAutoRefresh(context.Context)                {}
+func (f *fakeManager) StopAutoRefresh()                                {}
+
+func postJSON(t *testing.T, h gin.HandlerFunc, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	raw, _ := json.Marshal(body)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(raw))
+	c.Request.Header.Set("Content-Type", "application/json")
+	h(c)
+	return w
+}
+
+// TestBatchGetQuota_SkipsProvidersWithNoData is the regression test for the
+// bug e2e testing surfaced: a provider with no quota data (e.g. a vmodel/
+// local provider with no registered fetcher) used to 500 the WHOLE batch
+// request instead of just being omitted from the result — because
+// Manager.GetQuota re-wrapped ErrUsageNotFound into a new error, breaking
+// the handler's `err != quota.ErrUsageNotFound` identity check (fixed in
+// ai/quota/manager.go). This test exercises the real (non-fake) comparison
+// path in the handler with a manager that returns the sentinel directly.
+func TestBatchGetQuota_SkipsProvidersWithNoData(t *testing.T) {
+	mgr := &fakeManager{
+		quotas: map[string]*quota.ProviderUsage{
+			"has-data": {ProviderUUID: "has-data", ProviderName: "Real"},
+		},
+		// "no-data" provider: absent from both maps -> ErrUsageNotFound.
+	}
+	h := NewHandler(mgr, logrus.StandardLogger())
+
+	w := postJSON(t, h.BatchGetQuota, BatchGetQuotaRequest{ProviderUUIDs: []string{"has-data", "no-data"}})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp BatchGetQuotaResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := resp.Data["has-data"]; !ok {
+		t.Fatalf("expected has-data in response, got %+v", resp.Data)
+	}
+	if _, ok := resp.Data["no-data"]; ok {
+		t.Fatalf("expected no-data to be omitted (not errored), got %+v", resp.Data)
+	}
+}
+
+// TestBatchGetQuota_FailsOnlyWhenEveryProviderErrors confirms a genuine
+// (non-not-found) error still surfaces when NO provider in the batch
+// produced usable data — distinct from the not-found-is-a-skip case above.
+func TestBatchGetQuota_FailsOnlyWhenEveryProviderErrors(t *testing.T) {
+	mgr := &fakeManager{
+		errs: map[string]error{"broken": context.DeadlineExceeded},
+	}
+	h := NewHandler(mgr, logrus.StandardLogger())
+
+	w := postJSON(t, h.BatchGetQuota, BatchGetQuotaRequest{ProviderUUIDs: []string{"broken"}})
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestGetQuota_NotFoundReturns404 pins the single-provider GetQuota's
+// not-found response, the same sentinel path BatchGetQuota relies on.
+func TestGetQuota_NotFoundReturns404(t *testing.T) {
+	mgr := &fakeManager{}
+	h := NewHandler(mgr, logrus.StandardLogger())
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/provider-quota/no-data", nil)
+	c.Params = gin.Params{{Key: "uuid", Value: "no-data"}}
+	h.GetQuota(c)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// notFoundStore is a quota.Store whose Get always reports "no data yet".
+type notFoundStore struct{}
+
+func (notFoundStore) Save(context.Context, *quota.ProviderUsage) error { return nil }
+func (notFoundStore) Get(context.Context, string) (*quota.ProviderUsage, error) {
+	return nil, quota.ErrUsageNotFound
+}
+func (notFoundStore) List(context.Context) ([]*quota.ProviderUsage, error) { return nil, nil }
+func (notFoundStore) Delete(context.Context, string) error                 { return nil }
+func (notFoundStore) CleanupExpired(context.Context) (int64, error)        { return 0, nil }
+func (notFoundStore) Close() error                                         { return nil }
+
+// TestBatchGetQuota_RealManagerSkipsProvidersWithNoData is the end-to-end
+// regression test: the other tests here pin the handler's half of the contract
+// using a fake that already returns the bare sentinel, and
+// quota.TestGetQuota_NotFoundIsUnwrapped pins the manager's half. Neither
+// alone catches the bug, because the bug lives exactly in the seam between
+// them — a wrapped sentinel that the handler's == can no longer recognize.
+//
+// So drive the REAL quota.Manager through the REAL handler. Before the fix
+// this 500s the whole batch; after it, the provider with no data is skipped
+// and the batch succeeds.
+func TestBatchGetQuota_RealManagerSkipsProvidersWithNoData(t *testing.T) {
+	mgr := quota.NewManager(nil, notFoundStore{}, nil, logrus.StandardLogger())
+	h := NewHandler(mgr, logrus.StandardLogger())
+
+	w := postJSON(t, h.BatchGetQuota, BatchGetQuotaRequest{ProviderUUIDs: []string{"no-data"}})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (no-data providers must be skipped, not fatal); body=%s",
+			w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## The bug

`Manager.GetQuota` / `GetQuotaNoCache` wrapped the store's `ErrUsageNotFound` sentinel before returning it:

```go
if err == ErrUsageNotFound {
    return nil, fmt.Errorf("quota not found for provider: %s", providerUUID)
}
```

But the provider-quota HTTP handlers compare against that sentinel with `==` to decide *skip* vs *fail*:

```go
// internal/server/module/providerquota/handler.go:115
if err == quota.ErrUsageNotFound { ... }
// :242
if err != quota.ErrUsageNotFound { ... }
```

`==` never matches a wrapped error, so "no quota data yet" — an entirely normal state — was indistinguishable from a real failure.

**Worst case is `BatchGetQuota`:** a single provider with no data (a vmodel or local provider with no registered fetcher, say) fails the *whole* batch with a 500 and `{"error":"failed to get quota for any provider"}`, instead of being quietly omitted from the response.

## The fix

Return the sentinel unwrapped, and document at both call sites why it has to stay that way so a future refactor doesn't reintroduce the wrap. `GetQuotaNoCache` collapses to a direct `m.store.Get(...)` once the special case is gone.

Note the wrapping wasn't even reachable as an error *message* improvement — every caller either compares the sentinel or propagates, so the added string only ever destroyed information.

## Tests

The bug lives in the seam *between* two packages, so no single test catches it. Three, deliberately:

| test | pins | fails without the fix |
|---|---|---|
| `quota.TestGetQuota_NotFoundIsUnwrapped` | the manager's half — the sentinel comes back bare | ✅ |
| `providerquota` fakeManager tests | the handler's half — that `==` is what decides skip-vs-fail, plus the 404 and genuine-error paths | ❌ (fake already returns the bare sentinel) |
| `providerquota.TestBatchGetQuota_RealManagerSkipsProvidersWithNoData` | the seam — real `quota.Manager` through the real handler | ✅ |

Verified by reverting `manager.go` to the unfixed version and re-running:

```
--- FAIL: TestBatchGetQuota_RealManagerSkipsProvidersWithNoData
    handler_test.go:155: status = 500, want 200 (no-data providers must be
    skipped, not fatal); body={"error":"failed to get quota for any provider"}
--- FAIL: TestGetQuota_NotFoundIsUnwrapped
```

Both pass after.

## Scope

`go build ./...` and `go test ./ai/quota/... ./internal/server/module/providerquota/...` clean. Three files, no behavior change beyond the one described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUhuepUVCMWjMNVAkyunAG