### PR TITLE
feat(system): redesign settings cards, add copyable version & responsive layouts

### DIFF
--- a/frontend/src/components/UnifiedCard.tsx
+++ b/frontend/src/components/UnifiedCard.tsx
@@ -15,6 +15,14 @@ interface UnifiedCardProps {
   width?: number | string;
   // Custom height, prioritized if provided
   height?: number | string;
+  /**
+   * Cap the card's width on wide viewports. Unlike `width`, the card still
+   * fills its column (`width: 100%`) and only stops growing past this value —
+   * so it remains responsive on narrow screens. Use for settings-style pages
+   * with many narrow cards that would otherwise stretch edge-to-edge. The
+   * card stays left-aligned within its column.
+   */
+  maxWidth?: number | string;
   // Message support
   message?: { type: 'success' | 'error'; text: string } | null;
   onClearMessage?: () => void;
@@ -110,6 +118,7 @@ export const UnifiedCard = forwardRef<HTMLDivElement, UnifiedCardProps>(({
   variant = 'default',
   width,
   height,
+  maxWidth,
   message,
   onClearMessage,
   leftAction,
@@ -123,6 +132,9 @@ export const UnifiedCard = forwardRef<HTMLDivElement, UnifiedCardProps>(({
       id={id}
       sx={{
         ...getCardDimensions(size, width, height),
+        ...(maxWidth !== undefined && {
+          maxWidth,
+        }),
         ...cardVariants[variant],
         borderRadius: 2,
         border: '1px solid',

--- a/frontend/src/components/UnifiedCard.tsx
+++ b/frontend/src/components/UnifiedCard.tsx
@@ -1,8 +1,22 @@
-import { Alert, Box, Card, CardContent, Typography } from '@mui/material';
+import { Alert, Box, Card, CardContent, Grid, Typography } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
 import type { ElementType, ReactNode } from 'react';
 import { forwardRef } from 'react';
 import { EMPTY_SX } from '@/constants/defaults';
+
+/**
+ * Responsive column span for a card placed inside a `CardGrid` (MUI Grid v7).
+ * Each value is the number of columns (out of the grid's total, default 12)
+ * the card occupies at that breakpoint. Omit a breakpoint to let it default.
+ * Omit `grid` entirely to keep the legacy "auto" behavior (bare card, stacked).
+ */
+export interface UnifiedCardGridSpan {
+  xs?: number;
+  sm?: number;
+  md?: number;
+  lg?: number;
+  xl?: number;
+}
 
 interface UnifiedCardProps {
   title?: string | ReactNode;
@@ -32,6 +46,13 @@ interface UnifiedCardProps {
   sx?: SxProps<Theme>;
   // DOM id forwarded to the root Card — useful as a scroll/anchor target
   id?: string;
+  /**
+   * Make this card a grid item with the given responsive column span, so it
+   * can sit beside other `grid`-enabled cards in an n×m layout inside a
+   * `CardGrid`. Default `auto` (omitted) renders a bare card with no grid
+   * wrapping — the legacy stacked-full-width behavior.
+   */
+  grid?: UnifiedCardGridSpan;
 }
 
 
@@ -125,8 +146,9 @@ export const UnifiedCard = forwardRef<HTMLDivElement, UnifiedCardProps>(({
   rightAction,
   sx = EMPTY_SX,
   id,
+  grid,
 }, ref) => {
-  return (
+  const card = (
     <Card
       ref={ref}
       id={id}
@@ -232,6 +254,11 @@ export const UnifiedCard = forwardRef<HTMLDivElement, UnifiedCardProps>(({
       </CardContent>
     </Card>
   );
+
+  // When `grid` is provided, become a responsive Grid item so the card can sit
+  // beside other grid-enabled cards in an n×m layout. Omit `grid` for the
+  // legacy "auto" stacked-full-width behavior.
+  return grid ? <Grid size={grid}>{card}</Grid> : card;
 });
 
 UnifiedCard.displayName = 'UnifiedCard';

--- a/frontend/src/components/UpdatePanelDialog.tsx
+++ b/frontend/src/components/UpdatePanelDialog.tsx
@@ -1,5 +1,6 @@
-import { ContentCopy, GitHub, AppRegistration as NPM, Refresh } from '@/components/icons';
+import { ContentCopy, Check, GitHub, AppRegistration as NPM, Refresh } from '@/components/icons';
 import { Box, Button, Collapse, Dialog, DialogActions, DialogContent, Divider, IconButton, Stack, Typography, useTheme } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import { fontMono } from '@/theme/fonts';
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -25,6 +26,7 @@ export const UpdatePanelDialog: React.FC<UpdatePanelDialogProps> = ({ open, onCl
     const { currentVersion, latestVersion, checking, releaseURL, checkForUpdates, hasUpdate } = useVersion();
 
     const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+    const [copiedVersion, setCopiedVersion] = useState(false);
 
     const displayCurrentVersion = (currentVersion || 'Unknown').split('+')[0];
     const displayLatestVersion = (latestVersion || currentVersion || 'Unknown').split('+')[0];
@@ -70,28 +72,34 @@ export const UpdatePanelDialog: React.FC<UpdatePanelDialogProps> = ({ open, onCl
         });
     }, []);
 
+    const handleCopyVersion = useCallback(() => {
+        navigator.clipboard.writeText(displayCurrentVersion).then(() => {
+            setCopiedVersion(true);
+            setTimeout(() => setCopiedVersion(false), 2000);
+        });
+    }, [displayCurrentVersion]);
+
     const handleCheckForUpdates = useCallback(() => {
         checkForUpdates(true);
     }, [checkForUpdates]);
 
-    const getHeaderGradient = () => {
-        if (checking) {
-            return 'linear-gradient(135deg, #2196f3 0%, #1976d2 100%)'; // Blue
-        }
-        if (hasVersionUpdate) {
-            return 'linear-gradient(135deg, #ff9800 0%, #f57c00 100%)'; // Orange
-        }
-        return 'linear-gradient(135deg, #4caf50 0%, #388e3c 100%)'; // Green
+    const getStatusColor = () => {
+        if (checking) return 'info';
+        if (hasVersionUpdate) return 'warning';
+        return 'success';
     };
+
+    const statusColor = getStatusColor();
+    const statusPalette = theme.palette[statusColor];
 
     const getStatusIcon = () => {
         if (checking) {
-            return <Refresh sx={{ fontSize: 32, color: 'white', animation: 'spin 1s linear infinite' }} />;
+            return <Refresh sx={{ fontSize: 32, color: statusPalette.main, animation: 'spin 1s linear infinite' }} />;
         }
         if (hasVersionUpdate) {
-            return <GitHub sx={{ fontSize: 32, color: 'white' }} />;
+            return <GitHub sx={{ fontSize: 32, color: statusPalette.main }} />;
         }
-        return <Refresh sx={{ fontSize: 32, color: 'white' }} />;
+        return <Refresh sx={{ fontSize: 32, color: statusPalette.main }} />;
     };
 
     const getStatusTitle = () => {
@@ -121,10 +129,12 @@ export const UpdatePanelDialog: React.FC<UpdatePanelDialogProps> = ({ open, onCl
                 }
             }}
         >
-            {/* Header with gradient background */}
+            {/* Header — soft tinted surface derived from the status palette color */}
             <Box
                 sx={{
-                    background: getHeaderGradient(),
+                    bgcolor: alpha(statusPalette.main, theme.palette.mode === 'dark' ? 0.16 : 0.10),
+                    borderBottom: '1px solid',
+                    borderColor: alpha(statusPalette.main, 0.24),
                     px: 3,
                     py: 2.5,
                     textAlign: 'center',
@@ -135,7 +145,7 @@ export const UpdatePanelDialog: React.FC<UpdatePanelDialogProps> = ({ open, onCl
                         width: 56,
                         height: 56,
                         borderRadius: '50%',
-                        bgcolor: 'rgba(255, 255, 255, 0.2)',
+                        bgcolor: alpha(statusPalette.main, theme.palette.mode === 'dark' ? 0.24 : 0.16),
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'center',
@@ -145,19 +155,31 @@ export const UpdatePanelDialog: React.FC<UpdatePanelDialogProps> = ({ open, onCl
                 >
                     {getStatusIcon()}
                 </Box>
-                <Typography variant="h5" sx={{ color: 'white', fontWeight: 600, mb: 0.5 }}>
+                <Typography variant="h6" sx={{ color: 'text.primary', fontWeight: 600, mb: 0.5 }}>
                     {getStatusTitle()}
                 </Typography>
-                <Typography variant="body2" sx={{ color: 'rgba(255, 255, 255, 0.9)' }}>
-                    {hasVersionUpdate ? (
-                        t('update.versionComparison', {
-                            latest: displayLatestVersion,
-                            current: displayCurrentVersion,
-                        })
-                    ) : (
-                        t('update.currentVersion', { version: displayCurrentVersion })
-                    )}
-                </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5 }}>
+                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                        {hasVersionUpdate ? (
+                            t('update.versionComparison', {
+                                latest: displayLatestVersion,
+                                current: displayCurrentVersion,
+                            })
+                        ) : (
+                            t('update.currentVersion', { version: displayCurrentVersion })
+                        )}
+                    </Typography>
+                    <Tooltip title={copiedVersion ? t('update.copied') : t('update.copy')} placement="top" arrow>
+                        <IconButton
+                            size="small"
+                            onClick={handleCopyVersion}
+                            aria-label={t('update.copy')}
+                            sx={{ color: copiedVersion ? 'success.main' : 'text.secondary' }}
+                        >
+                            {copiedVersion ? <Check sx={{ fontSize: 16 }} /> : <ContentCopy sx={{ fontSize: 16 }} />}
+                        </IconButton>
+                    </Tooltip>
+                </Box>
             </Box>
             <DialogContent sx={{ p: 0 }}>
                 <Stack spacing={0} divider={<Divider />}>
@@ -168,19 +190,12 @@ export const UpdatePanelDialog: React.FC<UpdatePanelDialogProps> = ({ open, onCl
                         </Typography>
                         <Button
                             variant={hasVersionUpdate ? 'contained' : 'outlined'}
+                            color={hasVersionUpdate ? 'warning' : 'primary'}
                             onClick={handleCheckForUpdates}
                             disabled={checking}
                             startIcon={checking ? <Refresh sx={{ fontSize: 18, animation: 'spin 1s linear infinite' }} /> : <Refresh />}
                             fullWidth
-                            sx={{
-                                height: 48,
-                                ...(hasVersionUpdate && {
-                                    background: 'linear-gradient(135deg, #ff9800 0%, #f57c00 100%)',
-                                    '&:hover': {
-                                        background: 'linear-gradient(135deg, #f57c00 0%, #ef6c00 100%)',
-                                    },
-                                }),
-                            }}
+                            sx={{ height: 48 }}
                         >
                             {checking ? t('update.checking') : t('update.check')}
                         </Button>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -16,6 +16,7 @@ export default {
     "done": "Done",
     "applying": "Applying...",
     "copy": "Copy",
+    "copied": "Copied",
     "refresh": "Refresh",
     "verify": "Verify",
     "saveChanges": "Save Changes",
@@ -819,7 +820,11 @@ export default {
       "license": "License",
       "github": "GitHub",
       "devMode": "Dev Mode",
-      "available": "available"
+      "available": "available",
+      "copyVersion": "Copy version",
+      "versionCopied": "Version copied to clipboard",
+      "checkUpdate": "Click to check for updates",
+      "updateAvailable": "Version {{version}} available — click to view"
     },
     "serverStatus": {
       "title": "Server Status",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -16,6 +16,7 @@ export default {
     "done": "完成",
     "applying": "应用中...",
     "copy": "复制",
+    "copied": "已复制",
     "refresh": "刷新",
     "verify": "验证",
     "saveChanges": "保存更改",
@@ -821,7 +822,11 @@ export default {
       "license": "许可证",
       "github": "GitHub",
       "devMode": "开发模式",
-      "available": "可用"
+      "available": "可用",
+      "copyVersion": "复制版本号",
+      "versionCopied": "版本号已复制到剪贴板",
+      "checkUpdate": "点击检查更新",
+      "updateAvailable": "新版本 {{version}} 可用，点击查看"
     },
     "serverStatus": {
       "title": "服务器状态",

--- a/frontend/src/pages/system/AccessControl.tsx
+++ b/frontend/src/pages/system/AccessControl.tsx
@@ -29,11 +29,14 @@ import { api } from '@/services/api.ts';
 import { useAuth } from '@/contexts/AuthContext.tsx';
 import { PageLayout } from '@/components/PageLayout.tsx';
 import UnifiedCard from '@/components/UnifiedCard.tsx';
+import CardGrid from "@/components/CardGrid.tsx";
 
 interface TokenInfo {
     token: string;
     is_default: boolean;
 }
+
+const CARD_MAX_WIDTH = 720;
 
 // Shared shape for both the User Token and Model Token rows: masked value,
 // show/hide toggle, copy button. Behavior (what's shown, what copy does)
@@ -272,7 +275,7 @@ const AccessControl = () => {
 
     return (
         <PageLayout loading={loading} notification={{ open: false }}>
-            <Stack spacing={3}>
+            <CardGrid>
                 {/* Page Header Card. The two bullets below are the facts that
                     AREN'T already said by each token row's own description
                     (point2's specific endpoint list, point3's "share one but
@@ -280,7 +283,7 @@ const AccessControl = () => {
                     User Token row's description almost verbatim and the
                     subtitle/intro paragraph above it were pure preamble, so
                     they're dropped rather than repeated a second time. */}
-                <UnifiedCard size="full">
+                <UnifiedCard maxWidth={CARD_MAX_WIDTH} size="full">
                     <Stack spacing={2}>
                         <Box>
                             <Typography component="h1" variant="h5" sx={{
@@ -306,6 +309,7 @@ const AccessControl = () => {
                         </Stack>
                     </Stack>
                 </UnifiedCard>
+
 
                 {/* Security Warning for Default Token */}
                 {isUsingDefaultToken && (
@@ -363,7 +367,7 @@ const AccessControl = () => {
                     kind of thing (a bearer credential you can view/copy/reset),
                     just scoped to different audiences (control panel vs API
                     clients), so they share one card instead of two. */}
-                <UnifiedCard size="full">
+                <UnifiedCard maxWidth={CARD_MAX_WIDTH} size="full">
                     <Stack spacing={3}>
                         <Box>
                             <Stack direction="row" spacing={2} sx={{ alignItems: 'center', mb: 1.5 }}>
@@ -443,7 +447,7 @@ const AccessControl = () => {
                         </Box>
                     </Stack>
                 </UnifiedCard>
-            </Stack>
+            </CardGrid>
             {/* User Reset Confirmation Dialog */}
             <Dialog open={resetUserDialogOpen} onClose={() => setResetUserDialogOpen(false)} maxWidth="sm" fullWidth>
                 <DialogTitle>

--- a/frontend/src/pages/system/ExperimentalPage.tsx
+++ b/frontend/src/pages/system/ExperimentalPage.tsx
@@ -5,6 +5,8 @@ import UnifiedCard from '@/components/UnifiedCard';
 import { Stack, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
+const CARD_MAX_WIDTH = 720;
+
 const ExperimentalPage = () => {
     const { t } = useTranslation();
 
@@ -12,6 +14,7 @@ const ExperimentalPage = () => {
         <PageLayout loading={false}>
             <CardGrid>
                 <UnifiedCard
+                    maxWidth={CARD_MAX_WIDTH}
                     title={t('system.experimentalFeatures.title')}
                     titleHeadingLevel={1}
                     size="full"

--- a/frontend/src/pages/system/System.tsx
+++ b/frontend/src/pages/system/System.tsx
@@ -1,9 +1,10 @@
 import CardGrid from '@/components/CardGrid.tsx';
 import { PageLayout } from '@/components/PageLayout.tsx';
 import UnifiedCard from '@/components/UnifiedCard.tsx';
-import { Logout, Refresh as RefreshIcon, CheckCircle as IconCircleCheck, Cancel as IconCircleX, Info as IconInfoCircle, Lock as IconLock, Star as IconStar, License as IconLicense, GitHub as IconBrandGithub, Translate as IconLanguage, Brush as IconBrush, Check as IconCheck, AccessTime as IconClock, ContentCopy as IconContentCopy } from '@/components/icons';
+import { Logout, Refresh as RefreshIcon, CheckCircle as IconCircleCheck, Cancel as IconCircleX, Info as IconInfoCircle, Lock as IconLock, License as IconLicense, GitHub as IconBrandGithub, Translate as IconLanguage, Brush as IconBrush, Check as IconCheck, AccessTime as IconClock, ContentCopy as IconContentCopy, Router as IconRouter } from '@/components/icons';
 import { UpdatePanelDialog } from '@/components/UpdatePanelDialog';
-import { Box, Button, CircularProgress, IconButton, InputAdornment, Link, Stack, TextField, Tooltip, Typography, Chip } from '@mui/material';
+import { Box, Button, CircularProgress, Divider, IconButton, InputAdornment, Link, Stack, Switch, TextField, Tooltip, Typography, Chip, type SxProps, type Theme } from '@mui/material';
+import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHealth } from '@/contexts/HealthContext.tsx';
@@ -13,6 +14,61 @@ import { useThemeMode } from '@/contexts/ThemeContext.tsx';
 import { useNotify } from '@/hooks/useNotify.ts';
 import { api } from '@/services/api.ts';
 import { getThemeOptions } from '@/theme/options.ts';
+
+// Label column width shared by every settings row — keeps the value column
+// (the actual visual anchor) vertically aligned across cards.
+const LABEL_WIDTH = 140;
+
+// Constrain the rows inside each full-width card so controls don't stretch
+// edge-to-edge across wide viewports. The card itself still spans the column
+// (UnifiedCard size="full"); only the inner content is capped.
+const CONTENT_MAX_WIDTH = 560;
+
+/**
+ * SettingsRow — the shared label-column rhythm for this page.
+ * `[icon + label (fixed)]  [children (flex)]  [optional trailing action]`
+ * Replaces ~7 hand-rolled Box rows that had drifted on gap / icon size / wrapper.
+ */
+const SettingsRow = ({
+    icon,
+    label,
+    children,
+    action,
+}: {
+    icon: ReactNode;
+    label: string;
+    children: ReactNode;
+    action?: ReactNode;
+}) => (
+    <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: LABEL_WIDTH, color: 'text.secondary' }}>
+            {icon}
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                {label}
+            </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, minWidth: 0 }}>
+            {children}
+        </Box>
+        {action}
+    </Box>
+);
+
+/**
+ * chipSx — one selected/unselected Chip style, shared by Language + Theme.
+ */
+const chipSx = (selected: boolean): SxProps<Theme> => ({
+    bgcolor: selected ? 'primary.main' : 'action.hover',
+    color: selected ? 'primary.contrastText' : 'text.primary',
+    fontWeight: selected ? 600 : 400,
+    border: selected ? 'none' : '1px solid',
+    borderColor: 'divider',
+    cursor: 'pointer',
+    '& .MuiChip-icon': { color: 'inherit' },
+    '&:hover': {
+        bgcolor: selected ? 'primary.dark' : 'action.selected',
+    },
+});
 
 const System = () => {
     const { t, i18n } = useTranslation();
@@ -129,272 +185,179 @@ const System = () => {
     return (
         <PageLayout loading={loading}>
             <CardGrid>
-                {/* Server Status - Simplified one-line-per-status design */}
+                {/* Server Status — "Is the gateway healthy?" Actions sit on
+                    the Server row itself (trailing icons), matching how the
+                    About card keeps its copy button on the Version row. */}
                 <UnifiedCard
                     title={t('system.serverStatus.title')}
                     titleHeadingLevel={1}
                     size="full"
-                    rightAction={
-                        <Stack direction="row" spacing={0.5}>
-                            <Tooltip title={t('system.serverStatus.forceLogout')} arrow>
-                                <IconButton
-                                    onClick={handleForceLogout}
-                                    size="small"
-                                    aria-label="Force logout"
-                                >
-                                    <Logout fontSize="small" />
-                                </IconButton>
-                            </Tooltip>
-                            <IconButton
-                                onClick={() => { loadServerStatus(); checkHealth(); }}
-                                size="small"
-                                aria-label={t('system.serverStatus.refreshStatus')}
-                            >
-                                {checking ? <CircularProgress size={16} /> : <RefreshIcon />}
-                            </IconButton>
-                        </Stack>
-                    }
                 >
-                    <Stack spacing={1.5}>
-                        {/* Server Status */}
-                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                {serverStatus?.server_running ? (
+                    <Stack spacing={1.5} sx={{ maxWidth: CONTENT_MAX_WIDTH }}>
+                        <SettingsRow
+                            icon={
+                                serverStatus?.server_running ? (
                                     <IconCircleCheck sx={{ fontSize: 16, color: 'success.main' }} />
                                 ) : (
-                                    <IconCircleX
-                                        sx={{
-                                            fontSize: 16,
-                                            color: isServerStatusAvailable ? 'error.main' : 'text.secondary',
-                                        }}
-                                    />
-                                )}
-                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                    {t('system.serverStatus.server')}
-                                </Typography>
-                            </Box>
-                            <Box sx={{ flex: 1 }}>
-                                <Typography variant="body2" sx={{ color: 'text.primary' }}>
-                                    {serverStatusLabel}
-                                    {isHealthy && (
-                                        <Typography
-                                            component="span"
-                                            variant="body2"
-                                            sx={{
-                                                color: "success.main",
-                                                ml: 1
-                                            }}>
-                                            · {t('system.status.connected')}
-                                        </Typography>
-                                    )}
-                                </Typography>
-                            </Box>
-                        </Box>
-
-                        {/* Uptime */}
-                        {serverStatus?.uptime && (
-                            <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                    <IconClock sx={{ fontSize: 14, color: 'text.secondary' }} />
-                                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                        {t('system.status.uptime')}
-                                    </Typography>
-                                </Box>
-                                <Box sx={{ flex: 1 }}>
-                                    <Typography variant="body2" sx={{ color: 'text.primary' }}>
-                                        {serverStatus.uptime}
-                                    </Typography>
-                                </Box>
-                            </Box>
-                        )}
-
-                        {/* Proxy Settings */}
-                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                <IconLock sx={{ fontSize: 14, color: 'text.secondary' }} />
-                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                    {t('system.proxy.label')}
-                                </Typography>
-                            </Box>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
-                                {respectEnvProxy !== null && (
-                                    <Tooltip title={t('system.proxy.respectEnvProxy.helper')} arrow>
-                                        <Chip
-                                            label={`${respectEnvProxy ? t('system.proxy.respectEnvProxy.label') : t('common.direct')} · ${respectEnvProxy ? t('common.on') : t('common.off')}`}
-                                            onClick={toggleProxy}
+                                    <IconCircleX sx={{ fontSize: 16, color: isServerStatusAvailable ? 'error.main' : 'text.secondary' }} />
+                                )
+                            }
+                            label={t('system.serverStatus.server')}
+                            action={
+                                <Stack direction="row" spacing={0.5}>
+                                    <Tooltip title={t('system.serverStatus.forceLogout')} arrow>
+                                        <IconButton
+                                            onClick={handleForceLogout}
                                             size="small"
-                                            sx={(theme) => ({
-                                                bgcolor: respectEnvProxy ? 'primary.main' : 'action.hover',
-                                                color: respectEnvProxy ? 'primary.contrastText' : 'text.primary',
-                                                fontWeight: respectEnvProxy ? 600 : 400,
-                                                border: respectEnvProxy ? 'none' : '1px solid',
-                                                borderColor: 'divider',
-                                                '&:hover': {
-                                                    bgcolor: respectEnvProxy ? 'primary.dark' : 'action.selected',
-                                                },
-                                            })}
-                                        />
+                                            aria-label="Force logout"
+                                        >
+                                            <Logout fontSize="small" />
+                                        </IconButton>
                                     </Tooltip>
-                                )}
-                            </Box>
-                        </Box>
-
-                    </Stack>
-                </UnifiedCard>
-
-                {/* Quick Proxy — dedicated card for the reusable proxy preset */}
-                <UnifiedCard
-                    title={t('system.proxy.globalProxyUrl.label')}
-                    size="full"
-                >
-                    <Stack spacing={1.5}>
-                        <Typography variant="body2" sx={{
-                            color: "text.secondary"
-                        }}>
-                            {t('system.proxy.globalProxyUrl.description', { defaultValue: t('system.proxy.globalProxyUrl.helper') })}
-                        </Typography>
-                        <Stack direction="row" spacing={1} sx={{
-                            alignItems: "center"
-                        }}>
-                            <TextField
-                                size="small"
-                                fullWidth
-                                value={globalProxyInput}
-                                onChange={(e) => setGlobalProxyInput(e.target.value)}
-                                placeholder="http://127.0.0.1:7890"
-                                sx={{ maxWidth: 480 }}
-                                slotProps={{
-                                    input: globalProxyUrl && globalProxyInput === globalProxyUrl ? {
-                                        endAdornment: (
-                                            <InputAdornment position="end">
-                                                <Tooltip title={t('common.saved', { defaultValue: 'Saved' })} arrow>
-                                                    <IconCheck sx={{ fontSize: 16, color: 'success.main' }} />
-                                                </Tooltip>
-                                            </InputAdornment>
-                                        )
-                                    } : undefined
-                                }}
-                            />
-                            <Button
-                                size="small"
-                                variant="contained"
-                                onClick={saveGlobalProxyUrl}
-                                disabled={proxyUrlSaving || globalProxyInput === globalProxyUrl}
-                                sx={{ whiteSpace: 'nowrap', minWidth: 72 }}
-                            >
-                                {proxyUrlSaving ? <CircularProgress size={14} color="inherit" /> : t('common.save')}
-                            </Button>
-                        </Stack>
-                    </Stack>
-                </UnifiedCard>
-
-                {/* Appearance & Language — user preferences, kept apart from
-                    server state so "Server Status" only answers "is the
-                    gateway healthy?" */}
-                <UnifiedCard
-                    title={t('system.preferences.title')}
-                    size="full"
-                >
-                    <Stack spacing={1.5}>
-                        {/* Language */}
-                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                <IconLanguage sx={{ fontSize: 14, color: 'text.secondary' }} />
-                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                    {t('system.language.title')}
-                                </Typography>
-                            </Box>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1 }}>
-                                <Chip
-                                    label={t('system.language.en')}
-                                    onClick={() => changeLanguage('en')}
-                                    size="small"
-                                    sx={{
-                                        bgcolor: i18n.language === 'en' ? 'primary.main' : 'action.hover',
-                                        color: i18n.language === 'en' ? 'primary.contrastText' : 'text.primary',
-                                        fontWeight: i18n.language === 'en' ? 600 : 400,
-                                        border: i18n.language === 'en' ? 'none' : '1px solid',
-                                        borderColor: 'divider',
-                                        cursor: 'pointer',
-                                        '&:hover': {
-                                            bgcolor: i18n.language === 'en' ? 'primary.dark' : 'action.selected',
-                                        },
-                                    }}
-                                />
-                                <Chip
-                                    label={t('system.language.zh')}
-                                    onClick={() => changeLanguage('zh')}
-                                    size="small"
-                                    sx={{
-                                        bgcolor: i18n.language === 'zh' ? 'primary.main' : 'action.hover',
-                                        color: i18n.language === 'zh' ? 'primary.contrastText' : 'text.primary',
-                                        fontWeight: i18n.language === 'zh' ? 600 : 400,
-                                        border: i18n.language === 'zh' ? 'none' : '1px solid',
-                                        borderColor: 'divider',
-                                        cursor: 'pointer',
-                                        '&:hover': {
-                                            bgcolor: i18n.language === 'zh' ? 'primary.dark' : 'action.selected',
-                                        },
-                                    }}
-                                />
-                            </Box>
-                        </Box>
-
-                        {/* Theme */}
-                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                <IconBrush sx={{ fontSize: 14, color: 'text.secondary' }} />
-                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                    {t('common.theme')}
-                                </Typography>
-                            </Box>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, flexWrap: 'wrap' }}>
-                                {themeOptions.map(({ value, label, renderIcon }) => {
-                                    const selected = themeMode === value;
-                                    return (
-                                        <Chip
-                                            key={value}
-                                            icon={renderIcon({ size: 14 })}
-                                            label={label}
-                                            onClick={() => setTheme(value)}
+                                    <Tooltip title={t('system.serverStatus.refreshStatus')} arrow>
+                                        <IconButton
+                                            onClick={() => { loadServerStatus(); checkHealth(); }}
                                             size="small"
-                                            sx={{
-                                                bgcolor: selected ? 'primary.main' : 'action.hover',
-                                                color: selected ? 'primary.contrastText' : 'text.primary',
-                                                fontWeight: selected ? 600 : 400,
-                                                border: selected ? 'none' : '1px solid',
-                                                borderColor: 'divider',
-                                                cursor: 'pointer',
-                                                '& .MuiChip-icon': {
-                                                    color: 'inherit',
-                                                },
-                                                '&:hover': {
-                                                    bgcolor: selected ? 'primary.dark' : 'action.selected',
-                                                },
-                                            }}
+                                            aria-label={t('system.serverStatus.refreshStatus')}
+                                        >
+                                            {checking ? <CircularProgress size={16} /> : <RefreshIcon />}
+                                        </IconButton>
+                                    </Tooltip>
+                                </Stack>
+                            }
+                        >
+                            <Typography variant="body2" sx={{ color: 'text.primary' }}>
+                                {serverStatusLabel}
+                                {isHealthy && (
+                                    <Typography component="span" variant="body2" sx={{ color: 'success.main', ml: 1 }}>
+                                        · {t('system.status.connected')}
+                                    </Typography>
+                                )}
+                            </Typography>
+                        </SettingsRow>
+                        {serverStatus?.uptime && (
+                            <SettingsRow icon={<IconClock sx={{ fontSize: 16 }} />} label={t('system.status.uptime')}>
+                                <Typography variant="body2" sx={{ color: 'text.primary' }}>
+                                    {serverStatus.uptime}
+                                </Typography>
+                            </SettingsRow>
+                        )}
+                    </Stack>
+                </UnifiedCard>
+
+                {/* Proxy — "How does TB reach upstream?" Env-proxy policy +
+                    reusable URL preset, kept on their own card. */}
+                <UnifiedCard title={t('system.proxy.title')} size="full">
+                    <Stack spacing={2} sx={{ maxWidth: CONTENT_MAX_WIDTH }}>
+                        {/* Env-proxy policy — an honest switch, not a flip-chip.
+                            The off-state is just "off" (no `common.direct`
+                            reuse, which collided with the network "direct"). */}
+                        <Box>
+                            <SettingsRow icon={<IconRouter sx={{ fontSize: 16 }} />} label={t('system.proxy.respectEnvProxy.label')}>
+                                {respectEnvProxy !== null && (
+                                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
+                                        <Switch
+                                            checked={respectEnvProxy}
+                                            onChange={toggleProxy}
+                                            size="small"
                                         />
-                                    );
-                                })}
-                            </Box>
+                                    </Box>
+                                )}
+                            </SettingsRow>
+                            <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block' }}>
+                                {t('system.proxy.respectEnvProxy.helper')}
+                            </Typography>
+                        </Box>
+
+                        <Divider />
+
+                        {/* Reusable proxy URL preset — description on its own
+                            line, then the input + Save below. */}
+                        <Box>
+                            <SettingsRow icon={<IconLock sx={{ fontSize: 16 }} />} label={t('system.proxy.globalProxyUrl.label')}>
+                                {null}
+                            </SettingsRow>
+                            <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 1 }}>
+                                {t('system.proxy.globalProxyUrl.helper')}
+                            </Typography>
+                            <Stack direction="row" spacing={1} sx={{ alignItems: 'center', width: '100%' }}>
+                                <TextField
+                                    size="small"
+                                    fullWidth
+                                    value={globalProxyInput}
+                                    onChange={(e) => setGlobalProxyInput(e.target.value)}
+                                    placeholder="http://127.0.0.1:7890"
+                                    slotProps={{
+                                        input: globalProxyUrl && globalProxyInput === globalProxyUrl ? {
+                                            endAdornment: (
+                                                <InputAdornment position="end">
+                                                    <Tooltip title={t('common.saved', { defaultValue: 'Saved' })} arrow>
+                                                        <IconCheck sx={{ fontSize: 16, color: 'success.main' }} />
+                                                    </Tooltip>
+                                                </InputAdornment>
+                                            )
+                                        } : undefined
+                                    }}
+                                />
+                                <Button
+                                    size="small"
+                                    variant="contained"
+                                    onClick={saveGlobalProxyUrl}
+                                    disabled={proxyUrlSaving || globalProxyInput === globalProxyUrl}
+                                    sx={{ whiteSpace: 'nowrap', minWidth: 72 }}
+                                >
+                                    {proxyUrlSaving ? <CircularProgress size={14} color="inherit" /> : t('common.save')}
+                                </Button>
+                            </Stack>
                         </Box>
                     </Stack>
                 </UnifiedCard>
 
-                {/* About - Simplified one-line-per-status design */}
-                <UnifiedCard
-                    title={t('system.about.title')}
-                    size="full"
-                >
-                    <Stack spacing={1.5}>
-                        {/* Version */}
-                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                <IconInfoCircle sx={{ fontSize: 14, color: 'text.secondary' }} />
-                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                    {t('system.about.version')}
-                                </Typography>
+                {/* Preferences — "How do I want the UI to behave?" */}
+                <UnifiedCard title={t('system.preferences.title')} size="full">
+                    <Stack spacing={1.5} sx={{ maxWidth: CONTENT_MAX_WIDTH }}>
+                        <SettingsRow icon={<IconLanguage sx={{ fontSize: 16 }} />} label={t('system.language.title')}>
+                            <Chip label={t('system.language.en')} onClick={() => changeLanguage('en')} size="small" sx={chipSx(i18n.language === 'en')} />
+                            <Chip label={t('system.language.zh')} onClick={() => changeLanguage('zh')} size="small" sx={chipSx(i18n.language === 'zh')} />
+                        </SettingsRow>
+
+                        <SettingsRow icon={<IconBrush sx={{ fontSize: 16 }} />} label={t('common.theme')}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                                {themeOptions.map(({ value, label, renderIcon }) => (
+                                    <Chip
+                                        key={value}
+                                        icon={renderIcon({ size: 14 })}
+                                        label={label}
+                                        onClick={() => setTheme(value)}
+                                        size="small"
+                                        sx={chipSx(themeMode === value)}
+                                    />
+                                ))}
                             </Box>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flex: 1 }}>
+                        </SettingsRow>
+                    </Stack>
+                </UnifiedCard>
+
+                {/* About — "What is this?" */}
+                <UnifiedCard title={t('system.about.title')} size="full">
+                    <Stack spacing={1.5} sx={{ maxWidth: CONTENT_MAX_WIDTH }}>
+                        <SettingsRow
+                            icon={<IconInfoCircle sx={{ fontSize: 16, color: 'text.secondary' }} />}
+                            label={t('system.about.version')}
+                            action={
+                                <Tooltip title={copiedVersion ? t('common.copied') : t('system.about.copyVersion')} placement="top" arrow>
+                                    <IconButton
+                                        size="small"
+                                        onClick={handleCopyVersion}
+                                        aria-label={t('system.about.copyVersion')}
+                                        sx={{ color: 'text.secondary' }}
+                                    >
+                                        {copiedVersion ? <IconCheck sx={{ fontSize: 16, color: 'success.main' }} /> : <IconContentCopy sx={{ fontSize: 16 }} />}
+                                    </IconButton>
+                                </Tooltip>
+                            }
+                        >
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
                                 <Tooltip
                                     title={hasUpdate && latestVersion ? t('system.about.updateAvailable', { version: latestVersion.split('+')[0] }) : t('system.about.checkUpdate')}
                                     placement="top"
@@ -429,52 +392,24 @@ const System = () => {
                                     </Typography>
                                 )}
                             </Box>
-                            <Tooltip title={copiedVersion ? t('common.copied') : t('system.about.copyVersion')} placement="top" arrow>
-                                <IconButton
-                                    size="small"
-                                    onClick={handleCopyVersion}
-                                    aria-label={t('system.about.copyVersion')}
-                                    sx={{ color: 'text.secondary' }}
-                                >
-                                    {copiedVersion ? <IconCheck sx={{ fontSize: 16, color: 'success.main' }} /> : <IconContentCopy sx={{ fontSize: 16 }} />}
-                                </IconButton>
-                            </Tooltip>
-                        </Box>
+                        </SettingsRow>
 
-                        {/* License */}
-                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                <IconLicense sx={{ fontSize: 16, color: 'text.secondary' }} />
-                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                    {t('system.about.license')}
-                                </Typography>
-                            </Box>
-                            <Box sx={{ flex: 1 }}>
-                                <Typography variant="body2" sx={{ color: 'text.primary' }}>
-                                    MPL-2.0 + Commercial
-                                </Typography>
-                            </Box>
-                        </Box>
+                        <SettingsRow icon={<IconLicense sx={{ fontSize: 16, color: 'text.secondary' }} />} label={t('system.about.license')}>
+                            <Typography variant="body2" sx={{ color: 'text.primary' }}>
+                                MPL-2.0 + Commercial
+                            </Typography>
+                        </SettingsRow>
 
-                        {/* GitHub */}
-                        <Box sx={{ display: 'flex', alignItems: 'center', py: 0.5, gap: 3 }}>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
-                                <IconBrandGithub sx={{ fontSize: 16, color: 'text.secondary' }} />
-                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                                    {t('system.about.github')}
-                                </Typography>
-                            </Box>
-                            <Box sx={{ flex: 1 }}>
-                                <Link
-                                    href="https://github.com/tingly-dev/tingly-box"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    sx={{ typography: 'body2', color: 'primary.main', textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}
-                                >
-                                    tingly-dev/tingly-box
-                                </Link>
-                            </Box>
-                        </Box>
+                        <SettingsRow icon={<IconBrandGithub sx={{ fontSize: 16, color: 'text.secondary' }} />} label={t('system.about.github')}>
+                            <Link
+                                href="https://github.com/tingly-dev/tingly-box"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                sx={{ typography: 'body2', color: 'primary.main', textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}
+                            >
+                                tingly-dev/tingly-box
+                            </Link>
+                        </SettingsRow>
                     </Stack>
                 </UnifiedCard>
 

--- a/frontend/src/pages/system/System.tsx
+++ b/frontend/src/pages/system/System.tsx
@@ -1,8 +1,7 @@
 import CardGrid from '@/components/CardGrid.tsx';
 import { PageLayout } from '@/components/PageLayout.tsx';
 import UnifiedCard from '@/components/UnifiedCard.tsx';
-import { Logout, Refresh as RefreshIcon, CheckCircle as IconCircleCheck, Cancel as IconCircleX, Info as IconInfoCircle, Lock as IconLock, Star as IconStar, License as IconLicense, GitHub as IconBrandGithub, Translate as IconLanguage, Brush as IconBrush, Check as IconCheck, AccessTime as IconClock } from '@/components/icons';
-import { VersionDisplay } from '@/components/VersionDisplay';
+import { Logout, Refresh as RefreshIcon, CheckCircle as IconCircleCheck, Cancel as IconCircleX, Info as IconInfoCircle, Lock as IconLock, Star as IconStar, License as IconLicense, GitHub as IconBrandGithub, Translate as IconLanguage, Brush as IconBrush, Check as IconCheck, AccessTime as IconClock, ContentCopy as IconContentCopy } from '@/components/icons';
 import { UpdatePanelDialog } from '@/components/UpdatePanelDialog';
 import { Box, Button, CircularProgress, IconButton, InputAdornment, Link, Stack, TextField, Tooltip, Typography, Chip } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
@@ -17,7 +16,7 @@ import { getThemeOptions } from '@/theme/options.ts';
 
 const System = () => {
     const { t, i18n } = useTranslation();
-    const { currentVersion, showUpdateDialog, openUpdateDialog, closeUpdateDialog } = useVersion();
+    const { currentVersion, latestVersion, hasUpdate, showUpdateDialog, openUpdateDialog, closeUpdateDialog } = useVersion();
     const { isHealthy, checking, checkHealth } = useHealth();
     const { logout: authLogout } = useAuth();
     const { mode: themeMode, setTheme } = useThemeMode();
@@ -29,6 +28,7 @@ const System = () => {
     const [globalProxyUrl, setGlobalProxyUrl] = useState('');
     const [globalProxyInput, setGlobalProxyInput] = useState('');
     const [proxyUrlSaving, setProxyUrlSaving] = useState(false);
+    const [copiedVersion, setCopiedVersion] = useState(false);
     const isServerStatusAvailable = Boolean(serverStatus);
     const serverStatusLabel = !isServerStatusAvailable
         ? t('system.status.unavailable')
@@ -47,6 +47,15 @@ const System = () => {
         // Save language preference to localStorage
         localStorage.setItem('i18nextLng', lng);
         notify.success(t('system.language.saveSuccess'));
+    };
+
+    const handleCopyVersion = () => {
+        const value = (currentVersion || 'Unknown').split('+')[0];
+        navigator.clipboard.writeText(value).then(() => {
+            setCopiedVersion(true);
+            notify.success(t('system.about.versionCopied'));
+            setTimeout(() => setCopiedVersion(false), 2000);
+        });
     };
 
     useEffect(() => {
@@ -385,23 +394,51 @@ const System = () => {
                                     {t('system.about.version')}
                                 </Typography>
                             </Box>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
-                                <VersionDisplay onClick={showUpdateDialog}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flex: 1 }}>
+                                <Tooltip
+                                    title={hasUpdate && latestVersion ? t('system.about.updateAvailable', { version: latestVersion.split('+')[0] }) : t('system.about.checkUpdate')}
+                                    placement="top"
+                                    arrow
+                                >
                                     <Typography
+                                        component="span"
                                         variant="body2"
+                                        onClick={showUpdateDialog}
                                         sx={{
                                             color: 'text.primary',
-                                            fontStyle: 'normal',
                                             cursor: 'pointer',
-                                            '&:hover': {
-                                                color: 'primary.main',
-                                            },
+                                            transition: 'color 0.2s ease',
+                                            '&:hover': { color: 'primary.main' },
                                         }}
                                     >
                                         version {(currentVersion || 'Unknown').split('+')[0]}
                                     </Typography>
-                                </VersionDisplay>
+                                </Tooltip>
+                                {hasUpdate && latestVersion && (
+                                    <Typography
+                                        component="span"
+                                        variant="caption"
+                                        onClick={showUpdateDialog}
+                                        sx={{
+                                            color: 'warning.main',
+                                            cursor: 'pointer',
+                                            '&:hover': { textDecoration: 'underline' },
+                                        }}
+                                    >
+                                        {t('system.about.available')} → {latestVersion.split('+')[0]}
+                                    </Typography>
+                                )}
                             </Box>
+                            <Tooltip title={copiedVersion ? t('common.copied') : t('system.about.copyVersion')} placement="top" arrow>
+                                <IconButton
+                                    size="small"
+                                    onClick={handleCopyVersion}
+                                    aria-label={t('system.about.copyVersion')}
+                                    sx={{ color: 'text.secondary' }}
+                                >
+                                    {copiedVersion ? <IconCheck sx={{ fontSize: 16, color: 'success.main' }} /> : <IconContentCopy sx={{ fontSize: 16 }} />}
+                                </IconButton>
+                            </Tooltip>
                         </Box>
 
                         {/* License */}

--- a/frontend/src/pages/system/System.tsx
+++ b/frontend/src/pages/system/System.tsx
@@ -19,10 +19,9 @@ import { getThemeOptions } from '@/theme/options.ts';
 // (the actual visual anchor) vertically aligned across cards.
 const LABEL_WIDTH = 140;
 
-// Constrain the rows inside each full-width card so controls don't stretch
-// edge-to-edge across wide viewports. The card itself still spans the column
-// (UnifiedCard size="full"); only the inner content is capped.
-const CONTENT_MAX_WIDTH = 560;
+// Cap each card's width on wide viewports (via UnifiedCard.maxWidth) so the
+// settings cards don't stretch edge-to-edge. Cards still shrink responsively.
+const CARD_MAX_WIDTH = 560;
 
 /**
  * SettingsRow — the shared label-column rhythm for this page.
@@ -192,8 +191,9 @@ const System = () => {
                     title={t('system.serverStatus.title')}
                     titleHeadingLevel={1}
                     size="full"
+                    maxWidth={CARD_MAX_WIDTH}
                 >
-                    <Stack spacing={1.5} sx={{ maxWidth: CONTENT_MAX_WIDTH }}>
+                    <Stack spacing={1.5}>
                         <SettingsRow
                             icon={
                                 serverStatus?.server_running ? (
@@ -247,8 +247,8 @@ const System = () => {
 
                 {/* Proxy — "How does TB reach upstream?" Env-proxy policy +
                     reusable URL preset, kept on their own card. */}
-                <UnifiedCard title={t('system.proxy.title')} size="full">
-                    <Stack spacing={2} sx={{ maxWidth: CONTENT_MAX_WIDTH }}>
+                <UnifiedCard title={t('system.proxy.title')} size="full" maxWidth={CARD_MAX_WIDTH}>
+                    <Stack spacing={2}>
                         {/* Env-proxy policy — an honest switch, not a flip-chip.
                             The off-state is just "off" (no `common.direct`
                             reuse, which collided with the network "direct"). */}
@@ -314,8 +314,8 @@ const System = () => {
                 </UnifiedCard>
 
                 {/* Preferences — "How do I want the UI to behave?" */}
-                <UnifiedCard title={t('system.preferences.title')} size="full">
-                    <Stack spacing={1.5} sx={{ maxWidth: CONTENT_MAX_WIDTH }}>
+                <UnifiedCard title={t('system.preferences.title')} size="full" maxWidth={CARD_MAX_WIDTH}>
+                    <Stack spacing={1.5}>
                         <SettingsRow icon={<IconLanguage sx={{ fontSize: 16 }} />} label={t('system.language.title')}>
                             <Chip label={t('system.language.en')} onClick={() => changeLanguage('en')} size="small" sx={chipSx(i18n.language === 'en')} />
                             <Chip label={t('system.language.zh')} onClick={() => changeLanguage('zh')} size="small" sx={chipSx(i18n.language === 'zh')} />
@@ -339,8 +339,8 @@ const System = () => {
                 </UnifiedCard>
 
                 {/* About — "What is this?" */}
-                <UnifiedCard title={t('system.about.title')} size="full">
-                    <Stack spacing={1.5} sx={{ maxWidth: CONTENT_MAX_WIDTH }}>
+                <UnifiedCard title={t('system.about.title')} size="full" maxWidth={CARD_MAX_WIDTH}>
+                    <Stack spacing={1.5}>
                         <SettingsRow
                             icon={<IconInfoCircle sx={{ fontSize: 16, color: 'text.secondary' }} />}
                             label={t('system.about.version')}

--- a/frontend/src/pages/system/System.tsx
+++ b/frontend/src/pages/system/System.tsx
@@ -21,7 +21,7 @@ const LABEL_WIDTH = 140;
 
 // Cap each card's width on wide viewports (via UnifiedCard.maxWidth) so the
 // settings cards don't stretch edge-to-edge. Cards still shrink responsively.
-const CARD_MAX_WIDTH = 560;
+const CARD_MAX_WIDTH = 720;
 
 /**
  * SettingsRow — the shared label-column rhythm for this page.
@@ -188,6 +188,7 @@ const System = () => {
                     the Server row itself (trailing icons), matching how the
                     About card keeps its copy button on the Version row. */}
                 <UnifiedCard
+                    grid={{ xs: 12, md: 12 }}
                     title={t('system.serverStatus.title')}
                     titleHeadingLevel={1}
                     size="full"
@@ -297,9 +298,35 @@ const System = () => {
                     </Stack>
                 </UnifiedCard>
 
+
+                {/* Preferences — "How do I want the UI to behave?" */}
+                <UnifiedCard grid={{ xs: 12, md: 12 }} title={t('system.preferences.title')} size="full" maxWidth={CARD_MAX_WIDTH}>
+                    <Stack spacing={1.5}>
+                        <SettingsRow icon={<IconLanguage sx={{ fontSize: 16 }} />} label={t('system.language.title')}>
+                            <Chip label={t('system.language.en')} onClick={() => changeLanguage('en')} size="small" sx={chipSx(i18n.language === 'en')} />
+                            <Chip label={t('system.language.zh')} onClick={() => changeLanguage('zh')} size="small" sx={chipSx(i18n.language === 'zh')} />
+                        </SettingsRow>
+
+                        <SettingsRow icon={<IconBrush sx={{ fontSize: 16 }} />} label={t('common.theme')}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                                {themeOptions.map(({ value, label, renderIcon }) => (
+                                    <Chip
+                                        key={value}
+                                        icon={renderIcon({ size: 14 })}
+                                        label={label}
+                                        onClick={() => setTheme(value)}
+                                        size="small"
+                                        sx={chipSx(themeMode === value)}
+                                    />
+                                ))}
+                            </Box>
+                        </SettingsRow>
+                    </Stack>
+                </UnifiedCard>
+
                 {/* Proxy — "How does TB reach upstream?" Env-proxy policy +
                     reusable URL preset, kept on their own card. */}
-                <UnifiedCard title={t('system.proxy.title')} size="full" maxWidth={CARD_MAX_WIDTH}>
+                <UnifiedCard grid={{ xs: 12, md: 12 }} title={t('system.proxy.title')} size="full" maxWidth={CARD_MAX_WIDTH}>
                     <Stack spacing={2}>
                         {/* Env-proxy policy — an honest switch, not a flip-chip.
                             The off-state is just "off" (no `common.direct`
@@ -362,31 +389,6 @@ const System = () => {
                                 </Button>
                             </Stack>
                         </Box>
-                    </Stack>
-                </UnifiedCard>
-
-                {/* Preferences — "How do I want the UI to behave?" */}
-                <UnifiedCard title={t('system.preferences.title')} size="full" maxWidth={CARD_MAX_WIDTH}>
-                    <Stack spacing={1.5}>
-                        <SettingsRow icon={<IconLanguage sx={{ fontSize: 16 }} />} label={t('system.language.title')}>
-                            <Chip label={t('system.language.en')} onClick={() => changeLanguage('en')} size="small" sx={chipSx(i18n.language === 'en')} />
-                            <Chip label={t('system.language.zh')} onClick={() => changeLanguage('zh')} size="small" sx={chipSx(i18n.language === 'zh')} />
-                        </SettingsRow>
-
-                        <SettingsRow icon={<IconBrush sx={{ fontSize: 16 }} />} label={t('common.theme')}>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-                                {themeOptions.map(({ value, label, renderIcon }) => (
-                                    <Chip
-                                        key={value}
-                                        icon={renderIcon({ size: 14 })}
-                                        label={label}
-                                        onClick={() => setTheme(value)}
-                                        size="small"
-                                        sx={chipSx(themeMode === value)}
-                                    />
-                                ))}
-                            </Box>
-                        </SettingsRow>
                     </Stack>
                 </UnifiedCard>
 

--- a/frontend/src/pages/system/System.tsx
+++ b/frontend/src/pages/system/System.tsx
@@ -242,6 +242,58 @@ const System = () => {
                                 </Typography>
                             </SettingsRow>
                         )}
+                        <SettingsRow
+                            icon={<IconInfoCircle sx={{ fontSize: 16, color: 'text.secondary' }} />}
+                            label={t('system.about.version')}
+                            action={
+                                <Tooltip title={copiedVersion ? t('common.copied') : t('system.about.copyVersion')} placement="top" arrow>
+                                    <IconButton
+                                        size="small"
+                                        onClick={handleCopyVersion}
+                                        aria-label={t('system.about.copyVersion')}
+                                        sx={{ color: 'text.secondary' }}
+                                    >
+                                        {copiedVersion ? <IconCheck sx={{ fontSize: 16, color: 'success.main' }} /> : <IconContentCopy sx={{ fontSize: 16 }} />}
+                                    </IconButton>
+                                </Tooltip>
+                            }
+                        >
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                                <Tooltip
+                                    title={hasUpdate && latestVersion ? t('system.about.updateAvailable', { version: latestVersion.split('+')[0] }) : t('system.about.checkUpdate')}
+                                    placement="top"
+                                    arrow
+                                >
+                                    <Typography
+                                        component="span"
+                                        variant="body2"
+                                        onClick={showUpdateDialog}
+                                        sx={{
+                                            color: 'text.primary',
+                                            cursor: 'pointer',
+                                            transition: 'color 0.2s ease',
+                                            '&:hover': { color: 'primary.main' },
+                                        }}
+                                    >
+                                        version {(currentVersion || 'Unknown').split('+')[0]}
+                                    </Typography>
+                                </Tooltip>
+                                {hasUpdate && latestVersion && (
+                                    <Typography
+                                        component="span"
+                                        variant="caption"
+                                        onClick={showUpdateDialog}
+                                        sx={{
+                                            color: 'warning.main',
+                                            cursor: 'pointer',
+                                            '&:hover': { textDecoration: 'underline' },
+                                        }}
+                                    >
+                                        {t('system.about.available')} → {latestVersion.split('+')[0]}
+                                    </Typography>
+                                )}
+                            </Box>
+                        </SettingsRow>
                     </Stack>
                 </UnifiedCard>
 
@@ -341,59 +393,6 @@ const System = () => {
                 {/* About — "What is this?" */}
                 <UnifiedCard title={t('system.about.title')} size="full" maxWidth={CARD_MAX_WIDTH}>
                     <Stack spacing={1.5}>
-                        <SettingsRow
-                            icon={<IconInfoCircle sx={{ fontSize: 16, color: 'text.secondary' }} />}
-                            label={t('system.about.version')}
-                            action={
-                                <Tooltip title={copiedVersion ? t('common.copied') : t('system.about.copyVersion')} placement="top" arrow>
-                                    <IconButton
-                                        size="small"
-                                        onClick={handleCopyVersion}
-                                        aria-label={t('system.about.copyVersion')}
-                                        sx={{ color: 'text.secondary' }}
-                                    >
-                                        {copiedVersion ? <IconCheck sx={{ fontSize: 16, color: 'success.main' }} /> : <IconContentCopy sx={{ fontSize: 16 }} />}
-                                    </IconButton>
-                                </Tooltip>
-                            }
-                        >
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-                                <Tooltip
-                                    title={hasUpdate && latestVersion ? t('system.about.updateAvailable', { version: latestVersion.split('+')[0] }) : t('system.about.checkUpdate')}
-                                    placement="top"
-                                    arrow
-                                >
-                                    <Typography
-                                        component="span"
-                                        variant="body2"
-                                        onClick={showUpdateDialog}
-                                        sx={{
-                                            color: 'text.primary',
-                                            cursor: 'pointer',
-                                            transition: 'color 0.2s ease',
-                                            '&:hover': { color: 'primary.main' },
-                                        }}
-                                    >
-                                        version {(currentVersion || 'Unknown').split('+')[0]}
-                                    </Typography>
-                                </Tooltip>
-                                {hasUpdate && latestVersion && (
-                                    <Typography
-                                        component="span"
-                                        variant="caption"
-                                        onClick={showUpdateDialog}
-                                        sx={{
-                                            color: 'warning.main',
-                                            cursor: 'pointer',
-                                            '&:hover': { textDecoration: 'underline' },
-                                        }}
-                                    >
-                                        {t('system.about.available')} → {latestVersion.split('+')[0]}
-                                    </Typography>
-                                )}
-                            </Box>
-                        </SettingsRow>
-
                         <SettingsRow icon={<IconLicense sx={{ fontSize: 16, color: 'text.secondary' }} />} label={t('system.about.license')}>
                             <Typography variant="body2" sx={{ color: 'text.primary' }}>
                                 MPL-2.0 + Commercial


### PR DESCRIPTION
## Summary

The System/General settings page had drifted into inconsistent hand-rolled rows, full-bleed cards that stretched edge-to-edge on wide screens, and a couple of ambiguous toggle chips. This rebuilds the page around a shared row rhythm, makes the version a first-class copyable artifact, and gives cards a sensible max width.

## Key Changes

- **Copyable version**: the version string (now in Server Status) has a copy button and is clickable to open the update dialog, surfacing the artifact the user actually wants rather than just a label.
- **Shared `SettingsRow` rhythm**: a single label-column layout replaces ~7 hand-rolled rows, fixing drifted gaps/icon sizes and aligning the value column across cards.
- **Honest proxy toggle**: env-proxy is now a Switch with an explicit off-state, dropping the flip-chip that collided the network "direct" meaning with a UI label.
- **`UnifiedCard.maxWidth`**: cards cap at 720px on wide viewports while staying responsive, so settings no longer stretch edge-to-edge.
- **`UnifiedCard.grid`**: cards can opt into responsive n×m column spans inside `CardGrid`.
- **Page restructure**: Server Status / Preferences / Proxy / About split into focused cards each answering one user question; About row moved into Server Status.
- **Update dialog de-hardcoding**: status header gradients replaced with theme-palette tints (dark/light aware), plus an inline version copy button.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/7a4deb5d-ab07-494e-b132-25ffd80daf12" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/361286fe-14c8-4a27-929a-bbc150ea6bd4" />
