### PR TITLE
feat(models): make upstream refreshes observable and overrideable

### DIFF
--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -252,21 +252,19 @@ func (c *AnthropicClient) ListModels(ctx context.Context) (*ModelListResult, err
 			Reason:   "cloud-credential providers use template model lists",
 		}
 	}
-	models, err := c.client.Models.List(ctx, anthropic.ModelListParams{})
+	res, err := c.client.Models.List(ctx, anthropic.ModelListParams{})
 	if err != nil {
 		return nil, err
 	}
 
-	var result []string
-	for _, model := range models.Data {
-		result = append(result, model.ID)
+	var models []string
+	for _, model := range res.Data {
+		models = append(models, model.ID)
 	}
 
-	if len(result) == 0 {
-		return nil, fmt.Errorf("no models found in provider response")
+	if len(models) == 0 {
+		return &ModelListResult{Raw: res}, fmt.Errorf("no models found in provider response")
 	}
 
-	// Raw carries the SDK response slice for persistence/triage (mirrors
-	// provider_usage.raw_response). The caller marshals it.
-	return &ModelListResult{Models: result, Raw: models.Data}, nil
+	return &ModelListResult{Models: models, Raw: res}, nil
 }

--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -34,7 +34,7 @@ type AnthropicClientInterface interface {
 	BetaMessagesCountTokens(ctx context.Context, req *anthropic.BetaMessageCountTokensParams) (*anthropic.BetaMessageTokensCount, error)
 
 	// Utility methods
-	ListModels(ctx context.Context) ([]string, error)
+	ListModels(ctx context.Context) (*ModelListResult, error)
 	Close() error
 	GetProvider() *typ.Provider
 	APIStyle() protocol.APIStyle
@@ -243,7 +243,7 @@ func (c *AnthropicClient) GetProvider() *typ.Provider {
 }
 
 // ListModels returns the list of available models from the Anthropic API
-func (c *AnthropicClient) ListModels(ctx context.Context) ([]string, error) {
+func (c *AnthropicClient) ListModels(ctx context.Context) (*ModelListResult, error) {
 	// Bedrock / Vertex expose only the messages endpoint, not the Anthropic
 	// /v1/models list; use the template model list instead.
 	if c.provider.IsMultiFieldCredential() {
@@ -266,5 +266,7 @@ func (c *AnthropicClient) ListModels(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("no models found in provider response")
 	}
 
-	return result, nil
+	// Raw carries the SDK response slice for persistence/triage (mirrors
+	// provider_usage.raw_response). The caller marshals it.
+	return &ModelListResult{Models: result, Raw: models.Data}, nil
 }

--- a/internal/client/claude_client.go
+++ b/internal/client/claude_client.go
@@ -150,12 +150,8 @@ func applyClaudeCodeHeaders(options []anthropicOption.RequestOption, provider *t
 // ===================================================================
 
 // ListModels returns the list of available models.
-// For Claude Code OAuth, this returns an error as the token cannot access /models endpoint.
-func (c *ClaudeClient) ListModels(ctx context.Context) ([]string, error) {
-	return nil, &ErrModelsEndpointNotSupported{
-		Provider: c.provider.Name,
-		Reason:   "Claude Code OAuth token cannot access /models endpoint",
-	}
+func (c *ClaudeClient) ListModels(ctx context.Context) (*ModelListResult, error) {
+	return c.AnthropicClient.ListModels(ctx)
 }
 
 func (c *ClaudeClient) Guard(ctx context.Context, req *anthropic.MessageNewParams) (*AnthropicClient, map[string]string) {

--- a/internal/client/claude_client_test.go
+++ b/internal/client/claude_client_test.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -97,18 +99,34 @@ func TestNewClaudeClient_StripV1FromBase(t *testing.T) {
 // ListModels
 // ===================================================================
 
-func TestClaudeClient_ListModels_ReturnsError(t *testing.T) {
+func TestClaudeClient_ListModels_UsesUpstream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("unexpected model-list path: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data":[{"id":"claude-test","type":"model","display_name":"Claude Test","created_at":"2025-01-01T00:00:00Z"}],
+			"has_more":false,
+			"first_id":"claude-test",
+			"last_id":"claude-test"
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
 	provider := newOAuthProvider()
+	provider.APIBase = server.URL
 	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, c.Close()) })
 
-	models, err := c.ListModels(context.Background())
-	assert.Nil(t, models)
-	require.Error(t, err)
-
-	var modelsErr *ErrModelsEndpointNotSupported
-	require.ErrorAs(t, err, &modelsErr)
-	assert.Equal(t, provider.Name, modelsErr.Provider)
+	result, err := c.ListModels(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []string{"claude-test"}, result.Models)
+	assert.NotNil(t, result.Raw)
 }
 
 // ===================================================================

--- a/internal/client/claude_e2e_test.go
+++ b/internal/client/claude_e2e_test.go
@@ -73,18 +73,19 @@ func TestE2E_ClaudeRoundTripper(t *testing.T) {
 		defer cancel()
 
 		// List models
-		models, err := client.ListModels(ctx)
+		res, err := client.ListModels(ctx)
 		require.NoError(t, err)
-		require.NotEmpty(t, models, "expected at least one model")
+		require.NotNil(t, res)
+		require.NotEmpty(t, res.Models, "expected at least one model")
 
-		t.Logf("Found %d models:", len(models))
-		for _, m := range models {
+		t.Logf("Found %d models:", len(res.Models))
+		for _, m := range res.Models {
 			t.Logf("  - %s", m)
 		}
 
 		// Verify the requested model is in the list
 		found := false
-		for _, m := range models {
+		for _, m := range res.Models {
 			if strings.Contains(m, model) || m == model {
 				found = true
 				break

--- a/internal/client/codex_client.go
+++ b/internal/client/codex_client.go
@@ -371,7 +371,7 @@ func isAlnumunderscoreHyphen(c rune) bool {
 
 // ListModels returns the list of available models.
 // For Codex, this returns an error as ChatGPT OAuth tokens cannot access /models endpoint.
-func (c *CodexClient) ListModels(ctx context.Context) ([]string, error) {
+func (c *CodexClient) ListModels(ctx context.Context) (*ModelListResult, error) {
 	return nil, &ErrModelsEndpointNotSupported{
 		Provider: c.provider.Name,
 		Reason:   "ChatGPT OAuth token cannot access /models endpoint",

--- a/internal/client/google.go
+++ b/internal/client/google.go
@@ -153,7 +153,7 @@ func (c *GoogleClient) GetProvider() *typ.Provider {
 // ListModels returns the list of available models from the Google Gemini API
 // Note: Google genai SDK doesn't have a direct ListModels method, so we return
 // ErrModelsEndpointNotSupported to signal the caller to use template fallback.
-func (c *GoogleClient) ListModels(ctx context.Context) ([]string, error) {
+func (c *GoogleClient) ListModels(ctx context.Context) (*ModelListResult, error) {
 	// Google genai SDK doesn't provide a models list endpoint
 	// The caller should use template fallback instead
 	return nil, &ErrModelsEndpointNotSupported{

--- a/internal/client/kimi_client.go
+++ b/internal/client/kimi_client.go
@@ -278,6 +278,6 @@ func (c *KimiClient) ResponsesNewStreaming(ctx context.Context, req responses.Re
 }
 
 // ListModels returns the list of available models.
-func (c *KimiClient) ListModels(ctx context.Context) ([]string, error) {
+func (c *KimiClient) ListModels(ctx context.Context) (*ModelListResult, error) {
 	return c.OpenAIClient.ListModels(ctx)
 }

--- a/internal/client/model_lister.go
+++ b/internal/client/model_lister.go
@@ -20,6 +20,7 @@ type ModelLister interface {
 	// Returns ErrModelsEndpointNotSupported if the provider does not support the
 	// models endpoint.
 	ListModels(ctx context.Context) (*ModelListResult, error)
+	Close() error
 }
 
 // ModelListResult carries a fetched model list together with the raw upstream

--- a/internal/client/model_lister.go
+++ b/internal/client/model_lister.go
@@ -1,8 +1,6 @@
 package client
 
-import (
-	"context"
-)
+import "context"
 
 // IsModelsEndpointNotSupported checks if an error is ErrModelsEndpointNotSupported
 func IsModelsEndpointNotSupported(err error) bool {
@@ -12,7 +10,22 @@ func IsModelsEndpointNotSupported(err error) bool {
 
 // ModelLister defines the interface for fetching model lists from provider APIs
 type ModelLister interface {
-	// ListModels returns the list of available models from the provider API
-	// Returns ErrModelsEndpointNotSupported if the provider does not support the models endpoint
-	ListModels(ctx context.Context) ([]string, error)
+	// ListModels returns the list of available models from the provider API,
+	// together with the raw upstream payload (Raw) when the implementation has
+	// it in hand. Raw is persisted alongside Models so the genuine provider
+	// response is available for development triage and data accumulation,
+	// mirroring how provider_usage stores raw_response. It may be nil for
+	// clients that short-circuit (e.g. cloud-credential providers) or have no
+	// bytes to return.
+	// Returns ErrModelsEndpointNotSupported if the provider does not support the
+	// models endpoint.
+	ListModels(ctx context.Context) (*ModelListResult, error)
+}
+
+// ModelListResult carries a fetched model list together with the raw upstream
+// payload. Raw is any value the client already holds (an SDK response struct, a
+// response body, …); the caller marshals it to JSON when persisting.
+type ModelListResult struct {
+	Models []string
+	Raw    any
 }

--- a/internal/client/model_lister.go
+++ b/internal/client/model_lister.go
@@ -8,24 +8,15 @@ func IsModelsEndpointNotSupported(err error) bool {
 	return ok
 }
 
-// ModelLister defines the interface for fetching model lists from provider APIs
+// ModelLister fetches model lists from provider APIs.
 type ModelLister interface {
-	// ListModels returns the list of available models from the provider API,
-	// together with the raw upstream payload (Raw) when the implementation has
-	// it in hand. Raw is persisted alongside Models so the genuine provider
-	// response is available for development triage and data accumulation,
-	// mirroring how provider_usage stores raw_response. It may be nil for
-	// clients that short-circuit (e.g. cloud-credential providers) or have no
-	// bytes to return.
-	// Returns ErrModelsEndpointNotSupported if the provider does not support the
-	// models endpoint.
+	// ListModels returns parsed model IDs and, when available, the raw upstream
+	// payload. Unsupported providers return ErrModelsEndpointNotSupported.
 	ListModels(ctx context.Context) (*ModelListResult, error)
 	Close() error
 }
 
-// ModelListResult carries a fetched model list together with the raw upstream
-// payload. Raw is any value the client already holds (an SDK response struct, a
-// response body, …); the caller marshals it to JSON when persisting.
+// ModelListResult carries parsed model IDs and the raw upstream payload.
 type ModelListResult struct {
 	Models []string
 	Raw    any

--- a/internal/client/model_lister_test.go
+++ b/internal/client/model_lister_test.go
@@ -1,0 +1,42 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestOpenAIClient_ListModels_ReturnsRawErrorResponse(t *testing.T) {
+	const responseBody = `{"error":{"message":"rate limited","type":"rate_limit"}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+	t.Cleanup(server.Close)
+
+	provider := &typ.Provider{
+		Name:     "openai-compatible",
+		APIBase:  server.URL,
+		APIStyle: protocol.APIStyleOpenAI,
+		Token:    "test-token",
+	}
+	client, err := NewOpenAIClient(provider, "", typ.SessionID{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	result, err := client.ListModels(context.Background())
+	require.Error(t, err)
+	require.NotNil(t, result)
+	raw, ok := result.Raw.(json.RawMessage)
+	require.True(t, ok)
+	assert.JSONEq(t, responseBody, string(raw))
+}

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -285,7 +285,7 @@ func (c *OpenAIClient) ListModels(ctx context.Context) (*ModelListResult, error)
 	// Check response status
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("provider returned status %d (len=%d)", resp.StatusCode, len(bodyBytes))
+		return &ModelListResult{Raw: json.RawMessage(bodyBytes)}, fmt.Errorf("provider returned status %d (len=%d)", resp.StatusCode, len(bodyBytes))
 	}
 
 	// Parse response body
@@ -306,12 +306,12 @@ func (c *OpenAIClient) ListModels(ctx context.Context) (*ModelListResult, error)
 	}
 
 	if err := json.Unmarshal(body, &modelsResponse); err != nil {
-		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
+		return &ModelListResult{Raw: json.RawMessage(body)}, fmt.Errorf("failed to parse JSON response: %w", err)
 	}
 
 	// Check for API error
 	if modelsResponse.Error != nil {
-		return nil, fmt.Errorf("API error: %s (type: %s)", modelsResponse.Error.Message, modelsResponse.Error.Type)
+		return &ModelListResult{Raw: json.RawMessage(body)}, fmt.Errorf("API error: %s (type: %s)", modelsResponse.Error.Message, modelsResponse.Error.Type)
 	}
 
 	// Extract model IDs
@@ -331,7 +331,7 @@ func (c *OpenAIClient) ListModels(ctx context.Context) (*ModelListResult, error)
 	}
 
 	if len(models) == 0 {
-		return nil, fmt.Errorf("no models found in provider response")
+		return &ModelListResult{Raw: json.RawMessage(body)}, fmt.Errorf("no models found in provider response")
 	}
 
 	// Raw carries the response body (already JSON) for persistence/triage.

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -33,7 +33,7 @@ type OpenAIClientInterface interface {
 	EmbeddingsNew(ctx context.Context, req openai.EmbeddingNewParams) (*openai.CreateEmbeddingResponse, error)
 
 	// Utility methods
-	ListModels(ctx context.Context) ([]string, error)
+	ListModels(ctx context.Context) (*ModelListResult, error)
 	Close() error
 	GetProvider() *typ.Provider
 	APIStyle() protocol.APIStyle
@@ -194,7 +194,7 @@ func (c *OpenAIClient) GetProvider() *typ.Provider {
 }
 
 // ListModels returns the list of available models from the OpenAI-compatible API
-func (c *OpenAIClient) ListModels(ctx context.Context) ([]string, error) {
+func (c *OpenAIClient) ListModels(ctx context.Context) (*ModelListResult, error) {
 	// Special handling for Codex (ChatGPT OAuth) providers
 	// The ChatGPT OAuth token cannot access OpenAI's /models endpoint
 	// because it's a ChatGPT web interface token, not an OpenAI API token.
@@ -334,7 +334,8 @@ func (c *OpenAIClient) ListModels(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("no models found in provider response")
 	}
 
-	return models, nil
+	// Raw carries the response body (already JSON) for persistence/triage.
+	return &ModelListResult{Models: models, Raw: json.RawMessage(body)}, nil
 }
 
 // isCodexProvider checks if the current provider is a Codex OAuth provider

--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -259,7 +259,7 @@ func promptForAgentConfig(reader *bufio.Reader, appManager *AppManager, req *age
 	// fallback chain, so providers whose /models endpoint is unsupported
 	// (e.g. Codex) still yield their embedded template catalog.
 	globalConfig := appManager.GetGlobalConfig()
-	resolved, err := globalConfig.ResolveProviderModels(true, req.Provider)
+	resolved, err := globalConfig.ResolveProviderModels(true, false, req.Provider)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: Failed to fetch models from provider: %v\n", err)
 		fmt.Fprintln(os.Stderr, "Using cached model list...")

--- a/internal/command/remote.go
+++ b/internal/command/remote.go
@@ -204,7 +204,7 @@ func promptForSmartGuideModel(reader *bufio.Reader, appManager *AppManager) (str
 
 	// ResolveProviderModels walks the full fallback chain, so providers whose
 	// /models endpoint is unsupported (e.g. Codex) still return their catalog.
-	resolved, err := globalCfg.ResolveProviderModels(true, provider.UUID)
+	resolved, err := globalCfg.ResolveProviderModels(true, false, provider.UUID)
 	if err != nil {
 		logrus.WithError(err).Warn("Failed to fetch models from provider, using cached list")
 	}

--- a/internal/data/db/provider_model.go
+++ b/internal/data/db/provider_model.go
@@ -32,8 +32,20 @@ type ProviderModelRecord struct {
 	Models       string      `gorm:"column:models;type:text"`
 	Source       ModelSource `gorm:"column:source"`
 	LastUpdated  time.Time   `gorm:"column:last_updated"`
-	CreatedAt    time.Time   `gorm:"column:created_at"`
-	UpdatedAt    time.Time   `gorm:"column:updated_at"`
+
+	// RawResponse holds the raw upstream payload from the fetch that produced
+	// Models, for development triage and data accumulation (mirrors
+	// provider_usage.raw_response). Populated on every real API fetch where the
+	// client captured it; nil for template-sourced rows.
+	RawResponse *string `gorm:"column:raw_response;type:text"`
+	// LastError records the most recent fetch error string. Nil on success or
+	// when the endpoint is simply unsupported.
+	LastError *string `gorm:"column:last_error;type:text"`
+	// LastErrorAt is when LastError was captured.
+	LastErrorAt *time.Time `gorm:"column:last_error_at"`
+
+	CreatedAt time.Time `gorm:"column:created_at"`
+	UpdatedAt time.Time `gorm:"column:updated_at"`
 }
 
 // TableName specifies the table name for GORM
@@ -96,6 +108,31 @@ func (s *ModelStore) Close() error {
 
 // SaveModels saves models for a provider by UUID
 func (ms *ModelStore) SaveModels(provider *typ.Provider, models []string, source ModelSource) error {
+	return ms.saveModels(provider, models, source, nil, nil, time.Time{})
+}
+
+// SaveModelsWithRaw saves a successful real upstream fetch: the model list plus
+// the raw payload, and clears any prior error fields. source should be
+// ModelSourceAPI. A nil raw leaves RawResponse unset.
+func (ms *ModelStore) SaveModelsWithRaw(provider *typ.Provider, models []string, source ModelSource, raw json.RawMessage) error {
+	return ms.saveModels(provider, models, source, raw, nil, time.Time{})
+}
+
+// SaveFetchFailure records a fetch error for a provider without overwriting a
+// pre-existing Models list (a stale list from a prior successful fetch is more
+// useful than empty). lastErr is the error string; whenAt is the capture time
+// (pass time.Time{} to use now). A nil/empty lastErr clears nothing.
+func (ms *ModelStore) SaveFetchFailure(provider *typ.Provider, lastErr string, raw json.RawMessage, whenAt time.Time) error {
+	if lastErr == "" {
+		return nil
+	}
+	return ms.saveModels(provider, nil, "", raw, &lastErr, whenAt)
+}
+
+// saveModels is the single write path. It upserts the provider's row. When
+// models is nil (a failure-only write), the existing Models/Source values are
+// preserved and only the error/raw fields are touched.
+func (ms *ModelStore) saveModels(provider *typ.Provider, models []string, source ModelSource, raw json.RawMessage, lastErr *string, whenAt time.Time) error {
 	if provider == nil {
 		return errors.New("provider cannot be nil")
 	}
@@ -104,34 +141,81 @@ func (ms *ModelStore) SaveModels(provider *typ.Provider, models []string, source
 	defer ms.mu.Unlock()
 
 	now := time.Now()
-
-	modelsJSON, err := json.Marshal(models)
-	if err != nil {
-		return fmt.Errorf("failed to marshal models: %w", err)
+	if whenAt.IsZero() {
+		whenAt = now
 	}
 
-	record := ProviderModelRecord{
-		ProviderUUID: provider.UUID,
-		ProviderName: provider.Name,
-		APIBase:      provider.APIBase,
-		Models:       string(modelsJSON),
-		Source:       source,
-		LastUpdated:  now,
-		UpdatedAt:    now,
+	// Build the field map to update. Fields that should be preserved on a
+	// failure-only write (models == nil) are omitted from the map.
+	updates := map[string]any{
+		"provider_name": provider.Name,
+		"api_base":      provider.APIBase,
+		"updated_at":    now,
+	}
+
+	if models != nil {
+		modelsJSON, err := json.Marshal(models)
+		if err != nil {
+			return fmt.Errorf("failed to marshal models: %w", err)
+		}
+		updates["models"] = string(modelsJSON)
+		updates["source"] = source
+		updates["last_updated"] = now
+	}
+
+	// Raw payload: write when provided, clear when this is a clean success.
+	if len(raw) > 0 {
+		rawStr := string(raw)
+		updates["raw_response"] = rawStr
+	} else if models != nil {
+		updates["raw_response"] = nil
+	}
+
+	// Error fields: set on failure, cleared on success.
+	if lastErr != nil {
+		errStr := *lastErr
+		updates["last_error"] = errStr
+		updates["last_error_at"] = whenAt
+	} else if models != nil {
+		updates["last_error"] = nil
+		updates["last_error_at"] = nil
 	}
 
 	var existing ProviderModelRecord
-	err = ms.db.Where("provider_uuid = ?", provider.UUID).First(&existing).Error
+	err := ms.db.Where("provider_uuid = ?", provider.UUID).First(&existing).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		record.CreatedAt = now
+		record := ProviderModelRecord{
+			ProviderUUID: provider.UUID,
+			ProviderName: provider.Name,
+			APIBase:      provider.APIBase,
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		}
+		if models != nil {
+			modelsJSON, mErr := json.Marshal(models)
+			if mErr != nil {
+				return fmt.Errorf("failed to marshal models: %w", mErr)
+			}
+			record.Models = string(modelsJSON)
+			record.Source = source
+			record.LastUpdated = now
+		}
+		if len(raw) > 0 {
+			rawStr := string(raw)
+			record.RawResponse = &rawStr
+		}
+		if lastErr != nil {
+			errStr := *lastErr
+			record.LastError = &errStr
+			record.LastErrorAt = &whenAt
+		}
 		if err := ms.db.Create(&record).Error; err != nil {
 			return fmt.Errorf("failed to create model record: %w", err)
 		}
 	} else if err != nil {
 		return fmt.Errorf("failed to query existing record: %w", err)
 	} else {
-		record.CreatedAt = existing.CreatedAt
-		if err := ms.db.Model(&existing).Updates(&record).Error; err != nil {
+		if err := ms.db.Model(&existing).Updates(updates).Error; err != nil {
 			return fmt.Errorf("failed to update model record: %w", err)
 		}
 	}
@@ -273,4 +357,35 @@ func (ms *ModelStore) GetAllModelRecords() []ProviderModelRecord {
 	}
 
 	return records
+}
+
+// GetRawResponse returns the cached raw upstream payload for a provider, or "".
+func (ms *ModelStore) GetRawResponse(providerUUID string) string {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+
+	var record ProviderModelRecord
+	if err := ms.db.Where("provider_uuid = ?", providerUUID).First(&record).Error; err != nil {
+		return ""
+	}
+	if record.RawResponse == nil {
+		return ""
+	}
+	return *record.RawResponse
+}
+
+// GetFetchFailure returns the last recorded fetch error for a provider, if any.
+// Useful for triage and for tests asserting that a fetch was blocked/failed.
+func (ms *ModelStore) GetFetchFailure(providerUUID string) (lastErr string, exists bool) {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+
+	var record ProviderModelRecord
+	if err := ms.db.Where("provider_uuid = ?", providerUUID).First(&record).Error; err != nil {
+		return "", false
+	}
+	if record.LastError == nil {
+		return "", false
+	}
+	return *record.LastError, true
 }

--- a/internal/data/db/provider_model.go
+++ b/internal/data/db/provider_model.go
@@ -33,13 +33,11 @@ type ProviderModelRecord struct {
 	Source       ModelSource `gorm:"column:source"`
 	LastUpdated  time.Time   `gorm:"column:last_updated"`
 
-	// RawResponse holds the raw upstream payload from the fetch that produced
-	// Models, for development triage and data accumulation (mirrors
-	// provider_usage.raw_response). Populated on every real API fetch where the
-	// client captured it; nil for template-sourced rows.
+	// RawResponse holds the latest captured upstream payload. After a failed
+	// refresh it may describe the failure while Models retains the last success.
 	RawResponse *string `gorm:"column:raw_response;type:text"`
-	// LastError records the most recent fetch error string. Nil on success or
-	// when the endpoint is simply unsupported.
+	// LastError records the most recent fetch error, including an unsupported
+	// endpoint. It is cleared by the next successful fetch.
 	LastError *string `gorm:"column:last_error;type:text"`
 	// LastErrorAt is when LastError was captured.
 	LastErrorAt *time.Time `gorm:"column:last_error_at"`
@@ -145,8 +143,23 @@ func (ms *ModelStore) saveModels(provider *typ.Provider, models []string, source
 		whenAt = now
 	}
 
-	// Build the field map to update. Fields that should be preserved on a
-	// failure-only write (models == nil) are omitted from the map.
+	var modelsJSON string
+	if models != nil {
+		encoded, err := json.Marshal(models)
+		if err != nil {
+			return fmt.Errorf("failed to marshal models: %w", err)
+		}
+		modelsJSON = string(encoded)
+	}
+
+	var rawResponse *string
+	if len(raw) > 0 {
+		value := string(raw)
+		rawResponse = &value
+	}
+
+	// Failure-only writes omit model fields so the last successful list remains
+	// available as a stale fallback.
 	updates := map[string]any{
 		"provider_name": provider.Name,
 		"api_base":      provider.APIBase,
@@ -154,27 +167,19 @@ func (ms *ModelStore) saveModels(provider *typ.Provider, models []string, source
 	}
 
 	if models != nil {
-		modelsJSON, err := json.Marshal(models)
-		if err != nil {
-			return fmt.Errorf("failed to marshal models: %w", err)
-		}
-		updates["models"] = string(modelsJSON)
+		updates["models"] = modelsJSON
 		updates["source"] = source
 		updates["last_updated"] = now
 	}
 
-	// Raw payload: write when provided, clear when this is a clean success.
-	if len(raw) > 0 {
-		rawStr := string(raw)
-		updates["raw_response"] = rawStr
+	if rawResponse != nil {
+		updates["raw_response"] = *rawResponse
 	} else if models != nil {
 		updates["raw_response"] = nil
 	}
 
-	// Error fields: set on failure, cleared on success.
 	if lastErr != nil {
-		errStr := *lastErr
-		updates["last_error"] = errStr
+		updates["last_error"] = *lastErr
 		updates["last_error_at"] = whenAt
 	} else if models != nil {
 		updates["last_error"] = nil
@@ -192,21 +197,13 @@ func (ms *ModelStore) saveModels(provider *typ.Provider, models []string, source
 			UpdatedAt:    now,
 		}
 		if models != nil {
-			modelsJSON, mErr := json.Marshal(models)
-			if mErr != nil {
-				return fmt.Errorf("failed to marshal models: %w", mErr)
-			}
-			record.Models = string(modelsJSON)
+			record.Models = modelsJSON
 			record.Source = source
 			record.LastUpdated = now
 		}
-		if len(raw) > 0 {
-			rawStr := string(raw)
-			record.RawResponse = &rawStr
-		}
+		record.RawResponse = rawResponse
 		if lastErr != nil {
-			errStr := *lastErr
-			record.LastError = &errStr
+			record.LastError = lastErr
 			record.LastErrorAt = &whenAt
 		}
 		if err := ms.db.Create(&record).Error; err != nil {
@@ -255,7 +252,7 @@ func (ms *ModelStore) GetAllProviders() []string {
 	defer ms.mu.RUnlock()
 
 	var records []ProviderModelRecord
-	if err := ms.db.Find(&records).Error; err != nil {
+	if err := ms.db.Where("models <> ''").Find(&records).Error; err != nil {
 		return []string{}
 	}
 
@@ -274,7 +271,7 @@ func (ms *ModelStore) HasModels(providerUUID string) bool {
 
 	var count int64
 	if err := ms.db.Model(&ProviderModelRecord{}).
-		Where("provider_uuid = ?", providerUUID).
+		Where("provider_uuid = ? AND models <> ''", providerUUID).
 		Count(&count).Error; err != nil {
 		return false
 	}
@@ -299,6 +296,9 @@ func (ms *ModelStore) GetProviderInfo(providerUUID string) (apiBase string, last
 	err := ms.db.Where("provider_uuid = ?", providerUUID).First(&record).Error
 
 	if errors.Is(err, gorm.ErrRecordNotFound) || err != nil {
+		return "", "", false
+	}
+	if record.Models == "" || record.LastUpdated.IsZero() {
 		return "", "", false
 	}
 

--- a/internal/data/db/provider_model_cache_test.go
+++ b/internal/data/db/provider_model_cache_test.go
@@ -203,3 +203,17 @@ func TestSaveFetchFailure_EmptyErrorIsNoop(t *testing.T) {
 	require.NoError(t, store.SaveFetchFailure(provider, "", []byte(`{}`), time.Time{}))
 	assert.Empty(t, store.GetAllModelRecords())
 }
+
+func TestSaveFetchFailure_DoesNotCreateModelCache(t *testing.T) {
+	store := setupTestStore(t)
+	provider := &typ.Provider{UUID: "failure-only", Name: "P", APIBase: "x"}
+	require.NoError(t, store.SaveFetchFailure(provider, "upstream failed", nil, time.Time{}))
+
+	assert.False(t, store.HasModels(provider.UUID))
+	assert.Empty(t, store.GetAllProviders())
+	_, updated, exists := store.GetProviderInfo(provider.UUID)
+	assert.False(t, exists)
+	assert.Empty(t, updated)
+	_, failureExists := store.GetFetchFailure(provider.UUID)
+	assert.True(t, failureExists)
+}

--- a/internal/data/db/provider_model_cache_test.go
+++ b/internal/data/db/provider_model_cache_test.go
@@ -137,3 +137,69 @@ func TestRemoveProviderModels(t *testing.T) {
 	result = store.GetModels(provider.UUID, 1*time.Hour)
 	assert.Empty(t, result)
 }
+
+// TestSaveModelsWithRaw pins that a successful real upstream fetch persists
+// both the model list and the raw payload, and clears any prior error.
+func TestSaveModelsWithRaw(t *testing.T) {
+	store := setupTestStore(t)
+
+	provider := &typ.Provider{
+		UUID:    "raw-uuid",
+		Name:    "Raw Provider",
+		APIBase: "https://api.test.com",
+	}
+
+	// Seed a prior failure so we can verify SaveModelsWithRaw clears it.
+	require.NoError(t, store.SaveFetchFailure(provider, "boom", nil, time.Time{}))
+
+	models := []string{"m-1", "m-2"}
+	raw := []byte(`{"data":[{"id":"m-1"},{"id":"m-2"}]}`)
+	require.NoError(t, store.SaveModelsWithRaw(provider, models, ModelSourceAPI, raw))
+
+	// Models + raw persisted.
+	assert.Equal(t, models, store.GetModels(provider.UUID, time.Hour))
+	assert.Equal(t, string(raw), store.GetRawResponse(provider.UUID))
+
+	// Prior error cleared.
+	records := store.GetAllModelRecords()
+	require.Len(t, records, 1)
+	assert.Nil(t, records[0].LastError)
+	assert.Nil(t, records[0].LastErrorAt)
+}
+
+// TestSaveFetchFailure_PreservesModels pins that recording a fetch error does
+// not clobber a pre-existing model list — a stale list is more useful than
+// empty — while still recording the error and any partial raw body.
+func TestSaveFetchFailure_PreservesModels(t *testing.T) {
+	store := setupTestStore(t)
+
+	provider := &typ.Provider{
+		UUID:    "fail-uuid",
+		Name:    "Fail Provider",
+		APIBase: "https://api.test.com",
+	}
+	models := []string{"cached-1"}
+	require.NoError(t, store.SaveModels(provider, models, ModelSourceAPI))
+
+	raw := []byte(`{"error":"404"}`)
+	require.NoError(t, store.SaveFetchFailure(provider, "upstream returned 404", raw, time.Time{}))
+
+	// Existing models must survive.
+	assert.Equal(t, models, store.GetModels(provider.UUID, time.Hour))
+
+	records := store.GetAllModelRecords()
+	require.Len(t, records, 1)
+	require.NotNil(t, records[0].LastError)
+	assert.Equal(t, "upstream returned 404", *records[0].LastError)
+	require.NotNil(t, records[0].LastErrorAt)
+	assert.Equal(t, string(raw), *records[0].RawResponse)
+}
+
+// TestSaveFetchFailure_EmptyErrorIsNoop pins that an empty error string is a
+// no-op (the public guard in SaveFetchFailure).
+func TestSaveFetchFailure_EmptyErrorIsNoop(t *testing.T) {
+	store := setupTestStore(t)
+	provider := &typ.Provider{UUID: "noop-uuid", Name: "P", APIBase: "x"}
+	require.NoError(t, store.SaveFetchFailure(provider, "", []byte(`{}`), time.Time{}))
+	assert.Empty(t, store.GetAllModelRecords())
+}

--- a/internal/data/model_list.go
+++ b/internal/data/model_list.go
@@ -81,3 +81,8 @@ func (mm *ModelListManager) RemoveProvider(providerUUID string) error {
 func (mm *ModelListManager) GetProviderInfo(uid string) (apiBase string, lastUpdated string, exists bool) {
 	return mm.modelStore.GetProviderInfo(uid)
 }
+
+// GetFetchFailure returns the last recorded fetch error for a provider, if any.
+func (mm *ModelListManager) GetFetchFailure(uid string) (string, bool) {
+	return mm.modelStore.GetFetchFailure(uid)
+}

--- a/internal/data/model_list.go
+++ b/internal/data/model_list.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -41,6 +42,18 @@ func (mm *ModelListManager) Close() error {
 // source should be db.ModelSourceAPI or db.ModelSourceTemplate.
 func (mm *ModelListManager) SaveModels(provider *typ.Provider, models []string, source db.ModelSource) error {
 	return mm.modelStore.SaveModels(provider, models, source)
+}
+
+// SaveModelsWithRaw saves a successful real upstream fetch (model list + raw
+// payload) and clears any prior error fields.
+func (mm *ModelListManager) SaveModelsWithRaw(provider *typ.Provider, models []string, source db.ModelSource, raw json.RawMessage) error {
+	return mm.modelStore.SaveModelsWithRaw(provider, models, source, raw)
+}
+
+// SaveFetchFailure records a fetch error without clobbering an existing model
+// list. raw is optional (the upstream body, when available).
+func (mm *ModelListManager) SaveFetchFailure(provider *typ.Provider, lastErr string, raw json.RawMessage) error {
+	return mm.modelStore.SaveFetchFailure(provider, lastErr, raw, time.Time{})
 }
 
 // GetModels returns models for a provider by reading from database.

--- a/internal/probe/lightweight.go
+++ b/internal/probe/lightweight.go
@@ -144,7 +144,7 @@ func (l *LightweightService) probeModelsEndpoint(ctx context.Context, provider *
 	probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	models, err := lister.ListModels(probeCtx)
+	result, err := lister.ListModels(probeCtx)
 	responseTime := time.Since(startTime).Milliseconds()
 
 	if client.IsModelsEndpointNotSupported(err) {
@@ -161,15 +161,19 @@ func (l *LightweightService) probeModelsEndpoint(ctx context.Context, provider *
 		return modelsReport{false, fmt.Sprintf("Models endpoint failed: %v", err), responseTime, 0, ""}
 	}
 
-	if len(models) == 0 {
+	modelCount := 0
+	if result != nil {
+		modelCount = len(result.Models)
+	}
+	if modelCount == 0 {
 		return modelsReport{false, "Models endpoint returned no models", responseTime, 0, ""}
 	}
 
 	return modelsReport{
 		true,
-		fmt.Sprintf("Models endpoint accessible - %d models found", len(models)),
+		fmt.Sprintf("Models endpoint accessible - %d models found", modelCount),
 		responseTime,
-		len(models),
+		modelCount,
 		"",
 	}
 }

--- a/internal/probe/lightweight.go
+++ b/internal/probe/lightweight.go
@@ -120,19 +120,19 @@ func (l *LightweightService) probeModelsEndpoint(ctx context.Context, provider *
 
 	switch provider.APIStyle {
 	case protocol.APIStyleOpenAI:
-		c := l.pool.GetOpenAIClient(context.Background(), provider, "")
+		c := l.pool.GetOpenAIClient(ctx, provider, "")
 		if c == nil {
 			return modelsReport{false, "Failed to create OpenAI client", 0, 0, ""}
 		}
 		lister = c
 	case protocol.APIStyleAnthropic:
-		c := l.pool.GetAnthropicClient(context.Background(), provider, "")
+		c := l.pool.GetAnthropicClient(ctx, provider, "")
 		if c == nil {
 			return modelsReport{false, "Failed to create Anthropic client", 0, 0, ""}
 		}
 		lister = c
 	case protocol.APIStyleGoogle:
-		c := l.pool.GetGoogleClient(context.Background(), provider, "")
+		c := l.pool.GetGoogleClient(ctx, provider, "")
 		if c == nil {
 			return modelsReport{false, "Failed to create Google client", 0, 0, ""}
 		}
@@ -181,7 +181,7 @@ func (l *LightweightService) probeModelsEndpoint(ctx context.Context, provider *
 func (l *LightweightService) probeChatEndpoint(ctx context.Context, provider *typ.Provider) endpointReport {
 	startTime := time.Now()
 
-	c := l.pool.GetOpenAIClient(context.Background(), provider, "")
+	c := l.pool.GetOpenAIClient(ctx, provider, "")
 	if c == nil {
 		return endpointReport{false, "Failed to create OpenAI client", 0}
 	}
@@ -204,7 +204,7 @@ func (l *LightweightService) probeChatEndpoint(ctx context.Context, provider *ty
 func (l *LightweightService) probeResponsesEndpoint(ctx context.Context, provider *typ.Provider) endpointReport {
 	startTime := time.Now()
 
-	c := l.pool.GetOpenAIClient(context.Background(), provider, "")
+	c := l.pool.GetOpenAIClient(ctx, provider, "")
 	if c == nil {
 		return endpointReport{false, "Failed to create OpenAI client", 0}
 	}

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -2116,8 +2116,9 @@ func (c *Config) ResolveProviderModels(forceRefresh, forceUpstream bool, uid str
 		return ResolvedModels{Models: models, Source: src, LastUpdated: lastUpdated}
 	}
 
-	// Step 1: DB cache (unless forcing a refresh).
-	if !forceRefresh {
+	// A forced upstream fetch re-queries the real upstream by definition, so it
+	// bypasses the DB cache. (forceRefresh alone also bypasses it.)
+	if !forceRefresh && !forceUpstream {
 		if cached := c.modelManager.GetModels(uid); len(cached) > 0 {
 			return finalize(cached, ModelListSourceCache), nil
 		}
@@ -2127,8 +2128,11 @@ func (c *Config) ResolveProviderModels(forceRefresh, forceUpstream bool, uid str
 		return ResolvedModels{}, fmt.Errorf("provider with UUID %s not found: %w", uid, provErr)
 	}
 
-	// Step 2: VModel static list (virtual providers).
-	if provider.IsVirtual() {
+	// Step 2: VModel static list (virtual providers). A forced upstream fetch
+	// skips this — virtual providers have no upstream to hit, but forcing means
+	// the operator wants the real path, and falling through to the (empty)
+	// upstream step is the honest answer for a virtual provider.
+	if !forceUpstream && provider.IsVirtual() {
 		var models []string
 		if provider.VModelDetail != nil {
 			models = provider.VModelDetail.Models
@@ -2137,7 +2141,7 @@ func (c *Config) ResolveProviderModels(forceRefresh, forceUpstream bool, uid str
 	}
 
 	// Step 3: Upstream API (persisted on success).
-	if err := c.fetchAndSaveAPIModels(provider); err == nil {
+	if err := c.fetchAndSaveAPIModels(provider, forceUpstream); err == nil {
 		if fresh := c.modelManager.GetModels(uid); len(fresh) > 0 {
 			return finalize(fresh, ModelListSourceAPI), nil
 		}
@@ -2163,35 +2167,81 @@ func (c *Config) fetchAndSaveAPIModels(provider *typ.Provider, forceUpstream boo
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	lister, closer, err := c.newModelLister(provider)
+	lister, closer, err := c.newModelLister(ctx, provider)
 	if closer != nil {
-		defer closer()
+		defer func() { _ = closer() }()
 	}
 	if err != nil || lister == nil {
 		logrus.Errorf("Failed to create client for provider %s: %v", provider.Name, err)
 		return fmt.Errorf("failed to create client for provider %s: %w", provider.Name, err)
 	}
 
-	models, apiErr := lister.ListModels(ctx)
-	if apiErr != nil {
-		if client.IsModelsEndpointNotSupported(apiErr) {
-			logrus.Infof("Provider %s does not support models endpoint, using template fallback", provider.Name)
+	var result *client.ModelListResult
+	var apiErr error
+
+	// do some guard here to avoid model list for some special provider like claude code oauth
+	if provider.IsClaudeCodeProvider() {
+		if forceUpstream {
+			result, apiErr = lister.ListModels(ctx)
 		} else {
-			logrus.Errorf("Failed to fetch models from API: %v", apiErr)
+			apiErr = errors.New("do not allow to list models from claude code upstream")
 		}
+	} else {
+		result, apiErr = lister.ListModels(ctx)
+	}
+
+	if apiErr != nil {
+		// Persist the failure for triage — a not-supported endpoint is expected
+		// and still recorded for visibility. The operator can see the genuine
+		// upstream error on a force fetch.
+		if persistErr := c.modelManager.SaveFetchFailure(provider, apiErr.Error(), nil); persistErr != nil {
+			logrus.Warnf("Failed to persist model fetch failure for %s: %v", provider.Name, persistErr)
+		}
+
+		logrus.Errorf("Failed to fetch models from API: %v", apiErr)
+
 		return apiErr
 	}
-	if len(models) == 0 {
-		return fmt.Errorf("provider %s returned no models", provider.Name)
+
+	if result == nil || len(result.Models) == 0 {
+		errMsg := fmt.Sprintf("provider %s returned no models", provider.Name)
+		if persistErr := c.modelManager.SaveFetchFailure(provider, errMsg, nil); persistErr != nil {
+			logrus.Warnf("Failed to persist model fetch failure for %s: %v", provider.Name, persistErr)
+		}
+		return errors.New(errMsg)
 	}
 
 	// Persist the upstream list verbatim. It is authoritative for both
 	// additions and removals, so the embedded template snapshot must not be
 	// merged in here — that would resurrect retired models. Apply canonical
 	// ordering before persisting; the same sort is reapplied at the serving
-	// boundary so cached order is irrelevant.
-	SortProviderModels(provider, models)
-	return c.modelManager.SaveModels(provider, models, db.ModelSourceAPI)
+	// boundary so cached order is irrelevant. Raw is the genuine upstream
+	// payload, marshalled for persistence/triage.
+	SortProviderModels(provider, result.Models)
+	return c.modelManager.SaveModelsWithRaw(provider, result.Models, db.ModelSourceAPI, marshalRaw(result.Raw))
+}
+
+// marshalRaw serializes a client's raw upstream payload (an SDK response
+// struct, a json.RawMessage body, etc.) to bytes for persistence. nil and
+// already-raw values pass through. A marshal error yields nil rather than
+// failing the model save — the parsed Models list is still authoritative.
+func marshalRaw(raw any) json.RawMessage {
+	if raw == nil {
+		return nil
+	}
+	switch v := raw.(type) {
+	case json.RawMessage:
+		return v
+	case []byte:
+		return v
+	case string:
+		return []byte(v)
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	return b
 }
 
 // FetchAndSaveProviderModels fetches a provider's models and persists API
@@ -2217,7 +2267,7 @@ func (c *Config) FetchAndSaveProviderModels(uid string) error {
 		return c.modelManager.SaveModels(provider, models, db.ModelSourceAPI)
 	}
 
-	apiErr := c.fetchAndSaveAPIModels(provider)
+	apiErr := c.fetchAndSaveAPIModels(provider, false)
 	if apiErr == nil {
 		return nil
 	}
@@ -2243,7 +2293,7 @@ func (c *Config) FetchAndSaveProviderModels(uid string) error {
 //
 // The closer is non-nil whenever the lister is, so the caller can defer it
 // without checking the lister separately.
-func (c *Config) newModelLister(provider *typ.Provider) (client.ModelLister, func() error, error) {
+func (c *Config) newModelLister(ctx context.Context, provider *typ.Provider) (client.ModelLister, func() error, error) {
 	if strings.Contains(strings.ToLower(strings.TrimSpace(provider.APIBase)), "api.deepseek.com") {
 		providerForModels := *provider
 		providerForModels.APIBase = "https://api.deepseek.com"
@@ -2254,26 +2304,19 @@ func (c *Config) newModelLister(provider *typ.Provider) (client.ModelLister, fun
 		return oClient, oClient.Close, nil
 	}
 
+	pool := client.NewClientPool()
+
 	switch provider.APIStyle {
 	case protocol.APIStyleAnthropic:
-		aClient, err := client.NewAnthropicClient(provider, "", typ.SessionID{})
-		if err != nil {
-			return nil, nil, err
-		}
+		aClient := pool.GetAnthropicClient(ctx, provider, "")
 		return aClient, aClient.Close, nil
 	case protocol.APIStyleGoogle:
-		gClient, err := client.NewGoogleClient(provider, "", typ.SessionID{})
-		if err != nil {
-			return nil, nil, err
-		}
+		gClient := pool.GetGoogleClient(ctx, provider, "")
 		return gClient, gClient.Close, nil
 	case protocol.APIStyleOpenAI:
 		fallthrough
 	default:
-		oClient, err := client.NewOpenAIClient(provider, "", typ.SessionID{})
-		if err != nil {
-			return nil, nil, err
-		}
+		oClient := pool.GetOpenAIClient(ctx, provider, "")
 		return oClient, oClient.Close, nil
 	}
 }

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -2167,14 +2167,12 @@ func (c *Config) fetchAndSaveAPIModels(provider *typ.Provider, forceUpstream boo
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	lister, closer, err := c.newModelLister(ctx, provider)
-	if closer != nil {
-		defer func() { _ = closer() }()
-	}
+	lister, err := c.newModelLister(ctx, provider)
 	if err != nil || lister == nil {
 		logrus.Errorf("Failed to create client for provider %s: %v", provider.Name, err)
 		return fmt.Errorf("failed to create client for provider %s: %w", provider.Name, err)
 	}
+	defer lister.Close()
 
 	var result *client.ModelListResult
 	var apiErr error
@@ -2293,15 +2291,15 @@ func (c *Config) FetchAndSaveProviderModels(uid string) error {
 //
 // The closer is non-nil whenever the lister is, so the caller can defer it
 // without checking the lister separately.
-func (c *Config) newModelLister(ctx context.Context, provider *typ.Provider) (client.ModelLister, func() error, error) {
+func (c *Config) newModelLister(ctx context.Context, provider *typ.Provider) (client.ModelLister, error) {
 	if strings.Contains(strings.ToLower(strings.TrimSpace(provider.APIBase)), "api.deepseek.com") {
 		providerForModels := *provider
 		providerForModels.APIBase = "https://api.deepseek.com"
 		oClient, err := client.NewOpenAIClient(&providerForModels, "", typ.SessionID{})
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
-		return oClient, oClient.Close, nil
+		return oClient, nil
 	}
 
 	pool := client.NewClientPool()
@@ -2309,15 +2307,15 @@ func (c *Config) newModelLister(ctx context.Context, provider *typ.Provider) (cl
 	switch provider.APIStyle {
 	case protocol.APIStyleAnthropic:
 		aClient := pool.GetAnthropicClient(ctx, provider, "")
-		return aClient, aClient.Close, nil
+		return aClient, nil
 	case protocol.APIStyleGoogle:
 		gClient := pool.GetGoogleClient(ctx, provider, "")
-		return gClient, gClient.Close, nil
+		return gClient, nil
 	case protocol.APIStyleOpenAI:
 		fallthrough
 	default:
 		oClient := pool.GetOpenAIClient(ctx, provider, "")
-		return oClient, oClient.Close, nil
+		return oClient, nil
 	}
 }
 

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -2102,7 +2102,7 @@ type ResolvedModels struct {
 // effect immediately and a template snapshot never pollutes a real cached
 // list. This method always fetches on a cache miss — callers that must not
 // touch the network (e.g. TUI render) should read the cache/template directly.
-func (c *Config) ResolveProviderModels(forceRefresh bool, uid string) (ResolvedModels, error) {
+func (c *Config) ResolveProviderModels(forceRefresh, forceUpstream bool, uid string) (ResolvedModels, error) {
 	provider, provErr := c.GetProviderByUUID(uid)
 
 	finalize := func(models []string, src ModelListSource) ResolvedModels {
@@ -2159,7 +2159,7 @@ func (c *Config) ResolveProviderModels(forceRefresh bool, uid string) (ResolvedM
 // on success, persists the sorted list (ModelSourceAPI). It returns an error
 // when the endpoint is unsupported or the call fails; the caller falls back to
 // the template. It never persists template data.
-func (c *Config) fetchAndSaveAPIModels(provider *typ.Provider) error {
+func (c *Config) fetchAndSaveAPIModels(provider *typ.Provider, forceUpstream bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -2128,10 +2128,7 @@ func (c *Config) ResolveProviderModels(forceRefresh, forceUpstream bool, uid str
 		return ResolvedModels{}, fmt.Errorf("provider with UUID %s not found: %w", uid, provErr)
 	}
 
-	// Step 2: VModel static list (virtual providers). A forced upstream fetch
-	// skips this — virtual providers have no upstream to hit, but forcing means
-	// the operator wants the real path, and falling through to the (empty)
-	// upstream step is the honest answer for a virtual provider.
+	// Step 2: VModel static list. A forced upstream attempt skips this shortcut.
 	if !forceUpstream && provider.IsVirtual() {
 		var models []string
 		if provider.VModelDetail != nil {
@@ -2176,23 +2173,15 @@ func (c *Config) fetchAndSaveAPIModels(provider *typ.Provider, forceUpstream boo
 
 	var result *client.ModelListResult
 	var apiErr error
-
-	// do some guard here to avoid model list for some special provider like claude code oauth
-	if provider.IsClaudeCodeProvider() {
-		if forceUpstream {
-			result, apiErr = lister.ListModels(ctx)
-		} else {
-			apiErr = errors.New("do not allow to list models from claude code upstream")
-		}
+	if provider.IsClaudeCodeProvider() && !forceUpstream {
+		apiErr = errors.New("model listing from Claude Code upstream is disabled")
 	} else {
 		result, apiErr = lister.ListModels(ctx)
 	}
 
 	if apiErr != nil {
-		// Persist the failure for triage — a not-supported endpoint is expected
-		// and still recorded for visibility. The operator can see the genuine
-		// upstream error on a force fetch.
-		if persistErr := c.modelManager.SaveFetchFailure(provider, apiErr.Error(), nil); persistErr != nil {
+		// Unsupported endpoints are expected but still useful during triage.
+		if persistErr := c.modelManager.SaveFetchFailure(provider, apiErr.Error(), modelListRaw(result)); persistErr != nil {
 			logrus.Warnf("Failed to persist model fetch failure for %s: %v", provider.Name, persistErr)
 		}
 
@@ -2203,7 +2192,7 @@ func (c *Config) fetchAndSaveAPIModels(provider *typ.Provider, forceUpstream boo
 
 	if result == nil || len(result.Models) == 0 {
 		errMsg := fmt.Sprintf("provider %s returned no models", provider.Name)
-		if persistErr := c.modelManager.SaveFetchFailure(provider, errMsg, nil); persistErr != nil {
+		if persistErr := c.modelManager.SaveFetchFailure(provider, errMsg, modelListRaw(result)); persistErr != nil {
 			logrus.Warnf("Failed to persist model fetch failure for %s: %v", provider.Name, persistErr)
 		}
 		return errors.New(errMsg)
@@ -2217,6 +2206,13 @@ func (c *Config) fetchAndSaveAPIModels(provider *typ.Provider, forceUpstream boo
 	// payload, marshalled for persistence/triage.
 	SortProviderModels(provider, result.Models)
 	return c.modelManager.SaveModelsWithRaw(provider, result.Models, db.ModelSourceAPI, marshalRaw(result.Raw))
+}
+
+func modelListRaw(result *client.ModelListResult) json.RawMessage {
+	if result == nil {
+		return nil
+	}
+	return marshalRaw(result.Raw)
 }
 
 // marshalRaw serializes a client's raw upstream payload (an SDK response
@@ -2279,18 +2275,13 @@ func (c *Config) FetchAndSaveProviderModels(uid string) error {
 	return fmt.Errorf("failed to fetch models (API: %v, template fallback: not available)", apiErr)
 }
 
-// newModelLister builds the client used to list models for a provider.
-//
-// It returns a ModelLister, an optional closer the caller must defer, and any
-// construction error. Two special cases sit alongside the default APIStyle
-// dispatch:
+// newModelLister builds the provider-specific client used to list models.
+// ClientPool handles OAuth issuer dispatch; DeepSeek is the only endpoint
+// override because its model list lives on the bare host rather than /v1.
 //
 //   - DeepSeek exposes its model list only on the bare host (no /v1 path), so
 //     we override APIBase to https://api.deepseek.com before constructing the
 //     OpenAI client.
-//
-// The closer is non-nil whenever the lister is, so the caller can defer it
-// without checking the lister separately.
 func (c *Config) newModelLister(ctx context.Context, provider *typ.Provider) (client.ModelLister, error) {
 	if strings.Contains(strings.ToLower(strings.TrimSpace(provider.APIBase)), "api.deepseek.com") {
 		providerForModels := *provider
@@ -2303,20 +2294,21 @@ func (c *Config) newModelLister(ctx context.Context, provider *typ.Provider) (cl
 	}
 
 	pool := client.NewClientPool()
-
+	var lister client.ModelLister
 	switch provider.APIStyle {
 	case protocol.APIStyleAnthropic:
-		aClient := pool.GetAnthropicClient(ctx, provider, "")
-		return aClient, nil
+		lister = pool.GetAnthropicClient(ctx, provider, "")
 	case protocol.APIStyleGoogle:
-		gClient := pool.GetGoogleClient(ctx, provider, "")
-		return gClient, nil
+		lister = pool.GetGoogleClient(ctx, provider, "")
 	case protocol.APIStyleOpenAI:
 		fallthrough
 	default:
-		oClient := pool.GetOpenAIClient(ctx, provider, "")
-		return oClient, nil
+		lister = pool.GetOpenAIClient(ctx, provider, "")
 	}
+	if lister == nil {
+		return nil, fmt.Errorf("failed to create model-list client for provider %s", provider.Name)
+	}
+	return lister, nil
 }
 
 // SortProviderModels applies the canonical display ordering to a provider's

--- a/internal/server/config/model_resolve_test.go
+++ b/internal/server/config/model_resolve_test.go
@@ -45,7 +45,7 @@ func TestResolveProviderModels_Codex_TemplateFallback(t *testing.T) {
 	p := codexResolveProvider()
 	require.NoError(t, cfg.AddProvider(p))
 
-	got, err := cfg.ResolveProviderModels(true, p.UUID)
+	got, err := cfg.ResolveProviderModels(true, false, p.UUID)
 	require.NoError(t, err)
 	assert.Equal(t, ModelListSourceTemplate, got.Source)
 	assert.Contains(t, got.Models, "gpt-5.5")
@@ -59,7 +59,7 @@ func TestResolveProviderModels_CacheHit_NotRefetched(t *testing.T) {
 	require.NoError(t, cfg.AddProvider(p))
 	require.NoError(t, cfg.GetModelManager().SaveModels(p, []string{"cached-only"}, db.ModelSourceAPI))
 
-	got, err := cfg.ResolveProviderModels(false, p.UUID)
+	got, err := cfg.ResolveProviderModels(false, false, p.UUID)
 	require.NoError(t, err)
 	assert.Equal(t, ModelListSourceCache, got.Source)
 	assert.Equal(t, []string{"cached-only"}, got.Models)
@@ -74,7 +74,7 @@ func TestResolveProviderModels_ForceRefresh_BypassesCache(t *testing.T) {
 	require.NoError(t, cfg.AddProvider(p))
 	require.NoError(t, cfg.GetModelManager().SaveModels(p, []string{"stale-cached"}, db.ModelSourceAPI))
 
-	got, err := cfg.ResolveProviderModels(true, p.UUID)
+	got, err := cfg.ResolveProviderModels(true, false, p.UUID)
 	require.NoError(t, err)
 	assert.Equal(t, ModelListSourceTemplate, got.Source)
 	assert.NotContains(t, got.Models, "stale-cached")
@@ -86,6 +86,6 @@ func TestResolveProviderModels_ForceRefresh_BypassesCache(t *testing.T) {
 func TestResolveProviderModels_UnknownProvider_Errors(t *testing.T) {
 	cfg := newResolveTestConfig(t)
 
-	_, err := cfg.ResolveProviderModels(true, "does-not-exist")
+	_, err := cfg.ResolveProviderModels(true, false, "does-not-exist")
 	require.Error(t, err)
 }

--- a/internal/server/config/model_resolve_test.go
+++ b/internal/server/config/model_resolve_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -122,26 +124,33 @@ func TestResolveProviderModels_ClaudeCode_BannedByDefault(t *testing.T) {
 	// The ban must be recorded for triage — not just silently swallowed.
 	lastErr, exists := cfg.GetModelManager().GetFetchFailure(p.UUID)
 	require.True(t, exists, "expected a recorded fetch failure for the banned Claude Code fetch")
-	assert.Contains(t, lastErr, "claude code upstream")
+	assert.Contains(t, lastErr, "Claude Code upstream")
 }
 
-// With force_upstream, the ban is lifted and a real upstream fetch is
-// attempted. This test points the provider at a dead local address so the
-// fetch fails fast without depending on network reachability, and asserts the
-// ban was NOT applied (no "do not allow ..." record) — the failure, if any,
-// is the genuine connection error, not the ban.
+// With force_upstream, the normal Claude Code guard is bypassed and the real
+// model endpoint is used.
 func TestResolveProviderModels_ClaudeCode_ForceLiftsBan(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data":[{"id":"claude-upstream","type":"model","display_name":"Claude Upstream","created_at":"2025-01-01T00:00:00Z"}],
+			"has_more":false,
+			"first_id":"claude-upstream",
+			"last_id":"claude-upstream"
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
 	cfg := newResolveTestConfig(t)
 	p := claudeCodeResolveProvider()
-	// Dead local address: the real fetch fails instantly, deterministically.
-	p.APIBase = "http://127.0.0.1:1"
+	p.APIBase = server.URL
 	require.NoError(t, cfg.AddProvider(p))
 
-	_, _ = cfg.ResolveProviderModels(true, true, p.UUID)
+	got, err := cfg.ResolveProviderModels(true, true, p.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, ModelListSourceAPI, got.Source)
+	assert.Equal(t, []string{"claude-upstream"}, got.Models)
 
-	lastErr, exists := cfg.GetModelManager().GetFetchFailure(p.UUID)
-	if exists {
-		assert.NotContains(t, lastErr, "do not allow to list models from claude code upstream",
-			"force_upstream must lift the ban, not record it")
-	}
+	_, exists := cfg.GetModelManager().GetFetchFailure(p.UUID)
+	assert.False(t, exists)
 }

--- a/internal/server/config/model_resolve_test.go
+++ b/internal/server/config/model_resolve_test.go
@@ -89,3 +89,59 @@ func TestResolveProviderModels_UnknownProvider_Errors(t *testing.T) {
 	_, err := cfg.ResolveProviderModels(true, false, "does-not-exist")
 	require.Error(t, err)
 }
+
+// claudeCodeResolveProvider builds a Claude Code OAuth provider, for which the
+// upstream /models endpoint is normally unreachable (the OAuth token 404s).
+func claudeCodeResolveProvider() *typ.Provider {
+	return &typ.Provider{
+		Name:     "Claude Code OAuth",
+		APIBase:  "https://api.anthropic.com",
+		APIStyle: protocol.APIStyleAnthropic,
+		AuthType: typ.AuthTypeOAuth,
+		Enabled:  true,
+		OAuthDetail: &typ.OAuthDetail{
+			AccessToken: "sk-ant-oat01-testtoken",
+			Issuer:      ai.IssuerClaudeCode,
+		},
+	}
+}
+
+// By default the gateway bans model-list fetches from a Claude Code OAuth
+// upstream (the token cannot reach /models). The ban is recorded as a fetch
+// failure and the resolver falls through to the embedded template — the same
+// observable source as a provider whose /models is genuinely unsupported.
+func TestResolveProviderModels_ClaudeCode_BannedByDefault(t *testing.T) {
+	cfg := newResolveTestConfig(t)
+	p := claudeCodeResolveProvider()
+	require.NoError(t, cfg.AddProvider(p))
+
+	got, err := cfg.ResolveProviderModels(true, false, p.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, ModelListSourceTemplate, got.Source, "banned fetch falls back to template")
+
+	// The ban must be recorded for triage — not just silently swallowed.
+	lastErr, exists := cfg.GetModelManager().GetFetchFailure(p.UUID)
+	require.True(t, exists, "expected a recorded fetch failure for the banned Claude Code fetch")
+	assert.Contains(t, lastErr, "claude code upstream")
+}
+
+// With force_upstream, the ban is lifted and a real upstream fetch is
+// attempted. This test points the provider at a dead local address so the
+// fetch fails fast without depending on network reachability, and asserts the
+// ban was NOT applied (no "do not allow ..." record) — the failure, if any,
+// is the genuine connection error, not the ban.
+func TestResolveProviderModels_ClaudeCode_ForceLiftsBan(t *testing.T) {
+	cfg := newResolveTestConfig(t)
+	p := claudeCodeResolveProvider()
+	// Dead local address: the real fetch fails instantly, deterministically.
+	p.APIBase = "http://127.0.0.1:1"
+	require.NoError(t, cfg.AddProvider(p))
+
+	_, _ = cfg.ResolveProviderModels(true, true, p.UUID)
+
+	lastErr, exists := cfg.GetModelManager().GetFetchFailure(p.UUID)
+	if exists {
+		assert.NotContains(t, lastErr, "do not allow to list models from claude code upstream",
+			"force_upstream must lift the ban, not record it")
+	}
+}

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -1150,7 +1150,7 @@ func (h *Handler) createProviderFromToken(token *oauth.Token, issuer ai.Issuer, 
 	// falls back to the embedded template for issuers whose /models endpoint is
 	// unsupported (e.g. Codex), so the log reflects the real catalog size.
 	log.Printf("[OAuth] Fetching models for OAuth provider %s (%s)", providerName, providerUUID.String())
-	if resolved, err := h.config.ResolveProviderModels(true, providerUUID.String()); err != nil {
+	if resolved, err := h.config.ResolveProviderModels(true, false, providerUUID.String()); err != nil {
 		log.Printf("[OAuth] Warning: Failed to fetch models for OAuth provider %s: %v", providerName, err)
 	} else {
 		log.Printf("[OAuth] Successfully fetched %d models for OAuth provider %s", len(resolved.Models), providerName)

--- a/internal/server/module/provider/handler.go
+++ b/internal/server/module/provider/handler.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -483,12 +484,9 @@ func (h *Handler) UpdateProviderModelsByUUID(c *gin.Context) {
 		return
 	}
 
-	// force_upstream is an undocumented, operator-only escape hatch: when set
-	// a normally-banned provider (e.g. Claude Code OAuth) performs a real
-	// upstream /models fetch instead of falling back to the template. The
-	// frontend never sends it; it exists for special cases where the
-	// provider's APIBase/credential does expose /models.
-	forceUpstream := c.Query("force_upstream") == "1"
+	// force_upstream allows an upstream attempt for providers normally skipped,
+	// such as Claude Code OAuth. The regular template fallback still applies.
+	forceUpstream, _ := strconv.ParseBool(c.Query("force_upstream"))
 
 	resolved, err := h.config.ResolveProviderModels(true, forceUpstream, uid)
 	if err == nil && len(resolved.Models) == 0 {

--- a/internal/server/module/provider/handler.go
+++ b/internal/server/module/provider/handler.go
@@ -483,7 +483,14 @@ func (h *Handler) UpdateProviderModelsByUUID(c *gin.Context) {
 		return
 	}
 
-	resolved, err := h.config.ResolveProviderModels(true, uid)
+	// force_upstream is an undocumented, operator-only escape hatch: when set
+	// a normally-banned provider (e.g. Claude Code OAuth) performs a real
+	// upstream /models fetch instead of falling back to the template. The
+	// frontend never sends it; it exists for special cases where the
+	// provider's APIBase/credential does expose /models.
+	forceUpstream := c.Query("force_upstream") == "1"
+
+	resolved, err := h.config.ResolveProviderModels(true, forceUpstream, uid)
 	if err == nil && len(resolved.Models) == 0 {
 		// A manual refresh that surfaces nothing is a failure worth reporting,
 		// unlike the display path which tolerates an empty list.
@@ -544,7 +551,7 @@ func (h *Handler) GetProviderModelsByUUID(c *gin.Context) {
 	// Resolve through the shared fallback chain (cache → vmodel → api →
 	// template). A resolve error (e.g. provider not found) is non-fatal for the
 	// display path: serve an empty list rather than an error.
-	resolved, _ := h.config.ResolveProviderModels(false, uid)
+	resolved, _ := h.config.ResolveProviderModels(false, false, uid)
 
 	providerModels := ProviderModelInfo{
 		Models:      resolved.Models,

--- a/internal/server/module/provider/routes.go
+++ b/internal/server/module/provider/routes.go
@@ -54,6 +54,7 @@ func RegisterRoutes(api *swagger.RouteGroup, h *Handler) {
 	api.POST("/provider-models/:uuid", h.UpdateProviderModelsByUUID,
 		swagger.WithDescription("Fetch models for a specific provider"),
 		swagger.WithTags("models"),
+		swagger.WithQuery("force_upstream", "bool", "Attempt the upstream models endpoint even when normally skipped"),
 		swagger.WithResponseModel(ProviderModelsResponse{}),
 	)
 

--- a/vmodel/client/anthropic.go
+++ b/vmodel/client/anthropic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	anthropicstream "github.com/anthropics/anthropic-sdk-go/packages/ssestream"
 
+	"github.com/tingly-dev/tingly-box/internal/client"
 	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/token"
@@ -34,13 +35,13 @@ func (c *AnthropicClient) SetRecordSink(_ *obs.Sink)   {}
 func (c *AnthropicClient) Client() *anthropic.Client   { return nil }
 func (c *AnthropicClient) Close() error                { return nil }
 
-func (c *AnthropicClient) ListModels(_ context.Context) ([]string, error) {
+func (c *AnthropicClient) ListModels(_ context.Context) (*client.ModelListResult, error) {
 	models := c.reg.ListModels()
 	ids := make([]string, len(models))
 	for i, m := range models {
 		ids[i] = m.ID
 	}
-	return ids, nil
+	return &client.ModelListResult{Models: ids, Raw: models}, nil
 }
 
 // BetaMessagesNew calls the vmodel synchronously and returns an

--- a/vmodel/client/client_test.go
+++ b/vmodel/client/client_test.go
@@ -133,8 +133,10 @@ func TestOpenAIClient_ListModels(t *testing.T) {
 	svc := virtualserver.NewService()
 	c := vmodelclient.NewOpenAIClient(svc.GetOpenAIRegistry(), newVirtualProvider())
 
-	ids, err := c.ListModels(context.Background())
+	res, err := c.ListModels(context.Background())
 	require.NoError(t, err)
+	require.NotNil(t, res)
+	ids := res.Models
 	assert.NotEmpty(t, ids)
 	assert.Contains(t, ids, "virtual-gpt-4")
 }
@@ -238,8 +240,10 @@ func TestAnthropicClient_ListModels(t *testing.T) {
 	svc := virtualserver.NewService()
 	c := vmodelclient.NewAnthropicClient(svc.GetAnthropicRegistry(), newVirtualProvider())
 
-	ids, err := c.ListModels(context.Background())
+	res, err := c.ListModels(context.Background())
 	require.NoError(t, err)
+	require.NotNil(t, res)
+	ids := res.Models
 	assert.NotEmpty(t, ids)
 	assert.Contains(t, ids, "virtual-claude-3")
 }

--- a/vmodel/client/openai.go
+++ b/vmodel/client/openai.go
@@ -14,6 +14,7 @@ import (
 	openaistream "github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/openai/openai-go/v3/responses"
 
+	"github.com/tingly-dev/tingly-box/internal/client"
 	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/protocol/token"
@@ -39,13 +40,13 @@ func (c *OpenAIClient) SetRecordSink(_ *obs.Sink)   {}
 func (c *OpenAIClient) Client() *openai.Client      { return nil }
 func (c *OpenAIClient) Close() error                { return nil }
 
-func (c *OpenAIClient) ListModels(_ context.Context) ([]string, error) {
+func (c *OpenAIClient) ListModels(_ context.Context) (*client.ModelListResult, error) {
 	models := c.reg.ListModels()
 	ids := make([]string, len(models))
 	for i, m := range models {
 		ids[i] = m.ID
 	}
-	return ids, nil
+	return &client.ModelListResult{Models: ids, Raw: models}, nil
 }
 
 // ChatCompletionsNew calls the vmodel synchronously and returns an


### PR DESCRIPTION
## Summary
Model refresh failures previously lost upstream details and could leave misleading cache metadata. Refreshes now retain diagnostics while preserving the existing fallback behavior.

## Key Changes

- **Response fidelity**: Model clients return parsed IDs alongside captured upstream payloads.
- **Durable diagnostics**: Successful responses and latest fetch errors persist for troubleshooting.
- **Cache integrity**: Failed refreshes preserve stale models without creating false cache entries.
- **Controlled upstream access**: `force_upstream` permits guarded providers to attempt real model discovery.
- **Fallback consistency**: HTTP, CLI, OAuth, and virtual providers share the same resolution behavior.
- **Client lifecycle**: Model listers consistently receive request contexts and release their resources.

## Testing

- Related client, database, configuration, probe, provider, and virtual-model tests pass.
