### PR TITLE
fix(quota): diagnosable failures, fixed URL bugs, and UI visibility for quota reads

### DIFF
--- a/.design/kimi-config.md
+++ b/.design/kimi-config.md
@@ -227,6 +227,22 @@ without introducing a non-standard marker.
 
 ---
 
+## 5.5 Quota reads need only the token
+
+The quota fetcher (`ai/quota/fetcher/kimi_code.go`) calls
+`GET https://api.kimi.com/coding/v1/usages` with the OAuth access token, an
+`Accept` header, and an explicitly empty `User-Agent`. Unlike the inference
+endpoints, this one does **not** check the kimi-cli fingerprint headers — do
+not add `X-Msh-*` here on the strength of a 403.
+
+A **403 `permission_denied`** from this endpoint is an entitlement answer, not
+a client-shape answer: it is what a lapsed or unsubscribed Kimi Code plan
+reports. The fetcher carries the upstream body into the error text (and the
+quota transport logs it in full, see `ai/quota/httplog.go`), so the account
+reason is readable instead of a bare status code.
+
+---
+
 ## 6. API base and style
 
 ```go
@@ -275,4 +291,5 @@ All constants and endpoint URLs were verified against
 | Auth handler | `internal/server/module/oauth/handler.go` | device ID generation, `pollForDeviceCodeToken`, `createProviderFromToken` |
 | Background refresh | `internal/server/background/oauth_refresher.go` | reattaches device ID on token refresh |
 | Round tripper | `internal/client/kimi_round_tripper.go` | inference headers + body normalization |
+| Quota fetcher | `ai/quota/fetcher/kimi_code.go` | `/usages` read; bearer token only, no `X-Msh-*` (§5.5) |
 | Round tripper test | `internal/client/kimi_round_tripper_test.go` | normalization unit tests |

--- a/ai/quota/fetcher.go
+++ b/ai/quota/fetcher.go
@@ -113,9 +113,14 @@ func (e *quotaError) Error() string {
 
 // NewHTTPClient creates an HTTP client with optional proxy support.
 // proxyURL accepts formats such as "http://localhost:7890" or "socks5://localhost:1080".
+//
+// Every client is wrapped in loggingTransport: quota calls run unattended on a
+// ticker, so without a request trace a failing provider leaves nothing behind
+// but a status code on its usage record.
 func NewHTTPClient(proxyURL string, timeout time.Duration) *http.Client {
 	client := &http.Client{
-		Timeout: timeout,
+		Timeout:   timeout,
+		Transport: &loggingTransport{},
 	}
 
 	if proxyURL == "" {
@@ -153,7 +158,7 @@ func NewHTTPClient(proxyURL string, timeout time.Duration) *http.Client {
 		return client
 	}
 
-	client.Transport = transport
+	client.Transport = &loggingTransport{base: transport}
 	logrus.Debugf("Using proxy: %s", proxyURL)
 	return client
 }

--- a/ai/quota/fetcher/helpers.go
+++ b/ai/quota/fetcher/helpers.go
@@ -50,3 +50,21 @@ func windowTypeForMinutes(minutes int) quota.WindowType {
 func endpoint(override, production, path string) string {
 	return strings.TrimRight(cmp.Or(override, production), "/") + path
 }
+
+// errorDetail renders a non-2xx upstream response body as a ": <message>"
+// suffix for an error, so "unexpected status code: N" says what N actually
+// meant instead of leaving the caller to guess between an expired token, a
+// rejected client, or a lapsed plan. Whitespace (including the newlines an
+// HTML error page carries) is collapsed to keep it one line, and long bodies
+// are clipped on a rune boundary — 512 runes reaches past a typical vendor
+// error envelope's outer keys into the nested message that explains it.
+func errorDetail(body []byte) string {
+	text := strings.Join(strings.Fields(string(body)), " ")
+	if text == "" {
+		return ""
+	}
+	if runes := []rune(text); len(runes) > 512 {
+		text = string(runes[:512]) + "…"
+	}
+	return ": " + text
+}

--- a/ai/quota/fetcher/helpers.go
+++ b/ai/quota/fetcher/helpers.go
@@ -51,6 +51,23 @@ func endpoint(override, production, path string) string {
 	return strings.TrimRight(cmp.Or(override, production), "/") + path
 }
 
+// apiRoot reduces a provider's configured APIBase to the host root a fetcher
+// can append a full path to. A provider's APIBase is the inference endpoint
+// and normally already carries the vendor's API prefix ("…/api/v1"), while a
+// usage endpoint is addressed from the root — appending the full path to an
+// unstripped base doubles the prefix and the request 404s. Longest suffixes
+// first, since "/api/v1" also ends with "/v1".
+func apiRoot(apiBase, production string, suffixes ...string) string {
+	base := strings.TrimRight(strings.TrimSpace(apiBase), "/")
+	for _, suffix := range suffixes {
+		if trimmed, ok := strings.CutSuffix(base, suffix); ok {
+			base = strings.TrimRight(trimmed, "/")
+			break
+		}
+	}
+	return cmp.Or(base, production)
+}
+
 // errorDetail renders a non-2xx upstream response body as a ": <message>"
 // suffix for an error, so "unexpected status code: N" says what N actually
 // meant instead of leaving the caller to guess between an expired token, a

--- a/ai/quota/fetcher/kimi_code.go
+++ b/ai/quota/fetcher/kimi_code.go
@@ -213,7 +213,11 @@ func (f *KimiCodeFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*qu
 	req.Header.Set("Authorization", "Bearer "+provider.GetAccessToken())
 	req.Header.Set("Accept", "application/json")
 	// An explicitly empty User-Agent suppresses net/http's default Go user
-	// agent. The managed usage endpoint only needs auth and content negotiation.
+	// agent. The managed usage endpoint only needs auth and content
+	// negotiation — unlike the inference endpoints it does not check the
+	// kimi-cli fingerprint headers, and a 403 here reports the account's
+	// entitlement (an expired plan reads as permission_denied), not the shape
+	// of the client.
 	req.Header.Set("User-Agent", "")
 
 	client := quota.NewHTTPClient(provider.ProxyURL, 30*time.Second)
@@ -223,13 +227,15 @@ func (f *KimiCodeFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*qu
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// A bare status code cannot tell an expired token from an expired
+		// plan. Carry the upstream message into the error users see.
+		return nil, fmt.Errorf("unexpected status code: %d%s", resp.StatusCode, errorDetail(body))
 	}
 
 	var apiResp kimiCodeUsageResponse

--- a/ai/quota/fetcher/kimi_code_test.go
+++ b/ai/quota/fetcher/kimi_code_test.go
@@ -302,6 +302,24 @@ func kimiCodeTestProvider() *ai.Provider {
 	}
 }
 
+func TestKimiCodeFetcherStatusErrorCarriesUpstreamMessage(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "{\"error\":\n\"forbidden client\"}", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	_, err := (&KimiCodeFetcher{baseURL: server.URL}).Fetch(context.Background(), kimiCodeTestProvider())
+	if err == nil {
+		t.Fatal("Fetch() error = nil, want status error")
+	}
+	want := `unexpected status code: 403: {"error": "forbidden client"}`
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
 func TestKimiCodeSemantics(t *testing.T) {
 	t.Parallel()
 

--- a/ai/quota/fetcher/openai.go
+++ b/ai/quota/fetcher/openai.go
@@ -68,18 +68,9 @@ func (f *OpenAIFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quot
 	// Create an HTTP client with proxy support.
 	client := quota.NewHTTPClient(provider.ProxyURL, 30*time.Second)
 
-	// Build the request.
-	apiBase := provider.APIBase
-	if apiBase == "" {
-		apiBase = "https://api.openai.com"
-	}
-
-	// Remove a trailing /v1 suffix to avoid duplicating it.
-	if len(apiBase) > 3 && apiBase[len(apiBase)-3:] == "/v1" {
-		apiBase = apiBase[:len(apiBase)-3]
-	}
-
-	url := fmt.Sprintf("%s/v1/usage", apiBase)
+	// Build the request. The configured base already ends in /v1 for a normal
+	// OpenAI provider, so it comes off before the full path goes on.
+	url := apiRoot(provider.APIBase, "https://api.openai.com", "/v1") + "/v1/usage"
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)

--- a/ai/quota/fetcher/openai_test.go
+++ b/ai/quota/fetcher/openai_test.go
@@ -120,3 +120,28 @@ func TestOpenAIReportsSpendOnce(t *testing.T) {
 		t.Errorf("Cost = %+v; want nil — the spend window already reports it", usage.Cost)
 	}
 }
+
+// The OpenAI-compatible base a provider is configured with ends in /v1, so the
+// usage path must not add a second one.
+func TestOpenAIFetcherDoesNotDoubleVersionPrefix(t *testing.T) {
+	for _, suffix := range []string{"", "/v1", "/v1/"} {
+		t.Run("base"+suffix, func(t *testing.T) {
+			var gotPath string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+			}))
+			defer server.Close()
+
+			_, err := (&OpenAIFetcher{}).Fetch(context.Background(), &ai.Provider{
+				UUID: "u", Name: "OpenAI", Token: "k", APIBase: server.URL + suffix,
+			})
+			if err != nil {
+				t.Fatalf("Fetch() error: %v", err)
+			}
+			if gotPath != "/v1/usage" {
+				t.Errorf("path = %q, want /v1/usage", gotPath)
+			}
+		})
+	}
+}

--- a/ai/quota/fetcher/openrouter.go
+++ b/ai/quota/fetcher/openrouter.go
@@ -58,12 +58,11 @@ func (f *OpenRouterFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*
 	token := provider.GetAccessToken()
 	client := quota.NewHTTPClient(provider.ProxyURL, 30*time.Second)
 
-	// Use provider.APIBase for testing, fallback to production URL
-	apiBase := provider.APIBase
-	if apiBase == "" {
-		apiBase = "https://openrouter.ai"
-	}
-	url := apiBase + "/api/v1/key"
+	// OpenRouter providers are configured with the inference base
+	// ("https://openrouter.ai/api/v1", or "…/api" for the Anthropic style);
+	// the key endpoint is addressed from the root, so the prefix comes off
+	// before the full path goes on.
+	url := apiRoot(provider.APIBase, "https://openrouter.ai", "/api/v1", "/api") + "/api/v1/key"
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {

--- a/ai/quota/fetcher/openrouter_test.go
+++ b/ai/quota/fetcher/openrouter_test.go
@@ -261,3 +261,31 @@ func TestOpenRouterMonthlySpendNeverPosesAsACap(t *testing.T) {
 		t.Errorf("first window = %q; want key_limit ahead of the uncapped one", usage.Windows[0].Key)
 	}
 }
+
+// A provider's APIBase is its inference endpoint, which for OpenRouter already
+// carries the API prefix. Appending the key path to it unstripped produced
+// /api/v1/api/v1/key, which OpenRouter answers with a 404 from its web app.
+func TestOpenRouterFetcherDoesNotDoubleAPIPrefix(t *testing.T) {
+	const response = `{"data":{"label":"k","is_free_tier":true,"usage":1}}`
+
+	for _, suffix := range []string{"", "/", "/api/v1", "/api/v1/", "/api"} {
+		t.Run("base"+suffix, func(t *testing.T) {
+			var gotPath string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				_, _ = w.Write([]byte(response))
+			}))
+			defer server.Close()
+
+			_, err := (&OpenRouterFetcher{}).Fetch(context.Background(), &ai.Provider{
+				UUID: "u", Name: "OpenRouter", Token: "k", APIBase: server.URL + suffix,
+			})
+			if err != nil {
+				t.Fatalf("Fetch() error: %v", err)
+			}
+			if gotPath != "/api/v1/key" {
+				t.Errorf("path = %q, want /api/v1/key", gotPath)
+			}
+		})
+	}
+}

--- a/ai/quota/httplog.go
+++ b/ai/quota/httplog.go
@@ -1,0 +1,81 @@
+package quota
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// sensitiveHeaders are logged as "<redacted>" rather than dropped, so the log
+// still shows whether a credential header was sent at all.
+var sensitiveHeaders = map[string]bool{
+	"authorization": true, "cookie": true, "set-cookie": true,
+	"proxy-authorization": true, "x-api-key": true, "x-goog-api-key": true,
+	"api-key": true,
+}
+
+// loggingTransport traces every quota HTTP call, for every fetcher. Quota reads
+// run unattended on a ticker, so without this a failing provider leaves nothing
+// behind but a status code on its usage record.
+//
+// A failed call logs at warn with everything needed to explain it: what was
+// sent (headers, credential values redacted — several vendors gate their usage
+// endpoints on client identity, not just the token) and what came back
+// (headers, and the body in full, since a clipped body is exactly the case
+// where the log fails to explain the failure).
+type loggingTransport struct {
+	base http.RoundTripper
+}
+
+func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	log := logrus.WithFields(logrus.Fields{"method": req.Method, "url": req.URL.String()})
+
+	resp, err := base.RoundTrip(req)
+	if err != nil {
+		log.WithError(err).Warn("quota request failed")
+		return nil, err
+	}
+
+	// Anything below 400 is not a failure to report: the client follows
+	// redirects itself, so a 3xx here is a hop, not an outcome.
+	log = log.WithField("status", resp.StatusCode)
+	if resp.StatusCode < http.StatusBadRequest {
+		log.Debug("quota response")
+		return resp, nil
+	}
+
+	// A read error still leaves whatever arrived before it in raw, which is
+	// more useful in the log than dropping the body entirely.
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(raw))
+
+	log.WithFields(logrus.Fields{
+		"request_headers":  redactHeaders(req.Header),
+		"response_headers": redactHeaders(resp.Header),
+		"body":             string(raw),
+	}).Warn("quota upstream returned an error status")
+	return resp, nil
+}
+
+// redactHeaders renders headers as a "name=value" list with credential values
+// masked.
+func redactHeaders(header http.Header) string {
+	parts := make([]string, 0, len(header))
+	for name, values := range header {
+		if sensitiveHeaders[strings.ToLower(name)] {
+			parts = append(parts, name+"=<redacted>")
+			continue
+		}
+		parts = append(parts, name+"="+strings.Join(values, ","))
+	}
+	return strings.Join(parts, "; ")
+}

--- a/ai/quota/httplog_test.go
+++ b/ai/quota/httplog_test.go
@@ -1,0 +1,55 @@
+package quota
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The logging transport sits in front of every fetcher, so the one thing it
+// must never do is eat the response body it logs.
+func TestLoggingTransportPreservesErrorBody(t *testing.T) {
+	t.Parallel()
+
+	const body = `{"code":"permission_denied","message":"no coding plan"}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, body, http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	resp, err := NewHTTPClient("", 5*time.Second).Get(server.URL)
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != body {
+		t.Errorf("body = %q, want %q", strings.TrimSpace(string(got)), body)
+	}
+}
+
+func TestRedactHeaders(t *testing.T) {
+	t.Parallel()
+
+	header := http.Header{}
+	header.Set("Authorization", "Bearer secret-token")
+	header.Set("X-Msh-Platform", "kimi_cli")
+
+	got := redactHeaders(header)
+	if strings.Contains(got, "secret-token") {
+		t.Errorf("redactHeaders() leaked the credential: %q", got)
+	}
+	if !strings.Contains(got, "Authorization=<redacted>") {
+		t.Errorf("redactHeaders() = %q, want the header name kept", got)
+	}
+	if !strings.Contains(got, "X-Msh-Platform=kimi_cli") {
+		t.Errorf("redactHeaders() = %q, want non-credential headers verbatim", got)
+	}
+}

--- a/ai/quota/manager.go
+++ b/ai/quota/manager.go
@@ -2,6 +2,7 @@ package quota
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -90,6 +91,9 @@ func (m *Manager) Refresh(ctx context.Context) ([]*ProviderUsage, error) {
 			defer wg.Done()
 			for provider := range jobs {
 				usage, err := m.fetchProviderQuota(ctx, provider)
+				if errors.Is(err, ErrProviderUnsupported) {
+					continue
+				}
 				if err != nil {
 					m.loggerWithError(provider, err).Warn("failed to fetch quota")
 					continue
@@ -132,6 +136,10 @@ func (m *Manager) RefreshProvider(ctx context.Context, providerUUID string) (*Pr
 }
 
 // GetQuota returns cached quota data and refreshes it when expired.
+//
+// Both ErrUsageNotFound and ErrProviderUnsupported mean "there is nothing to
+// show for this provider" and reach the caller unwrapped, so handlers can skip
+// them instead of reporting a failure.
 //
 // A not-found store lookup returns ErrUsageNotFound UNWRAPPED — callers
 // (e.g. the provider-quota HTTP handlers) compare against that sentinel
@@ -265,14 +273,16 @@ func (m *Manager) fetchProviderQuota(ctx context.Context, provider *typ.Provider
 		"provider_type": providerType,
 	})
 
-	// Verify that a fetcher is registered.
+	// Verify that a fetcher is registered. No fetcher is the ordinary case for
+	// most providers, so it is reported as a skip, not stored as a failure:
+	// persisting it put "unsupported provider type" in the record's LastError,
+	// which the UI then showed as if the provider had broken. Any such record
+	// left by an earlier version is dropped here.
 	f, ok := m.registry.Get(providerType)
 	if !ok {
-		reason := fmt.Sprintf("unsupported provider type: %q", providerType)
-		log.Debug("skipping quota fetch: " + reason)
-		usage := m.unreadable(provider, providerType, now, reason)
-		_ = m.store.Save(ctx, usage)
-		return usage, nil
+		log.Debug("skipping quota fetch: no fetcher for this provider type")
+		_ = m.store.Delete(ctx, provider.UUID)
+		return nil, ErrProviderUnsupported
 	}
 	log = log.WithField("fetcher", f.Name())
 

--- a/ai/quota/manager.go
+++ b/ai/quota/manager.go
@@ -337,8 +337,8 @@ func inferProviderType(provider *typ.Provider) ProviderType {
 		return ProviderTypeAnthropic
 	case typ.IssuerGoogle:
 		return ProviderTypeGemini
-	case typ.IssuerOpenAI:
-		return ProviderTypeOpenAI
+	//case typ.IssuerOpenAI:
+	//	return ProviderTypeOpenAI
 	case typ.IssuerCopilot:
 		return ProviderTypeCopilot
 	case typ.IssuerCursor:
@@ -363,8 +363,8 @@ func inferProviderType(provider *typ.Provider) ProviderType {
 	switch {
 	case hostIs(host, "anthropic.com"):
 		return ProviderTypeAnthropic
-	case hostIs(host, "openai.com", "openai.azure.com"):
-		return ProviderTypeOpenAI
+	//case hostIs(host, "openai.com", "openai.azure.com"):
+	//	return ProviderTypeOpenAI
 	case hostIs(host, "googleapis.com"), strings.Contains(host, "gemini"):
 		return ProviderTypeGemini
 	case strings.Contains(host, "cursor"):

--- a/ai/quota/manager.go
+++ b/ai/quota/manager.go
@@ -254,17 +254,29 @@ func (m *Manager) fetchProviderQuota(ctx context.Context, provider *typ.Provider
 	providerType := inferProviderType(provider)
 	now := time.Now()
 
+	// Log here rather than in the callers: a quota read is reached from the
+	// background ticker, the manual refresh endpoint, and cache expiry, and
+	// every one of those used to fail silently into a stored LastError.
+	log := m.logger.WithFields(logrus.Fields{
+		"provider_uuid": provider.UUID,
+		"provider_name": provider.Name,
+		"provider_type": providerType,
+	})
+
 	// Verify that a fetcher is registered.
 	f, ok := m.registry.Get(providerType)
 	if !ok {
-		usage := m.unreadable(provider, providerType, now,
-			fmt.Sprintf("unsupported provider type: %q", providerType))
+		reason := fmt.Sprintf("unsupported provider type: %q", providerType)
+		log.Debug("skipping quota fetch: " + reason)
+		usage := m.unreadable(provider, providerType, now, reason)
 		_ = m.store.Save(ctx, usage)
 		return usage, nil
 	}
+	log = log.WithField("fetcher", f.Name())
 
 	// Validate the provider configuration.
 	if err := f.Validate(provider); err != nil {
+		log.WithError(err).Warn("quota fetch skipped: provider failed validation")
 		usage := m.unreadable(provider, providerType, now,
 			fmt.Sprintf("validation failed: %v", err))
 		_ = m.store.Save(ctx, usage)
@@ -272,14 +284,29 @@ func (m *Manager) fetchProviderQuota(ctx context.Context, provider *typ.Provider
 	}
 
 	// Fetch quota data.
+	start := time.Now()
 	usage, err := f.Fetch(ctx, provider)
+	elapsed := time.Since(start)
 	if err != nil {
+		log.WithFields(logrus.Fields{
+			"duration_ms": elapsed.Milliseconds(),
+			"error":       err.Error(),
+		}).Warn("quota fetch failed")
 		usage = m.unreadable(provider, providerType, now, err.Error())
+	} else {
+		fields := logrus.Fields{
+			"duration_ms": elapsed.Milliseconds(),
+			"windows":     len(usage.Windows),
+		}
+		if pct, ok := usage.Pct(); ok {
+			fields["used_percent"] = pct
+		}
+		log.WithFields(fields).Debug("quota fetched")
 	}
 
 	// Persist the result.
 	if saveErr := m.store.Save(ctx, usage); saveErr != nil {
-		m.logger.WithError(saveErr).Error("failed to save quota")
+		log.WithError(saveErr).Error("failed to save quota")
 	}
 
 	return usage, nil

--- a/ai/quota/manager.go
+++ b/ai/quota/manager.go
@@ -3,6 +3,8 @@ package quota
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -337,39 +339,92 @@ func inferProviderType(provider *typ.Provider) ProviderType {
 		return ProviderTypeKimiCode
 	}
 
-	// Fallback: infer from APIBase domain
-	apiBase := strings.ToLower(provider.APIBase)
+	// Fallback: infer from the APIBase host.
+	//
+	// The host, never the whole URL. Matching the URL made any path segment
+	// speak for the vendor: a local gateway at
+	// http://localhost:12581/tingly/codex1 was read as Codex — and the Codex
+	// fetcher would then take that provider's token to chatgpt.com. Paths are
+	// user-chosen names; only the host says who answers.
+	host, path := apiBaseHostPath(provider.APIBase)
+	if host == "" || isLocalAPIHost(host) {
+		return ""
+	}
 	switch {
-	case strings.Contains(apiBase, "anthropic.com"):
+	case hostIs(host, "anthropic.com"):
 		return ProviderTypeAnthropic
-	case strings.Contains(apiBase, "openai.com"), strings.Contains(apiBase, "openai.azure.com"):
+	case hostIs(host, "openai.com", "openai.azure.com"):
 		return ProviderTypeOpenAI
-	case strings.Contains(apiBase, "googleapis.com"), strings.Contains(apiBase, "gemini"):
+	case hostIs(host, "googleapis.com"), strings.Contains(host, "gemini"):
 		return ProviderTypeGemini
-	case strings.Contains(apiBase, "cursor"):
+	case strings.Contains(host, "cursor"):
 		return ProviderTypeCursor
-	case strings.Contains(apiBase, "copilot"):
+	case strings.Contains(host, "copilot"):
 		return ProviderTypeCopilot
-	case strings.Contains(apiBase, "vertex"):
+	case strings.Contains(host, "vertex"):
 		return ProviderTypeVertexAI
-	case strings.Contains(apiBase, "zai.app"):
+	case hostIs(host, "zai.app"):
 		return ProviderTypeZai
-	case strings.Contains(apiBase, "bigmodel.cn"):
+	case hostIs(host, "bigmodel.cn"):
 		return ProviderTypeGLM
-	case strings.Contains(apiBase, "moonshot.cn"):
+	case hostIs(host, "moonshot.cn"):
 		return ProviderTypeKimiK2
-	case strings.Contains(apiBase, "api.kimi.com/coding"):
+	// Kimi's coding product shares a host with the rest of kimi.com, so this
+	// one pair genuinely needs the path to tell them apart.
+	case hostIs(host, "kimi.com") && strings.HasPrefix(path, "/coding"):
 		return ProviderTypeKimiCode
-	case strings.Contains(apiBase, "openrouter.ai"):
+	case hostIs(host, "openrouter.ai"):
 		return ProviderTypeOpenRouter
-	case strings.Contains(apiBase, "minimaxi.com"):
+	case hostIs(host, "minimaxi.com"):
 		return ProviderTypeMiniMaxCN
-	case strings.Contains(apiBase, "minimax"):
+	case strings.Contains(host, "minimax"):
 		return ProviderTypeMiniMax
-	case strings.Contains(apiBase, "chatgpt.com"), strings.Contains(apiBase, "codex"):
+	case hostIs(host, "chatgpt.com"), strings.Contains(host, "codex"):
 		return ProviderTypeCodex
 	}
 	return ""
+}
+
+// apiBaseHostPath splits a configured API base into its lowercased host and
+// path. A base without a scheme ("api.openai.com/v1") is still understood.
+func apiBaseHostPath(apiBase string) (host, path string) {
+	trimmed := strings.TrimSpace(apiBase)
+	if trimmed == "" {
+		return "", ""
+	}
+	if !strings.Contains(trimmed, "://") {
+		trimmed = "http://" + trimmed
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", ""
+	}
+	return strings.ToLower(parsed.Hostname()), strings.ToLower(parsed.Path)
+}
+
+// hostIs reports whether host is one of the domains, or a subdomain of one.
+// Suffix matching, not substring: "notopenai.com.evil.test" is not OpenAI.
+func hostIs(host string, domains ...string) bool {
+	for _, domain := range domains {
+		if host == domain || strings.HasSuffix(host, "."+domain) {
+			return true
+		}
+	}
+	return false
+}
+
+// isLocalAPIHost reports whether the host is this machine or a private
+// network. A provider pointing there is a local gateway — frequently
+// tingly-box itself — and no vendor heuristic may claim it.
+func isLocalAPIHost(host string) bool {
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") || strings.HasSuffix(host, ".local") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() || ip.IsLinkLocalUnicast()
+	}
+	// A bare name with no dot is a LAN or container hostname, not a vendor.
+	return !strings.Contains(host, ".")
 }
 
 // Summary contains aggregate quota statistics.

--- a/ai/quota/manager_test.go
+++ b/ai/quota/manager_test.go
@@ -177,6 +177,67 @@ func TestUnreadableProvidersReportWhyAndNothingElse(t *testing.T) {
 	}
 }
 
+// recordingStore reports what a fetch attempt left behind.
+type recordingStore struct {
+	managerTestStore
+	saved   []*ProviderUsage
+	deleted []string
+}
+
+func (s *recordingStore) Save(_ context.Context, usage *ProviderUsage) error {
+	s.saved = append(s.saved, usage)
+	return nil
+}
+
+func (s *recordingStore) Delete(_ context.Context, uuid string) error {
+	s.deleted = append(s.deleted, uuid)
+	return nil
+}
+
+// Most providers have no quota fetcher, which is ordinary rather than broken.
+// Recording it as a usage record put "unsupported provider type" in LastError
+// and the UI showed that as a provider failure.
+func TestRefreshProviderUnsupportedIsASkipNotAnError(t *testing.T) {
+	provider := &typ.Provider{UUID: "u1", Name: "Some Gateway", AuthType: typ.AuthTypeAPIKey}
+	store := &recordingStore{}
+	m := NewManager(nil, store, managerTestProviderManager{providers: []*typ.Provider{provider}}, logrus.New())
+
+	usage, err := m.RefreshProvider(context.Background(), "u1")
+	if !errors.Is(err, ErrProviderUnsupported) {
+		t.Fatalf("RefreshProvider() error = %v, want ErrProviderUnsupported", err)
+	}
+	if usage != nil {
+		t.Errorf("usage = %+v, want nil", usage)
+	}
+	if len(store.saved) != 0 {
+		t.Errorf("saved %d records, want none", len(store.saved))
+	}
+	// Any record an earlier version wrote is cleared out on the way past.
+	if len(store.deleted) != 1 || store.deleted[0] != "u1" {
+		t.Errorf("deleted = %v, want [u1]", store.deleted)
+	}
+}
+
+// Refresh walks every enabled provider, most of which have no fetcher; those
+// must drop out quietly rather than land in the results as failures.
+func TestRefreshSkipsUnsupportedProviders(t *testing.T) {
+	store := &recordingStore{}
+	m := NewManager(nil, store, managerTestProviderManager{providers: []*typ.Provider{
+		{UUID: "u1", Name: "Some Gateway", AuthType: typ.AuthTypeAPIKey},
+	}}, logrus.New())
+
+	usages, err := m.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("Refresh() error: %v", err)
+	}
+	if len(usages) != 0 {
+		t.Errorf("Refresh() returned %d usages, want none", len(usages))
+	}
+	if len(store.saved) != 0 {
+		t.Errorf("saved %d records, want none", len(store.saved))
+	}
+}
+
 // A path segment is a user-chosen name and must never speak for a vendor.
 // Matching the whole URL read a local gateway route named "codex1" as Codex,
 // which sent that provider's token to chatgpt.com on the next refresh.

--- a/ai/quota/manager_test.go
+++ b/ai/quota/manager_test.go
@@ -41,7 +41,7 @@ type concurrencyTestFetcher struct {
 }
 
 func (*concurrencyTestFetcher) Name() string                 { return "concurrency-test" }
-func (*concurrencyTestFetcher) ProviderType() ProviderType   { return ProviderTypeOpenAI }
+func (*concurrencyTestFetcher) ProviderType() ProviderType   { return ProviderTypeAnthropic }
 func (*concurrencyTestFetcher) Validate(*typ.Provider) error { return nil }
 func (*concurrencyTestFetcher) RequiresAuth() typ.AuthType   { return "" }
 func (f *concurrencyTestFetcher) Fetch(_ context.Context, provider *typ.Provider) (*ProviderUsage, error) {
@@ -82,7 +82,7 @@ func TestRefreshBoundsConcurrency(t *testing.T) {
 		providers[i] = &typ.Provider{
 			UUID:    fmt.Sprintf("provider-%d", i),
 			Name:    fmt.Sprintf("Provider %d", i),
-			APIBase: "https://api.openai.com/v1",
+			APIBase: "https://api.anthropic.com/v1",
 			Enabled: true,
 		}
 	}
@@ -113,7 +113,10 @@ func TestInferProviderTypeAPIBaseCaseInsensitive(t *testing.T) {
 		want    ProviderType
 	}{
 		{"HTTPS://API.ANTHROPIC.COM/V1", ProviderTypeAnthropic},
-		{"https://OPENAI.Azure.com/openai", ProviderTypeOpenAI},
+		// OpenAI is intentionally unclassified (see the OpenAI-disabling
+		// commit): its legacy usage API's current requirements are unverified,
+		// so the manager skips it rather than reading it wrong.
+		{"https://OPENAI.Azure.com/openai", ""},
 		{"https://generativelanguage.GOOGLEAPIS.COM", ProviderTypeGemini},
 		{"https://openrouter.ai/api/v1", ProviderTypeOpenRouter},
 		{"https://api.minimaxi.com/v1", ProviderTypeMiniMaxCN},

--- a/ai/quota/manager_test.go
+++ b/ai/quota/manager_test.go
@@ -176,3 +176,38 @@ func TestUnreadableProvidersReportWhyAndNothingElse(t *testing.T) {
 		t.Errorf("ExpiresAt = %v; want the ttl applied to now", usage.ExpiresAt)
 	}
 }
+
+// A path segment is a user-chosen name and must never speak for a vendor.
+// Matching the whole URL read a local gateway route named "codex1" as Codex,
+// which sent that provider's token to chatgpt.com on the next refresh.
+func TestInferProviderTypeIgnoresPathAndLocalHosts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		apiBase string
+		want    ProviderType
+	}{
+		{"local gateway route named codex", "http://localhost:12581/tingly/codex1", ""},
+		{"loopback ip", "http://127.0.0.1:12581/tingly/gemini", ""},
+		{"private lan", "http://192.168.1.10:8080/v1/cursor", ""},
+		{"container hostname", "http://tingly-box:12581/tingly/codex1", ""},
+		{"mdns", "http://mac.local:12581/copilot/v1", ""},
+		{"vendor name only in the path", "https://gateway.example.com/proxy/openrouter.ai/api/v1", ""},
+		{"lookalike domain", "https://api.openai.com.evil.test/v1", ""},
+		{"scheme-less base", "api.anthropic.com/v1", ProviderTypeAnthropic},
+		{"subdomain of a vendor", "https://eu.api.anthropic.com/v1", ProviderTypeAnthropic},
+		{"kimi coding needs its path", "https://api.kimi.com/coding/v1", ProviderTypeKimiCode},
+		{"kimi without the coding path", "https://api.kimi.com/v1", ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := inferProviderType(&typ.Provider{APIBase: tt.apiBase}); got != tt.want {
+				t.Fatalf("inferProviderType(%q) = %q, want %q", tt.apiBase, got, tt.want)
+			}
+		})
+	}
+}

--- a/ai/quota/store.go
+++ b/ai/quota/store.go
@@ -18,6 +18,12 @@ import (
 
 var (
 	ErrUsageNotFound = errors.New("usage not found")
+
+	// ErrProviderUnsupported means the provider has no quota fetcher — most
+	// providers do not, and that is not a failure to report. It is a skip
+	// signal for callers, deliberately distinct from a fetch that was tried
+	// and failed: only the latter belongs in front of a user.
+	ErrProviderUnsupported = errors.New("provider does not support quota")
 )
 
 // ProviderUsageRecord is the GORM persistence model for provider usage.

--- a/frontend/src/components/credential/QuotaInlineDisplay.tsx
+++ b/frontend/src/components/credential/QuotaInlineDisplay.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Stack, IconButton, Typography, CircularProgress, Tooltip }
 import { Code as CodeIcon } from '@/components/icons';
 import { Refresh as RefreshIcon } from '@/components/icons';
 import { Info as InfoIcon } from '@/components/icons';
+import { Warning as AlertIcon } from '@/components/icons';
 import { QuotaBarItem } from './QuotaBarItem';
 import { QuotaBarRow, useQuotaBars } from './QuotaBarRow';
 import { QuotaRawResponseDialog } from './QuotaRawResponseDialog';
@@ -54,8 +55,12 @@ export function QuotaInlineDisplay({
   const hiddenWindows = windows.slice(maxInlineItems);
   const fetchedAgo = formatFetchedAgo(quota?.fetched_at);
 
-  // Show nothing if there's no data at all
-  if (!hasAny && !hasRawResponse) {
+  // A provider whose quota could not be read still has something to say. It
+  // used to render nothing at all, so a failing provider simply vanished from
+  // the row and the refresh button went with it — leaving no way to retry and
+  // no reason on screen.
+  const lastError = quota?.last_error;
+  if (!hasAny && !hasRawResponse && !lastError) {
     return null;
   }
 
@@ -197,10 +202,27 @@ export function QuotaInlineDisplay({
           {resourceItems.map(item => (
             <QuotaBarItem key={item.key} window={item.window} percentLabel={item.countLabel} barColor="#22c55e" tooltipContent={item.tooltipContent} />
           ))}
-          {!hasAny && hasRawResponse && (
+          {!hasAny && hasRawResponse && !lastError && (
             <Typography variant="caption" color="text.disabled" sx={{ whiteSpace: 'nowrap' }}>
               No quota limits reported
             </Typography>
+          )}
+          {lastError && (
+            <Tooltip title={lastError} arrow>
+              {/* Upstream reasons run long — a raw 403 envelope is a few hundred
+                  characters. The width is capped so the clipped text ends in an
+                  ellipsis inside the row instead of running past the table. */}
+              <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', minWidth: 0, maxWidth: 460 }}>
+                <AlertIcon sx={{ fontSize: 14, color: 'warning.main', flexShrink: 0 }} />
+                <Typography
+                  variant="caption"
+                  color="warning.main"
+                  sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                >
+                  {lastError}
+                </Typography>
+              </Stack>
+            </Tooltip>
           )}
         </Stack>
 

--- a/frontend/src/hooks/useProviderQuota.ts
+++ b/frontend/src/hooks/useProviderQuota.ts
@@ -13,6 +13,11 @@ interface UseProviderQuotaOptions {
   fetchOnMount?: boolean;
 }
 
+/** 404 means the provider has no quota to show — not an error worth raising. */
+function isMissingQuota(error: unknown): boolean {
+  return (error as { status?: number })?.status === 404;
+}
+
 /**
  * Helper function to fetch from API
  */
@@ -32,7 +37,9 @@ async function fetchUIAPI(url: string, options: RequestInit = {}): Promise<any> 
   });
 
   if (!response.ok) {
-    throw new Error(`API error: ${response.status}`);
+    // The status rides along so callers can tell "this provider has no quota"
+    // (404) from a real failure, and stay quiet about the former.
+    throw Object.assign(new Error(`API error: ${response.status}`), { status: response.status });
   }
 
   return response.json();
@@ -109,6 +116,9 @@ export function useProviderQuota(providers: Array<{ uuid: string }>, options: Us
 
       return null;
     } catch (error) {
+      if (isMissingQuota(error)) {
+        return null;
+      }
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       console.error(`[useProviderQuota] Failed to fetch quota for ${providerUuid}:`, error);
       setErrors(prev => new Map(prev).set(providerUuid, errorMessage));
@@ -125,6 +135,9 @@ export function useProviderQuota(providers: Array<{ uuid: string }>, options: Us
       });
       await fetchQuota(providerUuid);
     } catch (error) {
+      if (isMissingQuota(error)) {
+        return;
+      }
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       console.error(`[useProviderQuota] Failed to refresh quota for ${providerUuid}:`, error);
       setErrors(prev => new Map(prev).set(providerUuid, errorMessage));

--- a/frontend/src/hooks/useProviderQuota.ts
+++ b/frontend/src/hooks/useProviderQuota.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNotify } from '@/hooks/useNotify';
 import type { ProviderQuota } from '@/types/quota';
 
 interface ProviderQuotaData {
@@ -13,14 +14,14 @@ interface UseProviderQuotaOptions {
   fetchOnMount?: boolean;
 }
 
+/**
+ * Helper function to fetch from API
+ */
 /** 404 means the provider has no quota to show — not an error worth raising. */
 function isMissingQuota(error: unknown): boolean {
   return (error as { status?: number })?.status === 404;
 }
 
-/**
- * Helper function to fetch from API
- */
 async function fetchUIAPI(url: string, options: RequestInit = {}): Promise<any> {
   const basePath = window.location.origin;
   const fullUrl = `${basePath}/api/v1${url}`;
@@ -50,13 +51,26 @@ async function fetchUIAPI(url: string, options: RequestInit = {}): Promise<any> 
  *
  * Uses batch API to fetch quota for multiple providers efficiently.
  */
-export function useProviderQuota(providers: Array<{ uuid: string }>, options: UseProviderQuotaOptions = {}) {
+export function useProviderQuota(providers: Array<{ uuid: string; name?: string }>, options: UseProviderQuotaOptions = {}) {
   const { fetchOnMount = true } = options;
 
   const [quotaData, setQuotaData] = useState<ProviderQuotaData>({});
   const [refreshing, setRefreshing] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
   const [errors, setErrors] = useState<Map<string, string>>(new Map());
+  const notify = useNotify();
+
+  // Names are read through a ref so the fetch callbacks keep a stable identity:
+  // batchFetchQuota is a dependency of the mount effect, and re-creating it on
+  // every render would re-fetch on every render.
+  const namesRef = useRef<Map<string, string>>(new Map());
+  useEffect(() => {
+    namesRef.current = new Map(providers.map(p => [p.uuid, p.name || p.uuid]));
+  }, [providers]);
+  const providerName = useCallback(
+    (uuid: string) => namesRef.current.get(uuid) || uuid,
+    [],
+  );
 
   // Batch fetch quota for multiple providers
   const batchFetchQuota = useCallback(async (providerUuids: string[]): Promise<void> => {
@@ -85,6 +99,9 @@ export function useProviderQuota(providers: Array<{ uuid: string }>, options: Us
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       console.error('[useProviderQuota] Batch fetch failed:', error);
+      // One notification for the batch, not one per provider: the whole call
+      // failed, so per-provider toasts would repeat a single fact N times.
+      notify.error(`Failed to load quota: ${errorMessage}`);
       // Set error for all providers in the batch
       setErrors(prev => {
         const next = new Map(prev);
@@ -96,7 +113,7 @@ export function useProviderQuota(providers: Array<{ uuid: string }>, options: Us
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [notify]);
 
   // Fetch quota for a single provider
   const fetchQuota = useCallback(async (providerUuid: string): Promise<ProviderQuota | null> => {
@@ -133,13 +150,21 @@ export function useProviderQuota(providers: Array<{ uuid: string }>, options: Us
       await fetchUIAPI(`/provider-quota/${providerUuid}/refresh`, {
         method: 'POST',
       });
-      await fetchQuota(providerUuid);
+      const quota = await fetchQuota(providerUuid);
+      // The refresh endpoint answers 200 even when the upstream refused: an
+      // unreadable provider comes back as a usage record carrying last_error.
+      // Reporting only transport failures made that case look like a success
+      // that quietly rendered nothing.
+      if (quota?.last_error) {
+        notify.warning(`${providerName(providerUuid)}: ${quota.last_error}`);
+      }
     } catch (error) {
       if (isMissingQuota(error)) {
         return;
       }
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       console.error(`[useProviderQuota] Failed to refresh quota for ${providerUuid}:`, error);
+      notify.error(`Failed to refresh ${providerName(providerUuid)} quota: ${errorMessage}`);
       setErrors(prev => new Map(prev).set(providerUuid, errorMessage));
     } finally {
       setRefreshing(prev => {
@@ -148,7 +173,7 @@ export function useProviderQuota(providers: Array<{ uuid: string }>, options: Us
         return next;
       });
     }
-  }, [fetchQuota]);
+  }, [fetchQuota, notify, providerName]);
 
   // Fetch all quotas
   const fetchAllQuotas = useCallback(async () => {

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -883,8 +883,10 @@ const inThirtyDays = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000).toISOStr
 // rendering state: an allowance, a balance, an uncapped window, a scoped limit
 // that must not answer for the account, and a quota we cannot read at all.
 const mockQuotas: Record<string, any> = {
-    // Nothing readable: the reason is recorded, no windows are invented, and
-    // the credential row shows no quota section at all.
+    // Nothing readable: the reason is recorded and no windows are invented.
+    // The credential row still renders — the reason inline, refresh still
+    // reachable — since a provider that cannot be read is exactly the one a
+    // user needs to see and retry.
     'mock-provider-anthropic': {
         provider_uuid: 'mock-provider-anthropic',
         provider_name: 'Anthropic',
@@ -1953,12 +1955,16 @@ export const handlers = [
         return HttpResponse.json({ success: true, data: result })
     }),
 
+    // Shape matches the Go handler: GetQuota / RefreshProvider answer with the
+    // usage record itself, not a {success, data} envelope (only /batch wraps).
+    // While these wrapped it, the hook read no provider_uuid and treated every
+    // single-provider read as empty, so failure states never rendered in mock.
     http.get('/api/v1/provider-quota/:uuid', ({ params }) => {
         const { uuid } = params as { uuid: string }
         if (mockQuotas[uuid]) {
-            return HttpResponse.json({ success: true, data: { ...mockQuotas[uuid], fetched_at: new Date().toISOString() } })
+            return HttpResponse.json({ ...mockQuotas[uuid], fetched_at: new Date().toISOString() })
         }
-        return HttpResponse.json({ success: false, error: 'No quota data' }, { status: 404 })
+        return HttpResponse.json({ error: 'quota not found for provider' }, { status: 404 })
     }),
 
     http.post('/api/v1/provider-quota/:uuid/refresh', async ({ params }) => {
@@ -1966,10 +1972,9 @@ export const handlers = [
         // Simulate a short delay
         await new Promise(r => setTimeout(r, 800))
         if (mockQuotas[uuid]) {
-            const refreshed = { ...mockQuotas[uuid], fetched_at: new Date().toISOString() }
-            return HttpResponse.json({ success: true, data: refreshed })
+            return HttpResponse.json({ ...mockQuotas[uuid], fetched_at: new Date().toISOString() })
         }
-        return HttpResponse.json({ success: false, error: 'No quota data' }, { status: 404 })
+        return HttpResponse.json({ error: 'quota not found for provider' }, { status: 404 })
     }),
 
     http.post('/api/v1/provider-quota/refresh', async () => {

--- a/internal/server/module/providerquota/handler.go
+++ b/internal/server/module/providerquota/handler.go
@@ -2,6 +2,7 @@ package providerquota
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sync"
 	"time"
@@ -112,7 +113,9 @@ func (h *Handler) GetQuota(c *gin.Context) {
 
 	usage, err := h.manager.GetQuota(ctx, uuid)
 	if err != nil {
-		if err == quota.ErrUsageNotFound {
+		// Both sentinels mean the provider simply has nothing to show — no
+		// data yet, or no fetcher at all. Neither is a server failure.
+		if errors.Is(err, quota.ErrUsageNotFound) || errors.Is(err, quota.ErrProviderUnsupported) {
 			c.JSON(http.StatusNotFound, gin.H{
 				"error": "quota not found for provider",
 			})
@@ -166,6 +169,12 @@ func (h *Handler) RefreshProvider(c *gin.Context) {
 
 	usage, err := h.manager.RefreshProvider(ctx, uuid)
 	if err != nil {
+		if errors.Is(err, quota.ErrProviderUnsupported) {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "provider does not support quota",
+			})
+			return
+		}
 		h.logger.WithError(err).WithField("provider_uuid", uuid).Error("failed to refresh provider quota")
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "failed to refresh quota",
@@ -238,8 +247,8 @@ func (h *Handler) BatchGetQuota(c *gin.Context) {
 			defer wg.Done()
 			usage, err := h.manager.GetQuota(ctx, providerUUID)
 			if err != nil {
-				// 如果某个 provider 没有 quota 数据，不返回错误，只是跳过
-				if err != quota.ErrUsageNotFound {
+				// 如果某个 provider 没有 quota 数据（或不支持配额），不返回错误，只是跳过
+				if !errors.Is(err, quota.ErrUsageNotFound) && !errors.Is(err, quota.ErrProviderUnsupported) {
 					h.logger.WithError(err).WithField("provider_uuid", providerUUID).Warn("failed to get quota for provider")
 					errChan <- err
 				}
@@ -255,13 +264,13 @@ func (h *Handler) BatchGetQuota(c *gin.Context) {
 	close(errChan)
 
 	// 收集错误（如果有）
-	var errors []error
+	var fetchErrors []error
 	for err := range errChan {
-		errors = append(errors, err)
+		fetchErrors = append(fetchErrors, err)
 	}
 
 	// 如果全部失败，返回错误
-	if len(result) == 0 && len(errors) > 0 {
+	if len(result) == 0 && len(fetchErrors) > 0 {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "failed to get quota for any provider",
 		})


### PR DESCRIPTION
## Summary

The Kimi 403 turned out to be a lapsed plan, not a client-fingerprint problem — but chasing it down a diagnostics gap surfaced real bugs along the way:

- Trace every quota HTTP call (headers, non-2xx bodies in full) so failures stop being invisible
- Fix OpenRouter/OpenAI usage URLs doubling their API prefix
- Infer provider vendor from the host, not the whole URL — a local gateway path was misread as Codex and would've leaked its token to chatgpt.com
- Treat "no fetcher for this provider" as a skip, not a stored failure
- Surface failed quota reads in the UI instead of the row silently vanishing
- Disable OpenAI quota routing until its actual usage-API contract is confirmed

## Test plan

- [x] `go build ./...`, `go test ./ai/... ./internal/server/module/providerquota/...`, `pnpm typecheck` — clean
- [x] New regressions per fix above
- [ ] Manual: refresh a live OpenRouter provider, confirm 200

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhVrCgwWb4VVPB5iyDPf1j