### PR TITLE
fix(scenario): don't seed a default rule for "custom" (formerly agent/OpenClaw)

### DIFF
--- a/internal/server/config/builtin_rules.go
+++ b/internal/server/config/builtin_rules.go
@@ -40,15 +40,17 @@ const (
 	RuleUUIDOpenCode = "builtin:opencode:default"
 
 	// RuleUUIDAgent / RuleUUIDAgentClaw are deprecated — the "agent" scenario
-	// (OpenClaw) was renamed to "custom". Live configs are renamed to
-	// RuleUUIDCustom / RuleUUIDCustomClaw by migrateAgentScenarioToCustom;
-	// these constants remain so that migration (which runs before the rename)
-	// can still address pre-rename configs.
+	// (OpenClaw) was renamed to "custom". These constants remain only as
+	// migration source keys: legacySimpleRuleUUIDs renames a live rule's UUID
+	// to RuleUUIDCustom / RuleUUIDCustomClaw, and migrateAgentScenarioToCustom
+	// (migration.go) separately renames its Scenario field.
 	RuleUUIDAgent     = "builtin:agent:default"
 	RuleUUIDAgentClaw = "builtin:agent:claw"
 
-	// Custom scenario built-in rules (modern "builtin:<scenario>:<tier>" form,
-	// target of the RuleUUIDAgent* rename above).
+	// RuleUUIDCustom / RuleUUIDCustomClaw are the migration *targets* for the
+	// RuleUUIDAgent* rename above — a UUID a pre-existing rule gets renamed
+	// to, never a template DefaultRules seeds for new installs. "custom" is a
+	// bring-your-own-request-model scenario; it intentionally starts empty.
 	RuleUUIDCustom     = "builtin:custom:default"
 	RuleUUIDCustomClaw = "builtin:custom:claw"
 

--- a/internal/server/config/init.go
+++ b/internal/server/config/init.go
@@ -29,32 +29,6 @@ func init() {
 			Active: true,
 		},
 		{
-			UUID:          RuleUUIDCustom,
-			Scenario:      typ.ScenarioCustom,
-			RequestModel:  "tingly-agent",
-			ResponseModel: "",
-			Description:   "Default proxy rule in tingly-box for custom",
-			Services:      []*loadbalance.Service{},
-			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticRandom,
-				Params: typ.DefaultRandomParams(),
-			},
-			Active: true,
-		},
-		{
-			UUID:          RuleUUIDCustomClaw,
-			Scenario:      typ.ScenarioCustom,
-			RequestModel:  "tingly-claw",
-			ResponseModel: "",
-			Description:   "Built in model rule for custom - claw",
-			Services:      []*loadbalance.Service{},
-			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticRandom,
-				Params: typ.DefaultRandomParams(),
-			},
-			Active: true,
-		},
-		{
 			UUID:          RuleUUIDOpenAI,
 			Scenario:      typ.ScenarioOpenAI,
 			RequestModel:  "tingly-gpt",

--- a/internal/server/config/migration_test.go
+++ b/internal/server/config/migration_test.go
@@ -535,6 +535,33 @@ func TestMigrateAgentScenarioToCustom_ClawRuleUpgradesFromOldestLegacyForm(t *te
 	}
 }
 
+// TestCustomScenario_SeedsNoDefaultRule locks in that "custom" is a pure
+// bring-your-own-request-model scenario: unlike openai/anthropic/codex/etc.,
+// DefaultRules must not contain a "custom" entry, so InsertDefaultRule never
+// injects an uninvited "tingly-agent"/"tingly-claw" rule into a fresh
+// install — or, on an existing config, alongside a user's own custom-named
+// rule under the scenario.
+func TestCustomScenario_SeedsNoDefaultRule(t *testing.T) {
+	for _, r := range DefaultRules {
+		if r.Scenario == typ.ScenarioCustom {
+			t.Errorf("DefaultRules must not seed a custom-scenario rule, found %+v", r)
+		}
+	}
+
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+	if r := cfg.GetRuleByUUID(RuleUUIDCustom); r != nil {
+		t.Errorf("fresh install should not have a builtin custom rule, found %+v", r)
+	}
+	for _, r := range cfg.Rules {
+		if r.Scenario == typ.ScenarioCustom {
+			t.Errorf("fresh install should have no custom-scenario rules at all, found %+v", r)
+		}
+	}
+}
+
 func TestNewCCProfileRules_CanonicalUUIDs(t *testing.T) {
 	separate := newCCProfileRules(typ.RuleScenario("claude_code:p3"), false)
 	wantSeparate := map[string]string{


### PR DESCRIPTION
## Summary

Follow-up to #1537 (already merged). While the `agent` → `custom` scenario rename kept the old default `tingly-agent`/`tingly-claw` builtin rule pair (just renamed), `InsertDefaultRule` runs on every boot for every config — so it kept injecting that pair into the `custom` scenario for every existing/new user, whether or not they ever asked for it. `custom` is meant to be a pure bring-your-own-request-model bucket with no opinion of its own, so it should seed nothing.

- Removed the two `DefaultRules` entries (`RuleUUIDCustom`/`RuleUUIDCustomClaw`) from `internal/server/config/init.go`.
- The migration path for rules that already exist under the old identity is untouched: a rule already on `builtin:agent:default`/`builtin:agent:claw` (scenario `agent`) still renames to `builtin:custom:default`/`builtin:custom:claw` (scenario `custom`) via the existing `legacySimpleRuleUUIDs` + `migrateAgentScenarioToCustom` machinery, `request_model` preserved. Only the *new-install/every-boot seeding* is removed.
- Clarified the `RuleUUIDCustom`/`RuleUUIDCustomClaw` doc comments to state they're migration targets only, never a seed template.
- Added `TestCustomScenario_SeedsNoDefaultRule` to lock this in (asserts `DefaultRules` has no `custom`-scenario entry and a fresh install ends up with zero `custom`-scenario rules).

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/typ/... ./internal/tbclient/... ./internal/server/config/... ./internal/protocolserver/...`
- [x] `pnpm build` (frontend unaffected by this backend-only change)

---
_Generated by [Claude Code](https://claude.ai/code/session_011DQTE4u3arWzYtk4VwCRJd)_