### PR TITLE
fix(scenario): don't seed a default rule for codex; move custom to end of coding-tools nav

### DIFF
--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -106,6 +106,9 @@ export function useActivityItems(): ActivityItem[] {
             { id: 'pi', nav: { path: '/agent/pi', label: t('layout.nav.usePi', { defaultValue: 'Pi' }), icon: <Pi size={20} /> } },
             { id: 'xcode', nav: { path: '/agent/xcode', label: t('layout.nav.useXcode', { defaultValue: 'Xcode' }), icon: <Xcode size={20} /> } },
             { id: 'vscode', nav: { path: '/agent/vscode', label: t('layout.nav.useVSCode', { defaultValue: 'VS Code' }), icon: <VSCode size={20} /> } },
+            // "custom" (bring-your-own-request-model) closes out the coding
+            // tools group, right after the named integrations it's a fallback for.
+            { id: 'custom', nav: { path: '/agent/custom', label: t('layout.nav.useCustom', { defaultValue: 'Custom' }), icon: <IconExtension sx={{ fontSize: 20 }} /> } },
         ]);
         const sdkTools = visible([
             { id: 'openai', nav: { path: '/agent/openai', label: t('layout.nav.useOpenAI', { defaultValue: 'OpenAI' }), icon: <OpenAI size={20} /> } },
@@ -114,7 +117,6 @@ export function useActivityItems(): ActivityItem[] {
             { id: 'imagegen', nav: { path: '/agent/imagegen', label: t('layout.nav.useImageGen', { defaultValue: 'Image Gen' }), icon: <IconPhoto sx={{ fontSize: 20 }} /> } },
         ]);
         const agentTools = visible([
-            { id: 'custom', nav: { path: '/agent/custom', label: t('layout.nav.useCustom', { defaultValue: 'Custom' }), icon: <IconExtension sx={{ fontSize: 20 }} /> } },
             { id: 'team', nav: { path: '/agent/team', label: t('layout.nav.useTeam', { defaultValue: 'Team' }), icon: <IconUsers sx={{ fontSize: 20 }} /> } },
         ]);
 

--- a/frontend/src/pages/scenario/scenarioRegistry.tsx
+++ b/frontend/src/pages/scenario/scenarioRegistry.tsx
@@ -90,6 +90,14 @@ export const SCENARIOS: ScenarioDescriptor[] = [
         hideable: true,
     },
     {
+        id: 'custom',
+        labelKey: 'layout.nav.useCustom',
+        descKey: 'scenarioOverview.descriptions.custom',
+        path: '/agent/custom',
+        icon: (size) => <IconExtension sx={{ fontSize: size }} />,
+        hideable: true,
+    },
+    {
         id: 'openai',
         labelKey: 'layout.nav.useOpenAI',
         descKey: 'scenarioOverview.descriptions.openai',
@@ -119,14 +127,6 @@ export const SCENARIOS: ScenarioDescriptor[] = [
         descKey: 'scenarioOverview.descriptions.imagegen',
         path: '/agent/imagegen',
         icon: (size) => <IconPhoto sx={{ fontSize: size }} />,
-        hideable: true,
-    },
-    {
-        id: 'custom',
-        labelKey: 'layout.nav.useCustom',
-        descKey: 'scenarioOverview.descriptions.custom',
-        path: '/agent/custom',
-        icon: (size) => <IconExtension sx={{ fontSize: size }} />,
         hideable: true,
     },
     {

--- a/internal/server/config/flag_test.go
+++ b/internal/server/config/flag_test.go
@@ -155,11 +155,16 @@ func TestProfileScenarioFlagWriteInheritsBaseConfig(t *testing.T) {
 // TestBuiltInRulesSessionAffinity verifies the built-in Claude Code / Desktop /
 // Codex rules seed session_affinity to the 30-min default, while other built-in
 // rules leave it disabled.
+// Codex intentionally has no entry in DefaultRules (see
+// TestCustomScenario_SeedsNoDefaultRule's sibling reasoning for "custom" —
+// Codex still gets SessionAffinity defaulted on any rule, built-in or
+// user-created, via defaultBuiltinRuleFlagsOnce; see
+// TestDefaultBuiltinRuleFlagsOnce_SeedsRuleFlags), so it's excluded from the
+// DefaultRules-only assertion below.
 func TestBuiltInRulesSessionAffinity(t *testing.T) {
 	wantOn := map[typ.RuleScenario]bool{
 		typ.ScenarioClaudeCode:    true,
 		typ.ScenarioClaudeDesktop: true,
-		typ.ScenarioCodex:         true,
 	}
 
 	sawScenario := map[typ.RuleScenario]bool{}

--- a/internal/server/config/init.go
+++ b/internal/server/config/init.go
@@ -8,9 +8,11 @@ import (
 var DefaultRules []typ.Rule
 
 // defaultSessionAffinitySeconds is the 30-minute session-affinity TTL seeded on
-// the built-in Claude Code / Claude Desktop / Codex rules. session_affinity is
-// rule-only (no scenario-level inheritance); these seeds + migrate20260610 are
-// the sole source of the default. Other scenarios are off unless set per-rule.
+// the built-in Claude Code / Claude Desktop rules below, and applied to every
+// Claude Code / Claude Desktop / Codex rule (built-in or user-created) by
+// migrate20260610 (defaultBuiltinRuleFlagsOnce). session_affinity is rule-only
+// (no scenario-level inheritance); those are the sole sources of the default.
+// Other scenarios are off unless set per-rule.
 const defaultSessionAffinitySeconds = 1800
 
 func init() {
@@ -39,21 +41,6 @@ func init() {
 				Type:   loadbalance.TacticRandom,
 				Params: typ.DefaultRandomParams(),
 			},
-			Active: true,
-		},
-		{
-			UUID:          RuleUUIDCodex,
-			Scenario:      typ.ScenarioCodex,
-			RequestModel:  "tingly-codex",
-			ResponseModel: "",
-			Description:   "Default proxy rule for Codex",
-			Services:      []*loadbalance.Service{},
-			LBTactic: typ.Tactic{
-				Type:   loadbalance.TacticRandom,
-				Params: typ.DefaultRandomParams(),
-			},
-			// 30-min session affinity improves cache hit rate for Codex sessions.
-			Flags:  typ.RuleFlags{SessionAffinity: defaultSessionAffinitySeconds},
 			Active: true,
 		},
 		ccRule(RuleUUIDCC, "tingly/cc", "Default proxy rule for Claude Code", true),

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -429,10 +429,6 @@ func canonicalRuleUUID(rule *typ.Rule) (string, bool) {
 func ensureCurrentBuiltinRules(c *Config) {
 	needsSave := false
 
-	if _, ok := c.seedBuiltinRuleIfMissing(RuleUUIDBuiltinCodex, nil); ok {
-		needsSave = true
-	}
-
 	desktopRefServices := c.referenceServicesFor(typ.ScenarioClaudeCode, typ.ScenarioCodex)
 	for _, uuid := range []string{
 		RuleUUIDBuiltinClaudeDesktopSonnet46,

--- a/internal/server/config/migration_helpers_test.go
+++ b/internal/server/config/migration_helpers_test.go
@@ -78,14 +78,14 @@ func TestMigrationHelpers(t *testing.T) {
 func TestSeedBuiltinRuleIfMissing(t *testing.T) {
 	c := &Config{}
 
-	newRule, ok := c.seedBuiltinRuleIfMissing(RuleUUIDBuiltinCodex, []*loadbalance.Service{svc("p1")})
+	newRule, ok := c.seedBuiltinRuleIfMissing(RuleUUIDBuiltinOpenAI, []*loadbalance.Service{svc("p1")})
 	if !ok {
-		t.Fatal("expected missing Codex rule to be seeded")
+		t.Fatal("expected missing OpenAI rule to be seeded")
 	}
-	if newRule.UUID != RuleUUIDCodex {
-		t.Fatalf("seeded rule UUID = %q, want %q", newRule.UUID, RuleUUIDCodex)
+	if newRule.UUID != RuleUUIDOpenAI {
+		t.Fatalf("seeded rule UUID = %q, want %q", newRule.UUID, RuleUUIDOpenAI)
 	}
-	if len(c.Rules) != 1 || c.Rules[0].UUID != RuleUUIDCodex {
+	if len(c.Rules) != 1 || c.Rules[0].UUID != RuleUUIDOpenAI {
 		t.Fatalf("config rules after seed = %+v", c.Rules)
 	}
 	if len(c.Rules[0].Services) != 1 || c.Rules[0].Services[0].Provider != "p1" {
@@ -104,8 +104,8 @@ func TestSeedBuiltinRuleIfMissing(t *testing.T) {
 		t.Fatalf("seeded services should be cloned, got %+v (returned %+v)", seeded, newRule)
 	}
 
-	if _, ok := c.seedBuiltinRuleIfMissing(RuleUUIDBuiltinCodex, nil); ok {
-		t.Fatal("existing Codex rule should not be seeded twice")
+	if _, ok := c.seedBuiltinRuleIfMissing(RuleUUIDBuiltinOpenAI, nil); ok {
+		t.Fatal("existing OpenAI rule should not be seeded twice")
 	}
 	if len(c.Rules) != 2 {
 		t.Fatalf("rule count after duplicate seed = %d, want 2", len(c.Rules))

--- a/internal/usecase/agent_test.go
+++ b/internal/usecase/agent_test.go
@@ -186,9 +186,28 @@ func TestAgentUseCase_ResolveRouting(t *testing.T) {
 	})
 
 	t.Run("rule without services is still found", func(t *testing.T) {
+		// Codex has no built-in default rule (unlike Claude Code/OpenCode
+		// above), so create one explicitly here rather than relying on seeding.
+		provider := &typ.Provider{
+			UUID: serverconfig.GenerateUUID(), Name: "codex-provider",
+			APIBase: "https://api.example.com", APIStyle: "openai",
+			AuthType: typ.AuthTypeAPIKey, Token: "sk-test", Enabled: true,
+		}
+		if err := cfg.AddProvider(provider); err != nil {
+			t.Fatalf("AddProvider: %v", err)
+		}
+		ruleUC := NewRuleUseCase(cfg)
+		if _, err := ruleUC.Create(CreateRuleRequest{
+			Scenario:     typ.ScenarioCodex,
+			RequestModel: "tingly-codex",
+			Services:     []*loadbalance.Service{{Provider: provider.UUID, Model: "codex-model", Weight: 1, Active: true}},
+		}); err != nil {
+			t.Fatalf("RuleUseCase.Create: %v", err)
+		}
+
 		rule := cfg.GetRuleByRequestModelAndScenario("tingly-codex", typ.ScenarioCodex)
 		if rule == nil {
-			t.Fatal("expected migrated Codex rule")
+			t.Fatal("expected the codex rule just created")
 		}
 		rule.Services = nil
 		if err := cfg.UpdateRule(rule.UUID, *rule); err != nil {


### PR DESCRIPTION
## Summary

Codex's `request_model` can't be an arbitrary alias in every client: the CLI accepts any name via tingly-box's `model_catalog_json` override (`RenderCodexModelCatalog` in `apply_config_codex.go`), but the Codex **GUI app** enforces its own model whitelist regardless of that override — so the seeded `tingly-codex` default rule silently never matched real GUI traffic. There's no maintained source of truth for "the current real Codex model names" to seed instead (and hardcoding one would just trade one kind of staleness for another), so this removes the seed entirely — same reasoning/mechanism as the earlier "custom"-scenario default-rule fix.

- Removed the Codex entry from `DefaultRules` (`internal/server/config/init.go`).
- Removed `ensureCurrentBuiltinRules`' dedicated Codex `seedBuiltinRuleIfMissing` call — it becomes a permanent no-op once the `DefaultRules` template is gone, so it's deleted rather than left dead.
- Session-affinity default for Codex rules (built-in or user-created) is unaffected — that comes from `defaultBuiltinRuleFlagsOnce` (migrate20260610), not the removed seed.
- Retargeted tests that depended on an implicitly-seeded Codex rule:
  - `TestSeedBuiltinRuleIfMissing` now exercises the OpenAI template instead of Codex.
  - `TestBuiltInRulesSessionAffinity` drops Codex from the `DefaultRules`-only assertion (still covered for the migration-applied case).
  - `TestAgentUseCase_ResolveRouting`'s "rule without services" subtest now creates its own Codex rule explicitly, like its sibling subtests already do.

Also moves **custom** (the generic bring-your-own-request-model scenario) so it sits right after **VS Code** in the sidebar nav / Agent overview grid — the last entry of the coding-tools group it's the fallback for — instead of at the very end of the whole nav, after Team.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/...` (one pre-existing, unrelated flaky failure in `internal/protocoltest` reproduces identically on `origin/main` without this branch's changes — being fixed elsewhere)
- [x] `pnpm build`, `pnpm lint`, `pnpm typecheck` (no new errors vs. baseline), `pnpm test`
- [x] Manual verification in mock mode (headless Chrome): sidebar nav order

---
_Generated by [Claude Code](https://claude.ai/code/session_011DQTE4u3arWzYtk4VwCRJd)_