### PR TITLE
refactor(config): migration step registry + fold 2026-04/05 dated migrations into baseline

### DIFF
--- a/.design/config-migration.md
+++ b/.design/config-migration.md
@@ -1,0 +1,86 @@
+# Config Migration Pipeline
+
+`internal/server/config/migration.go` runs a pipeline of `Migrate` steps on
+every boot to repair/evolve `Config` (`~/.tingly/config.json`) across
+releases. After many iterations the step list only ever grew — this doc
+defines the classification and retirement policy that keeps it bounded.
+
+## Three kinds of step
+
+Every entry in `migrationSteps` (`migration.go`) is tagged with a
+`migrationKind` so its lifecycle is visible without reading the body:
+
+| Kind | Runs | Purpose | Example |
+|---|---|---|---|
+| `kindBaseline` | every boot, forever | repairs a structural invariant of the *current* config model | `normalizeLegacyConfigBaseline`, `normalizeBuiltinRuleIdentity` |
+| `kindDated` | every boot, unconditionally, idempotent via its own internal guard | a one-off data repair tied to a specific change | `migrate20260416`, `migrate20260712` |
+| `kindOnce` | exactly once, gated by a `MigrationsCompleted` marker | seeds/changes a value the user might deliberately override afterward | `defaultXcodeSkipUsageOnce` |
+
+Use `kindOnce` whenever a migration sets a default a user could reasonably
+turn back off — a marker-gated migration won't re-clobber that choice on the
+next boot. Use `kindDated` for pure data repairs where re-running forever is
+harmless and cheap (missing field backfill, renames, dropping now-invalid
+data) — no marker bookkeeping needed. `kindBaseline` is reserved for the
+handful of normalizers that define what a *valid* config looks like today;
+new ones are added rarely, when the baseline itself changes.
+
+`Migrate(c)` runs every step and calls `c.Save()` once at the end if any step
+reported a change, rather than each step saving independently.
+
+## Retiring a `kindDated` step
+
+A dated step is not permanent. Once it's safe to assume no config in active
+use predates it, fold its logic into `normalizeLegacyConfigBaseline` (or a
+future baseline snapshot) and delete the step + its dedicated tests, keeping
+only baseline-level coverage of the config shape it produces.
+
+**When to fold:** the step has been shipped for long enough that no
+supported client is expected to still be on a pre-migration config — as a
+rule of thumb, a couple of minor releases or a few months, whichever the
+team judges safe for this product's release cadence. This is a judgment
+call made at fold time, not a hard timer enforced by code.
+
+**How to fold (checklist):**
+1. Confirm the step's guard condition can no longer trigger in practice (or
+   accept that it's now dead weight either way).
+2. Move its effect into `normalizeLegacyConfigBaseline` (call it from there,
+   or inline the logic if it composes naturally with an existing helper).
+3. Remove the entry from `migrationSteps` and delete the standalone function.
+4. Delete the step's dedicated test cases; keep/add a baseline-level test
+   that exercises the same input shape through
+   `normalizeLegacyConfigBaseline` instead.
+5. If the step referenced a legacy lookup table (see below), re-check
+   whether that table can now be narrowed.
+
+`normalizeLegacyConfigBaseline` itself is the precedent: it already folds
+every pre-2026-04 repair migration into one baseline pass.
+
+## Legacy UUID lookup tables
+
+`legacySimpleRuleUUIDs` and `legacyCCRuleUUIDs` (`builtin_rules.go`) map old
+built-in rule UUIDs to their modern `builtin:<scenario>:<tier>` form. They
+are read from three places: `findRuleByUUID`, `defaultRuleByUUID`, and
+`canonicalRuleUUID` (used by `normalizeBuiltinRuleIdentity`, a
+`kindBaseline` step — see `.design/rule-uuid.md` for the full UUID
+convention).
+
+These tables have their own, slower-moving lifecycle, decoupled from any
+single dated migration:
+
+- They stay as long as `normalizeBuiltinRuleIdentity` is a `kindBaseline`
+  step self-healing renames from old configs — which is indefinite, since
+  a config restored from an old backup should keep working.
+- An individual entry can only be removed once **both** (a) the dated
+  migration that originally performed the one-time rename for that UUID has
+  been folded into baseline or deleted, **and** (b) no runtime fallback
+  outside migration code (e.g. `generateCCEnv`, `tbclient` resolvers) still
+  reads the legacy constant for configs loaded without migration.
+- Removing a table wholesale (rather than narrowing per-entry) is only safe
+  once `normalizeBuiltinRuleIdentity` itself is considered no longer
+  necessary — i.e. every supported config is guaranteed to already be on
+  canonical UUIDs. That is a much longer horizon than folding a single dated
+  step, and should be treated as its own decision, not a side effect of
+  folding one migration.
+
+No automatic scan enforces any of this — retirement is a manual, reviewed
+decision, made using the criteria above.

--- a/.design/config-migration.md
+++ b/.design/config-migration.md
@@ -13,7 +13,7 @@ Every entry in `migrationSteps` (`migration.go`) is tagged with a
 | Kind | Runs | Purpose | Example |
 |---|---|---|---|
 | `kindBaseline` | every boot, forever | repairs a structural invariant of the *current* config model | `normalizeLegacyConfigBaseline`, `normalizeBuiltinRuleIdentity` |
-| `kindDated` | every boot, unconditionally, idempotent via its own internal guard | a one-off data repair tied to a specific change | `migrate20260416`, `migrate20260712` |
+| `kindDated` | every boot, unconditionally, idempotent via its own internal guard | a one-off data repair tied to a specific change | `migrate20260712` |
 | `kindOnce` | exactly once, gated by a `MigrationsCompleted` marker | seeds/changes a value the user might deliberately override afterward | `defaultXcodeSkipUsageOnce` |
 
 Use `kindOnce` whenever a migration sets a default a user could reasonably
@@ -54,6 +54,17 @@ call made at fold time, not a hard timer enforced by code.
 
 `normalizeLegacyConfigBaseline` itself is the precedent: it already folds
 every pre-2026-04 repair migration into one baseline pass.
+
+**Folded so far:**
+- pre-2026-04 config repair migrations (original baseline)
+- 2026-04/05 batch, folded 2026-08-11: `migrate20260416` (multi-tenant
+  defaults) → `normalizeMultiTenantDefaults`; `migrate20260421` (profile
+  unified model `*`→`cc`) → `normalizeClaudeCodeProfileUnifiedModel`;
+  `migrate20260502` (drop smart_guide wildcard rules) →
+  `dropSmartGuideWildcardRules`; `migrate20260518` (Codex endpoint mode
+  backfill) → `normalizeCodexEndpointMode`. `migrate20260712` was left as
+  `kindDated` — too recent (shipped ~1 month prior) to assume no active
+  config predates it.
 
 ## Legacy UUID lookup tables
 

--- a/.design/openai-endpoint-routing.md
+++ b/.design/openai-endpoint-routing.md
@@ -176,7 +176,7 @@ Codex 是 OAuth-only 接入路径（Web `oauth/handler.go` 和 CLI `command/oaut
 
 无需用户配置。OAuth 完成即正确。
 
-存量 Codex provider（PR #976 之前已 OAuth 完成的）由 `migrate20260518` backfill。Idempotent。
+存量 Codex provider（PR #976 之前已 OAuth 完成的）由 `normalizeCodexEndpointMode`（`internal/server/config/migration.go`，已折入 baseline normalizer，原 `migrate20260518`）backfill。Idempotent。
 
 `ai.Provider.IsCodexProvider()` 方法**保留**——它仍被 client、UA pin、system message 注入等非路由代码消费。本文档讨论的 endpoint mode 只与路由相关。
 
@@ -234,7 +234,7 @@ Template 是用户实例化 provider 的预设入口。Template 里的 `openai_e
 PR #976 引入此设计。涉及行为变更的两个点：
 
 1. **默认从 mirror 变 Chat**：手搓的 OpenAI-proper provider（没用 `openai-com` template）若依赖 `/v1/responses` 直通上游，需手动加 `"openai_endpoint_mode": "both"` 到 config.json。Migration 不能自动处理这种情况（provider 没有 template_id 痕迹），文档化警告即可。
-2. **Codex 存量**：`migrate20260518` 自动 backfill，无感知。
+2. **Codex 存量**：`normalizeCodexEndpointMode` 自动 backfill，无感知。
 
 后续若新增 provider 类型，原则不变：默认 Chat，需要 Responses 就显式声明。
 

--- a/internal/server/config/builtin_rules.go
+++ b/internal/server/config/builtin_rules.go
@@ -70,9 +70,12 @@ const (
 )
 
 // legacyCCRuleUUIDs maps the legacy Claude Code built-in UUIDs to their modern
-// counterparts. Used by migrate20260611 to rename live configs and by
+// counterparts. Used by normalizeBuiltinRuleIdentity to rename live configs and by
 // defaultRuleByUUID to keep older migrations (written against the legacy
 // names) able to pull templates from the modern DefaultRules.
+//
+// Retirement of individual entries (or the table as a whole) follows the
+// policy in .design/config-migration.md — do not delete entries ad hoc.
 var legacyCCRuleUUIDs = map[string]string{
 	RuleUUIDBuiltinCC:         RuleUUIDCC,
 	RuleUUIDBuiltinCCDefault:  RuleUUIDCCDefault,
@@ -84,7 +87,10 @@ var legacyCCRuleUUIDs = map[string]string{
 
 // legacySimpleRuleUUIDs maps the remaining legacy built-in UUIDs (all
 // non-CC single-rule scenarios) to their modern "builtin:<scenario>:<model>"
-// counterparts. Used by migrate20260612 and defaultRuleByUUID.
+// counterparts. Used by normalizeBuiltinRuleIdentity and defaultRuleByUUID.
+//
+// Retirement of individual entries (or the table as a whole) follows the
+// policy in .design/config-migration.md — do not delete entries ad hoc.
 //
 // RuleUUIDBuiltinAgent* and RuleUUIDAgent* both map straight to the "custom"
 // UUIDs (not to each other) so a config on either pre-rename form converges

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -12,11 +12,75 @@ import (
 	typ "github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// --- Shared migration helpers -------------------------------------------------
+// --- Migration pipeline --------------------------------------------------
 //
 // Migrations are organized by the invariants they protect rather than by every
 // historical patch date. The current supported baseline is the scenario/provider
 // config model; very old config shapes are repaired through normalizeLegacyConfigBaseline.
+//
+// Every step is classified by migrationKind so a reader can tell its lifecycle
+// without reading the body, and Migrate saves once at the end instead of each
+// step saving individually. See .design/config-migration.md for the full
+// policy on when a dated step is expected to be folded into a baseline
+// normalizer, and how legacy UUID lookup tables are retired alongside it.
+
+// migrationKind classifies a migration step by its lifecycle.
+type migrationKind int
+
+const (
+	// kindBaseline repairs structural invariants and runs on every boot,
+	// forever. It is the target state itself, so it never gets folded away.
+	kindBaseline migrationKind = iota
+	// kindDated is a one-off data repair tied to a specific change. It runs
+	// unconditionally on every boot (idempotent via its own internal guard)
+	// until it is folded into a baseline normalizer once no active config
+	// can predate it — see .design/config-migration.md.
+	kindDated
+	// kindOnce is gated by a MigrationsCompleted marker: it runs exactly once
+	// per config, so it can change a value a user might since have overridden
+	// without re-clobbering that override on every boot.
+	kindOnce
+)
+
+// migrationStep is one entry in the migration pipeline. fn reports whether it
+// changed Config state that needs persisting; Migrate saves once at the end
+// if any step reported dirty.
+type migrationStep struct {
+	name    string
+	kind    migrationKind
+	addedAt string // when the step was introduced; empty for baseline steps
+	fn      func(*Config) bool
+}
+
+var migrationSteps = []migrationStep{
+	{"normalize-legacy-config-baseline", kindBaseline, "", normalizeLegacyConfigBaseline},
+	{"normalize-builtin-rule-identity", kindBaseline, "", normalizeBuiltinRuleIdentity},
+	{"agent-scenario-to-custom", kindBaseline, "", migrateAgentScenarioToCustom},
+	{"ensure-current-builtin-rules", kindBaseline, "", ensureCurrentBuiltinRules},
+	{"20260416-multi-tenant-default", kindDated, "2026-04-16", migrate20260416},
+	{"20260421-profile-unified-model", kindDated, "2026-04-21", migrate20260421},
+	{"20260502-drop-smart-guide-wildcard", kindDated, "2026-05-02", migrate20260502},
+	{"20260518-codex-endpoint-mode", kindDated, "2026-05-18", migrate20260518},
+	{"20260712-drop-unsupported-smart-routing", kindDated, "2026-07-12", migrate20260712},
+	{"20260606-xcode-skip-usage", kindOnce, "2026-06-06", defaultXcodeSkipUsageOnce},
+	{"20260610-builtin-rule-flags", kindOnce, "2026-06-10", defaultBuiltinRuleFlagsOnce},
+}
+
+// Migrate runs every registered migration step in order and persists the
+// config once at the end if any step reported a change, instead of each step
+// saving independently.
+func Migrate(c *Config) error {
+	dirty := false
+	for _, step := range migrationSteps {
+		if step.fn(c) {
+			dirty = true
+		}
+	}
+	if dirty {
+		c.saveMigration()
+	}
+	return nil
+}
 
 // findRuleByUUID returns a pointer to the rule with the given UUID, or nil.
 // Legacy simple-rule UUIDs (openai, anthropic, codex, …) are resolved to
@@ -115,20 +179,6 @@ func (c *Config) rekeyRuleUUIDState(migrationID string, renames map[string]strin
 	}
 }
 
-func Migrate(c *Config) error {
-	normalizeLegacyConfigBaseline(c)
-	normalizeBuiltinRuleIdentity(c)
-	migrateAgentScenarioToCustom(c) // Rename the "agent" (OpenClaw) scenario to "custom"
-	ensureCurrentBuiltinRules(c)
-	migrate20260416(c) // Enable multi-tenant by default
-	migrate20260421(c) // Migrate profile unified model from "*" to "cc"
-	migrate20260502(c) // Remove wildcard (*) rules for smart_guide scenario
-	migrate20260518(c) // Set OpenAIEndpointMode=responses on existing Codex OAuth providers
-	migrate20260712(c) // Drop smart-routing partitions using removed positions (tool_use)
-	normalizeRuleDefaultsOnce(c)
-	return nil
-}
-
 // migrateAgentScenarioToCustom renames every stored Rule and ScenarioConfig
 // still on the deprecated "agent" scenario (OpenClaw) to "custom". Runs every
 // boot, un-gated: it is cheap, and — unlike a "once" marker — self-heals a
@@ -140,7 +190,7 @@ func Migrate(c *Config) error {
 // legacyScenarioAliasMiddleware, which resolves "agent" -> "custom" at the
 // routing layer (typ.ResolveScenarioAlias) — independent of whether any rule
 // migrated here.
-func migrateAgentScenarioToCustom(c *Config) {
+func migrateAgentScenarioToCustom(c *Config) bool {
 	needsSave := false
 
 	for i := range c.Rules {
@@ -160,9 +210,9 @@ func migrateAgentScenarioToCustom(c *Config) {
 	}
 
 	if needsSave {
-		c.saveMigration()
 		logrus.Info("Migration agent-to-custom completed: renamed \"agent\" scenario rules/config to \"custom\"")
 	}
+	return needsSave
 }
 
 // migrate20260712 drops smart-routing partitions whose ops reference a
@@ -174,7 +224,7 @@ func migrateAgentScenarioToCustom(c *Config) {
 // Dropping the partition preserves observed behavior: a tool_use partition
 // never matched real traffic. Runs every boot (idempotent) so configs
 // restored from backups heal too.
-func migrate20260712(c *Config) {
+func migrate20260712(c *Config) bool {
 	needsSave := false
 
 	for i := range c.Rules {
@@ -210,15 +260,15 @@ func migrate20260712(c *Config) {
 	}
 
 	if needsSave {
-		c.saveMigration()
 		logrus.Info("Migration 2026-07-12 completed: removed smart-routing partitions with unsupported positions")
 	}
+	return needsSave
 }
 
 // normalizeLegacyConfigBaseline folds the pre-2026-04 config repair migrations
 // into one baseline normalizer. It keeps very old configs usable without keeping
 // every historical date migration as a permanent startup phase.
-func normalizeLegacyConfigBaseline(c *Config) {
+func normalizeLegacyConfigBaseline(c *Config) bool {
 	needsSave := false
 
 	if normalizeLegacyProviders(c) {
@@ -229,9 +279,9 @@ func normalizeLegacyConfigBaseline(c *Config) {
 	}
 
 	if needsSave {
-		c.saveMigration()
 		logrus.Info("Migration baseline normalization completed: repaired legacy provider/rule config")
 	}
+	return needsSave
 }
 
 func normalizeLegacyProviders(c *Config) bool {
@@ -379,7 +429,7 @@ func legacyRuleScenario(uuid string) (typ.RuleScenario, bool) {
 // normalizeBuiltinRuleIdentity keeps built-in rule UUIDs on the canonical
 // "builtin:<scenario>:<tier/model>" form. It is intentionally not marker-gated:
 // the pass is idempotent and self-healing for configs written by older builds.
-func normalizeBuiltinRuleIdentity(c *Config) {
+func normalizeBuiltinRuleIdentity(c *Config) bool {
 	renames := map[string]string{}
 	for i := range c.Rules {
 		rule := &c.Rules[i]
@@ -400,11 +450,11 @@ func normalizeBuiltinRuleIdentity(c *Config) {
 	}
 
 	if len(renames) == 0 {
-		return
+		return false
 	}
 	c.rekeyRuleUUIDState("builtin-rule-identity", renames)
-	c.saveMigration()
 	logrus.Infof("Migration builtin-rule-identity completed: normalized %d built-in rule UUID(s)", len(renames))
+	return true
 }
 
 func canonicalRuleUUID(rule *typ.Rule) (string, bool) {
@@ -426,7 +476,7 @@ func canonicalRuleUUID(rule *typ.Rule) (string, bool) {
 	return BuiltinRuleUUID(rule.Scenario, tier), true
 }
 
-func ensureCurrentBuiltinRules(c *Config) {
+func ensureCurrentBuiltinRules(c *Config) bool {
 	needsSave := false
 
 	desktopRefServices := c.referenceServicesFor(typ.ScenarioClaudeCode, typ.ScenarioCodex)
@@ -453,19 +503,19 @@ func ensureCurrentBuiltinRules(c *Config) {
 	}
 
 	if needsSave {
-		c.saveMigration()
 		logrus.Info("Migration current-builtin-rules completed: ensured current built-in rules")
 	}
+	return needsSave
 }
 
 // migrate20260416 enables multi-tenant by default for existing configurations.
-func migrate20260416(c *Config) {
+func migrate20260416(c *Config) bool {
 	// Skip migration if multi-tenant config has any values set.
 	// This means the user has explicitly configured multi-tenant settings.
 	if c.MultiTenantConfig.APITokenSecret != "" ||
 		c.MultiTenantConfig.APITokenAlgorithm != "" ||
 		c.MultiTenantConfig.APITokenIssuer != "" {
-		return
+		return false
 	}
 
 	// All three token fields are empty (guaranteed by the guard above), so seed
@@ -475,14 +525,14 @@ func migrate20260416(c *Config) {
 	c.MultiTenantConfig.APITokenIssuer = "tingly-box"
 	c.MultiTenantConfig.Enabled = true
 
-	c.saveMigration()
+	return true
 }
 
 // migrate20260421 migrates profile unified model name from "*" to "cc".
 // This ensures consistency with the new naming convention where profile
 // rules use simplified names: "cc" (unified), "default", "haiku", etc. (separate).
 // Only applies to claude-code scenario profiles.
-func migrate20260421(c *Config) {
+func migrate20260421(c *Config) bool {
 	needsSave := false
 
 	for i := range c.Rules {
@@ -506,15 +556,13 @@ func migrate20260421(c *Config) {
 		}
 	}
 
-	if needsSave {
-		c.saveMigration()
-	}
+	return needsSave
 }
 
 // migrate20260502 removes wildcard (*) rules for smart_guide scenario.
 // This cleans up legacy wildcard rules that are no longer needed
 // as SmartGuide now uses bot-specific rules with UUID pattern: _internal_smart_guide_{botUUID}.
-func migrate20260502(c *Config) {
+func migrate20260502(c *Config) bool {
 	needsSave := false
 
 	// Filter out smart_guide rules with wildcard RequestModel.
@@ -535,9 +583,9 @@ func migrate20260502(c *Config) {
 
 	if needsSave {
 		c.Rules = filteredRules
-		c.saveMigration()
 		logrus.Info("Migration 2026-05-02 completed: removed smart_guide wildcard rules")
 	}
+	return needsSave
 }
 
 // migrate20260518 sets OpenAIEndpointMode=responses on existing Codex OAuth
@@ -548,7 +596,10 @@ func migrate20260502(c *Config) {
 // /chat/completions requests to Codex and fail.
 //
 // Idempotent: only flips the mode when issuer is Codex and the mode is unset.
-func migrate20260518(c *Config) {
+// Unlike the other dated migrations, this never reports dirty: providers live
+// in SQLite (db.ProviderStore) and are backfilled directly there, so there is
+// no Config JSON state for Migrate's end-of-pipeline save to persist.
+func migrate20260518(c *Config) bool {
 	// Providers live in SQLite (the JSON c.Providers slice is legacy backup).
 	// Backfill the DB-stored ones directly so the resolver sees the right mode.
 	if c.providerStore != nil {
@@ -571,19 +622,15 @@ func migrate20260518(c *Config) {
 			logrus.WithError(err).Warn("Failed to list OAuth providers for openai_endpoint_mode backfill")
 		}
 	}
-}
-
-func normalizeRuleDefaultsOnce(c *Config) {
-	defaultXcodeSkipUsageOnce(c)
-	defaultBuiltinRuleFlagsOnce(c)
+	return false
 }
 
 // defaultXcodeSkipUsageOnce ensures the Xcode scenario defaults SkipUsage on
 // (the Xcode client cannot handle usage in streaming chunks). The marker is
 // retained so a user who later turns it off keeps that choice across restarts.
-func defaultXcodeSkipUsageOnce(c *Config) {
+func defaultXcodeSkipUsageOnce(c *Config) bool {
 	if c.hasMigrationCompleted("20260606") {
-		return
+		return false
 	}
 
 	needsSave := false
@@ -608,16 +655,20 @@ func defaultXcodeSkipUsageOnce(c *Config) {
 
 	c.markMigrationCompleted("20260606")
 	if needsSave {
-		c.saveMigration()
 		logrus.Info("Migration 2026-06-06 completed: defaulted SkipUsage on for the Xcode scenario")
 	}
+	// The marker itself just changed c.MigrationsCompleted, so this run needs
+	// persisting even when needsSave (the substantive Scenarios change) is
+	// false — e.g. a config that already had SkipUsage=true before this
+	// migration shipped.
+	return true
 }
 
 // defaultBuiltinRuleFlagsOnce seeds rule-level defaults for built-in agent
 // scenarios. The marker is retained so user-disabled defaults stay disabled.
-func defaultBuiltinRuleFlagsOnce(c *Config) {
+func defaultBuiltinRuleFlagsOnce(c *Config) bool {
 	if c.hasMigrationCompleted("20260610") {
-		return
+		return false
 	}
 
 	needsSave := false
@@ -647,7 +698,9 @@ func defaultBuiltinRuleFlagsOnce(c *Config) {
 
 	c.markMigrationCompleted("20260610")
 	if needsSave {
-		c.saveMigration()
 		logrus.Info("Migration 20260610 completed: seeded default rule flags (claude_code_compat / clean_header / session_affinity) for Claude Code, Claude Desktop, and Codex rules")
 	}
+	// Same reasoning as defaultXcodeSkipUsageOnce: the marker append alone
+	// needs persisting even when no rule flag actually changed.
+	return true
 }

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -57,10 +57,6 @@ var migrationSteps = []migrationStep{
 	{"normalize-builtin-rule-identity", kindBaseline, "", normalizeBuiltinRuleIdentity},
 	{"agent-scenario-to-custom", kindBaseline, "", migrateAgentScenarioToCustom},
 	{"ensure-current-builtin-rules", kindBaseline, "", ensureCurrentBuiltinRules},
-	{"20260416-multi-tenant-default", kindDated, "2026-04-16", migrate20260416},
-	{"20260421-profile-unified-model", kindDated, "2026-04-21", migrate20260421},
-	{"20260502-drop-smart-guide-wildcard", kindDated, "2026-05-02", migrate20260502},
-	{"20260518-codex-endpoint-mode", kindDated, "2026-05-18", migrate20260518},
 	{"20260712-drop-unsupported-smart-routing", kindDated, "2026-07-12", migrate20260712},
 	{"20260606-xcode-skip-usage", kindOnce, "2026-06-06", defaultXcodeSkipUsageOnce},
 	{"20260610-builtin-rule-flags", kindOnce, "2026-06-10", defaultBuiltinRuleFlagsOnce},
@@ -265,9 +261,13 @@ func migrate20260712(c *Config) bool {
 	return needsSave
 }
 
-// normalizeLegacyConfigBaseline folds the pre-2026-04 config repair migrations
-// into one baseline normalizer. It keeps very old configs usable without keeping
-// every historical date migration as a permanent startup phase.
+// normalizeLegacyConfigBaseline folds config repair migrations that are old
+// enough no active config can predate them into one baseline normalizer. It
+// keeps old configs usable without keeping every historical date migration as
+// a permanent startup phase — see .design/config-migration.md for the fold
+// policy. Originally covered everything pre-2026-04; the 2026-04/05 batch
+// (multi-tenant defaults, profile unified model naming, smart_guide wildcard
+// cleanup, Codex endpoint mode) was folded in on top of that.
 func normalizeLegacyConfigBaseline(c *Config) bool {
 	needsSave := false
 
@@ -275,6 +275,18 @@ func normalizeLegacyConfigBaseline(c *Config) bool {
 		needsSave = true
 	}
 	if normalizeRuleBasics(c) {
+		needsSave = true
+	}
+	if normalizeMultiTenantDefaults(c) {
+		needsSave = true
+	}
+	if normalizeClaudeCodeProfileUnifiedModel(c) {
+		needsSave = true
+	}
+	if dropSmartGuideWildcardRules(c) {
+		needsSave = true
+	}
+	if normalizeCodexEndpointMode(c) {
 		needsSave = true
 	}
 
@@ -508,10 +520,14 @@ func ensureCurrentBuiltinRules(c *Config) bool {
 	return needsSave
 }
 
-// migrate20260416 enables multi-tenant by default for existing configurations.
-func migrate20260416(c *Config) bool {
-	// Skip migration if multi-tenant config has any values set.
-	// This means the user has explicitly configured multi-tenant settings.
+// normalizeMultiTenantDefaults enables multi-tenant by default for configs
+// written before multi-tenant existed. New installs already seed
+// MultiTenantConfig in CreateDefaultConfig; this only backfills older ones.
+// Folded from the dated migrate20260416 migration (2026-04-16).
+func normalizeMultiTenantDefaults(c *Config) bool {
+	// Skip if multi-tenant config has any values set — that means either a
+	// prior run of this normalizer already seeded it, or the user has
+	// explicitly configured multi-tenant settings.
 	if c.MultiTenantConfig.APITokenSecret != "" ||
 		c.MultiTenantConfig.APITokenAlgorithm != "" ||
 		c.MultiTenantConfig.APITokenIssuer != "" {
@@ -519,7 +535,7 @@ func migrate20260416(c *Config) bool {
 	}
 
 	// All three token fields are empty (guaranteed by the guard above), so seed
-	// the defaults and enable multi-tenant — the main purpose of the migration.
+	// the defaults and enable multi-tenant.
 	c.MultiTenantConfig.APITokenSecret = generateSecret()
 	c.MultiTenantConfig.APITokenAlgorithm = "HS256"
 	c.MultiTenantConfig.APITokenIssuer = "tingly-box"
@@ -528,11 +544,12 @@ func migrate20260416(c *Config) bool {
 	return true
 }
 
-// migrate20260421 migrates profile unified model name from "*" to "cc".
-// This ensures consistency with the new naming convention where profile
-// rules use simplified names: "cc" (unified), "default", "haiku", etc. (separate).
-// Only applies to claude-code scenario profiles.
-func migrate20260421(c *Config) bool {
+// normalizeClaudeCodeProfileUnifiedModel migrates profile unified model name
+// from "*" to "cc". This ensures consistency with the naming convention where
+// profile rules use simplified names: "cc" (unified), "default", "haiku",
+// etc. (separate). Only applies to claude-code scenario profiles.
+// Folded from the dated migrate20260421 migration (2026-04-21).
+func normalizeClaudeCodeProfileUnifiedModel(c *Config) bool {
 	needsSave := false
 
 	for i := range c.Rules {
@@ -559,10 +576,12 @@ func migrate20260421(c *Config) bool {
 	return needsSave
 }
 
-// migrate20260502 removes wildcard (*) rules for smart_guide scenario.
-// This cleans up legacy wildcard rules that are no longer needed
-// as SmartGuide now uses bot-specific rules with UUID pattern: _internal_smart_guide_{botUUID}.
-func migrate20260502(c *Config) bool {
+// dropSmartGuideWildcardRules removes wildcard (*) rules for the smart_guide
+// scenario. This cleans up legacy wildcard rules that are no longer needed
+// as SmartGuide now uses bot-specific rules with UUID pattern:
+// _internal_smart_guide_{botUUID}.
+// Folded from the dated migrate20260502 migration (2026-05-02).
+func dropSmartGuideWildcardRules(c *Config) bool {
 	needsSave := false
 
 	// Filter out smart_guide rules with wildcard RequestModel.
@@ -583,23 +602,24 @@ func migrate20260502(c *Config) bool {
 
 	if needsSave {
 		c.Rules = filteredRules
-		logrus.Info("Migration 2026-05-02 completed: removed smart_guide wildcard rules")
+		logrus.Info("Removed smart_guide wildcard rules")
 	}
 	return needsSave
 }
 
-// migrate20260518 sets OpenAIEndpointMode=responses on existing Codex OAuth
-// providers. Codex's API only exposes /responses (no /chat/completions); the
-// mode is now declared on Codex providers at OAuth instantiation, but
-// existing user configs from before this change don't carry it. Without the
-// backfill, the new resolver's default-Chat semantics would silently send
+// normalizeCodexEndpointMode sets OpenAIEndpointMode=responses on existing
+// Codex OAuth providers. Codex's API only exposes /responses (no
+// /chat/completions); the mode is declared on Codex providers at OAuth
+// instantiation, but providers created before that don't carry it. Without
+// the backfill, the resolver's default-Chat semantics would silently send
 // /chat/completions requests to Codex and fail.
 //
 // Idempotent: only flips the mode when issuer is Codex and the mode is unset.
-// Unlike the other dated migrations, this never reports dirty: providers live
-// in SQLite (db.ProviderStore) and are backfilled directly there, so there is
-// no Config JSON state for Migrate's end-of-pipeline save to persist.
-func migrate20260518(c *Config) bool {
+// Unlike the other baseline sub-steps, this never reports dirty: providers
+// live in SQLite (db.ProviderStore) and are backfilled directly there, so
+// there is no Config JSON state for the caller to persist.
+// Folded from the dated migrate20260518 migration (2026-05-18).
+func normalizeCodexEndpointMode(c *Config) bool {
 	// Providers live in SQLite (the JSON c.Providers slice is legacy backup).
 	// Backfill the DB-stored ones directly so the resolver sees the right mode.
 	if c.providerStore != nil {

--- a/internal/server/config/migration_test.go
+++ b/internal/server/config/migration_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/tingly-dev/tingly-box/ai"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -70,6 +71,118 @@ func TestNormalizeLegacyConfigBaseline_MultiTierRulesBecomeTierWithRandomWithinT
 	}
 	if params.WithinTierTactic != loadbalance.TacticRandom {
 		t.Fatalf("within tier tactic = %q, want random", params.WithinTierTactic)
+	}
+}
+
+// TestNormalizeLegacyConfigBaseline_SeedsMultiTenantDefaults exercises the
+// 2026-04-16 multi-tenant default backfill folded into the baseline
+// normalizer: a config with no MultiTenantConfig fields set gets one seeded.
+func TestNormalizeLegacyConfigBaseline_SeedsMultiTenantDefaults(t *testing.T) {
+	c := &Config{}
+
+	normalizeLegacyConfigBaseline(c)
+
+	if !c.MultiTenantConfig.Enabled {
+		t.Error("multi-tenant should be enabled by default")
+	}
+	if c.MultiTenantConfig.APITokenSecret == "" {
+		t.Error("APITokenSecret should be seeded")
+	}
+	if c.MultiTenantConfig.APITokenAlgorithm != "HS256" {
+		t.Errorf("APITokenAlgorithm = %q, want HS256", c.MultiTenantConfig.APITokenAlgorithm)
+	}
+	if c.MultiTenantConfig.APITokenIssuer != "tingly-box" {
+		t.Errorf("APITokenIssuer = %q, want tingly-box", c.MultiTenantConfig.APITokenIssuer)
+	}
+}
+
+// TestNormalizeLegacyConfigBaseline_PreservesExplicitMultiTenantConfig covers
+// the guard: any pre-existing MultiTenantConfig field means the user (or a
+// prior run) already configured it, so the normalizer must not overwrite it.
+func TestNormalizeLegacyConfigBaseline_PreservesExplicitMultiTenantConfig(t *testing.T) {
+	c := &Config{
+		MultiTenantConfig: MultiTenantConfig{
+			APITokenIssuer: "custom-issuer",
+		},
+	}
+
+	normalizeLegacyConfigBaseline(c)
+
+	if c.MultiTenantConfig.APITokenIssuer != "custom-issuer" {
+		t.Errorf("APITokenIssuer = %q, want unchanged custom-issuer", c.MultiTenantConfig.APITokenIssuer)
+	}
+	if c.MultiTenantConfig.APITokenSecret != "" {
+		t.Errorf("APITokenSecret should stay empty, got %q", c.MultiTenantConfig.APITokenSecret)
+	}
+}
+
+// TestNormalizeLegacyConfigBaseline_RenamesProfileUnifiedModel exercises the
+// 2026-04-21 migration folded into the baseline normalizer: a claude-code
+// profile rule with the old "*" unified-model name is renamed to "cc".
+func TestNormalizeLegacyConfigBaseline_RenamesProfileUnifiedModel(t *testing.T) {
+	c := &Config{
+		Rules: []typ.Rule{
+			{UUID: "profile-rule", Scenario: typ.ProfiledScenarioName(typ.ScenarioClaudeCode, "p1"), RequestModel: "*"},
+			{UUID: "non-profile-rule", Scenario: typ.ScenarioClaudeCode, RequestModel: "*"},
+		},
+	}
+
+	normalizeLegacyConfigBaseline(c)
+
+	if c.Rules[0].RequestModel != "cc" {
+		t.Errorf("profile rule RequestModel = %q, want cc", c.Rules[0].RequestModel)
+	}
+	if c.Rules[1].RequestModel != "*" {
+		t.Errorf("non-profile rule RequestModel should be untouched, got %q", c.Rules[1].RequestModel)
+	}
+}
+
+// TestNormalizeLegacyConfigBaseline_DropsSmartGuideWildcardRules exercises
+// the 2026-05-02 migration folded into the baseline normalizer: a smart_guide
+// rule with a wildcard RequestModel is dropped, other rules survive.
+func TestNormalizeLegacyConfigBaseline_DropsSmartGuideWildcardRules(t *testing.T) {
+	c := &Config{
+		Rules: []typ.Rule{
+			{UUID: "wildcard", Scenario: typ.ScenarioSmartGuide, RequestModel: "*"},
+			{UUID: "keep-me", Scenario: typ.ScenarioSmartGuide, RequestModel: "gpt-5"},
+		},
+	}
+
+	normalizeLegacyConfigBaseline(c)
+
+	if len(c.Rules) != 1 {
+		t.Fatalf("rule count = %d, want 1: %+v", len(c.Rules), c.Rules)
+	}
+	if c.Rules[0].UUID != "keep-me" {
+		t.Errorf("surviving rule = %q, want keep-me", c.Rules[0].UUID)
+	}
+}
+
+// TestNormalizeCodexEndpointMode_BackfillsResponsesMode exercises the
+// 2026-05-18 migration folded into the baseline normalizer: a Codex OAuth
+// provider persisted before OpenAIEndpointMode was declared at OAuth
+// instantiation time gets backfilled to "responses" in the DB store.
+func TestNormalizeCodexEndpointMode_BackfillsResponsesMode(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	p := codexResolveProvider()
+	if err := cfg.AddProvider(p); err != nil {
+		t.Fatalf("AddProvider error: %v", err)
+	}
+
+	if normalizeCodexEndpointMode(cfg) {
+		t.Error("normalizeCodexEndpointMode should never report dirty (DB-only backfill, no Config JSON state)")
+	}
+
+	got, err := cfg.GetProviderByUUID(p.UUID)
+	if err != nil {
+		t.Fatalf("GetProviderByUUID error: %v", err)
+	}
+	if got.OpenAIEndpointMode != ai.EndpointModeResponses {
+		t.Errorf("OpenAIEndpointMode = %q, want %q", got.OpenAIEndpointMode, ai.EndpointModeResponses)
 	}
 }
 


### PR DESCRIPTION
## Summary

`internal/server/config`'s `Migrate()` chain had grown into a flat list of functions mixing three different lifecycles (self-healing baseline repairs, unconditional dated data fixes, marker-gated once migrations) with no way to tell which was which without reading the body, and each function saved the config independently.

- Introduce a `migrationStep` registry tagged by `migrationKind` (`kindBaseline` / `kindDated` / `kindOnce`); `Migrate()` now saves once at the end if any step reported a change, instead of each step calling `Save()` on its own.
- Fold the 2026-04/05 dated migrations (`migrate20260416`, `migrate20260421`, `migrate20260502`, `migrate20260518`) into `normalizeLegacyConfigBaseline` now that they're old enough no active config can predate them, per the fold policy documented below. `migrate20260712` stays `kindDated` (shipped too recently, ~1 month, to assume no active config predates it).
- Add `.design/config-migration.md` documenting the three-kind classification and the checklist for folding a dated migration into baseline, plus the retirement rules for the legacy built-in rule UUID lookup tables in `builtin_rules.go`.
- Fix stale `migrate20260518` references in `.design/openai-endpoint-routing.md` (caught by code review).

## Behavior notes

- Both `NewConfig` call sites already call `cfg.Save()` unconditionally right after `Migrate()`, so consolidating the end-of-pipeline save doesn't change persistence behavior for the normal boot path.
- `defaultXcodeSkipUsageOnce`/`defaultBuiltinRuleFlagsOnce` now report dirty whenever they run past their `MigrationsCompleted` guard, not just when a substantive field changed — this fixes a latent bug where the completion marker could be set in memory but not persisted until an unrelated save happened later.
- None of the four folded migrations had dedicated tests before; added baseline-level coverage for each in `migration_test.go`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/server/config/...`
- [x] `go test ./internal/server/config/...` (111 tests, all passing)
- [x] Reviewed with `/code-review`; one finding (stale doc references) fixed

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Li5SJG7UurYJiPSnfRhhPw