### PR TITLE
fix(routing): stop unmatched smart-routing partitions leaking into LB fallback

### DIFF
--- a/internal/routing/filters.go
+++ b/internal/routing/filters.go
@@ -4,6 +4,14 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 )
 
+// Narrowing convention (SelectionStage.Evaluate implementations rely on
+// this): every function below that returns a filtered []*loadbalance.Service
+// allocates a fresh backing array via append-to-nil. None of them truncate
+// or append onto an input slice's existing backing array, so a caller's
+// slice — including one being threaded through the pipeline as another
+// stage's `candidates` argument — is never mutated out from under it. Keep
+// this property when adding new narrowing helpers here.
+
 // FilterActiveServices returns only active services from the input list
 func FilterActiveServices(services []*loadbalance.Service) []*loadbalance.Service {
 	if len(services) == 0 {

--- a/internal/routing/pipeline_scenarios_test.go
+++ b/internal/routing/pipeline_scenarios_test.go
@@ -130,7 +130,7 @@ func TestServiceSelectorPipelineScenarios(t *testing.T) {
 	})
 
 	t.Run("pipeline-smart-routing-before-load-balancer/no-match-excludes-partition-only-services", func(t *testing.T) {
-		// Regression: newSelectionState seeds candidates with base ∪ every
+		// Regression: initialCandidateServices seeds candidates with base ∪ every
 		// partition's services (so HealthStage can pre-filter partition-only
 		// services too). When the request matches no partition, that union
 		// must not leak into the terminal LoadBalancer pick — services that

--- a/internal/routing/pipeline_scenarios_test.go
+++ b/internal/routing/pipeline_scenarios_test.go
@@ -128,4 +128,30 @@ func TestServiceSelectorPipelineScenarios(t *testing.T) {
 		require.Equal(t, []string{firstSmart.ServiceID(), secondSmart.ServiceID()}, lb.seen,
 			"load balancing must receive the smart partition, not the global candidate pool")
 	})
+
+	t.Run("pipeline-smart-routing-before-load-balancer/no-match-excludes-partition-only-services", func(t *testing.T) {
+		// Regression: newSelectionState seeds candidates with base ∪ every
+		// partition's services (so HealthStage can pre-filter partition-only
+		// services too). When the request matches no partition, that union
+		// must not leak into the terminal LoadBalancer pick — services that
+		// only exist inside an unmatched partition are never a valid
+		// fallback; only the rule's base pool is (see DuoRoutingRule.Services
+		// doc: "the base pool the LB falls back to when no partition
+		// matches").
+		base := testService("base", "base-model", true)
+		firstSmart := testService("smart-a", "smart-a-model", true)
+		secondSmart := testService("smart-b", "smart-b-model", true)
+		rule := pipelineSmartRule([]*loadbalance.Service{base}, []*loadbalance.Service{firstSmart, secondSmart})
+		lb := &pipelineScenarioLB{}
+		sel := NewServiceSelector(pipelineScenarioConfig(base, firstSmart, secondSmart), newMockAffinityStore(), lb)
+		ctx := testContext(rule, "")
+		ctx.Request = testOpenAIRequest("plain-request")
+
+		result, err := sel.Select(ctx)
+		require.NoError(t, err)
+		require.Equal(t, base.ServiceID(), result.Service.ServiceID())
+		require.Equal(t, []string{base.ServiceID()}, lb.seen,
+			"an unmatched request must fall back to the base pool only, not base+partition services")
+		require.Equal(t, -1, ctx.MatchedSmartRuleIndex)
+	})
 }

--- a/internal/routing/result.go
+++ b/internal/routing/result.go
@@ -19,13 +19,12 @@ const (
 
 // SelectionResult represents the output of service selection pipeline.
 // It includes the selected service, provider, and metadata about the selection.
+// A SelectionResult only ever represents a TERMINAL pick (a stage's `final`
+// return value) — non-terminal narrowing is carried by the `narrowed` slice
+// SelectionStage.Evaluate returns alongside it, not by this struct.
 type SelectionResult struct {
 	// Service is the selected load-balanced service
 	Service *loadbalance.Service
-
-	// FilteredServices contains a narrowed candidate set produced by filter stages.
-	// When set, selector updates SelectionContext.CandidateServices with this value.
-	FilteredServices []*loadbalance.Service
 
 	// Provider is the resolved provider for the service
 	Provider *typ.Provider
@@ -52,12 +51,3 @@ func NewResult(service *loadbalance.Service, source string) *SelectionResult {
 	}
 }
 
-// NewFilterResult creates a non-terminal result for filtering stages.
-func NewFilterResult(source string, services []*loadbalance.Service) *SelectionResult {
-	return &SelectionResult{
-		FilteredServices:      services,
-		Source:                source,
-		EvaluatedStages:       []string{},
-		MatchedSmartRuleIndex: -1,
-	}
-}

--- a/internal/routing/selector.go
+++ b/internal/routing/selector.go
@@ -57,13 +57,18 @@ type healthFilterProvider interface {
 	HealthFilter() *HealthFilter
 }
 
-type selectionState struct {
-	candidateServices []*loadbalance.Service
-}
-
-func newSelectionState(rule *typ.Rule) *selectionState {
+// initialCandidateServices builds the pipeline's starting candidate set:
+// base ∪ every smart-routing partition's services, deduplicated by service
+// ID (partition entries override a same-ID base entry in place). The union
+// exists so HealthStage — which runs first — can pre-filter partition-only
+// services too (see pipeline-health-before-smart-routing); SmartRoutingStage
+// is responsible for narrowing back down to a single scope (the matched
+// partition, or the base pool when none matches) before handing candidates
+// to Affinity/LoadBalancer, so a service that only exists inside an
+// unmatched partition never reaches the terminal pick.
+func initialCandidateServices(rule *typ.Rule) []*loadbalance.Service {
 	if rule == nil {
-		return &selectionState{candidateServices: nil}
+		return nil
 	}
 
 	// Deduplicate services by service ID while preserving first-seen order.
@@ -99,7 +104,7 @@ func newSelectionState(rule *typ.Rule) *selectionState {
 		}
 	}
 
-	return &selectionState{candidateServices: services}
+	return services
 }
 
 // NewServiceSelector creates a new service selector
@@ -171,7 +176,7 @@ func NewServiceSelectorWithLogger(
 // Select is the main entry point for service selection.
 // It picks a pre-built pipeline based on rule configuration and executes it.
 func (s *ServiceSelector) Select(ctx *SelectionContext) (*SelectionResult, error) {
-	state := newSelectionState(ctx.Rule)
+	candidates := initialCandidateServices(ctx.Rule)
 	evaluatedStages := make([]string, 0, len(s.pipeline))
 
 	logrus.Debugf("[selector] executing pipeline with %d stages for rule %s",
@@ -183,25 +188,20 @@ func (s *ServiceSelector) Select(ctx *SelectionContext) (*SelectionResult, error
 		evaluatedStages = append(evaluatedStages, stageName)
 		logrus.Debugf("[selector] evaluating stage: %s", stageName)
 
-		result, handled := stage.Evaluate(ctx, state)
+		narrowed, result, err := stage.Evaluate(ctx, candidates)
+		if err != nil {
+			return nil, fmt.Errorf("stage %s: %w", stageName, err)
+		}
+		candidates = narrowed
 
 		if result != nil {
-			if result.FilteredServices != nil {
-				state.candidateServices = result.FilteredServices
-			}
-		}
+			// Attach the cumulative path at the terminal boundary so
+			// observability reports every stage that actually ran, including
+			// pass-through stages that only narrowed the candidate set.
+			result.EvaluatedStages = append([]string(nil), evaluatedStages...)
 
-		if handled {
-			if result != nil {
-				// A filter stage's result is intentionally replaced as the
-				// pipeline advances. Attach the cumulative path at the terminal
-				// boundary so observability reports every stage that actually ran,
-				// including pass-through stages that returned nil.
-				result.EvaluatedStages = append([]string(nil), evaluatedStages...)
-			}
-			// Stage produced a result, validate and return
-			if result == nil || result.Service == nil {
-				logrus.Warnf("[selector] stage %s returned handled=true but nil result", stageName)
+			if result.Service == nil {
+				logrus.Warnf("[selector] stage %s returned a final result with a nil service", stageName)
 				continue
 			}
 

--- a/internal/routing/stage.go
+++ b/internal/routing/stage.go
@@ -1,16 +1,35 @@
 package routing
 
-// SelectionStage represents a single stage in the service selection pipeline.
-// Each stage can evaluate the context and either:
-// - Return a service selection (result, true)
-// - Pass to the next stage (nil, false)
+import "github.com/tingly-dev/tingly-box/internal/loadbalance"
+
+// SelectionStage is one step in the service-selection pipeline. Stages are
+// pure with respect to the pipeline's control flow: each receives the
+// current candidate set as an explicit argument and returns what it asserts
+// the set now is. There is no shared mutable state between stages, and no
+// "nil means unchanged" — a stage with no opinion returns its input slice
+// unchanged.
+//
+// Stages may only READ fields on the *loadbalance.Service values in
+// candidates; they must not write to them (Service.InitializeStats's
+// idempotent lazy-init is the one sanctioned exception — see its doc
+// comment). Narrowing must allocate a fresh slice — never truncate or
+// append onto the input slice's backing array — so a caller's slice is
+// never mutated out from under it.
 type SelectionStage interface {
-	// Name returns the stage identifier for logging and metrics
+	// Name returns the stage identifier for logging, metrics, and the
+	// Source* constants on SelectionResult.
 	Name() string
 
-	// Evaluate attempts to select a service based on the context.
-	// Returns:
-	//   - (result, true) if this stage selected a service (stops pipeline)
-	//   - (nil, false) if this stage cannot select (continue to next stage)
-	Evaluate(ctx *SelectionContext, state *selectionState) (*SelectionResult, bool)
+	// Evaluate narrows candidates (or returns them unchanged) and reports
+	// whether this stage picked the final winner.
+	//
+	//   - err != nil: this stage could not be evaluated; the pipeline
+	//     aborts and the error propagates to the caller of Select.
+	//   - final != nil: this stage selected the winning service; the
+	//     pipeline stops here. The returned narrowed slice is ignored in
+	//     this case.
+	//   - otherwise: narrowed becomes the input candidate set for the next
+	//     stage (or, if this is the last stage, the pipeline reports "no
+	//     service available").
+	Evaluate(ctx *SelectionContext, candidates []*loadbalance.Service) (narrowed []*loadbalance.Service, final *SelectionResult, err error)
 }

--- a/internal/routing/stage_affinity.go
+++ b/internal/routing/stage_affinity.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/clock"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -49,21 +50,21 @@ func (s *AffinityStage) Name() string {
 }
 
 // Evaluate checks for locked service affinity
-func (s *AffinityStage) Evaluate(ctx *SelectionContext, state *selectionState) (*SelectionResult, bool) {
+func (s *AffinityStage) Evaluate(ctx *SelectionContext, candidates []*loadbalance.Service) ([]*loadbalance.Service, *SelectionResult, error) {
 	rule := ctx.Rule
 
 	// Skip if affinity not enabled. Affinity is a load-balancing concern and
 	// is independent of smart routing — it applies whenever a session can be
 	// identified, regardless of rule.SmartEnabled.
 	if !rule.AffinityEnabled() || ctx.SessionID.IsEmpty() {
-		return nil, false
+		return candidates, nil, nil
 	}
 
 	// Look up the pin in the partition smart routing just matched (or the
 	// top-level partition when nothing matched).
 	entry, ok := s.store.Get(rule.UUID, AffinitySessionKey(ctx.SessionID.String(), ctx.MatchedSmartRuleIndex))
 	if !ok {
-		return nil, false
+		return candidates, nil, nil
 	}
 
 	// Strict TTL: honor the pin only while the entry has not expired.
@@ -72,16 +73,16 @@ func (s *AffinityStage) Evaluate(ctx *SelectionContext, state *selectionState) (
 	if clock.Now().After(entry.ExpiresAt) {
 		logrus.Infof("[affinity] affinity entry for session %s expired at %s; dropping pin so strategy re-selects",
 			ctx.SessionID.String(), entry.ExpiresAt)
-		return nil, false
+		return candidates, nil, nil
 	}
 
 	logrus.Infof("[affinity] using locked service for session %s: %s",
 		ctx.SessionID.String(), entry.Service.Model)
 
-	if state != nil && len(state.candidateServices) > 0 && !ContainsService(state.candidateServices, entry.Service) {
+	if len(candidates) > 0 && !ContainsService(candidates, entry.Service) {
 		logrus.Debugf("[affinity] locked service %s not in candidate set, skipping",
 			entry.Service.ServiceID())
-		return nil, false
+		return candidates, nil, nil
 	}
 
 	// Health scoping (breaker-aware): only honor a pin while the locked service
@@ -94,14 +95,13 @@ func (s *AffinityStage) Evaluate(ctx *SelectionContext, state *selectionState) (
 	//   - one service: always honored (nothing else to pick).
 	// On decline the pipeline falls through to the strategy, which re-selects a
 	// currently-valid service, and postProcess re-pins the session there.
-	if state != nil && len(state.candidateServices) > 0 &&
-		!typ.IsAffinityEligible(rule.UUID, state.candidateServices, entry.Service) {
+	if len(candidates) > 0 && !typ.IsAffinityEligible(rule.UUID, candidates, entry.Service) {
 		logrus.Infof("[affinity] locked service %s is not currently selectable for session %s; dropping pin so strategy re-selects",
 			entry.Service.ServiceID(), ctx.SessionID.String())
-		return nil, false
+		return candidates, nil, nil
 	}
 
 	result := NewResult(entry.Service, SourceAffinity)
 	result.MatchedSmartRuleIndex = ctx.MatchedSmartRuleIndex
-	return result, true
+	return candidates, result, nil
 }

--- a/internal/routing/stage_affinity_test.go
+++ b/internal/routing/stage_affinity_test.go
@@ -37,9 +37,9 @@ func TestAffinity_LockedSession(t *testing.T) {
 	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "session-1")
 
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled, "should return handled=true for locked session")
-	require.NotNil(t, result)
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.NotNil(t, result, "should return a final result for a locked session")
 	require.Equal(t, "gpt-4", result.Service.Model)
 	require.Equal(t, "affinity", result.Source)
 }
@@ -54,9 +54,9 @@ func TestAffinity_NoLock(t *testing.T) {
 	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "session-1")
 
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "should pass to next stage when no lock")
-	require.Nil(t, result)
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result, "should pass to next stage when no lock")
 }
 
 func TestAffinity_AffinityDisabled(t *testing.T) {
@@ -71,8 +71,9 @@ func TestAffinity_AffinityDisabled(t *testing.T) {
 	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "session-1")
 
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "should pass when affinity disabled")
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result, "should pass when affinity disabled")
 }
 
 func TestAffinity_SmartDisabled(t *testing.T) {
@@ -89,8 +90,9 @@ func TestAffinity_SmartDisabled(t *testing.T) {
 	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "session-1")
 
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled, "affinity should apply even when smart routing is disabled")
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.NotNil(t, result, "affinity should apply even when smart routing is disabled")
 	require.Equal(t, "provider-a", result.Service.Provider)
 }
 
@@ -106,8 +108,9 @@ func TestAffinity_EmptySession(t *testing.T) {
 	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "") // empty session
 
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "should pass when session is empty")
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result, "should pass when session is empty")
 }
 
 // Pins are partition-scoped: a pin created in the top-level partition must
@@ -132,21 +135,24 @@ func TestAffinity_PartitionScoping(t *testing.T) {
 	// A request routed by smart partition 1 must see the subset pin.
 	ctx := testContext(rule, "session-1")
 	ctx.MatchedSmartRuleIndex = 1
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled)
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.NotNil(t, result)
 	require.Equal(t, "provider-sub", result.Service.Provider)
 
 	// A request with no smart match must see the top-level pin.
 	ctx = testContext(rule, "session-1")
-	result, handled = stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled)
+	_, result, err = stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.NotNil(t, result)
 	require.Equal(t, "provider-top", result.Service.Provider)
 
 	// A request routed by a DIFFERENT partition must find no pin at all.
 	ctx = testContext(rule, "session-1")
 	ctx.MatchedSmartRuleIndex = 2
-	_, handled = stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "a pin must never leak across partitions")
+	_, result, err = stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result, "a pin must never leak across partitions")
 }
 
 // --- Tier-scoped affinity (breaker-aware) ---
@@ -164,8 +170,9 @@ func TestAffinity_TierScope_DeclinesStalePinWhenPrimaryHealthy(t *testing.T) {
 	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled,
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result,
 		"stale pin to a lower tier must be declined while the primary tier is healthy")
 }
 
@@ -188,8 +195,9 @@ func TestAffinity_TierScope_HonorsPinWhilePrimaryDown(t *testing.T) {
 	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled, "pin must be honored while the primary tier breaker is open")
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.NotNil(t, result, "pin must be honored while the primary tier breaker is open")
 	require.Equal(t, t1.ServiceID(), result.Service.ServiceID())
 }
 
@@ -212,8 +220,9 @@ func TestAffinity_TierScope_DeclinesWhenPinnedBreakerOpen(t *testing.T) {
 	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled,
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result,
 		"pin to an open lower-tier service must be declined when a higher tier is available")
 }
 
@@ -229,8 +238,9 @@ func TestAffinity_TierScope_WithinTierStickinessPreserved(t *testing.T) {
 	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled, "within-tier pin must be honored")
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.NotNil(t, result, "within-tier pin must be honored")
 	require.Equal(t, b.ServiceID(), result.Service.ServiceID())
 }
 
@@ -257,8 +267,9 @@ func TestAffinity_HorizontalRule_DropsPinToDeadPeer(t *testing.T) {
 	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled,
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result,
 		"pin to a dead same-tier peer must be dropped even without a tier tactic label")
 }
 
@@ -282,8 +293,9 @@ func TestAffinity_MatchedSmartRuleIndex_Propagated(t *testing.T) {
 	ctx := testContext(rule, "session-1")
 	ctx.MatchedSmartRuleIndex = 2
 
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled)
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.NotNil(t, result)
 	require.Equal(t, 2, result.MatchedSmartRuleIndex)
 }
 
@@ -320,14 +332,16 @@ func TestAffinity_MultipleSessions(t *testing.T) {
 
 	// Session A should get provider A
 	ctxA := testContext(rule, "session-a")
-	resultA, handledA := stage.Evaluate(ctxA, newSelectionState(ctxA.Rule))
-	require.True(t, handledA)
+	_, resultA, errA := stage.Evaluate(ctxA, initialCandidateServices(ctxA.Rule))
+	require.NoError(t, errA)
+	require.NotNil(t, resultA)
 	require.Equal(t, "provider-a", resultA.Service.Provider)
 
 	// Session B should get provider B
 	ctxB := testContext(rule, "session-b")
-	resultB, handledB := stage.Evaluate(ctxB, newSelectionState(ctxB.Rule))
-	require.True(t, handledB)
+	_, resultB, errB := stage.Evaluate(ctxB, initialCandidateServices(ctxB.Rule))
+	require.NoError(t, errB)
+	require.NotNil(t, resultB)
 	require.Equal(t, "provider-b", resultB.Service.Provider)
 }
 
@@ -353,8 +367,9 @@ func TestAffinity_StrictTTL_Expired(t *testing.T) {
 	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "expired affinity entry must be dropped")
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result, "expired affinity entry must be dropped")
 }
 
 // TestAffinity_StrictTTL_NotExpired verifies that a valid (unexpired) affinity
@@ -377,7 +392,8 @@ func TestAffinity_StrictTTL_NotExpired(t *testing.T) {
 	stage := NewAffinityStage(store)
 	ctx := testContext(rule, "s1")
 
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled, "valid affinity entry must be honored")
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.NotNil(t, result, "valid affinity entry must be honored")
 	require.Equal(t, "provider-a", result.Service.Provider)
 }

--- a/internal/routing/stage_health.go
+++ b/internal/routing/stage_health.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 )
 
 // HealthStage filters unhealthy services from the context.
@@ -21,18 +23,18 @@ func (s *HealthStage) Name() string {
 	return SourceHealth
 }
 
-func (s *HealthStage) Evaluate(ctx *SelectionContext, state *selectionState) (*SelectionResult, bool) {
-	if state == nil || state.candidateServices == nil {
-		return nil, false
+func (s *HealthStage) Evaluate(ctx *SelectionContext, candidates []*loadbalance.Service) ([]*loadbalance.Service, *SelectionResult, error) {
+	if len(candidates) == 0 {
+		return candidates, nil, nil
 	}
 
 	// If no health filter configured, pass through unchanged
 	if s.filter == nil {
-		return NewFilterResult(SourceHealth, state.candidateServices), false
+		return candidates, nil, nil
 	}
 
-	before := len(state.candidateServices)
-	healthy := s.filter.Filter(state.candidateServices)
+	before := len(candidates)
+	healthy := s.filter.Filter(candidates)
 
 	// Degrade, don't disappear: if every candidate is unhealthy, keep the full
 	// set rather than emptying it — mirrors LoadBalancer.SelectService, so the
@@ -44,7 +46,7 @@ func (s *HealthStage) Evaluate(ctx *SelectionContext, state *selectionState) (*S
 			"rule_uuid":  selectionRuleUUID(ctx),
 			"candidates": before,
 		}).Warnf("[health] all %d candidates unhealthy; keeping the full set (degrade)", before)
-		return NewFilterResult(SourceHealth, state.candidateServices), false
+		return candidates, nil, nil
 	}
 
 	filteredCount := before - len(healthy)
@@ -59,7 +61,7 @@ func (s *HealthStage) Evaluate(ctx *SelectionContext, state *selectionState) (*S
 		}).Warnf("[health] Filtered %d unhealthy services, %d remaining (of %d total)",
 			filteredCount, len(healthy), before)
 		// Log each filtered service for debugging
-		for _, svc := range state.candidateServices {
+		for _, svc := range candidates {
 			if !s.filter.IsHealthy(svc.ServiceID()) {
 				logrus.WithContext(selectionLogContext(ctx)).WithFields(logrus.Fields{
 					"stage":         "routing_health_filtered_service",
@@ -75,7 +77,7 @@ func (s *HealthStage) Evaluate(ctx *SelectionContext, state *selectionState) (*S
 	}
 
 	// Continue pipeline (don't select, just filter)
-	return NewFilterResult(SourceHealth, healthy), false
+	return healthy, nil, nil
 }
 
 func selectionLogContext(ctx *SelectionContext) context.Context {

--- a/internal/routing/stage_health_test.go
+++ b/internal/routing/stage_health_test.go
@@ -24,15 +24,13 @@ func TestHealthStage_FiltersUnhealthy(t *testing.T) {
 
 	rule := testRule("rule-1", "gpt-4", []*loadbalance.Service{svcA, svcB, svcC})
 	ctx := testContext(rule, "")
-	state := newSelectionState(ctx.Rule)
 
-	result, handled := stage.Evaluate(ctx, state)
-	require.False(t, handled, "should not select, just filter")
-	require.NotNil(t, result)
-	state.candidateServices = result.FilteredServices
-	require.Len(t, state.candidateServices, 2, "unhealthy service should be filtered out")
-	require.Equal(t, "provider-a", state.candidateServices[0].Provider)
-	require.Equal(t, "provider-c", state.candidateServices[1].Provider)
+	candidates, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result, "should not select, just filter")
+	require.Len(t, candidates, 2, "unhealthy service should be filtered out")
+	require.Equal(t, "provider-a", candidates[0].Provider)
+	require.Equal(t, "provider-c", candidates[1].Provider)
 }
 
 func TestHealthStage_AllHealthy_NoFilter(t *testing.T) {
@@ -45,13 +43,11 @@ func TestHealthStage_AllHealthy_NoFilter(t *testing.T) {
 
 	rule := testRule("rule-1", "gpt-4", []*loadbalance.Service{svcA, svcB})
 	ctx := testContext(rule, "")
-	state := newSelectionState(ctx.Rule)
 
-	result, handled := stage.Evaluate(ctx, state)
-	require.False(t, handled, "should not select, just filter")
-	require.NotNil(t, result)
-	state.candidateServices = result.FilteredServices
-	require.Len(t, state.candidateServices, 2, "all services should remain")
+	candidates, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result, "should not select, just filter")
+	require.Len(t, candidates, 2, "all services should remain")
 }
 
 func TestHealthStage_AllUnhealthy(t *testing.T) {
@@ -67,15 +63,13 @@ func TestHealthStage_AllUnhealthy(t *testing.T) {
 
 	rule := testRule("rule-1", "gpt-4", []*loadbalance.Service{svcA, svcB})
 	ctx := testContext(rule, "")
-	state := newSelectionState(ctx.Rule)
 
 	// Degrade, don't disappear: when every candidate is unhealthy, keep the full
 	// set so a service (and the real upstream 429/auth) still reaches the client.
-	result, handled := stage.Evaluate(ctx, state)
-	require.False(t, handled, "should continue even when all unhealthy")
-	require.NotNil(t, result)
-	state.candidateServices = result.FilteredServices
-	require.Len(t, state.candidateServices, 2, "all-unhealthy degrades to the full set, not empty")
+	candidates, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result, "should continue even when all unhealthy")
+	require.Len(t, candidates, 2, "all-unhealthy degrades to the full set, not empty")
 }
 
 func TestHealthStage_NilServices(t *testing.T) {
@@ -85,13 +79,10 @@ func TestHealthStage_NilServices(t *testing.T) {
 	rule := testRule("rule-1", "gpt-4", nil)
 	ctx := testContext(rule, "")
 
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "should pass when no services")
-	// newSelectionState returns an empty (non-nil) candidate slice for a rule
-	// with no Services. HealthStage filters that empty slice and returns a
-	// filter result so downstream stages observe the narrowed state.
-	require.NotNil(t, result)
-	require.Empty(t, result.FilteredServices)
+	candidates, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result, "should pass when no services")
+	require.Empty(t, candidates)
 }
 
 func TestHealthStage_NilFilter(t *testing.T) {
@@ -102,17 +93,15 @@ func TestHealthStage_NilFilter(t *testing.T) {
 
 	rule := testRule("rule-1", "gpt-4", []*loadbalance.Service{svcA, svcB})
 	ctx := testContext(rule, "")
-	state := newSelectionState(ctx.Rule)
 
-	result, handled := stage.Evaluate(ctx, state)
-	require.False(t, handled, "should not select")
-	require.NotNil(t, result)
-	state.candidateServices = result.FilteredServices
-	require.Len(t, state.candidateServices, 2, "all services should remain when filter is nil")
+	candidates, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result, "should not select")
+	require.Len(t, candidates, 2, "all services should remain when filter is nil")
 }
 
 func TestHealthStage_ContinuesPipeline(t *testing.T) {
-	// Test that health stage returns (nil, false) so pipeline continues
+	// Test that health stage returns a nil final result so the pipeline continues.
 	filter := NewHealthFilter(nil)
 	stage := NewHealthStage(filter)
 
@@ -120,9 +109,10 @@ func TestHealthStage_ContinuesPipeline(t *testing.T) {
 	rule := testRule("rule-1", "gpt-4", []*loadbalance.Service{svc})
 	ctx := testContext(rule, "")
 
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "should return handled=false to continue pipeline")
-	require.NotNil(t, result, "should return filter result while continuing pipeline")
+	candidates, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, result, "should return a nil final result to continue the pipeline")
+	require.Len(t, candidates, 1, "should return the (unchanged) candidate set")
 }
 
 func TestHealthStage_Name(t *testing.T) {

--- a/internal/routing/stage_load_balancer.go
+++ b/internal/routing/stage_load_balancer.go
@@ -1,6 +1,8 @@
 package routing
 
 import (
+	"fmt"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
@@ -24,23 +26,21 @@ func (s *LoadBalancerStage) Name() string {
 	return SourceLoadBalancer
 }
 
-// Evaluate selects a service using load balancing
-func (s *LoadBalancerStage) Evaluate(ctx *SelectionContext, state *selectionState) (*SelectionResult, bool) {
+// Evaluate selects a service using load balancing. This is the terminal
+// stage: a failure here is a real error (there is no next stage to fall
+// through to), so it is reported via err rather than a silent pass-through.
+func (s *LoadBalancerStage) Evaluate(ctx *SelectionContext, candidates []*loadbalance.Service) ([]*loadbalance.Service, *SelectionResult, error) {
 	tempRule := *ctx.Rule
-	if state != nil {
-		tempRule.Services = state.candidateServices
-	}
+	tempRule.Services = candidates
 	logOpenBreakerSkips(ctx, &tempRule)
 
 	service, err := s.loadBalancer.SelectService(&tempRule)
 	if err != nil {
-		logrus.Errorf("[load_balancer] selection failed: %v", err)
-		return nil, false
+		return candidates, nil, fmt.Errorf("selection failed: %w", err)
 	}
 
 	if service == nil {
-		logrus.Errorf("[load_balancer] no service returned")
-		return nil, false
+		return candidates, nil, fmt.Errorf("no service returned")
 	}
 
 	// When a smart partition matched, the candidate set IS that partition, so
@@ -52,7 +52,7 @@ func (s *LoadBalancerStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	}
 	result := NewResult(service, source)
 	result.MatchedSmartRuleIndex = ctx.MatchedSmartRuleIndex
-	return result, true
+	return candidates, result, nil
 }
 
 func logOpenBreakerSkips(ctx *SelectionContext, rule interface {

--- a/internal/routing/stage_load_balancer_test.go
+++ b/internal/routing/stage_load_balancer_test.go
@@ -17,22 +17,24 @@ func TestLoadBalancer_SelectsService(t *testing.T) {
 	stage := NewLoadBalancerStage(lb)
 	ctx := testContext(rule, "")
 
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.True(t, handled)
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, "gpt-4", result.Service.Model)
 	require.Equal(t, "load_balancer", result.Source)
 }
 
 func TestLoadBalancer_Error(t *testing.T) {
+	// The load balancer stage is terminal: a failure here has no next stage
+	// to fall through to, so it is reported via err rather than a silent pass.
 	lb := &mockLoadBalancer{err: errors.New("no service available")}
 
 	rule := testRule("rule-1", "gpt-4", nil)
 	stage := NewLoadBalancerStage(lb)
 	ctx := testContext(rule, "")
 
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "should pass on LB error")
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.Error(t, err, "should surface the LB error")
 	require.Nil(t, result)
 }
 
@@ -43,8 +45,8 @@ func TestLoadBalancer_NilResult(t *testing.T) {
 	stage := NewLoadBalancerStage(lb)
 	ctx := testContext(rule, "")
 
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "should pass when LB returns nil")
+	_, result, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.Error(t, err, "a nil service with no error is still a failure to select")
 	require.Nil(t, result)
 }
 

--- a/internal/routing/stage_smart_routing.go
+++ b/internal/routing/stage_smart_routing.go
@@ -137,10 +137,26 @@ func formatTraceMessage(matched bool, idx int, model, outcome string) string {
 func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionState) (*SelectionResult, bool) {
 	rule := ctx.Rule
 
+	// narrowToBasePool restricts the candidate set back down to the rule's
+	// top-level Services (the documented LB fallback pool) whenever this
+	// stage decides it will NOT narrow to a matched partition. newSelectionState
+	// seeds candidateServices with base ∪ every partition's services so
+	// HealthStage (which runs first) can pre-filter partition-only services
+	// too (see pipeline-health-before-smart-routing); but once this stage
+	// determines no partition applies, those partition-only services must not
+	// leak into the terminal LoadBalancer pick — a service that only exists
+	// inside an unmatched (or bypassed) partition is never a valid fallback.
+	narrowToBasePool := func() {
+		if state != nil {
+			state.candidateServices = IntersectServices(state.candidateServices, rule.Services)
+		}
+	}
+
 	// Skip if smart routing not enabled
 	if !rule.SmartEnabled || len(rule.SmartRouting) == 0 || ctx.Request == nil {
 		logrus.Debugf("[smart_routing] skipped - SmartEnabled=%v, SmartRoutingCount=%d, Request=%v",
 			rule.SmartEnabled, len(rule.SmartRouting), ctx.Request != nil)
+		narrowToBasePool()
 		return nil, false
 	}
 
@@ -150,6 +166,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	reqCtx := smartrouting.ExtractContext(ctx.Request)
 	if reqCtx == nil {
 		s.emitTrace(ctx, nil, nil, -1, 0, 0, nil, "no_context", "request type not supported for smart routing")
+		narrowToBasePool()
 		return nil, false
 	}
 
@@ -169,6 +186,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	if err != nil {
 		logrus.Debugf("[smart_routing] failed to create router: %v", err)
 		s.emitTrace(ctx, reqCtx, nil, -1, 0, 0, nil, "router_invalid", err.Error())
+		narrowToBasePool()
 		return nil, false
 	}
 
@@ -176,6 +194,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	if !matched || len(matchedServices) == 0 {
 		logrus.Debugf("[smart_routing] no rule matched - matched=%v, services=%d", matched, len(matchedServices))
 		s.emitTrace(ctx, reqCtx, trace, -1, 0, 0, nil, "no_match", "no rule matched the request")
+		narrowToBasePool()
 		return nil, false
 	}
 
@@ -186,6 +205,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	if _, already := ctx.BypassedSmartRules[matchedRuleIndex]; already {
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), 0, nil,
 			"bypass_already_done", "rule already bypassed by op-level processor; falling through to LoadBalancer")
+		narrowToBasePool()
 		return nil, false
 	}
 
@@ -199,6 +219,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	if s.runOpProcessors(ctx, reqCtx, matchedRule, matchedRuleIndex, matchedServices) {
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), 0, nil,
 			"bypass_processor_run", "op-level processor ran; falling through to LoadBalancer")
+		narrowToBasePool()
 		return nil, false
 	}
 
@@ -211,6 +232,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 		logrus.Debugf("[smart_routing] matched rule has no services in current candidate set")
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, 0, 0, nil, "no_candidates",
 			"matched rule has no services in current candidate set")
+		narrowToBasePool()
 		return nil, false
 	}
 
@@ -220,6 +242,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 		logrus.Debugf("[smart_routing] no active services in matched set")
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), 0, nil, "no_active_services",
 			"matched rule has no active services")
+		narrowToBasePool()
 		return nil, false
 	}
 

--- a/internal/routing/stage_smart_routing.go
+++ b/internal/routing/stage_smart_routing.go
@@ -145,13 +145,16 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, candidates []*loadba
 	// exit below that does NOT narrow to a matched partition instead
 	// narrows to basePool, so a service that only exists inside an
 	// unmatched (or bypassed) partition never reaches the terminal pick.
-	basePool := IntersectServices(candidates, rule.Services)
+	// basePool is computed lazily (only the branches that actually take the
+	// non-matched exit pay for the intersection + its map allocation) since
+	// the common case — a partition matches — never needs it.
+	basePool := func() []*loadbalance.Service { return IntersectServices(candidates, rule.Services) }
 
 	// Skip if smart routing not enabled
 	if !rule.SmartEnabled || len(rule.SmartRouting) == 0 || ctx.Request == nil {
 		logrus.Debugf("[smart_routing] skipped - SmartEnabled=%v, SmartRoutingCount=%d, Request=%v",
 			rule.SmartEnabled, len(rule.SmartRouting), ctx.Request != nil)
-		return basePool, nil, nil
+		return basePool(), nil, nil
 	}
 
 	logrus.Debugf("[smart_routing] evaluating %d rules for model %s", len(rule.SmartRouting), rule.RequestModel)
@@ -160,7 +163,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, candidates []*loadba
 	reqCtx := smartrouting.ExtractContext(ctx.Request)
 	if reqCtx == nil {
 		s.emitTrace(ctx, nil, nil, -1, 0, 0, nil, "no_context", "request type not supported for smart routing")
-		return basePool, nil, nil
+		return basePool(), nil, nil
 	}
 
 	// Annotate the request context with the agent.claude_code request kind when
@@ -179,14 +182,14 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, candidates []*loadba
 	if err != nil {
 		logrus.Debugf("[smart_routing] failed to create router: %v", err)
 		s.emitTrace(ctx, reqCtx, nil, -1, 0, 0, nil, "router_invalid", err.Error())
-		return basePool, nil, nil
+		return basePool(), nil, nil
 	}
 
 	matchedServices, matchedRuleIndex, matched, trace := router.Evaluate(reqCtx)
 	if !matched || len(matchedServices) == 0 {
 		logrus.Debugf("[smart_routing] no rule matched - matched=%v, services=%d", matched, len(matchedServices))
 		s.emitTrace(ctx, reqCtx, trace, -1, 0, 0, nil, "no_match", "no rule matched the request")
-		return basePool, nil, nil
+		return basePool(), nil, nil
 	}
 
 	matchedRule := rule.SmartRouting[matchedRuleIndex]
@@ -196,7 +199,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, candidates []*loadba
 	if _, already := ctx.BypassedSmartRules[matchedRuleIndex]; already {
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), 0, nil,
 			"bypass_already_done", "rule already bypassed by op-level processor; falling through to LoadBalancer")
-		return basePool, nil, nil
+		return basePool(), nil, nil
 	}
 
 	// Implicit bypass: if the matched rule's ops carry registered processors,
@@ -207,7 +210,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, candidates []*loadba
 	if s.runOpProcessors(ctx, reqCtx, matchedRule, matchedRuleIndex, matchedServices) {
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), 0, nil,
 			"bypass_processor_run", "op-level processor ran; falling through to LoadBalancer")
-		return basePool, nil, nil
+		return basePool(), nil, nil
 	}
 
 	if len(candidates) > 0 {
@@ -219,7 +222,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, candidates []*loadba
 		logrus.Debugf("[smart_routing] matched rule has no services in current candidate set")
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, 0, 0, nil, "no_candidates",
 			"matched rule has no services in current candidate set")
-		return basePool, nil, nil
+		return basePool(), nil, nil
 	}
 
 	// Filter active services
@@ -228,7 +231,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, candidates []*loadba
 		logrus.Debugf("[smart_routing] no active services in matched set")
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), 0, nil, "no_active_services",
 			"matched rule has no active services")
-		return basePool, nil, nil
+		return basePool(), nil, nil
 	}
 
 	// Narrow the candidate set to the matched partition — this stage decides

--- a/internal/routing/stage_smart_routing.go
+++ b/internal/routing/stage_smart_routing.go
@@ -127,37 +127,31 @@ func formatTraceMessage(matched bool, idx int, model, outcome string) string {
 	return "smart routing fell through for " + model + " (" + outcome + ")"
 }
 
-// Evaluate evaluates smart routing rules and selects a service. When a
-// matched rule carries op-level processors, the stage runs them (the
-// "implicit bypass") and then returns (nil, false) so the LoadBalancer
-// (global fallback) picks an upstream with the mutated request. The
-// mutated request is NOT re-evaluated against the smart-routing rules —
-// re-entering evaluation with a post-processor request invites surprising
-// matches and is intentionally avoided.
-func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionState) (*SelectionResult, bool) {
+// Evaluate evaluates smart routing rules and narrows the candidate set. It
+// never terminates the pipeline (final is always nil) — it only decides
+// WHICH scope the next stages see. When a matched rule carries op-level
+// processors, the stage runs them (the "implicit bypass") so the
+// LoadBalancer (global fallback) picks an upstream with the mutated
+// request. The mutated request is NOT re-evaluated against the
+// smart-routing rules — re-entering evaluation with a post-processor input
+// invites surprising matches and is intentionally avoided.
+func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, candidates []*loadbalance.Service) ([]*loadbalance.Service, *SelectionResult, error) {
 	rule := ctx.Rule
 
-	// newSelectionState seeds candidateServices with base ∪ every partition's
-	// services so HealthStage (which runs first) can pre-filter partition-only
-	// services too (see pipeline-health-before-smart-routing). That union is
-	// only valid while a partition might still match; the moment this stage
-	// decides it won't narrow to one, partition-only services must not leak
-	// into the terminal LoadBalancer pick. matchedPartition flips to true on
-	// the one success path below (matched, not bypassed, has active
-	// services); every other exit — including any added later — defaults to
-	// restoring the rule's base Services as the fallback pool.
-	matchedPartition := false
-	defer func() {
-		if !matchedPartition && state != nil {
-			state.candidateServices = IntersectServices(state.candidateServices, rule.Services)
-		}
-	}()
+	// candidates arrives seeded with base ∪ every partition's services (see
+	// initialCandidateServices) so HealthStage — which runs first — can
+	// pre-filter partition-only services too (pipeline-health-before-smart-routing).
+	// That union is only valid while a partition might still match: every
+	// exit below that does NOT narrow to a matched partition instead
+	// narrows to basePool, so a service that only exists inside an
+	// unmatched (or bypassed) partition never reaches the terminal pick.
+	basePool := IntersectServices(candidates, rule.Services)
 
 	// Skip if smart routing not enabled
 	if !rule.SmartEnabled || len(rule.SmartRouting) == 0 || ctx.Request == nil {
 		logrus.Debugf("[smart_routing] skipped - SmartEnabled=%v, SmartRoutingCount=%d, Request=%v",
 			rule.SmartEnabled, len(rule.SmartRouting), ctx.Request != nil)
-		return nil, false
+		return basePool, nil, nil
 	}
 
 	logrus.Debugf("[smart_routing] evaluating %d rules for model %s", len(rule.SmartRouting), rule.RequestModel)
@@ -166,7 +160,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	reqCtx := smartrouting.ExtractContext(ctx.Request)
 	if reqCtx == nil {
 		s.emitTrace(ctx, nil, nil, -1, 0, 0, nil, "no_context", "request type not supported for smart routing")
-		return nil, false
+		return basePool, nil, nil
 	}
 
 	// Annotate the request context with the agent.claude_code request kind when
@@ -185,14 +179,14 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	if err != nil {
 		logrus.Debugf("[smart_routing] failed to create router: %v", err)
 		s.emitTrace(ctx, reqCtx, nil, -1, 0, 0, nil, "router_invalid", err.Error())
-		return nil, false
+		return basePool, nil, nil
 	}
 
 	matchedServices, matchedRuleIndex, matched, trace := router.Evaluate(reqCtx)
 	if !matched || len(matchedServices) == 0 {
 		logrus.Debugf("[smart_routing] no rule matched - matched=%v, services=%d", matched, len(matchedServices))
 		s.emitTrace(ctx, reqCtx, trace, -1, 0, 0, nil, "no_match", "no rule matched the request")
-		return nil, false
+		return basePool, nil, nil
 	}
 
 	matchedRule := rule.SmartRouting[matchedRuleIndex]
@@ -202,32 +196,30 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	if _, already := ctx.BypassedSmartRules[matchedRuleIndex]; already {
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), 0, nil,
 			"bypass_already_done", "rule already bypassed by op-level processor; falling through to LoadBalancer")
-		return nil, false
+		return basePool, nil, nil
 	}
 
 	// Implicit bypass: if the matched rule's ops carry registered processors,
-	// run them (they mutate ctx.Request in place) and return (nil, false).
-	// The LoadBalancer stage then picks an upstream from the parent rule's
-	// top-level Services with the mutated request. We do NOT re-evaluate
-	// smart-routing rules against the mutated request — keeping the bypass
-	// strictly one-shot prevents post-processor inputs from triggering
-	// unintended matches downstream.
+	// run them (they mutate ctx.Request in place) and fall through to
+	// basePool. We do NOT re-evaluate smart-routing rules against the
+	// mutated request — keeping the bypass strictly one-shot prevents
+	// post-processor inputs from triggering unintended matches downstream.
 	if s.runOpProcessors(ctx, reqCtx, matchedRule, matchedRuleIndex, matchedServices) {
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), 0, nil,
 			"bypass_processor_run", "op-level processor ran; falling through to LoadBalancer")
-		return nil, false
+		return basePool, nil, nil
 	}
 
-	if state != nil && len(state.candidateServices) > 0 {
+	if len(candidates) > 0 {
 		beforeCount := len(matchedServices)
-		matchedServices = IntersectServices(matchedServices, state.candidateServices)
+		matchedServices = IntersectServices(matchedServices, candidates)
 		logrus.Debugf("[smart_routing] intersection: %d -> %d services", beforeCount, len(matchedServices))
 	}
 	if len(matchedServices) == 0 {
 		logrus.Debugf("[smart_routing] matched rule has no services in current candidate set")
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, 0, 0, nil, "no_candidates",
 			"matched rule has no services in current candidate set")
-		return nil, false
+		return basePool, nil, nil
 	}
 
 	// Filter active services
@@ -236,7 +228,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 		logrus.Debugf("[smart_routing] no active services in matched set")
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), 0, nil, "no_active_services",
 			"matched rule has no active services")
-		return nil, false
+		return basePool, nil, nil
 	}
 
 	// Narrow the candidate set to the matched partition — this stage decides
@@ -245,13 +237,12 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	// routing used to terminal-select here, but that ran after affinity, so a
 	// first-request pin could defeat content routing for the whole session
 	// TTL and skip processor ops entirely for pinned sessions.
-	matchedPartition = true
 	ctx.MatchedSmartRuleIndex = matchedRuleIndex
 	logrus.Debugf("[smart_routing] rule %d matched, narrowing candidates to %d services",
 		matchedRuleIndex, len(activeServices))
 	s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), len(activeServices),
 		nil, "matched", "candidates narrowed to the matched subset")
-	return NewFilterResult(SourceSmartRouting, activeServices), false
+	return activeServices, nil, nil
 }
 
 // runOpProcessors runs the registered op-level processors of the matched rule

--- a/internal/routing/stage_smart_routing.go
+++ b/internal/routing/stage_smart_routing.go
@@ -138,20 +138,25 @@ func formatTraceMessage(matched bool, idx int, model, outcome string) string {
 func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, candidates []*loadbalance.Service) ([]*loadbalance.Service, *SelectionResult, error) {
 	rule := ctx.Rule
 
-	// candidates arrives seeded with base ∪ every partition's services (see
-	// initialCandidateServices) so HealthStage — which runs first — can
-	// pre-filter partition-only services too (pipeline-health-before-smart-routing).
-	// That union is only valid while a partition might still match: every
-	// exit below that does NOT narrow to a matched partition instead
-	// narrows to basePool, so a service that only exists inside an
-	// unmatched (or bypassed) partition never reaches the terminal pick.
-	// basePool is computed lazily (only the branches that actually take the
-	// non-matched exit pay for the intersection + its map allocation) since
-	// the common case — a partition matches — never needs it.
+	// candidates arrives seeded with base ∪ every partition's services — see
+	// initialCandidateServices for why. Every exit below that does NOT narrow
+	// to a matched partition instead narrows to basePool, so a service that
+	// only exists inside an unmatched (or bypassed) partition never reaches
+	// the terminal pick. basePool is computed lazily (only the branches that
+	// actually take the non-matched exit pay for the intersection + its map
+	// allocation) since the common case — a partition matches — never needs it.
 	basePool := func() []*loadbalance.Service { return IntersectServices(candidates, rule.Services) }
 
-	// Skip if smart routing not enabled
-	if !rule.SmartEnabled || len(rule.SmartRouting) == 0 || ctx.Request == nil {
+	// Skip if smart routing not enabled. When SmartRouting is empty,
+	// initialCandidateServices never added anything beyond rule.Services, so
+	// candidates already IS the base pool — basePool() would be a provable
+	// no-op there (a wasted map-build + scan on every plain, non-smart rule,
+	// the common case), so skip straight to returning candidates unchanged.
+	if len(rule.SmartRouting) == 0 {
+		logrus.Debugf("[smart_routing] skipped - SmartRoutingCount=0")
+		return candidates, nil, nil
+	}
+	if !rule.SmartEnabled || ctx.Request == nil {
 		logrus.Debugf("[smart_routing] skipped - SmartEnabled=%v, SmartRoutingCount=%d, Request=%v",
 			rule.SmartEnabled, len(rule.SmartRouting), ctx.Request != nil)
 		return basePool(), nil, nil

--- a/internal/routing/stage_smart_routing.go
+++ b/internal/routing/stage_smart_routing.go
@@ -137,26 +137,26 @@ func formatTraceMessage(matched bool, idx int, model, outcome string) string {
 func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionState) (*SelectionResult, bool) {
 	rule := ctx.Rule
 
-	// narrowToBasePool restricts the candidate set back down to the rule's
-	// top-level Services (the documented LB fallback pool) whenever this
-	// stage decides it will NOT narrow to a matched partition. newSelectionState
-	// seeds candidateServices with base ∪ every partition's services so
-	// HealthStage (which runs first) can pre-filter partition-only services
-	// too (see pipeline-health-before-smart-routing); but once this stage
-	// determines no partition applies, those partition-only services must not
-	// leak into the terminal LoadBalancer pick — a service that only exists
-	// inside an unmatched (or bypassed) partition is never a valid fallback.
-	narrowToBasePool := func() {
-		if state != nil {
+	// newSelectionState seeds candidateServices with base ∪ every partition's
+	// services so HealthStage (which runs first) can pre-filter partition-only
+	// services too (see pipeline-health-before-smart-routing). That union is
+	// only valid while a partition might still match; the moment this stage
+	// decides it won't narrow to one, partition-only services must not leak
+	// into the terminal LoadBalancer pick. matchedPartition flips to true on
+	// the one success path below (matched, not bypassed, has active
+	// services); every other exit — including any added later — defaults to
+	// restoring the rule's base Services as the fallback pool.
+	matchedPartition := false
+	defer func() {
+		if !matchedPartition && state != nil {
 			state.candidateServices = IntersectServices(state.candidateServices, rule.Services)
 		}
-	}
+	}()
 
 	// Skip if smart routing not enabled
 	if !rule.SmartEnabled || len(rule.SmartRouting) == 0 || ctx.Request == nil {
 		logrus.Debugf("[smart_routing] skipped - SmartEnabled=%v, SmartRoutingCount=%d, Request=%v",
 			rule.SmartEnabled, len(rule.SmartRouting), ctx.Request != nil)
-		narrowToBasePool()
 		return nil, false
 	}
 
@@ -166,7 +166,6 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	reqCtx := smartrouting.ExtractContext(ctx.Request)
 	if reqCtx == nil {
 		s.emitTrace(ctx, nil, nil, -1, 0, 0, nil, "no_context", "request type not supported for smart routing")
-		narrowToBasePool()
 		return nil, false
 	}
 
@@ -186,7 +185,6 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	if err != nil {
 		logrus.Debugf("[smart_routing] failed to create router: %v", err)
 		s.emitTrace(ctx, reqCtx, nil, -1, 0, 0, nil, "router_invalid", err.Error())
-		narrowToBasePool()
 		return nil, false
 	}
 
@@ -194,7 +192,6 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	if !matched || len(matchedServices) == 0 {
 		logrus.Debugf("[smart_routing] no rule matched - matched=%v, services=%d", matched, len(matchedServices))
 		s.emitTrace(ctx, reqCtx, trace, -1, 0, 0, nil, "no_match", "no rule matched the request")
-		narrowToBasePool()
 		return nil, false
 	}
 
@@ -205,7 +202,6 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	if _, already := ctx.BypassedSmartRules[matchedRuleIndex]; already {
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), 0, nil,
 			"bypass_already_done", "rule already bypassed by op-level processor; falling through to LoadBalancer")
-		narrowToBasePool()
 		return nil, false
 	}
 
@@ -219,7 +215,6 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	if s.runOpProcessors(ctx, reqCtx, matchedRule, matchedRuleIndex, matchedServices) {
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), 0, nil,
 			"bypass_processor_run", "op-level processor ran; falling through to LoadBalancer")
-		narrowToBasePool()
 		return nil, false
 	}
 
@@ -232,7 +227,6 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 		logrus.Debugf("[smart_routing] matched rule has no services in current candidate set")
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, 0, 0, nil, "no_candidates",
 			"matched rule has no services in current candidate set")
-		narrowToBasePool()
 		return nil, false
 	}
 
@@ -242,7 +236,6 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 		logrus.Debugf("[smart_routing] no active services in matched set")
 		s.emitTrace(ctx, reqCtx, trace, matchedRuleIndex, len(matchedServices), 0, nil, "no_active_services",
 			"matched rule has no active services")
-		narrowToBasePool()
 		return nil, false
 	}
 
@@ -252,6 +245,7 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, state *selectionStat
 	// routing used to terminal-select here, but that ran after affinity, so a
 	// first-request pin could defeat content routing for the whole session
 	// TTL and skip processor ops entirely for pinned sessions.
+	matchedPartition = true
 	ctx.MatchedSmartRuleIndex = matchedRuleIndex
 	logrus.Debugf("[smart_routing] rule %d matched, narrowing candidates to %d services",
 		matchedRuleIndex, len(activeServices))

--- a/internal/routing/stage_smart_routing_processor_test.go
+++ b/internal/routing/stage_smart_routing_processor_test.go
@@ -17,28 +17,29 @@ import (
 // runStagePipeline mimics the body of ServiceSelector.Select's stage loop for
 // in-package assertions. Returns the first result a stage produced, the index
 // of the producing stage, and a slice naming every stage that was evaluated.
-func runStagePipeline(t *testing.T, stages []SelectionStage, ctx *SelectionContext, state *selectionState) (*SelectionResult, int, []string) {
+func runStagePipeline(t *testing.T, stages []SelectionStage, ctx *SelectionContext, candidates []*loadbalance.Service) (*SelectionResult, int, []string) {
 	t.Helper()
 	var evaluated []string
 	for i, stage := range stages {
 		evaluated = append(evaluated, stage.Name())
-		result, handled := stage.Evaluate(ctx, state)
-		if handled {
+		narrowed, result, err := stage.Evaluate(ctx, candidates)
+		require.NoError(t, err)
+		if result != nil {
 			return result, i, evaluated
 		}
+		candidates = narrowed
 	}
 	return nil, -1, evaluated
 }
 
 // recordingStage records every Evaluate call (with the request pointer it
-// observed) and returns a canned result. Used as a stand-in for the
+// observed) and returns a canned final result. Used as a stand-in for the
 // LoadBalancerStage so tests can verify the request handed downstream after
 // a bypass is the MUTATED one.
 type recordingStage struct {
-	name    string
-	calls   []recordedCall
-	result  *SelectionResult
-	handled bool
+	name  string
+	calls []recordedCall
+	final *SelectionResult
 }
 
 type recordedCall struct {
@@ -47,9 +48,9 @@ type recordedCall struct {
 
 func (s *recordingStage) Name() string { return s.name }
 
-func (s *recordingStage) Evaluate(ctx *SelectionContext, _ *selectionState) (*SelectionResult, bool) {
+func (s *recordingStage) Evaluate(ctx *SelectionContext, candidates []*loadbalance.Service) ([]*loadbalance.Service, *SelectionResult, error) {
 	s.calls = append(s.calls, recordedCall{Request: ctx.Request})
-	return s.result, s.handled
+	return candidates, s.final, nil
 }
 
 // betaReqWithImage builds a Beta request carrying one image — local copy to
@@ -101,8 +102,8 @@ func bypassOp() smartrouting.SmartOp {
 
 func TestSmartRoutingStage_ProcessorBypass_RunsProcessorAndContinues(t *testing.T) {
 	// A processor registered for a matched op must run, and the smart-routing
-	// stage must return (nil, false) so the pipeline continues to the next
-	// stage (implicit bypass).
+	// stage must not terminate (final == nil) so the pipeline continues to
+	// the next stage (implicit bypass).
 	called := 0
 	smartrouting.RegisterProcessor(bypassOpPosition, bypassOpEnabled,
 		processorFunc(func(_ *smartrouting.ProcessorContext) error {
@@ -119,9 +120,10 @@ func TestSmartRoutingStage_ProcessorBypass_RunsProcessorAndContinues(t *testing.
 	ctx.Request = betaReqWithImage("describe")
 
 	stage := NewSmartRoutingStage(newMockAffinityStore())
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	_, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
 
-	require.False(t, handled, "stage must not terminate when a processor is present (implicit bypass)")
+	require.NoError(t, err)
+	require.Nil(t, final, "stage must not terminate when a processor is present (implicit bypass)")
 	require.Equal(t, 1, called, "registered processor must be invoked")
 }
 
@@ -134,12 +136,12 @@ func TestSmartRoutingStage_NoProcessor_NarrowsCandidates(t *testing.T) {
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
 	stage := NewSmartRoutingStage(newMockAffinityStore())
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
 
-	require.False(t, handled, "no processor → narrow, never terminate")
-	require.NotNil(t, result)
-	require.Len(t, result.FilteredServices, 1)
-	require.Equal(t, "gpt-4", result.FilteredServices[0].Model)
+	require.NoError(t, err)
+	require.Nil(t, final, "no processor → narrow, never terminate")
+	require.Len(t, narrowed, 1)
+	require.Equal(t, "gpt-4", narrowed[0].Model)
 	require.Equal(t, 0, ctx.MatchedSmartRuleIndex)
 }
 
@@ -162,9 +164,10 @@ func TestSmartRoutingStage_BypassedRule_NotReentered(t *testing.T) {
 	ctx.BypassedSmartRules = map[int]struct{}{0: {}}
 
 	stage := NewSmartRoutingStage(newMockAffinityStore())
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
+	_, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
 
-	require.False(t, handled, "stage must not terminate; pipeline continues")
+	require.NoError(t, err)
+	require.Nil(t, final, "stage must not terminate; pipeline continues")
 	require.Equal(t, 0, called, "processor must NOT be re-invoked for an already-bypassed rule")
 }
 
@@ -197,9 +200,9 @@ func TestSmartRoutingStage_ProcessorMutatesRequest_LoadBalancerSeesMutation(t *t
 	ctx.Request = betaReqWithImage("describe")
 
 	smart := NewSmartRoutingStage(newMockAffinityStore())
-	rec := &recordingStage{name: "recording", result: NewResult(services[0], "recording"), handled: true}
+	rec := &recordingStage{name: "recording", final: NewResult(services[0], "recording")}
 
-	_, idx, evaluated := runStagePipeline(t, []SelectionStage{smart, rec}, ctx, newSelectionState(ctx.Rule))
+	_, idx, evaluated := runStagePipeline(t, []SelectionStage{smart, rec}, ctx, initialCandidateServices(ctx.Rule))
 
 	require.Equal(t, 1, idx, "recording stage produced the result (smart bypassed)")
 	require.Equal(t, []string{"smart_routing", "recording"}, evaluated)

--- a/internal/routing/stage_smart_routing_test.go
+++ b/internal/routing/stage_smart_routing_test.go
@@ -52,15 +52,14 @@ func TestSmartRouting_RuleMatch(t *testing.T) {
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
-	// A match is a FILTER, not a terminal selection: the stage narrows the
-	// candidate set to the matched subset so affinity/LB run within it.
+	// A match narrows the candidate set to the matched subset; the stage
+	// never terminates (final is always nil) — affinity/LB run within it.
 	stage := NewSmartRoutingStage(newMockAffinityStore())
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "smart routing narrows candidates; it does not select")
-	require.NotNil(t, result)
-	require.Equal(t, "smart_routing", result.Source)
-	require.Len(t, result.FilteredServices, 1)
-	require.Equal(t, "gpt-4", result.FilteredServices[0].Model)
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final, "smart routing narrows candidates; it does not select")
+	require.Len(t, narrowed, 1)
+	require.Equal(t, "gpt-4", narrowed[0].Model)
 	require.Equal(t, 0, ctx.MatchedSmartRuleIndex)
 }
 
@@ -72,9 +71,10 @@ func TestSmartRouting_NoMatch(t *testing.T) {
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
 	stage := NewSmartRoutingStage(newMockAffinityStore())
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "should pass when rule doesn't match")
-	require.Nil(t, result, "no match must not narrow the candidate set")
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final, "should pass when rule doesn't match")
+	require.Equal(t, services, narrowed, "no match must fall back to the rule's base pool")
 	require.Equal(t, -1, ctx.MatchedSmartRuleIndex)
 }
 
@@ -84,8 +84,9 @@ func TestSmartRouting_Disabled(t *testing.T) {
 
 	stage := NewSmartRoutingStage(newMockAffinityStore())
 	ctx := testContext(rule, "")
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled)
+	_, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final)
 }
 
 func TestSmartRouting_EmptyRules(t *testing.T) {
@@ -97,8 +98,9 @@ func TestSmartRouting_EmptyRules(t *testing.T) {
 	ctx := testContext(rule, "")
 	ctx.Request = testOpenAIRequest("gpt-4")
 
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled)
+	_, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final)
 }
 
 func TestSmartRouting_NilRequest(t *testing.T) {
@@ -109,8 +111,9 @@ func TestSmartRouting_NilRequest(t *testing.T) {
 	ctx := testContext(rule, "")
 	ctx.Request = nil
 
-	_, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled)
+	_, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final)
 }
 
 func TestSmartRouting_InactiveServiceFiltered(t *testing.T) {
@@ -121,9 +124,10 @@ func TestSmartRouting_InactiveServiceFiltered(t *testing.T) {
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
 	stage := NewSmartRoutingStage(newMockAffinityStore())
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled, "should pass when matched service is inactive")
-	require.Nil(t, result, "an all-inactive subset must not narrow the candidate set")
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final, "should pass when matched service is inactive")
+	require.Equal(t, services, narrowed, "an all-inactive subset falls back to the base pool")
 }
 
 func TestSmartRouting_MultipleServices_Narrowed(t *testing.T) {
@@ -138,9 +142,10 @@ func TestSmartRouting_MultipleServices_Narrowed(t *testing.T) {
 
 	// The full matched subset is handed downstream; the LB stage picks within it.
 	stage := NewSmartRoutingStage(newMockAffinityStore())
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled)
-	require.Len(t, result.FilteredServices, 2)
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final)
+	require.Len(t, narrowed, 2)
 }
 
 func TestSmartRouting_MatchedRuleIndex(t *testing.T) {
@@ -159,10 +164,11 @@ func TestSmartRouting_MatchedRuleIndex(t *testing.T) {
 	ctx.Request = testOpenAIRequest("gpt-4o")
 
 	stage := NewSmartRoutingStage(newMockAffinityStore())
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled)
-	require.Len(t, result.FilteredServices, 1)
-	require.Equal(t, "provider-b", result.FilteredServices[0].Provider)
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final)
+	require.Len(t, narrowed, 1)
+	require.Equal(t, "provider-b", narrowed[0].Provider)
 	require.Equal(t, 1, ctx.MatchedSmartRuleIndex, "second rule should match")
 }
 
@@ -209,11 +215,11 @@ func TestSmartRouting_AgentClaudeCode_SubagentRoutesToCheapPool(t *testing.T) {
 	ctx.Request = subagentReq
 
 	stage := NewSmartRoutingStage(newMockAffinityStore())
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled)
-	require.NotNil(t, result, "subagent request should match and narrow candidates")
-	require.Len(t, result.FilteredServices, 1)
-	require.Equal(t, "provider-cheap", result.FilteredServices[0].Provider)
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final)
+	require.Len(t, narrowed, 1, "subagent request should match and narrow candidates")
+	require.Equal(t, "provider-cheap", narrowed[0].Provider)
 }
 
 func TestSmartRouting_AgentClaudeCode_MainDoesNotMatchSubagentRule(t *testing.T) {
@@ -252,9 +258,11 @@ func TestSmartRouting_AgentClaudeCode_MainDoesNotMatchSubagentRule(t *testing.T)
 	ctx.Request = mainReq
 
 	stage := NewSmartRoutingStage(newMockAffinityStore())
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled)
-	require.Nil(t, result, "main-agent request should not match subagent-only rule")
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final, "main-agent request should not match subagent-only rule")
+	require.Equal(t, []*loadbalance.Service{cheapSvc}, narrowed, "falls back to the base pool")
+	require.Equal(t, -1, ctx.MatchedSmartRuleIndex)
 }
 
 // TestSmartRouting_LatestUser_ToolResultDoesNotLockBranch is the stage-level
@@ -279,10 +287,12 @@ func TestSmartRouting_LatestUser_ToolResultDoesNotLockBranch(t *testing.T) {
 	ctx.Request = betaRequestWithToolResult("keyword")
 
 	stage := NewSmartRoutingStage(newMockAffinityStore())
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled)
-	require.Nil(t, result,
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final,
 		"tool_result as last user message must not match latest_user contains rule")
+	require.Equal(t, []*loadbalance.Service{specialSvc}, narrowed, "falls back to the base pool")
+	require.Equal(t, -1, ctx.MatchedSmartRuleIndex)
 }
 
 // TestSmartRouting_LatestUser_TextMatchesAfterToolResult verifies that when a
@@ -329,10 +339,11 @@ func TestSmartRouting_LatestUser_TextMatchesAfterToolResult(t *testing.T) {
 	ctx.Request = req
 
 	stage := NewSmartRoutingStage(newMockAffinityStore())
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled)
-	require.NotNil(t, result, "real user text with keyword must match")
-	require.Equal(t, "provider-special", result.FilteredServices[0].Provider)
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final)
+	require.Len(t, narrowed, 1, "real user text with keyword must match")
+	require.Equal(t, "provider-special", narrowed[0].Provider)
 }
 
 func TestSmartRouting_AgentClaudeCode_NonClaudeCodeScenarioDoesNotMatch(t *testing.T) {
@@ -362,7 +373,8 @@ func TestSmartRouting_AgentClaudeCode_NonClaudeCodeScenarioDoesNotMatch(t *testi
 	ctx.Request = testOpenAIRequest("gpt-4")
 
 	stage := NewSmartRoutingStage(newMockAffinityStore())
-	result, handled := stage.Evaluate(ctx, newSelectionState(ctx.Rule))
-	require.False(t, handled)
-	require.Nil(t, result, "non-claude_code scenarios should not satisfy agent.claude_code ops")
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final, "non-claude_code scenarios should not satisfy agent.claude_code ops")
+	require.Equal(t, []*loadbalance.Service{svc}, narrowed, "falls back to the base pool")
 }


### PR DESCRIPTION
## Summary
`harness routing`'s `pipeline-smart-routing-before-load-balancer` scenario caught an intermittent misroute: when a request matched no smart-routing partition, services that only exist inside an *unmatched* partition could still leak into the terminal LoadBalancer pick. 

Base-pool and partition-scoped services get their `Service.Tier` normalized independently on save, so an unmatched partition service could collide into the same tier bucket as the intended base-pool primary and randomly win the within-tier pick — a ~1-in-3 flake, not a hard failure, which is why it slipped through.

## Key Changes

- **Base-pool fallback enforced**: `SmartRoutingStage` now narrows the candidate set back down to the rule's base `Services` on every exit that does NOT land on a matched partition (no match, disabled, bypassed, no active services in the matched set, ...) — a partition-only service can no longer reach the fallback pick.
- **Explicit candidate passing replaces shared mutable state**: `SelectionStage.Evaluate` used to thread a shared `*selectionState` pointer through all four stages and signal "no opinion" with a bare `nil` — the exact shape that let the bug above hide across 7 separate early-return branches. It's now `(narrowed []*loadbalance.Service, final *SelectionResult, err error)`: every stage receives candidates as an explicit argument and returns what it asserts the set now is, so a future early-return can't silently skip narrowing again.
- **Lazy base-pool computation**: the intersection this fix needs only runs on branches that actually take the non-matched exit; the common "partition matched" path pays nothing for it, and rules with no smart routing configured at all skip it entirely (a provable no-op there).

## Minor
- Collapsed a duplicated rationale comment between `selector.go` and `stage_smart_routing.go` onto its one canonical location.

## Testing
- `go build ./...`, `go test ./internal/...`
- `./harness routing` — all 11 built-in scenarios, 5 consecutive clean runs
- `./harness routing --scenarios pipeline-smart-routing-before-load-balancer` looped 30+ times to confirm the flake is gone
- New regression unit test (`pipeline_scenarios_test.go`) — fails on the pre-fix code, passes after
- 4-angle cleanup review (reuse/simplification/efficiency/altitude) over the diff, no correctness findings