### PR TITLE
fix(nvidia): strip top-level prompt_cache fields for NIM (Claude Code 400)

### DIFF
--- a/internal/protocol/ops/request_openai_extensions.go
+++ b/internal/protocol/ops/request_openai_extensions.go
@@ -26,6 +26,11 @@ func ApplyProviderTransforms(req *openai.ChatCompletionNewParams, providerURL, m
 		strings.Contains(url, "opencode.ai/zen/go") && strings.Contains(modelLower, "deepseek"):
 		return applyDeepSeekTransform(req, providerURL, model, config)
 
+	case strings.Contains(url, "integrate.api.nvidia.com"):
+		// NVIDIA NIM rejects prompt-cache fields that Claude Code sends:
+		// "Unsupported parameter(s): `prompt_cache_options`". Strip them.
+		return applyDefaultTransform(stripPromptCacheForNVIDIA(req), config)
+
 	case strings.Contains(url, "generativelanguage.googleapis.com") && strings.Contains(modelLower, "gemini"):
 		return applyGeminiTransform(req, providerURL, model, config)
 

--- a/internal/protocol/ops/request_openai_nvidia.go
+++ b/internal/protocol/ops/request_openai_nvidia.go
@@ -1,0 +1,22 @@
+package ops
+
+import (
+	"github.com/openai/openai-go/v3"
+)
+
+// stripPromptCacheForNVIDIA removes prompt-cache fields that the NVIDIA NIM
+// OpenAI-compatible endpoint rejects with:
+//
+//	400 Bad Request: {"message":"Validation: Unsupported parameter(s): `prompt_cache_options`"}
+//
+// Claude Code sends `prompt_cache_options` / `prompt_cache_retention` at the
+// request top level on every multi-turn request. Both fields are tagged
+// `omitzero` in the SDK, so zeroing them omits them from the marshaled request
+// without a JSON round-trip — which would drop per-message extra fields such
+// as `x_thinking` / `reasoning_content`.
+func stripPromptCacheForNVIDIA(req *openai.ChatCompletionNewParams) *openai.ChatCompletionNewParams {
+	req.PromptCacheOptions = openai.ChatCompletionNewParamsPromptCacheOptions{}
+	req.PromptCacheRetention = ""
+
+	return req
+}

--- a/internal/protocol/ops/request_openai_nvidia_test.go
+++ b/internal/protocol/ops/request_openai_nvidia_test.go
@@ -1,0 +1,129 @@
+package ops
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+const nvidiaNIMURL = "https://integrate.api.nvidia.com/v1"
+
+// TestNVIDIAStripPromptCacheTopLevel proves that the top-level
+// prompt_cache_options / prompt_cache_retention fields Claude Code sends are
+// removed before the request is forwarded to NVIDIA NIM.
+func TestNVIDIAStripPromptCacheTopLevel(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:                openai.ChatModel("thinkingmachines/inkling"),
+		PromptCacheOptions:   openai.ChatCompletionNewParamsPromptCacheOptions{Mode: "implicit"},
+		PromptCacheRetention: openai.ChatCompletionNewParamsPromptCacheRetention("1400h"),
+		Messages: []openai.ChatCompletionMessageParamUnion{{
+			OfUser: &openai.ChatCompletionUserMessageParam{
+				Name:    openai.String("u"),
+				Content: openai.ChatCompletionUserMessageParamContentUnion{OfString: openai.String("hi")},
+			},
+		}},
+	}
+
+	ApplyProviderTransforms(req, nvidiaNIMURL, string(req.Model), &protocol.OpenAIConfig{})
+
+	raw := marshalParams(t, req)
+	assert.NotContains(t, raw, "prompt_cache_options",
+		"prompt_cache_options must be stripped for NVIDIA NIM")
+	assert.NotContains(t, raw, "prompt_cache_retention",
+		"prompt_cache_retention must be stripped for NVIDIA NIM")
+}
+
+// TestNVIDIAStripOnlyPromptCacheOptions proves stripping also works when only
+// prompt_cache_options is set (retention absent).
+func TestNVIDIAStripOnlyPromptCacheOptions(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:              openai.ChatModel("thinkingmachines/inkling"),
+		PromptCacheOptions: openai.ChatCompletionNewParamsPromptCacheOptions{Mode: "implicit"},
+		Messages: []openai.ChatCompletionMessageParamUnion{{
+			OfUser: &openai.ChatCompletionUserMessageParam{
+				Name:    openai.String("u"),
+				Content: openai.ChatCompletionUserMessageParamContentUnion{OfString: openai.String("hi")},
+			},
+		}},
+	}
+
+	ApplyProviderTransforms(req, nvidiaNIMURL, string(req.Model), &protocol.OpenAIConfig{})
+
+	raw := marshalParams(t, req)
+	assert.NotContains(t, raw, "prompt_cache_options",
+		"prompt_cache_options must be stripped for NVIDIA NIM")
+	assert.NotContains(t, raw, "prompt_cache_retention",
+		"prompt_cache_retention must not be injected when absent")
+}
+
+// TestNVIDIAStripPreservesMessageExtras proves that per-message extra fields
+// (x_thinking / reasoning_content) survive the transform for NVIDIA NIM.
+func TestNVIDIAStripPreservesMessageExtras(t *testing.T) {
+	msg := assistantToolCallMessage(t)
+	msg.OfAssistant.SetExtraFields(map[string]any{"x_thinking": "I need to call a tool"})
+
+	req := &openai.ChatCompletionNewParams{
+		Model:    openai.ChatModel("thinkingmachines/inkling"),
+		Messages: []openai.ChatCompletionMessageParamUnion{msg},
+	}
+
+	ApplyProviderTransforms(req, nvidiaNIMURL, string(req.Model), &protocol.OpenAIConfig{})
+
+	raw := marshalMessage(t, req.Messages[0])
+	assert.Equal(t, "I need to call a tool", raw["x_thinking"],
+		"x_thinking must survive the NVIDIA transform untouched")
+	assert.NotContains(t, raw, "reasoning_content",
+		"NVIDIA models must not get a DeepSeek-style reasoning_content injection")
+}
+
+// TestNVIDIAStripPreservesRequestExtras proves that request-level extra fields
+// (e.g. thinking passthrough) survive the transform for NVIDIA NIM.
+func TestNVIDIAStripPreservesRequestExtras(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model: openai.ChatModel("thinkingmachines/inkling"),
+		Messages: []openai.ChatCompletionMessageParamUnion{{
+			OfUser: &openai.ChatCompletionUserMessageParam{
+				Name:    openai.String("u"),
+				Content: openai.ChatCompletionUserMessageParamContentUnion{OfString: openai.String("hi")},
+			},
+		}},
+	}
+	req.SetExtraFields(map[string]any{"x_tb_test": "kept"})
+
+	ApplyProviderTransforms(req, nvidiaNIMURL, string(req.Model), &protocol.OpenAIConfig{})
+
+	raw := marshalParams(t, req)
+	assert.Equal(t, "kept", raw["x_tb_test"],
+		"request-level extra fields must survive the NVIDIA transform")
+}
+
+// TestNVIDIANonNVIDIAProvidersUnaffected proves the transform only fires for
+// NVIDIA NIM URLs.
+func TestNVIDIANonNVIDIAProvidersUnaffected(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:              openai.ChatModel("gpt-oss-20b"),
+		PromptCacheOptions: openai.ChatCompletionNewParamsPromptCacheOptions{Mode: "implicit"},
+	}
+	req.SetExtraFields(map[string]any{"x_tb_test": "kept"})
+
+	ApplyProviderTransforms(req, "https://api.openai.com/v1", string(req.Model), &protocol.OpenAIConfig{})
+
+	raw := marshalParams(t, req)
+	assert.Contains(t, raw, "prompt_cache_options",
+		"non-NVIDIA providers must keep prompt_cache_options")
+}
+
+func marshalParams(t *testing.T, req *openai.ChatCompletionNewParams) map[string]any {
+	t.Helper()
+
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(reqBytes, &raw))
+	return raw
+}


### PR DESCRIPTION
## What
Routing Claude Code through tingly-box to NVIDIA NIM (`integrate.api.nvidia.com`, model `thinkingmachines/inkling`) fails with `400 "Unsupported parameter(s): prompt_cache_options"`. Claude Code sends an Anthropic-format request with `cache_control: {type: ephemeral}` on its system blocks; tingly's Anthropic->OpenAI conversion **derives** top-level `prompt_cache_options` / `prompt_cache_retention` from those markers, and NIM rejects both top-level fields (per-message markers are fine). The MITM-captured body sent to NIM contained a top-level `prompt_cache_options`; a direct probe of NIM confirms that field (and `prompt_cache_retention`) is the sole cause of the `400`.

## Fix
- New `stripPromptCacheForNVIDIA` zeroes `PromptCacheOptions` + `PromptCacheRetention`. Both carry `omitzero`; the SDK marshals via `param.MarshalObject` (shimmed `encoding/json` honoring `omitzero`), so the keys are omitted with no JSON round-trip -- per-message extras (`x_thinking` / `reasoning_content` / `prompt_cache_breakpoint`) are preserved. (An earlier round-trip iteration silently dropped `ExtraFields` and was rejected.)
- New `integrate.api.nvidia.com` case in `ApplyProviderTransforms`. Scoped: `api.openai.com` and other providers keep `prompt_cache_options` (covered by `TestNVIDIANonNVIDIAProvidersUnaffected`).
- `applyDefaultTransform` after the strip only sets `ReasoningEffort` / `thinking`; it does not re-inject the cache fields. Mirrors `sanitizeCodexPromptCacheJSON` in `codex_round_tripper.go:239-240`.
- Scope is NVIDIA only; other providers keep `prompt_cache_options`.

## Testing
- `go test ./internal/protocol/ops/` -> ok (5 new unit tests; existing untouched). Tests are pure unit (no HTTP); they verify `omitzero` omission + extra-field preservation + non-NVIDIA scope.
- `go test ./internal/protocol/transform/` + `./internal/protocoltest/` -> ok. `go build ./internal/...` clean.
- Direct `curl` against NIM (router-independent): `prompt_cache_options` top-level -> 400, `prompt_cache_retention` top-level -> 400, neither -> 200, per-message `prompt_cache_breakpoint` -> 200.
- 1:1 A/B on the router with the same multi-turn payload carrying `cache_control`: original binary -> 400, patched binary -> 200.
- Live: rebuilt daemon, real `claude-cli/2.1.220` on `thinkingmachines/inkling` -> `upstream 200 via direct` (was `400`); recorded transformed body keeps `prompt_cache_breakpoint:{mode:"explicit"}` on the system content part and omits top-level `prompt_cache_options`.

Fixes #1548

