### PR TITLE
bugfix(frontend): keep paste-detect action buttons reachable on long results

### DIFF
--- a/frontend/src/components/paste-detect/PasteDetectDialog.tsx
+++ b/frontend/src/components/paste-detect/PasteDetectDialog.tsx
@@ -58,14 +58,7 @@ const PasteDetectDialog: React.FC<PasteDetectDialogProps> = ({open, onClose, onP
                     <IconButton aria-label="Close Paste and detect" onClick={onClose} size="small"><Close/></IconButton>
                 </Stack>
             </DialogTitle>
-            <DialogContent
-                dividers
-                sx={{
-                    pt: 2,
-                    flex: 1,
-                    overflowY: 'hidden', // Panel handles its own scrolling
-                }}
-            >
+            <DialogContent dividers sx={{pt: 2}}>
                 <PasteDetectPanel
                     onPick={onPick}
                     onManualFill={() => onPick(emptyForm())}

--- a/frontend/src/components/paste-detect/PasteDetectPanel.tsx
+++ b/frontend/src/components/paste-detect/PasteDetectPanel.tsx
@@ -95,8 +95,8 @@ const PasteDetectPanel: React.FC<PasteDetectPanelProps> = ({onPick, onManualFill
             <TextField
                 fullWidth
                 multiline
-                minRows={6}
-                maxRows={14}
+                minRows={4}
+                maxRows={8}
                 value={input}
                 onChange={e => setInput(e.target.value)}
                 placeholder={PLACEHOLDER}
@@ -146,7 +146,7 @@ const PasteDetectPanel: React.FC<PasteDetectPanelProps> = ({onPick, onManualFill
                             </Typography>
 
                             <Stack direction={{xs: 'column', md: 'row'}} spacing={2}>
-                                <Paper variant="outlined" sx={{flex: 1, p: 1.5, minWidth: 0}}>
+                                <Paper variant="outlined" sx={{flex: 1, p: 1.5, minWidth: 0, display: 'flex', flexDirection: 'column', maxHeight: 260}}>
                                     <Stack
                                         direction="row"
                                         spacing={1}
@@ -169,7 +169,7 @@ const PasteDetectPanel: React.FC<PasteDetectPanelProps> = ({onPick, onManualFill
                                             {t('onboarding.paste.noURL', {defaultValue: 'No URLs detected.'})}
                                         </Typography>
                                     ) : (
-                                        <List dense disablePadding>
+                                        <List dense disablePadding sx={{overflowY: 'auto', flex: 1, minHeight: 0, mr: -0.5, pr: 0.5}}>
                                             {urls!.map(u => (
                                                 <ListItemButton
                                                     key={u}
@@ -193,7 +193,7 @@ const PasteDetectPanel: React.FC<PasteDetectPanelProps> = ({onPick, onManualFill
                                     )}
                                 </Paper>
 
-                                <Paper variant="outlined" sx={{flex: 1, p: 1.5, minWidth: 0}}>
+                                <Paper variant="outlined" sx={{flex: 1, p: 1.5, minWidth: 0, display: 'flex', flexDirection: 'column', maxHeight: 260}}>
                                     <Stack
                                         direction="row"
                                         spacing={1}
@@ -216,7 +216,7 @@ const PasteDetectPanel: React.FC<PasteDetectPanelProps> = ({onPick, onManualFill
                                             {t('onboarding.paste.noToken', {defaultValue: 'No tokens detected.'})}
                                         </Typography>
                                     ) : (
-                                        <List dense disablePadding>
+                                        <List dense disablePadding sx={{overflowY: 'auto', flex: 1, minHeight: 0, mr: -0.5, pr: 0.5}}>
                                             {tokens!.map(tok => (
                                                 <ListItemButton
                                                     key={tok.value}


### PR DESCRIPTION
## Summary

In the Connect AI "Paste & detect" dialog, detecting many URLs/tokens stretched the candidate lists past the 88vh dialog and pushed the "Use selected" button off-screen, so it couldn't be clicked. The DialogContent also hid its own overflow while the panel never actually scrolled.

## Key Changes

- **Shorter input**: paste textarea dropped from 6–14 rows to 4–8, freeing vertical space for results.
- **Per-card scroll**: each "Detected URLs" / "Detected tokens" card is capped at `maxHeight: 260` and only its inner list scrolls, so the two cards scroll independently instead of stretching the whole dialog.
- **Whole-panel fallback**: DialogContent reverted to MUI's default `scroll="paper"`, so on small viewports the entire panel still scrolls and the buttons stay reachable.