### PR TITLE
feat(layout): collapsible sidebar + consolidated nav styles

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -65,7 +65,9 @@ export default {
       "separate": "Separate",
       "unified": "Unified",
       "createProfileTooltip": "Create a new Claude Code profile with custom settings",
-      "sloganTooltip": "For all Solo Builders, Dev Teams and Agents."
+      "sloganTooltip": "For all Solo Builders, Dev Teams and Agents.",
+      "collapse": "Collapse sidebar",
+      "expand": "Expand sidebar"
     },
     "activityBar": {
       "disconnected": "Disconnected",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -67,7 +67,9 @@ export default {
       "separate": "分离",
       "unified": "统一",
       "createProfileTooltip": "创建一个新的 Claude Code 配置文件，自定义设置",
-      "sloganTooltip": "致，所有独立开发者、开发团队和智能应用。"
+      "sloganTooltip": "致，所有独立开发者、开发团队和智能应用。",
+      "collapse": "收起侧边栏",
+      "expand": "展开侧边栏"
     },
     "activityBar": {
       "disconnected": "已断开",

--- a/frontend/src/layout/ActivityBar.tsx
+++ b/frontend/src/layout/ActivityBar.tsx
@@ -1,7 +1,6 @@
-import { Person as IconUser, Translate as IconLanguage, AutoFixHigh as IconWand, MessageReport as IconMessageReport } from '@/components/icons';
-import { tablerMui } from '@/components/icons';
-import { IconLayoutSidebarLeftCollapse, IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
-import { Box, Divider, ListItemButton, ListItemIcon, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
+import { Person as IconUser, Translate as IconLanguage, AutoFixHigh as IconWand, MessageReport as IconMessageReport, tablerMui } from '@/components/icons';
+import { IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
+import { Box, Divider, IconButton, ListItemButton, ListItemIcon, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
 import React, { useMemo, useState } from 'react';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -14,6 +13,7 @@ import {
 import {
     activityBottomClusterSx,
     activityBottomItemSx,
+    activityExpandHandleSx,
     activityIconsScrollSx,
     activityItemSx,
     activityLogoButtonSx,
@@ -25,7 +25,6 @@ import type { ActivityItem } from './types';
 import type { ThemeMode } from '@/theme';
 import { getThemeOptions } from '@/theme/options';
 
-const IconCollapseSidebar = tablerMui(IconLayoutSidebarLeftCollapse);
 const IconExpandSidebar = tablerMui(IconLayoutSidebarLeftExpand);
 
 interface ActivityBarProps {
@@ -87,6 +86,19 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
         <Box
             sx={{ width: activityBarWidth, ...activityRailSx }}
         >
+            {/* Edge expand handle — only when the Sidebar is collapsed. Straddles
+                the rail's right border so it reads as a handle attached to it. */}
+            {sidebarCollapsed && (
+                <Tooltip title={t('layout.sidebar.expand')} placement="right" arrow>
+                    <IconButton
+                        onClick={toggleSidebar}
+                        aria-label={t('layout.sidebar.expand')}
+                        sx={activityExpandHandleSx}
+                    >
+                        <IconExpandSidebar sx={{ fontSize: 16 }} />
+                    </IconButton>
+                </Tooltip>
+            )}
             {/* Logo */}
             <Box sx={activityLogoCellSx}>
                 <Tooltip title={`Tingly-Box v${currentVersion}`} placement="right" arrow>
@@ -306,24 +318,6 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
                         <Typography variant="caption" sx={{ color: 'inherit', textAlign: 'center', lineHeight: 1.1, fontSize: '0.65rem' }}>
                             {currentThemeOption?.label ?? 'Light'}
                         </Typography>
-                    </ListItemButton>
-                </Tooltip>
-            </Box>
-
-            {/* Collapse sidebar toggle - shows the secondary list when expanded,
-                hides it (keeping this icon rail) when collapsed. */}
-            <Box sx={activityBottomClusterSx}>
-                <Tooltip title={t(sidebarCollapsed ? 'layout.sidebar.expand' : 'layout.sidebar.collapse')} placement="right" arrow>
-                    <ListItemButton
-                        onClick={toggleSidebar}
-                        aria-label={t(sidebarCollapsed ? 'layout.sidebar.expand' : 'layout.sidebar.collapse')}
-                        sx={activityBottomItemSx({
-                            '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
-                        })}
-                    >
-                        <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
-                            {sidebarCollapsed ? <IconExpandSidebar sx={{ fontSize: 22 }} /> : <IconCollapseSidebar sx={{ fontSize: 22 }} />}
-                        </ListItemIcon>
                     </ListItemButton>
                 </Tooltip>
             </Box>

--- a/frontend/src/layout/ActivityBar.tsx
+++ b/frontend/src/layout/ActivityBar.tsx
@@ -1,5 +1,4 @@
-import { Person as IconUser, Translate as IconLanguage, AutoFixHigh as IconWand, MessageReport as IconMessageReport, tablerMui } from '@/components/icons';
-import { IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
+import { Person as IconUser, Translate as IconLanguage, AutoFixHigh as IconWand, MessageReport as IconMessageReport, ChevronRight as IconChevronRight } from '@/components/icons';
 import { Box, Divider, IconButton, ListItemButton, ListItemIcon, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
 import React, { useMemo, useState } from 'react';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
@@ -24,8 +23,6 @@ import { useSidebarCollapsed } from './useSidebarCollapsed';
 import type { ActivityItem } from './types';
 import type { ThemeMode } from '@/theme';
 import { getThemeOptions } from '@/theme/options';
-
-const IconExpandSidebar = tablerMui(IconLayoutSidebarLeftExpand);
 
 interface ActivityBarProps {
     activityItems: ActivityItem[];
@@ -86,8 +83,9 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
         <Box
             sx={{ width: activityBarWidth, ...activityRailSx }}
         >
-            {/* Edge expand handle — only when the Sidebar is collapsed. Straddles
-                the rail's right border so it reads as a handle attached to it. */}
+            {/* Expand handle — only when the Sidebar is collapsed. Sits at the
+                logo divider's right end so it aligns with the collapse button in
+                the Sidebar header (the two form a symmetric pair). */}
             {sidebarCollapsed && (
                 <Tooltip title={t('layout.sidebar.expand')} placement="right" arrow>
                     <IconButton
@@ -95,7 +93,7 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
                         aria-label={t('layout.sidebar.expand')}
                         sx={activityExpandHandleSx}
                     >
-                        <IconExpandSidebar sx={{ fontSize: 16 }} />
+                        <IconChevronRight sx={{ fontSize: 18 }} />
                     </IconButton>
                 </Tooltip>
             )}

--- a/frontend/src/layout/ActivityBar.tsx
+++ b/frontend/src/layout/ActivityBar.tsx
@@ -7,13 +7,17 @@ import { useVersion as useAppVersion } from '../contexts/VersionContext';
 import { useThemeMode } from '../contexts/ThemeContext';
 import {
     activityBarWidth,
-    activityContainerPaddingY,
-    activityItemPaddingX,
-    activityItemRadius,
-    activityItemSx,
     footerHeight,
-    headerHeight,
 } from './constants';
+import {
+    activityBottomClusterSx,
+    activityBottomItemSx,
+    activityIconsScrollSx,
+    activityItemSx,
+    activityLogoButtonSx,
+    activityLogoCellSx,
+    activityRailSx,
+} from './styles';
 import type { ActivityItem } from './types';
 import type { ThemeMode } from '@/theme';
 import { getThemeOptions } from '@/theme/options';
@@ -74,44 +78,17 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
 
     return (
         <Box
-            sx={{
-                width: activityBarWidth,
-                height: '100%',
-                display: 'flex',
-                flexDirection: 'column',
-                bgcolor: 'background.paper',
-                borderRight: '1px solid',
-                borderColor: 'divider',
-            }}
+            sx={{ width: activityBarWidth, ...activityRailSx }}
         >
             {/* Logo */}
-            <Box
-                sx={{
-                    height: headerHeight,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    borderBottom: '1px solid',
-                    borderColor: 'divider',
-                }}
-            >
+            <Box sx={activityLogoCellSx}>
                 <Tooltip title={`Tingly-Box v${currentVersion}`} placement="right" arrow>
                     <Box
                         component="a"
                         href="https://github.com/tingly-dev/tingly-box"
                         target="_blank"
                         rel="noopener noreferrer"
-                        sx={{
-                            width: 36,
-                            height: 36,
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            textDecoration: 'none',
-                            cursor: 'pointer',
-                            transition: 'opacity 0.18s ease-out',
-                            '&:hover': { opacity: 0.82 },
-                        }}
+                        sx={activityLogoButtonSx}
                     >
                         <Box
                             component="img"
@@ -124,7 +101,7 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
             </Box>
 
             {/* Activity Icons */}
-            <Box sx={{ flex: 1, py: activityContainerPaddingY, overflowY: 'auto' }}>
+            <Box sx={activityIconsScrollSx}>
                 {activityItems.map((item) => {
                     const isActiveItem = activeActivity === item.key;
                     const shortLabel = item.label.length > 12 ? item.label.slice(0, 7) + '…' : item.label;
@@ -267,37 +244,16 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
             </Box>
 
             {/* Feedback button - bottom-left, above language icon */}
-            <Box
-                sx={{
-                    py: 0.5,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    flexShrink: 0,
-                }}
-            >
+            <Box sx={activityBottomClusterSx}>
                 <Tooltip title={t('layout.activityBar.feedbackTooltip')} placement="right" arrow>
                     <ListItemButton
                         component="a"
                         href="https://github.com/tingly-dev/tingly-box/issues/new/choose"
                         target="_blank"
                         rel="noopener noreferrer"
-                        sx={{
-                            minHeight: 48,
-                            mx: 0.5,
-                            px: activityItemPaddingX,
-                            py: 0.75,
-                            flexDirection: 'column',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            gap: 0.25,
-                            position: 'relative',
-                            color: 'text.secondary',
-                            borderRadius: activityItemRadius,
-                            cursor: 'pointer',
+                        sx={activityBottomItemSx({
                             '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
-                        }}
+                        })}
                     >
                         <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
                             <IconMessageReport sx={{ fontSize: 22 }} />
@@ -310,84 +266,42 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
             </Box>
 
             {/* Language button - bottom-left, above user icon */}
-                <Box
-                    sx={{
-                        py: 0.5,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        flexShrink: 0,
-                    }}
-                >
-                    <Tooltip title={t('system.language.title')} placement="right" arrow>
-                        <ListItemButton
-                            onClick={handleLanguageMenuClick}
-                            sx={{
-                                minHeight: 48,
-                                mx: 0.5,
-                                px: activityItemPaddingX,
-                                py: 0.75,
-                                flexDirection: 'column',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                gap: 0.25,
-                                position: 'relative',
-                                color: 'text.secondary',
-                                borderRadius: activityItemRadius,
-                                cursor: 'pointer',
-                                '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
-                            }}
-                        >
-                            <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
-                                <IconLanguage sx={{ fontSize: 22 }} />
-                            </ListItemIcon>
-                            <Typography variant="caption" sx={{ color: 'inherit', textAlign: 'center', lineHeight: 1.1, fontSize: '0.65rem' }}>
-                                {i18n.language === 'zh' ? '中文' : 'EN'}
-                            </Typography>
-                        </ListItemButton>
-                    </Tooltip>
-                </Box>
+            <Box sx={activityBottomClusterSx}>
+                <Tooltip title={t('system.language.title')} placement="right" arrow>
+                    <ListItemButton
+                        onClick={handleLanguageMenuClick}
+                        sx={activityBottomItemSx({
+                            '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
+                        })}
+                    >
+                        <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
+                            <IconLanguage sx={{ fontSize: 22 }} />
+                        </ListItemIcon>
+                        <Typography variant="caption" sx={{ color: 'inherit', textAlign: 'center', lineHeight: 1.1, fontSize: '0.65rem' }}>
+                            {i18n.language === 'zh' ? '中文' : 'EN'}
+                        </Typography>
+                    </ListItemButton>
+                </Tooltip>
+            </Box>
 
             {/* Theme button - bottom-left, above language icon */}
-                <Box
-                    sx={{
-                        py: 0.5,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        flexShrink: 0,
-                    }}
-                >
-                    <Tooltip title={t('layout.activityBar.theme')} placement="right" arrow>
-                        <ListItemButton
-                            onClick={handleThemeMenuClick}
-                            sx={{
-                                minHeight: 48,
-                                mx: 0.5,
-                                px: activityItemPaddingX,
-                                py: 0.75,
-                                flexDirection: 'column',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                gap: 0.25,
-                                position: 'relative',
-                                color: 'text.secondary',
-                                borderRadius: activityItemRadius,
-                                cursor: 'pointer',
-                                '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
-                            }}
-                        >
-                            <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
-                                {renderCurrentThemeIcon({ size: 22 })}
-                            </ListItemIcon>
-                            <Typography variant="caption" sx={{ color: 'inherit', textAlign: 'center', lineHeight: 1.1, fontSize: '0.65rem' }}>
-                                {currentThemeOption?.label ?? 'Light'}
-                            </Typography>
-                        </ListItemButton>
-                    </Tooltip>
-                </Box>
+            <Box sx={activityBottomClusterSx}>
+                <Tooltip title={t('layout.activityBar.theme')} placement="right" arrow>
+                    <ListItemButton
+                        onClick={handleThemeMenuClick}
+                        sx={activityBottomItemSx({
+                            '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
+                        })}
+                    >
+                        <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
+                            {renderCurrentThemeIcon({ size: 22 })}
+                        </ListItemIcon>
+                        <Typography variant="caption" sx={{ color: 'inherit', textAlign: 'center', lineHeight: 1.1, fontSize: '0.65rem' }}>
+                            {currentThemeOption?.label ?? 'Light'}
+                        </Typography>
+                    </ListItemButton>
+                </Tooltip>
+            </Box>
 
             {/* Bottom: User icon */}
             <Box
@@ -408,21 +322,9 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
                 <Tooltip title={t('layout.activityBar.click')} placement="right" arrow>
                     <ListItemButton
                         onClick={onUserClick}
-                        sx={{
-                            minHeight: 48,
-                            mx: 0.5,
-                            px: activityItemPaddingX,
-                            py: 0.75,
-                            flexDirection: 'column',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            gap: 0.25,
-                            position: 'relative',
-                            color: 'text.secondary',
-                            borderRadius: activityItemRadius,
-                            cursor: 'pointer',
+                        sx={activityBottomItemSx({
                             '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
-                        }}
+                        })}
                     >
                         <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
                             <IconUser sx={{ fontSize: 20 }} />

--- a/frontend/src/layout/ActivityBar.tsx
+++ b/frontend/src/layout/ActivityBar.tsx
@@ -1,4 +1,6 @@
 import { Person as IconUser, Translate as IconLanguage, AutoFixHigh as IconWand, MessageReport as IconMessageReport } from '@/components/icons';
+import { tablerMui } from '@/components/icons';
+import { IconLayoutSidebarLeftCollapse, IconLayoutSidebarLeftExpand } from '@tabler/icons-react';
 import { Box, Divider, ListItemButton, ListItemIcon, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
 import React, { useMemo, useState } from 'react';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
@@ -18,9 +20,13 @@ import {
     activityLogoCellSx,
     activityRailSx,
 } from './styles';
+import { useSidebarCollapsed } from './useSidebarCollapsed';
 import type { ActivityItem } from './types';
 import type { ThemeMode } from '@/theme';
 import { getThemeOptions } from '@/theme/options';
+
+const IconCollapseSidebar = tablerMui(IconLayoutSidebarLeftCollapse);
+const IconExpandSidebar = tablerMui(IconLayoutSidebarLeftExpand);
 
 interface ActivityBarProps {
     activityItems: ActivityItem[];
@@ -48,6 +54,7 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
     const currentThemeOption = themeOptions.find((option) => option.value === themeMode);
     const renderCurrentThemeIcon = currentThemeOption?.renderIcon ?? themeOptions[0].renderIcon;
     const isOnboardingActive = location.pathname === '/onboarding';
+    const { collapsed: sidebarCollapsed, toggle: toggleSidebar } = useSidebarCollapsed();
 
     const handleLanguageMenuClick = (event: React.MouseEvent<HTMLElement>) => {
         setLanguageMenuAnchorEl(event.currentTarget);
@@ -299,6 +306,24 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
                         <Typography variant="caption" sx={{ color: 'inherit', textAlign: 'center', lineHeight: 1.1, fontSize: '0.65rem' }}>
                             {currentThemeOption?.label ?? 'Light'}
                         </Typography>
+                    </ListItemButton>
+                </Tooltip>
+            </Box>
+
+            {/* Collapse sidebar toggle - shows the secondary list when expanded,
+                hides it (keeping this icon rail) when collapsed. */}
+            <Box sx={activityBottomClusterSx}>
+                <Tooltip title={t(sidebarCollapsed ? 'layout.sidebar.expand' : 'layout.sidebar.collapse')} placement="right" arrow>
+                    <ListItemButton
+                        onClick={toggleSidebar}
+                        aria-label={t(sidebarCollapsed ? 'layout.sidebar.expand' : 'layout.sidebar.collapse')}
+                        sx={activityBottomItemSx({
+                            '&:hover': { bgcolor: 'action.hover', color: 'primary.main' },
+                        })}
+                    >
+                        <ListItemIcon sx={{ minWidth: 0, color: 'inherit', justifyContent: 'center' }}>
+                            {sidebarCollapsed ? <IconExpandSidebar sx={{ fontSize: 22 }} /> : <IconCollapseSidebar sx={{ fontSize: 22 }} />}
+                        </ListItemIcon>
                     </ListItemButton>
                 </Tooltip>
             </Box>

--- a/frontend/src/layout/Layout.tsx
+++ b/frontend/src/layout/Layout.tsx
@@ -10,6 +10,7 @@ import { mobileContentSx, mobileMenuButtonSx, mobileNavigationBarSx } from './st
 import { ActivityBar } from './ActivityBar.tsx';
 import { Sidebar } from './Sidebar';
 import { useActivityItems } from './useActivityItems.tsx';
+import { SidebarCollapsedProvider, useSidebarCollapsed } from './useSidebarCollapsed';
 import type { ActivityItem, LayoutProps } from './types';
 import { FloatingStatusIndicators } from '../components/FloatingStatusIndicators';
 
@@ -28,7 +29,7 @@ const MobileNavigationBar = ({ onMenuClick }: { onMenuClick: () => void }) => (
     </Box>
 );
 
-const Layout = ({ children }: LayoutProps) => {
+const LayoutInner = ({ children }: LayoutProps) => {
     const { t } = useTranslation();
     const location = useLocation();
     const navigate = useNavigate();
@@ -37,6 +38,7 @@ const Layout = ({ children }: LayoutProps) => {
     const [easterEggAnchorEl, setEasterEggAnchorEl] = useState<HTMLElement | null>(null);
 
     const activityItems = useActivityItems();
+    const { collapsed: sidebarCollapsed } = useSidebarCollapsed();
 
     const isActive = (path: string) => location.pathname === path;
     const isChildActive = (children?: ActivityItem['children']) =>
@@ -125,7 +127,7 @@ const Layout = ({ children }: LayoutProps) => {
                 onUserClick={(e) => setEasterEggAnchorEl(e.currentTarget)}
                 onStandaloneNavigate={() => setMobileOpen(false)}
             />
-            {sidebarItems.length > 0 && (
+            {sidebarItems.length > 0 && !sidebarCollapsed && (
                 <Sidebar
                     sidebarItems={sidebarItems}
                     activeActivityLabel={activeActivityLabel}
@@ -189,5 +191,14 @@ const Layout = ({ children }: LayoutProps) => {
         </Box>
     );
 };
+
+// The collapse state is shared between ActivityBar (toggle) and the Sidebar
+// slot here, so the provider is mounted at the Layout boundary — both children
+// consume the same context.
+const Layout = ({ children }: LayoutProps) => (
+    <SidebarCollapsedProvider>
+        <LayoutInner>{children}</LayoutInner>
+    </SidebarCollapsedProvider>
+);
 
 export default Layout;

--- a/frontend/src/layout/Layout.tsx
+++ b/frontend/src/layout/Layout.tsx
@@ -1,5 +1,6 @@
 import { Box, Drawer, IconButton, Popover, Tooltip, Stack } from '@mui/material';
-import { Menu as IconMenu, Create as IconPencil } from '@/components/icons';
+import { Menu as IconMenu, Create as IconPencil, tablerMui } from '@/components/icons';
+import { IconLayoutSidebarLeftCollapse } from '@tabler/icons-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
@@ -13,6 +14,8 @@ import { useActivityItems } from './useActivityItems.tsx';
 import { SidebarCollapsedProvider, useSidebarCollapsed } from './useSidebarCollapsed';
 import type { ActivityItem, LayoutProps } from './types';
 import { FloatingStatusIndicators } from '../components/FloatingStatusIndicators';
+
+const IconCollapseSidebar = tablerMui(IconLayoutSidebarLeftCollapse);
 
 const MobileNavigationBar = ({ onMenuClick }: { onMenuClick: () => void }) => (
     <Box
@@ -38,7 +41,7 @@ const LayoutInner = ({ children }: LayoutProps) => {
     const [easterEggAnchorEl, setEasterEggAnchorEl] = useState<HTMLElement | null>(null);
 
     const activityItems = useActivityItems();
-    const { collapsed: sidebarCollapsed } = useSidebarCollapsed();
+    const { collapsed: sidebarCollapsed, toggle: toggleSidebar } = useSidebarCollapsed();
 
     const isActive = (path: string) => location.pathname === path;
     const isChildActive = (children?: ActivityItem['children']) =>
@@ -97,26 +100,44 @@ const LayoutInner = ({ children }: LayoutProps) => {
         if (targetPath) navigate(targetPath);
     };
 
-    // The scenario activity exposes a quick link to manage which agents are
-    // visible (the overview page hosts the show/hide controls).
-    const sidebarHeaderAction = activeActivity === 'scenario' ? (
-        <Stack direction="row" spacing={0.5} sx={{
-            alignItems: "center"
-        }}>
-            <Tooltip title={t('scenarioOverview.editTooltip', { defaultValue: 'Manage visible agents' })} arrow placement="right">
-                <IconButton
-                    size="small"
-                    onClick={() => navigate('/agent')}
-                    sx={{
-                        color: 'text.secondary',
-                        '&:hover': { color: 'primary.main' },
-                    }}
-                >
-                    <IconPencil sx={{ fontSize: 16 }} />
-                </IconButton>
-            </Tooltip>
+    // Sidebar header actions: the collapse toggle always sits in the header
+    // (it owns the Sidebar, so it lives on it). The scenario activity also
+    // exposes a quick link to manage which agents are visible.
+    const collapseButton = (
+        <Tooltip title={t('layout.sidebar.collapse')} arrow placement="bottom">
+            <IconButton
+                size="small"
+                onClick={toggleSidebar}
+                aria-label={t('layout.sidebar.collapse')}
+                sx={{
+                    color: 'text.secondary',
+                    '&:hover': { color: 'primary.main' },
+                }}
+            >
+                <IconCollapseSidebar sx={{ fontSize: 18 }} />
+            </IconButton>
+        </Tooltip>
+    );
+
+    const sidebarHeaderAction = (
+        <Stack direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
+            {activeActivity === 'scenario' && (
+                <Tooltip title={t('scenarioOverview.editTooltip', { defaultValue: 'Manage visible agents' })} arrow placement="bottom">
+                    <IconButton
+                        size="small"
+                        onClick={() => navigate('/agent')}
+                        sx={{
+                            color: 'text.secondary',
+                            '&:hover': { color: 'primary.main' },
+                        }}
+                    >
+                        <IconPencil sx={{ fontSize: 16 }} />
+                    </IconButton>
+                </Tooltip>
+            )}
+            {collapseButton}
         </Stack>
-    ) : undefined;
+    );
 
     const navigationContent = (
         <Box sx={{ display: 'flex', height: '100%' }}>

--- a/frontend/src/layout/Layout.tsx
+++ b/frontend/src/layout/Layout.tsx
@@ -6,54 +6,22 @@ import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useVersion as useAppVersion } from '../contexts/VersionContext';
 import { Z_INDEX } from '../constants/zIndex';
 import { activityBarWidth, sidebarWidth } from './constants';
+import { mobileContentSx, mobileMenuButtonSx, mobileNavigationBarSx } from './styles';
 import { ActivityBar } from './ActivityBar.tsx';
 import { Sidebar } from './Sidebar';
 import { useActivityItems } from './useActivityItems.tsx';
 import type { ActivityItem, LayoutProps } from './types';
 import { FloatingStatusIndicators } from '../components/FloatingStatusIndicators';
 
-const mobileContentSx = {
-    flex: 1,
-    px: { xs: 2, md: 3 },
-    pt: { xs: 9, md: 3 },
-    pb: 3,
-    overflowY: 'auto',
-    scrollBehavior: 'smooth',
-    '&::-webkit-scrollbar': { width: 8 },
-    '&::-webkit-scrollbar-track': { backgroundColor: 'grey.100', borderRadius: 1 },
-    '&::-webkit-scrollbar-thumb': {
-        backgroundColor: 'grey.300',
-        borderRadius: 1,
-        '&:hover': { backgroundColor: 'grey.400' },
-    },
-} as const;
-
 const MobileNavigationBar = ({ onMenuClick }: { onMenuClick: () => void }) => (
     <Box
-        sx={{
-            display: { xs: 'flex', md: 'none' },
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            right: 0,
-            height: 56,
-            zIndex: Z_INDEX.mobileToggle,
-            alignItems: 'center',
-            px: 1,
-            bgcolor: 'background.paper',
-            borderBottom: '1px solid',
-            borderColor: 'divider',
-        }}
+        sx={mobileNavigationBarSx}
     >
         <IconButton
             color="primary"
             aria-label="Open navigation menu"
             onClick={onMenuClick}
-            sx={{
-                width: 44,
-                height: 44,
-                '&:hover': { bgcolor: 'action.hover' },
-            }}
+            sx={mobileMenuButtonSx}
         >
             <IconMenu sx={{ fontSize: 24 }} />
         </IconButton>

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -21,32 +21,21 @@ import { Link as RouterLink, useLocation } from 'react-router-dom';
 import { api } from '@/services/api';
 import { useProfileContext } from '@/contexts/ProfileContext';
 import { useVersion } from '@/contexts/VersionContext';
-import { footerHeight, headerHeight, sidebarWidth } from './constants';
+import { footerHeight, sidebarWidth } from './constants';
+import {
+    NAV_ROW_SX,
+    navRowTextSlotProps,
+    sidebarContainerSx,
+    sidebarHeaderSx,
+    sidebarListScrollSx,
+} from './styles';
 import type { NavItem } from './types';
 import { VersionDisplay } from '@/components/VersionDisplay';
 import { UpdatePanelDialog } from '@/components/UpdatePanelDialog';
 
-// Shared sizing for the sidebar's nav-style rows, kept alongside the one
-// place that uses it — every row is the same height whether or not it
-// happens to carry a subtitle.
-const NAV_ROW_SX = {
-    minHeight: 52,
-    borderRadius: 1.25,
-    py: 1.25,
-    px: 2,
-} as const;
-
-const navRowTextSlotProps = (active: boolean) => ({
-    primary: { noWrap: true, variant: 'body2' as const, sx: { fontWeight: 500, lineHeight: 1.3, fontSize: '0.875rem' } },
-    secondary: {
-        variant: 'caption' as const,
-        sx: {
-            fontSize: '0.6875rem',
-            lineHeight: 1.2,
-            color: active ? 'rgba(255,255,255,0.7)' : 'text.secondary',
-        },
-    },
-});
+// Shared sizing for the sidebar's nav-style rows now lives in ./styles
+// (NAV_ROW_SX / navRowTextSlotProps), so every row is the same height whether
+// or not it carries a subtitle.
 
 interface SidebarProps {
     sidebarItems: NavItem[];
@@ -101,50 +90,17 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
 
     return (
         <Box
-            sx={{
-                width: sidebarWidth,
-                height: '100%',
-                display: 'flex',
-                flexDirection: 'column',
-                bgcolor: 'background.paper',
-                borderRight: '1px solid',
-                borderColor: 'divider',
-                overflow: 'hidden',
-            }}
+            sx={{ width: sidebarWidth, ...sidebarContainerSx }}
         >
             {/* Header */}
-            <Box
-                sx={{
-                    height: headerHeight,
-                    px: 2,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    gap: 1,
-                    borderBottom: '1px solid',
-                    borderColor: 'divider',
-                }}
-            >
+            <Box sx={sidebarHeaderSx}>
                 <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 600 }}>
                     {activeActivityLabel}
                 </Typography>
                 {headerAction}
             </Box>
             {/* Nav Items */}
-            <List
-                sx={{
-                    flex: 1,
-                    py: 1,
-                    overflowY: 'auto',
-                    '&::-webkit-scrollbar': { width: 6 },
-                    '&::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
-                    '&::-webkit-scrollbar-thumb': {
-                        backgroundColor: 'grey.300',
-                        borderRadius: 1,
-                        '&:hover': { backgroundColor: 'grey.400' },
-                    },
-                }}
-            >
+            <List sx={sidebarListScrollSx}>
                 {sidebarItems.map((item, index) => {
                     if (item.type === 'divider') {
                         return <Divider key={`divider-${index}`} sx={{ mx: 2, my: 1 }} />;
@@ -161,7 +117,6 @@ export const Sidebar: React.FC<SidebarProps> = ({ sidebarItems, activeActivityLa
                                     : { component: RouterLink, to: item.path, onClick: onClose }
                                 )}
                                 sx={{
-                                    mx: 1.5,
                                     ...NAV_ROW_SX,
                                     color: 'text.secondary',
                                     position: 'relative',

--- a/frontend/src/layout/constants.ts
+++ b/frontend/src/layout/constants.ts
@@ -1,28 +1,17 @@
+// Pure numeric sizing for the layout chrome. Style *objects* live in
+// `./styles.ts`; this file only holds numbers so the two concerns stay split.
 export const activityBarWidth = 88;
 export const sidebarWidth = 200;
 export const headerHeight = 60;
 export const footerHeight = 60;
 
-// --- Activity Bar Item Styles ---
-export const activityItemMinHeight = 64;
+// --- Activity Bar Item sizing ---
+export const activityItemMinHeight = 48;
 export const activityItemGap = 0.5;
 export const activityItemRadius = 1.25;
 export const activityItemPaddingX = 1;
 export const activityItemPaddingY = 1.25;
 export const activityContainerPaddingY = 1;
 
-export const activityItemSx = (extra?: Record<string, unknown>) => ({
-    minHeight: activityItemMinHeight,
-    mx: 0.5,
-    px: activityItemPaddingX,
-    py: activityItemPaddingY,
-    flexDirection: 'column' as const,
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: activityItemGap,
-    position: 'relative' as const,
-    color: 'text.secondary',
-    borderRadius: activityItemRadius,
-    cursor: 'pointer',
-    ...extra,
-});
+// --- Activity Bar bottom-row button sizing (language / theme / feedback / user) ---
+export const activityBottomItemMinHeight = 48;

--- a/frontend/src/layout/constants.ts
+++ b/frontend/src/layout/constants.ts
@@ -6,7 +6,7 @@ export const headerHeight = 60;
 export const footerHeight = 60;
 
 // --- Activity Bar Item sizing ---
-export const activityItemMinHeight = 48;
+export const activityItemMinHeight = 52;
 export const activityItemGap = 0.5;
 export const activityItemRadius = 1.25;
 export const activityItemPaddingX = 1;

--- a/frontend/src/layout/styles.ts
+++ b/frontend/src/layout/styles.ts
@@ -152,12 +152,14 @@ export const activityLogoButtonSx: SxProps<Theme> = {
 
 /** Shared sizing for the sidebar's nav-style rows, kept here so every row is
  *  the same height whether or not it happens to carry a subtitle. `mx` is part
- *  of the row geometry (inset from the rail edge), so it lives here too. */
+ *  of the row geometry (inset from the rail edge), so it lives here too.
+ *  minHeight is sized to comfortably fit two text lines (primary 14px +
+ *  secondary 11px ≈ 31px) with breathing room above and below. */
 export const NAV_ROW_SX = {
     mx: 1,
-    minHeight: 40,
+    minHeight: 52,
     borderRadius: 1.25,
-    py: 0.75,
+    py: 1,
     px: 2,
 } as const;
 

--- a/frontend/src/layout/styles.ts
+++ b/frontend/src/layout/styles.ts
@@ -1,0 +1,208 @@
+// Centralized style objects for the layout chrome. Numeric sizing lives in
+// `./constants.ts`; this file holds the sx objects / factory functions that
+// were previously inlined across Layout.tsx, Sidebar.tsx, ActivityBar.tsx and
+// constants.ts. Grouped by surface.
+
+import {
+    activityBottomItemMinHeight,
+    activityContainerPaddingY,
+    activityItemGap,
+    activityItemMinHeight,
+    activityItemPaddingX,
+    activityItemPaddingY,
+    activityItemRadius,
+    headerHeight,
+} from './constants';
+import { Z_INDEX } from '../constants/zIndex';
+import type { SxProps } from '@mui/material';
+import type { Theme } from '@mui/material/styles';
+
+// ---------------------------------------------------------------------------
+// Layout — main content area
+// ---------------------------------------------------------------------------
+
+export const mobileContentSx = {
+    flex: 1,
+    px: { xs: 2, md: 3 },
+    pt: { xs: 9, md: 3 },
+    pb: 3,
+    overflowY: 'auto',
+    scrollBehavior: 'smooth',
+    '&::-webkit-scrollbar': { width: 8 },
+    '&::-webkit-scrollbar-track': { backgroundColor: 'grey.100', borderRadius: 1 },
+    '&::-webkit-scrollbar-thumb': {
+        backgroundColor: 'grey.300',
+        borderRadius: 1,
+        '&:hover': { backgroundColor: 'grey.400' },
+    },
+} as const;
+
+export const mobileNavigationBarSx = {
+    display: { xs: 'flex', md: 'none' },
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 56,
+    zIndex: Z_INDEX.mobileToggle,
+    alignItems: 'center',
+    px: 1,
+    bgcolor: 'background.paper',
+    borderBottom: '1px solid',
+    borderColor: 'divider',
+} as const;
+
+export const mobileMenuButtonSx = {
+    width: 44,
+    height: 44,
+    '&:hover': { bgcolor: 'action.hover' },
+} as const;
+
+// ---------------------------------------------------------------------------
+// ActivityBar — primary icon rail
+// ---------------------------------------------------------------------------
+
+/** A primary activity entry in the ActivityBar (icon + label stacked). */
+export const activityItemSx = (extra?: Record<string, unknown>) => ({
+    minHeight: activityItemMinHeight,
+    mx: 0.5,
+    px: activityItemPaddingX,
+    py: activityItemPaddingY,
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: activityItemGap,
+    position: 'relative' as const,
+    color: 'text.secondary',
+    borderRadius: activityItemRadius,
+    cursor: 'pointer',
+    ...extra,
+});
+
+/** Shared sizing for the ActivityBar's icon-only bottom buttons
+ *  (feedback / language / theme / user / collapse toggle). Every bottom
+ *  button is the same height; only the active/hover tint differs, which the
+ *  caller passes via `extra`. */
+export const activityBottomItemSx = (extra?: Record<string, unknown>) => ({
+    minHeight: activityBottomItemMinHeight,
+    mx: 0.5,
+    px: activityItemPaddingX,
+    py: 0.75,
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 0.25,
+    position: 'relative' as const,
+    color: 'text.secondary',
+    borderRadius: activityItemRadius,
+    cursor: 'pointer',
+    ...extra,
+});
+
+/** Wrapper Box for a bottom-of-rail button cluster (feedback / language / theme / collapse). */
+export const activityBottomClusterSx: SxProps<Theme> = {
+    py: 0.5,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+};
+
+export const activityIconsScrollSx: SxProps<Theme> = {
+    flex: 1,
+    py: activityContainerPaddingY,
+    overflowY: 'auto',
+};
+
+export const activityRailSx: SxProps<Theme> = {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    bgcolor: 'background.paper',
+    borderRight: '1px solid',
+    borderColor: 'divider',
+};
+
+/** The logo / brand cell at the top of the ActivityBar (fixed at headerHeight). */
+export const activityLogoCellSx: SxProps<Theme> = {
+    height: headerHeight,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderBottom: '1px solid',
+    borderColor: 'divider',
+};
+
+export const activityLogoButtonSx: SxProps<Theme> = {
+    width: 36,
+    height: 36,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textDecoration: 'none',
+    cursor: 'pointer',
+    transition: 'opacity 0.18s ease-out',
+    '&:hover': { opacity: 0.82 },
+};
+
+// ---------------------------------------------------------------------------
+// Sidebar — secondary nav list
+// ---------------------------------------------------------------------------
+
+/** Shared sizing for the sidebar's nav-style rows, kept here so every row is
+ *  the same height whether or not it happens to carry a subtitle. `mx` is part
+ *  of the row geometry (inset from the rail edge), so it lives here too. */
+export const NAV_ROW_SX = {
+    mx: 1,
+    minHeight: 40,
+    borderRadius: 1.25,
+    py: 0.75,
+    px: 2,
+} as const;
+
+export const navRowTextSlotProps = (active: boolean) => ({
+    primary: { noWrap: true, variant: 'body2' as const, sx: { fontWeight: 500, lineHeight: 1.3, fontSize: '0.875rem' } },
+    secondary: {
+        variant: 'caption' as const,
+        sx: {
+            fontSize: '0.6875rem',
+            lineHeight: 1.2,
+            color: active ? 'rgba(255,255,255,0.7)' : 'text.secondary',
+        },
+    },
+});
+
+export const sidebarContainerSx: SxProps<Theme> = {
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    bgcolor: 'background.paper',
+    borderRight: '1px solid',
+    borderColor: 'divider',
+    overflow: 'hidden',
+};
+
+export const sidebarHeaderSx: SxProps<Theme> = {
+    height: headerHeight,
+    px: 2,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 1,
+    borderBottom: '1px solid',
+    borderColor: 'divider',
+};
+
+export const sidebarListScrollSx: SxProps<Theme> = {
+    flex: 1,
+    py: 1,
+    overflowY: 'auto',
+    '&::-webkit-scrollbar': { width: 6 },
+    '&::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
+    '&::-webkit-scrollbar-thumb': {
+        backgroundColor: 'grey.300',
+        borderRadius: 1,
+        '&:hover': { backgroundColor: 'grey.400' },
+    },
+};

--- a/frontend/src/layout/styles.ts
+++ b/frontend/src/layout/styles.ts
@@ -125,12 +125,13 @@ export const activityRailSx: SxProps<Theme> = {
     borderColor: 'divider',
 };
 
-/** Edge-mounted expand handle on the ActivityBar's right border — only shown
- *  when the Sidebar is collapsed. Straddles the border so it reads as a handle
- *  attached to the rail. */
+/** Expand handle on the ActivityBar — only shown when the Sidebar is collapsed.
+ *  Sits at the right edge of the logo cell (just under the top divider), so it
+ *  vertically aligns with the collapse button in the Sidebar header: the two
+ *  controls form a symmetric pair at the same height. */
 export const activityExpandHandleSx: SxProps<Theme> = {
     position: 'absolute',
-    top: '50%',
+    top: headerHeight / 2,
     right: -13,
     transform: 'translateY(-50%)',
     width: 26,
@@ -142,6 +143,10 @@ export const activityExpandHandleSx: SxProps<Theme> = {
     color: 'text.secondary',
     zIndex: Z_INDEX.main,
     '&:hover': {
+        // Keep an opaque paper background — the handle straddles the rail
+        // border, so MUI's default translucent hover overlay would show the
+        // content behind it and read as the button going transparent.
+        backgroundColor: 'background.paper',
         color: 'primary.main',
         borderColor: 'primary.main',
     },

--- a/frontend/src/layout/styles.ts
+++ b/frontend/src/layout/styles.ts
@@ -116,12 +116,35 @@ export const activityIconsScrollSx: SxProps<Theme> = {
 };
 
 export const activityRailSx: SxProps<Theme> = {
+    position: 'relative',
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
     bgcolor: 'background.paper',
     borderRight: '1px solid',
     borderColor: 'divider',
+};
+
+/** Edge-mounted expand handle on the ActivityBar's right border — only shown
+ *  when the Sidebar is collapsed. Straddles the border so it reads as a handle
+ *  attached to the rail. */
+export const activityExpandHandleSx: SxProps<Theme> = {
+    position: 'absolute',
+    top: '50%',
+    right: -13,
+    transform: 'translateY(-50%)',
+    width: 26,
+    height: 26,
+    minHeight: 26,
+    border: '1px solid',
+    borderColor: 'divider',
+    bgcolor: 'background.paper',
+    color: 'text.secondary',
+    zIndex: Z_INDEX.main,
+    '&:hover': {
+        color: 'primary.main',
+        borderColor: 'primary.main',
+    },
 };
 
 /** The logo / brand cell at the top of the ActivityBar (fixed at headerHeight). */

--- a/frontend/src/layout/useSidebarCollapsed.tsx
+++ b/frontend/src/layout/useSidebarCollapsed.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+
+// Persisted "is the secondary Sidebar collapsed?" preference. Mirrors the
+// ThemeContext pattern (module-level storage key, lazy read, persist-on-change
+// effect, Context + guarded hook). Scoped to the layout area: the provider is
+// mounted inside <Layout/>, so this hook is only meaningful there.
+
+const STORAGE_KEY = 'layout.sidebarCollapsed';
+
+interface SidebarCollapsedValue {
+    collapsed: boolean;
+    toggle: () => void;
+    setCollapsed: (next: boolean) => void;
+}
+
+const SidebarCollapsedContext = createContext<SidebarCollapsedValue | undefined>(undefined);
+
+interface SidebarCollapsedProviderProps {
+    children: ReactNode;
+}
+
+export const SidebarCollapsedProvider = ({ children }: SidebarCollapsedProviderProps) => {
+    const [collapsed, setCollapsed] = useState<boolean>(() => localStorage.getItem(STORAGE_KEY) === 'true');
+
+    useEffect(() => {
+        localStorage.setItem(STORAGE_KEY, String(collapsed));
+    }, [collapsed]);
+
+    const value = useMemo<SidebarCollapsedValue>(
+        () => ({
+            collapsed,
+            toggle: () => setCollapsed((prev) => !prev),
+            setCollapsed,
+        }),
+        [collapsed],
+    );
+
+    return <SidebarCollapsedContext.Provider value={value}>{children}</SidebarCollapsedContext.Provider>;
+};
+
+export const useSidebarCollapsed = (): SidebarCollapsedValue => {
+    const context = useContext(SidebarCollapsedContext);
+    if (!context) {
+        throw new Error('useSidebarCollapsed must be used within a SidebarCollapsedProvider');
+    }
+    return context;
+};


### PR DESCRIPTION
## Summary
Tightens the oversized left nav and makes the secondary sidebar collapsible, with layout styles centralized into one file.

## Key Changes

- **Collapsible sidebar**: toggle in the Sidebar header + chevron handle on the ActivityBar edge; persists via `localStorage`.
- **Tighter rows**: nav heights sized to hold a primary + secondary line comfortably (52px).
- **Centralized styles**: all layout `sx` moved into `layout/styles.ts`; duplicated bottom-button styles merged into one.
