### PR TITLE
bugfix(frontend): fixed non-responsive column widths for credential tables

### DIFF
--- a/frontend/src/components/ApiKeyTable.tsx
+++ b/frontend/src/components/ApiKeyTable.tsx
@@ -72,6 +72,20 @@ interface ModelListDialogState {
     provider: Provider | null;
 }
 
+// Column widths, in one place — tweak here rather than hunting through the
+// TableHead/TableBody JSX. `align`/`sx` are merged onto both the header
+// TableCell's default styling; body cells still render their own content.
+const COLUMNS: { label: string; width: number; align?: "center"; sx?: object }[] = [
+    {label: "Status", width: 72},
+    {label: "Name", width: 140},
+    {label: "API Style", width: 88, align: "center", sx: {px: 1, whiteSpace: "nowrap"}},
+    {label: "API Base URL", width: 150},
+    {label: "API Key", width: 140},
+    {label: "Proxy", width: 60},
+    {label: "Actions", width: 190},
+];
+const TABLE_MIN_WIDTH = COLUMNS.reduce((sum, c) => sum + c.width, 0);
+
 const ApiKeyTable = ({
                          providers,
                          onEdit,
@@ -231,20 +245,20 @@ const ApiKeyTable = ({
                 overflowX: "auto",
             }}
         >
-            <Table sx={{tableLayout: "fixed", width: '100%', minWidth: {xs: 720, md: 840, xl: 1120}}}>
+            {/* Fixed column widths (see COLUMNS above); the table itself
+                scrolls horizontally below minWidth instead of columns resizing. */}
+            <Table sx={{tableLayout: "fixed", width: '100%', minWidth: TABLE_MIN_WIDTH}}>
                 <TableHead>
                     <TableRow sx={{bgcolor: "action.hover"}}>
-                        <TableCell sx={{fontWeight: 600, width: {xs: 72, xl: 90}, py: 1.25}}>Status</TableCell>
-                        <TableCell sx={{fontWeight: 600, width: {xs: 130, xl: 140}, py: 1.25}}>Name</TableCell>
-                        <TableCell align="center" sx={{fontWeight: 600, width: 88, px: 1, py: 1.25, whiteSpace: 'nowrap'}}>
-                            API Style
-                        </TableCell>
-                        <TableCell sx={{fontWeight: 600, width: {xs: 180, xl: 200}, py: 1.25}}>
-                            API Base URL
-                        </TableCell>
-                        <TableCell sx={{fontWeight: 600, width: {xs: 125, xl: 140}, py: 1.25}}>API Key</TableCell>
-                        <TableCell sx={{fontWeight: 600, width: 60, py: 1.25, display: {xs: 'none', xl: 'table-cell'}}}>Proxy</TableCell>
-                        <TableCell sx={{fontWeight: 600, width: {xs: 205, xl: 250}, py: 1.25}}>Actions</TableCell>
+                        {COLUMNS.map((col) => (
+                            <TableCell
+                                key={col.label}
+                                align={col.align}
+                                sx={{fontWeight: 600, width: col.width, py: 1.25, ...col.sx}}
+                            >
+                                {col.label}
+                            </TableCell>
+                        ))}
                     </TableRow>
                 </TableHead>
                 <TableBody>
@@ -292,7 +306,7 @@ const ApiKeyTable = ({
                                             variant="body2"
                                             sx={{
                                                 fontWeight: 500,
-                                                maxWidth: 120,
+                                                maxWidth: 140,
                                                 overflow: "hidden",
                                                 textOverflow: "ellipsis",
                                                 whiteSpace: "nowrap",
@@ -371,7 +385,7 @@ const ApiKeyTable = ({
                                     </Stack>
                                 </TableCell>
                                 {/* Proxy */}
-                                <TableCell align="center" sx={{display: {xs: 'none', xl: 'table-cell'}}}>
+                                <TableCell align="center">
                                     {provider.proxy_url ? (
                                         <Tooltip title={provider.proxy_url} arrow>
                                             <Route

--- a/frontend/src/components/OAuthTable.tsx
+++ b/frontend/src/components/OAuthTable.tsx
@@ -21,7 +21,6 @@ import {
 import {
     Box,
     Button,
-    Chip,
     CircularProgress,
     Divider,
     IconButton,
@@ -73,6 +72,20 @@ interface ModelListDialogState {
     open: boolean;
     provider: Provider | null;
 }
+
+// Column widths, in one place — tweak here rather than hunting through the
+// TableHead/TableBody JSX. `align`/`sx` are merged onto the header
+// TableCell's default styling; body cells still render their own content.
+const COLUMNS: { label: string; width: number; align?: "center"; sx?: object }[] = [
+    {label: "Status", width: 72},
+    {label: "Name", width: 140},
+    {label: "API Style", width: 88, align: "center", sx: {px: 1, whiteSpace: "nowrap"}},
+    {label: "Provider", width: 150},
+    {label: "Expires At", width: 140},
+    {label: "Proxy", width: 60},
+    {label: "Actions", width: 190},
+];
+const TABLE_MIN_WIDTH = COLUMNS.reduce((sum, c) => sum + c.width, 0);
 
 const OAuthTable = ({
                         providers,
@@ -247,28 +260,25 @@ const OAuthTable = ({
                 overflowX: "auto",
             }}
         >
-            <Table sx={{tableLayout: "fixed", width: '100%', minWidth: {xs: 720, md: 840, xl: 1120}}}>
+            {/* Fixed column widths (see COLUMNS above); the table itself
+                scrolls horizontally below minWidth instead of columns resizing. */}
+            <Table sx={{tableLayout: "fixed", width: '100%', minWidth: TABLE_MIN_WIDTH}}>
                 <TableHead>
                     <TableRow sx={{bgcolor: "action.hover"}}>
-                        <TableCell sx={{fontWeight: 600, width: {xs: 72, xl: 90}, py: 1.25}}>Status</TableCell>
-                        <TableCell sx={{fontWeight: 600, width: 140, py: 1.25}}>Name</TableCell>
-                        <TableCell align="center" sx={{fontWeight: 600, width: 88, px: 1, py: 1.25, whiteSpace: 'nowrap'}}>
-                            API Style
-                        </TableCell>
-                        <TableCell sx={{fontWeight: 600, width: {xs: 150, xl: 200}, py: 1.25}}>Provider</TableCell>
-                        <TableCell sx={{fontWeight: 600, width: {xs: 130, xl: 140}, py: 1.25}}>
-                            Expires At
-                        </TableCell>
-                        <TableCell sx={{fontWeight: 600, width: 60, py: 1.25, display: {xs: 'none', xl: 'table-cell'}}}>Proxy</TableCell>
-                        <TableCell sx={{fontWeight: 600, width: {xs: 205, xl: 250}, py: 1.25}}>Actions</TableCell>
+                        {COLUMNS.map((col) => (
+                            <TableCell
+                                key={col.label}
+                                align={col.align}
+                                sx={{fontWeight: 600, width: col.width, py: 1.25, ...col.sx}}
+                            >
+                                {col.label}
+                            </TableCell>
+                        ))}
                     </TableRow>
                 </TableHead>
                 <TableBody>
                     {providers.map((provider) => {
                         const expiresAt = provider.oauth_detail?.expires_at;
-                        const isExpired = expiresAt
-                            ? new Date(expiresAt) < new Date()
-                            : false;
 
                         return (
                             <React.Fragment key={provider.uuid}>
@@ -315,7 +325,7 @@ const OAuthTable = ({
                                             >
                                                 <Typography
                                                     variant="body2"
-                                                    sx={{fontWeight: 500, minWidth: 120}}
+                                                    sx={{fontWeight: 500, maxWidth: 140, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap"}}
                                                 >
                                                     {provider.name}
                                                 </Typography>
@@ -356,18 +366,10 @@ const OAuthTable = ({
                                             >
                                                 {formatExpiresAt(expiresAt)}
                                             </Typography>
-                                            {isExpired && (
-                                                <Chip
-                                                    label="Expired"
-                                                    color="error"
-                                                    size="small"
-                                                    sx={{height: 20}}
-                                                />
-                                            )}
                                         </Stack>
                                     </TableCell>
                                     {/* Proxy */}
-                                    <TableCell align="center" sx={{display: {xs: 'none', xl: 'table-cell'}}}>
+                                    <TableCell align="center">
                                         {provider.proxy_url ? (
                                             <Tooltip title={provider.proxy_url} arrow>
                                                 <Route

--- a/frontend/src/components/credential/QuotaInlineDisplay.tsx
+++ b/frontend/src/components/credential/QuotaInlineDisplay.tsx
@@ -111,7 +111,10 @@ export function QuotaInlineDisplay({
     <>
       <Box
         sx={{
-          pl: 8,
+          // Aligns with the Name column's left edge — the Status column
+          // (first column in ApiKeyTable/OAuthTable) is 72px wide, so this
+          // indent must match that, not an arbitrary spacing value.
+          pl: '86px',
           pr: 2,
           py: 1,
           display: 'flex',


### PR DESCRIPTION
ApiKeyTable/OAuthTable used responsive {xs,xl} breakpoint widths per column; collapse to fixed pixel widths and let the table scroll horizontally below minWidth instead. Widths are now extracted into a local COLUMNS array per table (label+width in one place) with minWidth derived from their sum so it can't drift out of sync.

Also: drop the OAuthTable "Expired" chip (formatExpiresAt already renders that text), remove the Proxy column's now-redundant responsive display toggle, and fix QuotaInlineDisplay's quota-row indent (was a disconnected magic number) to match the Status column's actual width so it lines up under Name.

<img width="2396" height="1070" alt="image" src="https://github.com/user-attachments/assets/197d6782-3dcc-4cd6-b89d-6b4da9fcaf1c" />
