### PR TITLE
perf(db): cache hot-path reads, merge stats+usage writes

### DIFF
--- a/.design/hot-path-db-access.md
+++ b/.design/hot-path-db-access.md
@@ -1,0 +1,110 @@
+# Hot-Path DB Access: Cache Reads, Don't Lock+Query Them
+
+Status: `ProviderStore` fixed on branch `claude/routing-pipeline-benchmark-e6aq73`. Rest of the pattern below is diagnosed but **not yet fixed** — tracked here as the holistic follow-up.
+
+## Why
+
+`internal/routing/pipeline_bench_test.go` benchmarks the real production selection
+pipeline (`ServiceSelector` + `protocolserver.LoadBalancer`, wired exactly as
+`internal/server/server.go` does). Profiling it (`go test ./internal/routing/...
+-bench . -cpuprofile=cpu.prof`) showed `ServiceSelector.Select` spending **83% of
+its own time** in one line:
+
+```go
+provider, err := s.config.GetProviderByUUID(result.Service.Provider)
+```
+
+That call chain — `config.Config.GetProviderByUUID` → `db.ProviderStore.GetByUUID`
+→ `gorm.DB.First` → SQLite via cgo — accounted for **47.5% of the entire
+benchmark's CPU time** (`cgocall` alone was 20.6%; `database/sql` locking/scan
+machinery another ~25%). `ProviderStore` additionally guarded every method,
+reads included, with a plain `sync.Mutex` — so even *read* traffic across
+concurrent requests fully serialized on one lock, on top of paying for a disk
+round-trip that returns data changing only on admin CRUD.
+
+This isn't a one-off: every routed request resolves exactly one provider by
+UUID, so this cost was paid **once per LLM request**, unconditionally.
+
+## What changed
+
+`internal/db/provider_store.go`'s `ProviderStore` now keeps a write-through
+in-memory mirror of the `providers` table:
+
+- `cache map[string]*ProviderRecord` + an `order []string` slice (map
+  iteration is randomized in Go; `order` keeps `List`/`ListOAuth`/`ListEnabled`
+  stable in insertion order, matching what SQLite returned before and what the
+  provider table UI depends on).
+- `mu` changed from `sync.Mutex` to `sync.RWMutex`.
+- All **read** methods (`GetByUUID`, `GetByName`, `List`, `ListOAuth`,
+  `ListEnabled`, `Exists`, `Count`, `GetAccessToken`, `IsOAuthExpired`) serve
+  from the cache under `RLock` — no SQLite call, no exclusive lock.
+- All **write** methods (`Save`, `Delete`, `UpdateCredential`,
+  `UpdateCredentialBundle`, `UpdateOAuthAccessToken`) write to SQLite first
+  (still the source of truth / durability boundary), then update the cache
+  entry, under `Lock`.
+- The cache is loaded once at construction (`loadCache`, called from both
+  `NewProviderStore` and `StoreManager.initProviderStore` — the latter builds
+  `ProviderStore` via a struct literal rather than the constructor, so it
+  needed the same `cache: make(...)` + `loadCache()` wiring or the cache would
+  stay a nil map in the shipped binary; this bit a first pass and was caught
+  by `TestStoreManager_StoreOperations` panicking on a nil-map write).
+
+Single-process, single-DB-connection deployment (see `StoreManager`, which
+owns the one `*gorm.DB` shared by every store) makes this store the sole
+writer of its table, so the mirror can't drift from concurrent external
+writers.
+
+### Result (same benchmark, before → after)
+
+| Benchmark | before | after | allocs before → after |
+|---|---|---|---|
+| `BenchmarkSelect_Plain` | 59.7 µs/op | 5.8 µs/op (**10.2×**) | 236 → 76 |
+| `BenchmarkSelect_SmartMatch` | 61.5 µs/op | 10.5 µs/op (**5.9×**) | 252 → 92 |
+| `BenchmarkSelect_SmartNoMatch` | 66.9 µs/op | 9.7 µs/op (**6.9×**) | 251 → 91 |
+| `BenchmarkSelect_Affinity` | 65.7 µs/op | 8.3 µs/op (**7.9×**) | 252 → 86 |
+
+Re-profiling after the fix: `GetProviderByUUID` no longer appears in the
+profile's top nodes at all. The new dominant cost (~27% cum) is
+`loadbalance.ServiceID.String()` / `fmt.Sprintf` inside `HealthFilter.Filter`
+(itself called twice per request — see the double active/health filtering
+note in `pipeline_bench_test.go`) — a separate, much smaller inefficiency,
+noted here as a candidate for a future pass but out of scope of this fix.
+
+## The pattern is systemic — audit of `internal/db/*_store.go`
+
+Every store under `internal/db/` follows the same shape: a GORM-backed SQLite
+table, one `sync.Mutex` (not `RWMutex`) per store, and every method —
+including pure reads — takes the exclusive lock and issues a query. Only
+`provider_model.go` (`ModelStore`) and `usage_record.go`/`store_manager.go`
+already used `RWMutex`, and none of them cache. Whether this matters for a
+given store depends entirely on whether it's read on the **request hot path**
+(every inbound request) versus an **admin/UI path** (occasional, human-paced):
+
+| Store | Hot-path read? | Where | Risk |
+|---|---|---|---|
+| `ProviderStore` | **Yes — fixed** | `ServiceSelector.Select` resolves a provider every request | was the #1 cost, now cached |
+| `APITokenStore` | **Yes — not yet fixed** | `internal/middleware/auth.go`'s `AuthMiddleware` calls `ValidateToken` on every API-token-authenticated request | same shape: `sync.Mutex` + `gorm.First` per request. Likely the next-highest-impact fix — same recipe applies (cache by `token_id`, invalidate on `RevokeToken`/create), with the added nuance that a revoked token must stop working immediately, so the cache write on `RevokeToken` must land before the DB write's transaction is visible to concurrent readers (write-DB-then-update-cache under the same lock, as done here, satisfies that) |
+| `ModelStore`, `ToolConfigStore`, `ImBotSettingsStore`, `TaskStore`, `ServiceStatStore` | No (or infrequent/admin-path) | config/UI/background jobs | low priority — `RWMutex` alone (no caching) is probably sufficient if ever contended |
+| `RemoteChatStore`, `RemoteSessionStore`, `BotAccessStore`, `UsageStore` | No (IM/remote-control and usage-recording paths, not the LLM proxy hot path) | — | low priority |
+
+## Recommended approach for future stores
+
+1. **Classify first**: is this store read on the per-request hot path? If not,
+   don't bother caching — `sync.Mutex` → `sync.RWMutex` is enough, and only
+   worth doing if profiling shows contention.
+2. **For hot-path reads**: mirror the pattern here — write-through cache keyed
+   by the natural lookup key, `RWMutex`, writes go to SQLite first then update
+   the cache under the same write lock. Don't invent a TTL/invalidation
+   scheme; these stores are single-writer-per-process, so "cache is only ever
+   mutated by this store's own write methods" is sufficient and avoids
+   staleness bugs.
+3. **Watch for bypass construction**: `StoreManager` builds several stores via
+   struct literals (`&XStore{db: ..., dbPath: ...}`) instead of calling each
+   store's `NewXStore` constructor. Any future cached store must get its cache
+   initialized (and loaded) in *both* places, or add a `StoreManager`-only
+   constructor path and delete the literal. This is exactly what broke
+   `TestStoreManager_StoreOperations` on the first pass here.
+4. **Re-run `internal/routing/pipeline_bench_test.go` (and add an analogous
+   benchmark for the auth middleware path before fixing `APITokenStore`)**
+   before/after — don't reason about the win from first principles, measure
+   it, the way this fix was validated.

--- a/.design/hot-path-db-access.md
+++ b/.design/hot-path-db-access.md
@@ -1,6 +1,8 @@
 # Hot-Path DB Access: Cache Reads, Don't Lock+Query Them
 
-Status: `ProviderStore` fixed on branch `claude/routing-pipeline-benchmark-e6aq73`. Rest of the pattern below is diagnosed but **not yet fixed** — tracked here as the holistic follow-up.
+Status: `ProviderStore` and `APITokenStore` fixed on branch
+`claude/routing-pipeline-benchmark-e6aq73`. Rest of the pattern below is
+diagnosed but **not yet fixed** — tracked here as the holistic follow-up.
 
 ## Why
 
@@ -70,6 +72,48 @@ profile's top nodes at all. The new dominant cost (~27% cum) is
 note in `pipeline_bench_test.go`) — a separate, much smaller inefficiency,
 noted here as a candidate for a future pass but out of scope of this fix.
 
+## `APITokenStore`: same shape, confirmed by benchmark before the fix
+
+`ValidateToken` is called by `AuthMiddleware.ModelAuthMiddleware` (see
+`internal/middleware/auth.go`) on every request bearing a `tb-share-`-prefixed
+multi-tenant API token — the exact same "every request, data barely ever
+changes" shape as `ProviderStore.GetByUUID`. Per the follow-up plan above, a
+benchmark was written first (`internal/middleware/auth_bench_test.go`,
+wired against a real `db.APITokenStore`, mirroring how
+`pipeline_bench_test.go` wires the real production routing pipeline) and
+profiled *before* changing anything:
+
+| Benchmark | before | after | change |
+|---|---|---|---|
+| `BenchmarkAPITokenStore_ValidateToken` (isolated store call) | 30.0 µs/op, 99 allocs | 119 ns/op, 1 alloc | **~251×** |
+| `BenchmarkModelAuthMiddleware_APIToken` (full gin middleware chain) | 103.8 µs/op, 182 allocs | 55.4 µs/op, 80 allocs | **1.87×** |
+
+The fix mirrors `ProviderStore` exactly: `APITokenStore` now keeps a
+write-through `map[string]*APITokenRecord` cache keyed by `TokenID`, guarded
+by `RWMutex`. `ValidateToken`, `GetToken`, and the now-`RLock`-only
+`ListTokens` read the cache; `CreateTokenWithTokenID`, `RevokeToken`,
+`UpdateLastUsed`, `SetTokenEnabled`, `UpdateTokenString`, and `DeleteToken`
+write SQLite first, then update (or remove) the cache entry under the same
+write lock — so a revoked token stops validating the instant `RevokeToken`
+returns, with no window where SQLite says revoked but the cache still says
+enabled. `CleanupExpiredTokens` (a bulk, predicate-based delete) just
+reloads the whole cache from SQLite afterward rather than re-deriving its
+`WHERE` clause in Go — it's a maintenance job, not hot path, so the O(n)
+reload cost doesn't matter.
+
+**Why the full-middleware number only improved 1.87× despite `ValidateToken`
+itself improving 251×**: profiling `BenchmarkModelAuthMiddleware_APIToken`
+after the fix shows the remaining cost is almost entirely
+`APITokenStore.UpdateLastUsed` — the fire-and-forget `go
+am.apiTokenStore.UpdateLastUsed(...)` call in `ModelAuthMiddleware` — which
+is a genuine SQLite **write** on every authenticated request (updating
+`last_used_at`), not a read this caching pattern touches. It doesn't block
+the response (it's backgrounded), but it's real DB load per request and
+still serializes against other cache writes under `s.mu.Lock()`. That's a
+separate finding, noted here as a candidate for a future pass (e.g.
+debouncing/batching last-used-at writes so it's not one SQLite transaction
+per request) but out of scope for this "cache the hot read path" fix.
+
 ## The pattern is systemic — audit of `internal/db/*_store.go`
 
 Every store under `internal/db/` follows the same shape: a GORM-backed SQLite
@@ -83,7 +127,7 @@ given store depends entirely on whether it's read on the **request hot path**
 | Store | Hot-path read? | Where | Risk |
 |---|---|---|---|
 | `ProviderStore` | **Yes — fixed** | `ServiceSelector.Select` resolves a provider every request | was the #1 cost, now cached |
-| `APITokenStore` | **Yes — not yet fixed** | `internal/middleware/auth.go`'s `AuthMiddleware` calls `ValidateToken` on every API-token-authenticated request | same shape: `sync.Mutex` + `gorm.First` per request. Likely the next-highest-impact fix — same recipe applies (cache by `token_id`, invalidate on `RevokeToken`/create), with the added nuance that a revoked token must stop working immediately, so the cache write on `RevokeToken` must land before the DB write's transaction is visible to concurrent readers (write-DB-then-update-cache under the same lock, as done here, satisfies that) |
+| `APITokenStore` | **Yes — fixed** | `internal/middleware/auth.go`'s `AuthMiddleware` calls `ValidateToken` on every API-token-authenticated request | see benchmark section above — `ValidateToken` itself dropped ~251×; `UpdateLastUsed`'s per-request write remains a separate, smaller follow-up |
 | `ModelStore`, `ToolConfigStore`, `ImBotSettingsStore`, `TaskStore`, `ServiceStatStore` | No (or infrequent/admin-path) | config/UI/background jobs | low priority — `RWMutex` alone (no caching) is probably sufficient if ever contended |
 | `RemoteChatStore`, `RemoteSessionStore`, `BotAccessStore`, `UsageStore` | No (IM/remote-control and usage-recording paths, not the LLM proxy hot path) | — | low priority |
 
@@ -101,10 +145,15 @@ given store depends entirely on whether it's read on the **request hot path**
 3. **Watch for bypass construction**: `StoreManager` builds several stores via
    struct literals (`&XStore{db: ..., dbPath: ...}`) instead of calling each
    store's `NewXStore` constructor. Any future cached store must get its cache
-   initialized (and loaded) in *both* places, or add a `StoreManager`-only
-   constructor path and delete the literal. This is exactly what broke
-   `TestStoreManager_StoreOperations` on the first pass here.
-4. **Re-run `internal/routing/pipeline_bench_test.go` (and add an analogous
-   benchmark for the auth middleware path before fixing `APITokenStore`)**
-   before/after — don't reason about the win from first principles, measure
-   it, the way this fix was validated.
+   initialized (and loaded) in *both* places (`internal/db/store_manager.go`'s
+   `initXStore` and the store's own `NewXStore`), or add a
+   `StoreManager`-only constructor path and delete the literal. This is
+   exactly what broke `TestStoreManager_StoreOperations` on the first pass on
+   `ProviderStore`, and would have broken `APITokenStore` the same way had
+   `initAPITokenStore` not been fixed alongside it.
+4. **Write the benchmark first, against the real production wiring, and
+   profile before touching any code** — `internal/routing/pipeline_bench_test.go`
+   for the routing pipeline, `internal/middleware/auth_bench_test.go` for the
+   auth middleware path. Both fixes here were validated this way (see the
+   before/after tables above); don't reason about the win from first
+   principles.

--- a/.design/hot-path-db-access.md
+++ b/.design/hot-path-db-access.md
@@ -109,10 +109,33 @@ am.apiTokenStore.UpdateLastUsed(...)` call in `ModelAuthMiddleware` — which
 is a genuine SQLite **write** on every authenticated request (updating
 `last_used_at`), not a read this caching pattern touches. It doesn't block
 the response (it's backgrounded), but it's real DB load per request and
-still serializes against other cache writes under `s.mu.Lock()`. That's a
-separate finding, noted here as a candidate for a future pass (e.g.
-debouncing/batching last-used-at writes so it's not one SQLite transaction
-per request) but out of scope for this "cache the hot read path" fix.
+still serialized against other cache writes under `s.mu.Lock()`.
+
+### `UpdateLastUsed`: debounce the write instead of caching a read
+
+`last_used_at` is only ever consumed for "when was this token last used"
+display in the token admin UI — nothing in the codebase reads it at
+per-request precision. So instead of caching (there's no read to cache; this
+*is* the write), `UpdateLastUsed` now coalesces: it persists at most once per
+`defaultLastUsedDebounce` (1 minute) per token, checked cheaply under
+`RLock` against the cached `LastUsedAt` before ever taking the write lock or
+touching SQLite; a call inside the window is a no-op. A token idle for over
+a minute still gets a fresh write on its next use, same as before — only the
+common case (bursty/sustained traffic on the same token) collapses from "one
+SQLite UPDATE per request" to "one per debounce window."
+
+| Benchmark | cached only | + debounced `UpdateLastUsed` | additional change |
+|---|---|---|---|
+| `BenchmarkModelAuthMiddleware_APIToken` | 55.4 µs/op, 80 allocs | 1.39 µs/op, 10 allocs | **~40×** (≈75× vs. the original 103.8 µs/op baseline) |
+
+No TTL cache or background flusher was introduced — the debounce state
+*is* the existing per-token cache entry's `LastUsedAt` field, so there's
+nothing extra to keep in sync or expire. `internal/db/api_token_store_test.go`
+covers all three cases: first call persists, a second call inside the window
+is a no-op (checked against the DB row, not just the cache, so a caching bug
+that skipped the write but claimed success can't hide), and a call after the
+window (simulated by rewriting the cached `LastUsedAt` into the past — no
+`time.Sleep` in the test) persists again.
 
 ## The pattern is systemic — audit of `internal/db/*_store.go`
 
@@ -127,7 +150,7 @@ given store depends entirely on whether it's read on the **request hot path**
 | Store | Hot-path read? | Where | Risk |
 |---|---|---|---|
 | `ProviderStore` | **Yes — fixed** | `ServiceSelector.Select` resolves a provider every request | was the #1 cost, now cached |
-| `APITokenStore` | **Yes — fixed** | `internal/middleware/auth.go`'s `AuthMiddleware` calls `ValidateToken` on every API-token-authenticated request | see benchmark section above — `ValidateToken` itself dropped ~251×; `UpdateLastUsed`'s per-request write remains a separate, smaller follow-up |
+| `APITokenStore` | **Yes — fixed** | `internal/middleware/auth.go`'s `AuthMiddleware` calls `ValidateToken` (cached read) and `UpdateLastUsed` (debounced write) on every API-token-authenticated request | see benchmark sections above — `ValidateToken` dropped ~251×, `UpdateLastUsed`'s debounce took the full middleware path a further ~40× |
 | `ModelStore`, `ToolConfigStore`, `ImBotSettingsStore`, `TaskStore`, `ServiceStatStore` | No (or infrequent/admin-path) | config/UI/background jobs | low priority — `RWMutex` alone (no caching) is probably sufficient if ever contended |
 | `RemoteChatStore`, `RemoteSessionStore`, `BotAccessStore`, `UsageStore` | No (IM/remote-control and usage-recording paths, not the LLM proxy hot path) | — | low priority |
 

--- a/.design/hot-path-db-access.md
+++ b/.design/hot-path-db-access.md
@@ -1,8 +1,9 @@
 # Hot-Path DB Access: Cache Reads, Don't Lock+Query Them
 
-Status: `ProviderStore` and `APITokenStore` fixed on branch
-`claude/routing-pipeline-benchmark-e6aq73`. Rest of the pattern below is
-diagnosed but **not yet fixed** — tracked here as the holistic follow-up.
+Status: `ProviderStore` and `APITokenStore` (read-cache fixes) and
+`StatsStore`/`UsageStore` (transaction-merge fix) shipped on branch
+`claude/routing-pipeline-benchmark-e6aq73`. Batched/debounced stats+usage
+writes remain open — tracked here as the holistic follow-up.
 
 ## Why
 
@@ -137,6 +138,102 @@ that skipped the write but claimed success can't hide), and a call after the
 window (simulated by rewriting the cached `LastUsedAt` into the past — no
 `time.Sleep` in the test) persists again.
 
+## `StatsStore` + `UsageStore`: write-heavy hot path, a different fix shape
+
+A follow-up audit of every `internal/db/*_store.go` (below) turned up two
+stores that ARE on the request hot path despite looking like background
+bookkeeping: `StatsStore.UpdateFromService` and `UsageStore.RecordUsage`.
+Both are called synchronously, once per completed LLM request (streaming and
+non-streaming, success and error paths), from
+`ProtocolHandler.trackUsageWithTokenUsage` / `trackUsageFromContext`
+(`internal/protocolserver/usage_tracking.go`) — and, unlike `ProviderStore`
+and `APITokenStore`, both are genuine per-request **writes** with no prior
+read: there's a real row to persist every time, so the read-cache pattern
+above doesn't apply. Benchmarked in `internal/db/stats_usage_bench_test.go`:
+
+| Benchmark | Result |
+|---|---|
+| `BenchmarkStatsStore_UpdateFromService` (upsert) | ~80 µs/op, 129 allocs |
+| `BenchmarkUsageStore_RecordUsage` (insert) | ~307 µs/op, 117 allocs |
+| `BenchmarkStatsAndUsage_Combined` (both, back to back, separate stores) | ~440 µs/op, 246 allocs |
+
+pprof showed both dominated by gorm's implicit transaction wrapper
+(`BEGIN`/`COMMIT`) around each write, with `UsageStore.RecordUsage` costing
+~4× `StatsStore.UpdateFromService` because `usage_records` has 6 indexed
+columns to maintain per insert against `service_stats`' single composite
+primary key.
+
+**Two directions were considered and one was rejected on evidence:**
+
+- **`PRAGMA synchronous=NORMAL`** (skip the fsync SQLite issues after each
+  `COMMIT` under the default `FULL`) — investigated, implemented, benchmarked,
+  and **reverted**: `PRAGMA synchronous` read back as `1` (NORMAL) both
+  before and after the change. The driver, `mattn/go-sqlite3`, is compiled
+  with `-DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1` and additionally forces
+  `synchronous=NORMAL` itself whenever `_journal_mode=WAL` is requested
+  (every store here already sets that) — see the driver's `sqlite3.go`
+  around `case "WAL": ... synchronousMode = "NORMAL"`. So every store was
+  already running at NORMAL; explicitly setting it was a no-op. (Confirmed
+  the pragma itself is real and matters when it isn't already the effective
+  default: an isolated raw-driver benchmark forcing `FULL` vs `NORMAL`
+  explicitly showed 373 µs/op vs 26 µs/op — 14× — but that headroom was
+  never available here.) Lesson: always read back the actual `PRAGMA` value
+  before crediting a DSN change with a win, and don't trust a driver's
+  surface-level defaults without checking what it does internally.
+
+- **Merge the two writes into one transaction** (`db.RecordRequestOutcome`,
+  `internal/db/record_outcome.go`) — implemented. `StatsStore.UpdateFromService`
+  and `UsageStore.RecordUsage` were split into a pure record-builder
+  (`buildStatsRecordFromService`, `prepareUsageRecord`) and the DB write, so
+  `RecordRequestOutcome` can build both records and `tx.Save`/`tx.Create`
+  them inside one `gorm.DB.Transaction(...)` call when both stores share the
+  same underlying `*gorm.DB` (always true in production — `StoreManager`
+  wires every store to one shared connection; a `db != db` fallback exists
+  for the never-exercised-in-production case of independently constructed
+  stores). `usage_tracking.go`'s `updateServiceStats` and
+  `recordDetailedUsage[WithTokenUsage]` now build-and-return instead of
+  persisting inline; a new `persistRequestOutcome` calls
+  `db.RecordRequestOutcome` once per request instead of two independent
+  store calls.
+
+  | Benchmark | separate transactions | merged transaction | change |
+  |---|---|---|---|
+  | `BenchmarkStatsAndUsage_Combined` vs. `_RecordRequestOutcome` | ~440 µs/op, 246 allocs | ~420 µs/op, 235 allocs | **~4–8%** (noisy across runs), 11 fewer allocs/op |
+
+  Confirmed via pprof that the merge is real (`gorm.(*DB).Commit` appears
+  once per call, not twice), but the win is modest: most of the ~440 µs
+  isn't transaction-wrapper overhead, it's the two per-row statements
+  themselves (`INSERT` + `UPDATE`, each its own cgo call into SQLite plus
+  gorm's reflection/scan machinery) — removing one `COMMIT` doesn't remove
+  either statement. Don't expect "halve the commits" to mean "halve the
+  latency" when per-statement cost dominates per-transaction cost, as it
+  does here. Kept anyway: the win is real (not regression, ~4–8% lower
+  latency on the client-visible path, fewer allocations) and it adds a
+  genuine correctness improvement beyond performance —
+  `TestRecordRequestOutcome_AtomicRollback` (`internal/db/record_outcome_test.go`)
+  proves the stats and usage rows for one request can no longer partially
+  persist (previously two independent best-effort writes; a stats-store
+  failure and a usage-store success, or vice versa, could silently
+  disagree — now they're all-or-nothing).
+
+**Still open** (option 1 from the original discussion, not attempted here):
+batching/debouncing multiple requests' stats and usage writes into fewer,
+larger transactions (e.g. an in-memory buffer flushed by a ticker or a
+bounded channel + background writer) — the actual lever for the remaining
+per-statement cost, since it amortizes the cgo/gorm overhead across N rows
+instead of paying it per request. Marked complex/deferred in the original
+discussion; the numbers above suggest it's the only remaining direction with
+real headroom on this path, at the cost of async durability (a crash loses
+whatever's still buffered) and added complexity (buffer, flush trigger,
+backpressure if the writer falls behind).
+
+**Also fixed in passing**: `NewUsageStore` never created the `db`
+subdirectory `constant.GetDBFile` expects (every other `NewXStore`
+constructor in this package does). Never hit in production because
+`StoreManager` builds `UsageStore` directly over its own already-open
+`*gorm.DB` — `NewUsageStore` had zero callers anywhere in the codebase until
+`stats_usage_bench_test.go` became its first, which is how this surfaced.
+
 ## The pattern is systemic — audit of `internal/db/*_store.go`
 
 Every store under `internal/db/` follows the same shape: a GORM-backed SQLite
@@ -144,15 +241,21 @@ table, one `sync.Mutex` (not `RWMutex`) per store, and every method —
 including pure reads — takes the exclusive lock and issues a query. Only
 `provider_model.go` (`ModelStore`) and `usage_record.go`/`store_manager.go`
 already used `RWMutex`, and none of them cache. Whether this matters for a
-given store depends entirely on whether it's read on the **request hot path**
-(every inbound request) versus an **admin/UI path** (occasional, human-paced):
+given store depends entirely on whether it's read (or written) on the
+**request hot path** (every inbound request) versus an **admin/UI path**
+(occasional, human-paced) or the lower-QPS **IM-bot/remote-control message
+path**:
 
-| Store | Hot-path read? | Where | Risk |
+| Store | Hot-path? | Where | Status |
 |---|---|---|---|
-| `ProviderStore` | **Yes — fixed** | `ServiceSelector.Select` resolves a provider every request | was the #1 cost, now cached |
-| `APITokenStore` | **Yes — fixed** | `internal/middleware/auth.go`'s `AuthMiddleware` calls `ValidateToken` (cached read) and `UpdateLastUsed` (debounced write) on every API-token-authenticated request | see benchmark sections above — `ValidateToken` dropped ~251×, `UpdateLastUsed`'s debounce took the full middleware path a further ~40× |
-| `ModelStore`, `ToolConfigStore`, `ImBotSettingsStore`, `TaskStore`, `ServiceStatStore` | No (or infrequent/admin-path) | config/UI/background jobs | low priority — `RWMutex` alone (no caching) is probably sufficient if ever contended |
-| `RemoteChatStore`, `RemoteSessionStore`, `BotAccessStore`, `UsageStore` | No (IM/remote-control and usage-recording paths, not the LLM proxy hot path) | — | low priority |
+| `ProviderStore` | **Yes (read)** | `ServiceSelector.Select` resolves a provider every request | **Fixed** — read cache |
+| `APITokenStore` | **Yes (read + write)** | `AuthMiddleware.ModelAuthMiddleware` validates every API-token request and updates `last_used_at` | **Fixed** — read cache + debounced write |
+| `StatsStore`, `UsageStore` | **Yes (write)** | `usage_tracking.go` persists stats + a usage row every completed request | **Partially fixed** — merged transaction; batching still open |
+| `ImBotSettingsStore` | No | Bot lifecycle events (start/stop) and admin REST/CLI only | Not touched — genuinely low frequency |
+| `ModelStore` | No | Admin "list/refresh models" REST endpoints, OAuth completion, CLI | Not touched — already `RWMutex`, admin-paced |
+| `TaskStore` | **Dead code** | Zero callers anywhere in the repo; the real task subsystem uses `internal/task/store.go` instead | Not touched — flag for a separate cleanup ticket |
+| `ToolConfigStore` | **Effectively unreachable** | The one method on the request-adjacent MCP-tool-config path (`Config.GetToolConfig`) is a different, in-memory-only implementation on `Config.ToolConfigs` that never touches this store | Not touched — flag for a separate cleanup ticket |
+| `RemoteChatStore`, `RemoteSessionStore`, `BotAccessStore` | IM-bot message path (several round trips per inbound chat message) | `remote/control/remoteagent/handler_message.go` et al. | Not touched — real per-message traffic, but QPS is chat-message-rate, not LLM-API-rate, and none has an app-level mutex at all today (rely on gorm/SQLite's own WAL concurrency) |
 
 ## Recommended approach for future stores
 

--- a/.design/hot-path-db-access.md
+++ b/.design/hot-path-db-access.md
@@ -185,16 +185,18 @@ primary key.
   `internal/db/record_outcome.go`) — implemented. `StatsStore.UpdateFromService`
   and `UsageStore.RecordUsage` were split into a pure record-builder
   (`buildStatsRecordFromService`, `prepareUsageRecord`) and the DB write, so
-  `RecordRequestOutcome` can build both records and `tx.Save`/`tx.Create`
-  them inside one `gorm.DB.Transaction(...)` call when both stores share the
-  same underlying `*gorm.DB` (always true in production — `StoreManager`
-  wires every store to one shared connection; a `db != db` fallback exists
-  for the never-exercised-in-production case of independently constructed
-  stores). `usage_tracking.go`'s `updateServiceStats` and
-  `recordDetailedUsage[WithTokenUsage]` now build-and-return instead of
-  persisting inline; a new `persistRequestOutcome` calls
-  `db.RecordRequestOutcome` once per request instead of two independent
-  store calls.
+  `RecordRequestOutcome` can build both records (outside any lock — neither
+  builder touches store state) and `tx.Save`/`tx.Create` them inside one
+  `gorm.DB.Transaction(...)` call. This assumes both stores share the same
+  underlying `*gorm.DB`, which every production call site guarantees
+  (`StoreManager` wires every store to one shared connection) — an earlier
+  version carried a fallback for mismatched-DB stores, removed in a
+  follow-up simplify pass once review converged on it being speculative
+  generality for a path with no real caller (see below). `usage_tracking.go`'s
+  `updateServiceStats` and `recordDetailedUsage[WithTokenUsage]` now
+  build-and-return instead of persisting inline; a new `persistRequestOutcome`
+  calls `db.RecordRequestOutcome` once per request instead of two
+  independent store calls.
 
   | Benchmark | separate transactions | merged transaction | change |
   |---|---|---|---|
@@ -276,7 +278,14 @@ path**:
    `StoreManager`-only constructor path and delete the literal. This is
    exactly what broke `TestStoreManager_StoreOperations` on the first pass on
    `ProviderStore`, and would have broken `APITokenStore` the same way had
-   `initAPITokenStore` not been fixed alongside it.
+   `initAPITokenStore` not been fixed alongside it. A follow-up simplify pass
+   closed this off structurally rather than relying on remembering to update
+   both places by hand: `ProviderStore`/`APITokenStore` each now have a
+   `newXStoreOverDB(db *gorm.DB, dbPath string)` that does the post-open setup
+   (migrate + cache init + `loadCache`), called by both `NewXStore` (which
+   opens its own connection) and `StoreManager.initXStore` (which reuses the
+   shared one) — one code path for "how to finish building this store," not
+   two copies that can drift.
 4. **Write the benchmark first, against the real production wiring, and
    profile before touching any code** — `internal/routing/pipeline_bench_test.go`
    for the routing pipeline, `internal/middleware/auth_bench_test.go` for the

--- a/internal/db/api_token_store.go
+++ b/internal/db/api_token_store.go
@@ -36,11 +36,25 @@ func (APITokenRecord) TableName() string {
 	return "api_tokens"
 }
 
-// APITokenStore manages API tokens for multi-tenant authentication
+// APITokenStore manages API tokens for multi-tenant authentication.
+//
+// ValidateToken sits on the request hot path (called from every
+// "tb-share-"-prefixed request by AuthMiddleware.ModelAuthMiddleware, see
+// internal/middleware/auth.go) but token records change only on admin CRUD
+// (create/revoke/rename). Benchmarking it the way
+// internal/routing/pipeline_bench_test.go benchmarks ServiceSelector.Select
+// (see internal/middleware/auth_bench_test.go and
+// .design/hot-path-db-access.md) showed the same shape as
+// db.ProviderStore.GetByUUID had: a SQLite round-trip serialized behind a
+// plain sync.Mutex that blocked concurrent readers too. cache mirrors the
+// api_tokens table by TokenID the same way ProviderStore mirrors providers:
+// reads are served from the cache under RWMutex, writes hit SQLite first
+// (durability) and then update the cache entry.
 type APITokenStore struct {
 	db     *gorm.DB
 	dbPath string
-	mu     sync.Mutex
+	mu     sync.RWMutex
+	cache  map[string]*APITokenRecord
 }
 
 // NewAPITokenStore creates or loads an API token store using SQLite database.
@@ -69,6 +83,7 @@ func NewAPITokenStore(baseDir string) (*APITokenStore, error) {
 	store := &APITokenStore{
 		db:     db,
 		dbPath: dbPath,
+		cache:  make(map[string]*APITokenRecord),
 	}
 
 	// Auto-migrate schema
@@ -81,8 +96,30 @@ func NewAPITokenStore(baseDir string) (*APITokenStore, error) {
 		return nil, fmt.Errorf("failed to align API token schema: %w", err)
 	}
 
+	if err := store.loadCache(); err != nil {
+		return nil, fmt.Errorf("failed to load API token cache: %w", err)
+	}
+
 	logrus.Debugf("API token store initialization completed")
 	return store, nil
+}
+
+// loadCache (re)populates the in-memory mirror from SQLite. Called at
+// construction, before the store is shared with any other goroutine, and
+// from CleanupExpiredTokens (under s.mu already held) since a bulk delete's
+// predicate is simplest to just re-derive from the DB rather than
+// duplicating in Go.
+func (s *APITokenStore) loadCache() error {
+	var records []APITokenRecord
+	if err := s.db.Find(&records).Error; err != nil {
+		return err
+	}
+	s.cache = make(map[string]*APITokenRecord, len(records))
+	for i := range records {
+		r := records[i]
+		s.cache[r.TokenID] = &r
+	}
+	return nil
 }
 
 // ensureAPITokenSchema ensures the API token table schema is up to date
@@ -131,6 +168,7 @@ func (s *APITokenStore) createTokenRecord(userID, tokenID, displayName, createdB
 		return nil, fmt.Errorf("failed to create API token record: %w", err)
 	}
 
+	s.cache[tokenID] = record
 	logrus.Debugf("Created API token: %s for user: %s", tokenID, userID)
 	return record, nil
 }
@@ -156,18 +194,16 @@ func (s *APITokenStore) ValidateToken(tokenID string) (*APITokenRecord, error) {
 		return nil, errors.New("token ID cannot be empty")
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	var record APITokenRecord
-	if err := s.db.Where("token_id = ? AND enabled = ?", tokenID, true).First(&record).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("token not found or disabled")
-		}
-		return nil, fmt.Errorf("failed to validate token: %w", err)
+	record, ok := s.cache[tokenID]
+	if !ok || !record.Enabled {
+		return nil, fmt.Errorf("token not found or disabled")
 	}
 
-	return &record, nil
+	clone := *record
+	return &clone, nil
 }
 
 // RevokeToken revokes a token by setting enabled to false
@@ -178,6 +214,11 @@ func (s *APITokenStore) RevokeToken(tokenID, reason string) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	record, ok := s.cache[tokenID]
+	if !ok {
+		return fmt.Errorf("token with ID '%s' not found", tokenID)
+	}
 
 	now := time.Now()
 	result := s.db.Model(&APITokenRecord{}).
@@ -195,14 +236,18 @@ func (s *APITokenStore) RevokeToken(tokenID, reason string) error {
 		return fmt.Errorf("token with ID '%s' not found", tokenID)
 	}
 
+	record.Enabled = false
+	record.RevokedAt = &now
+	record.RevokeReason = reason
+
 	logrus.Debugf("Revoked API token: %s, reason: %s", tokenID, reason)
 	return nil
 }
 
 // ListTokens returns tokens matching filters
 func (s *APITokenStore) ListTokens(userID string, enabled *bool, limit, offset int) ([]APITokenRecord, int64, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	db := s.db.Model(&APITokenRecord{})
 
@@ -234,18 +279,16 @@ func (s *APITokenStore) ListTokens(userID string, enabled *bool, limit, offset i
 
 // GetToken retrieves a token by token ID
 func (s *APITokenStore) GetToken(tokenID string) (*APITokenRecord, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	var record APITokenRecord
-	if err := s.db.Where("token_id = ?", tokenID).First(&record).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("token with ID '%s' not found", tokenID)
-		}
-		return nil, fmt.Errorf("failed to get token: %w", err)
+	record, ok := s.cache[tokenID]
+	if !ok {
+		return nil, fmt.Errorf("token with ID '%s' not found", tokenID)
 	}
 
-	return &record, nil
+	clone := *record
+	return &clone, nil
 }
 
 // UpdateLastUsed updates the last_used_at timestamp for a token
@@ -260,6 +303,10 @@ func (s *APITokenStore) UpdateLastUsed(tokenID string) error {
 
 	if result.Error != nil {
 		return fmt.Errorf("failed to update last used: %w", result.Error)
+	}
+
+	if record, ok := s.cache[tokenID]; ok {
+		record.LastUsedAt = &now
 	}
 
 	return nil
@@ -279,6 +326,10 @@ func (s *APITokenStore) SetTokenEnabled(tokenID string, enabled bool) error {
 	}
 	if result.RowsAffected == 0 {
 		return fmt.Errorf("token with ID '%s' not found", tokenID)
+	}
+
+	if record, ok := s.cache[tokenID]; ok {
+		record.Enabled = enabled
 	}
 
 	logrus.Debugf("Token %s enabled state set to: %v", tokenID, enabled)
@@ -301,6 +352,12 @@ func (s *APITokenStore) UpdateTokenString(tokenID, newTokenString string) error 
 		return fmt.Errorf("token with ID '%s' not found", tokenID)
 	}
 
+	if record, ok := s.cache[tokenID]; ok {
+		delete(s.cache, tokenID)
+		record.TokenID = newTokenString
+		s.cache[newTokenString] = record
+	}
+
 	logrus.Debugf("Token regenerated, old ID: %s, new ID: %s", tokenID, newTokenString)
 	return nil
 }
@@ -318,6 +375,8 @@ func (s *APITokenStore) DeleteToken(tokenID string) error {
 		return fmt.Errorf("token with ID '%s' not found", tokenID)
 	}
 
+	delete(s.cache, tokenID)
+
 	logrus.Debugf("Deleted API token: %s", tokenID)
 	return nil
 }
@@ -332,6 +391,14 @@ func (s *APITokenStore) CleanupExpiredTokens(olderThan time.Duration) (int64, er
 
 	if result.Error != nil {
 		return 0, fmt.Errorf("failed to cleanup expired tokens: %w", result.Error)
+	}
+
+	// Bulk, predicate-based delete — simplest to resync the whole mirror from
+	// SQLite rather than re-deriving the same predicate against the cache.
+	if result.RowsAffected > 0 {
+		if err := s.loadCache(); err != nil {
+			return result.RowsAffected, fmt.Errorf("cleaned up %d tokens but failed to refresh cache: %w", result.RowsAffected, err)
+		}
 	}
 
 	logrus.Debugf("Cleaned up %d expired tokens", result.RowsAffected)

--- a/internal/db/api_token_store.go
+++ b/internal/db/api_token_store.go
@@ -92,14 +92,21 @@ func NewAPITokenStore(baseDir string) (*APITokenStore, error) {
 	}
 	logrus.Debugf("SQLite database opened successfully for API token store")
 
-	store := &APITokenStore{
-		db:               db,
-		dbPath:           dbPath,
-		cache:            make(map[string]*APITokenRecord),
-		lastUsedDebounce: defaultLastUsedDebounce,
+	store, err := newAPITokenStoreOverDB(db, dbPath)
+	if err != nil {
+		return nil, err
 	}
 
-	// Auto-migrate schema
+	logrus.Debugf("API token store initialization completed")
+	return store, nil
+}
+
+// newAPITokenStoreOverDB finishes setting up an APITokenStore (schema
+// migration + cache load) over an already-open *gorm.DB, whether that
+// connection is NewAPITokenStore's own or StoreManager's shared one. See
+// newProviderStoreOverDB in provider_store.go for why both construction
+// paths funnel through one function instead of duplicating this wiring.
+func newAPITokenStoreOverDB(db *gorm.DB, dbPath string) (*APITokenStore, error) {
 	if err := db.AutoMigrate(&APITokenRecord{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate API token database: %w", err)
 	}
@@ -109,11 +116,16 @@ func NewAPITokenStore(baseDir string) (*APITokenStore, error) {
 		return nil, fmt.Errorf("failed to align API token schema: %w", err)
 	}
 
+	store := &APITokenStore{
+		db:               db,
+		dbPath:           dbPath,
+		cache:            make(map[string]*APITokenRecord),
+		lastUsedDebounce: defaultLastUsedDebounce,
+	}
 	if err := store.loadCache(); err != nil {
 		return nil, fmt.Errorf("failed to load API token cache: %w", err)
 	}
 
-	logrus.Debugf("API token store initialization completed")
 	return store, nil
 }
 
@@ -228,11 +240,6 @@ func (s *APITokenStore) RevokeToken(tokenID, reason string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	record, ok := s.cache[tokenID]
-	if !ok {
-		return fmt.Errorf("token with ID '%s' not found", tokenID)
-	}
-
 	now := time.Now()
 	result := s.db.Model(&APITokenRecord{}).
 		Where("token_id = ?", tokenID).
@@ -249,9 +256,11 @@ func (s *APITokenStore) RevokeToken(tokenID, reason string) error {
 		return fmt.Errorf("token with ID '%s' not found", tokenID)
 	}
 
-	record.Enabled = false
-	record.RevokedAt = &now
-	record.RevokeReason = reason
+	if record, ok := s.cache[tokenID]; ok {
+		record.Enabled = false
+		record.RevokedAt = &now
+		record.RevokeReason = reason
+	}
 
 	logrus.Debugf("Revoked API token: %s, reason: %s", tokenID, reason)
 	return nil

--- a/internal/db/api_token_store.go
+++ b/internal/db/api_token_store.go
@@ -36,6 +36,13 @@ func (APITokenRecord) TableName() string {
 	return "api_tokens"
 }
 
+// defaultLastUsedDebounce is how often UpdateLastUsed will actually persist
+// a new last_used_at. A busy token can see many requests per second; the
+// column exists for "when was this last used" display in the token admin
+// UI, which needs freshness on the order of minutes, not per-request
+// precision. See UpdateLastUsed.
+const defaultLastUsedDebounce = time.Minute
+
 // APITokenStore manages API tokens for multi-tenant authentication.
 //
 // ValidateToken sits on the request hot path (called from every
@@ -55,6 +62,11 @@ type APITokenStore struct {
 	dbPath string
 	mu     sync.RWMutex
 	cache  map[string]*APITokenRecord
+
+	// lastUsedDebounce is the minimum interval between persisted
+	// last_used_at writes for the same token; see UpdateLastUsed. Only
+	// overridden by tests, hence unexported with no constructor param.
+	lastUsedDebounce time.Duration
 }
 
 // NewAPITokenStore creates or loads an API token store using SQLite database.
@@ -81,9 +93,10 @@ func NewAPITokenStore(baseDir string) (*APITokenStore, error) {
 	logrus.Debugf("SQLite database opened successfully for API token store")
 
 	store := &APITokenStore{
-		db:     db,
-		dbPath: dbPath,
-		cache:  make(map[string]*APITokenRecord),
+		db:               db,
+		dbPath:           dbPath,
+		cache:            make(map[string]*APITokenRecord),
+		lastUsedDebounce: defaultLastUsedDebounce,
 	}
 
 	// Auto-migrate schema
@@ -291,12 +304,47 @@ func (s *APITokenStore) GetToken(tokenID string) (*APITokenRecord, error) {
 	return &clone, nil
 }
 
-// UpdateLastUsed updates the last_used_at timestamp for a token
+// debounceWindow returns lastUsedDebounce, falling back to the package
+// default for stores built via a struct literal that never set it (e.g.
+// StoreManager's init* helpers before this field existed, or a future one
+// added the same way — see the "watch for bypass construction" note in
+// .design/hot-path-db-access.md).
+func (s *APITokenStore) debounceWindow() time.Duration {
+	if s.lastUsedDebounce > 0 {
+		return s.lastUsedDebounce
+	}
+	return defaultLastUsedDebounce
+}
+
+// UpdateLastUsed updates the last_used_at timestamp for a token.
+//
+// Called on every authenticated request (see AuthMiddleware.ModelAuthMiddleware
+// in internal/middleware/auth.go), but the column is only ever read for "last
+// used" display in the token admin UI, which doesn't need per-request
+// precision. Writes within debounceWindow() of the last persisted value are
+// coalesced away — cheap under the read lock, so a hot token pays almost
+// nothing between flushes instead of one SQLite UPDATE per request.
 func (s *APITokenStore) UpdateLastUsed(tokenID string) error {
+	now := time.Now()
+	window := s.debounceWindow()
+
+	s.mu.RLock()
+	if record, ok := s.cache[tokenID]; ok && record.LastUsedAt != nil && now.Sub(*record.LastUsedAt) < window {
+		s.mu.RUnlock()
+		return nil
+	}
+	s.mu.RUnlock()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	now := time.Now()
+	// Re-check under the write lock: another goroutine may have already
+	// flushed while this one was waiting.
+	record, ok := s.cache[tokenID]
+	if ok && record.LastUsedAt != nil && now.Sub(*record.LastUsedAt) < window {
+		return nil
+	}
+
 	result := s.db.Model(&APITokenRecord{}).
 		Where("token_id = ?", tokenID).
 		Update("last_used_at", now)
@@ -305,7 +353,7 @@ func (s *APITokenStore) UpdateLastUsed(tokenID string) error {
 		return fmt.Errorf("failed to update last used: %w", result.Error)
 	}
 
-	if record, ok := s.cache[tokenID]; ok {
+	if ok {
 		record.LastUsedAt = &now
 	}
 

--- a/internal/db/api_token_store.go
+++ b/internal/db/api_token_store.go
@@ -37,26 +37,15 @@ func (APITokenRecord) TableName() string {
 }
 
 // defaultLastUsedDebounce is how often UpdateLastUsed will actually persist
-// a new last_used_at. A busy token can see many requests per second; the
-// column exists for "when was this last used" display in the token admin
-// UI, which needs freshness on the order of minutes, not per-request
-// precision. See UpdateLastUsed.
+// a new last_used_at — the column only needs display-level freshness, not
+// per-request precision. See UpdateLastUsed.
 const defaultLastUsedDebounce = time.Minute
 
 // APITokenStore manages API tokens for multi-tenant authentication.
 //
-// ValidateToken sits on the request hot path (called from every
-// "tb-share-"-prefixed request by AuthMiddleware.ModelAuthMiddleware, see
-// internal/middleware/auth.go) but token records change only on admin CRUD
-// (create/revoke/rename). Benchmarking it the way
-// internal/routing/pipeline_bench_test.go benchmarks ServiceSelector.Select
-// (see internal/middleware/auth_bench_test.go and
-// .design/hot-path-db-access.md) showed the same shape as
-// db.ProviderStore.GetByUUID had: a SQLite round-trip serialized behind a
-// plain sync.Mutex that blocked concurrent readers too. cache mirrors the
-// api_tokens table by TokenID the same way ProviderStore mirrors providers:
-// reads are served from the cache under RWMutex, writes hit SQLite first
-// (durability) and then update the cache entry.
+// ValidateToken is on the request hot path (every "tb-share-"-prefixed
+// request, see internal/middleware/auth.go), so cache mirrors the
+// api_tokens table by TokenID the same way ProviderStore mirrors providers.
 type APITokenStore struct {
 	db     *gorm.DB
 	dbPath string
@@ -64,8 +53,7 @@ type APITokenStore struct {
 	cache  map[string]*APITokenRecord
 
 	// lastUsedDebounce is the minimum interval between persisted
-	// last_used_at writes for the same token; see UpdateLastUsed. Only
-	// overridden by tests, hence unexported with no constructor param.
+	// last_used_at writes for the same token; see UpdateLastUsed.
 	lastUsedDebounce time.Duration
 }
 
@@ -101,11 +89,9 @@ func NewAPITokenStore(baseDir string) (*APITokenStore, error) {
 	return store, nil
 }
 
-// newAPITokenStoreOverDB finishes setting up an APITokenStore (schema
-// migration + cache load) over an already-open *gorm.DB, whether that
-// connection is NewAPITokenStore's own or StoreManager's shared one. See
-// newProviderStoreOverDB in provider_store.go for why both construction
-// paths funnel through one function instead of duplicating this wiring.
+// newAPITokenStoreOverDB finishes setting up an APITokenStore (migrate +
+// cache load) over an already-open *gorm.DB, shared by NewAPITokenStore and
+// StoreManager.initAPITokenStore -- see newProviderStoreOverDB.
 func newAPITokenStoreOverDB(db *gorm.DB, dbPath string) (*APITokenStore, error) {
 	if err := db.AutoMigrate(&APITokenRecord{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate API token database: %w", err)
@@ -130,10 +116,9 @@ func newAPITokenStoreOverDB(db *gorm.DB, dbPath string) (*APITokenStore, error) 
 }
 
 // loadCache (re)populates the in-memory mirror from SQLite. Called at
-// construction, before the store is shared with any other goroutine, and
-// from CleanupExpiredTokens (under s.mu already held) since a bulk delete's
-// predicate is simplest to just re-derive from the DB rather than
-// duplicating in Go.
+// construction and from CleanupExpiredTokens (under s.mu already held),
+// where re-deriving a bulk delete's predicate against the cache isn't
+// worth it.
 func (s *APITokenStore) loadCache() error {
 	var records []APITokenRecord
 	if err := s.db.Find(&records).Error; err != nil {
@@ -314,10 +299,7 @@ func (s *APITokenStore) GetToken(tokenID string) (*APITokenRecord, error) {
 }
 
 // debounceWindow returns lastUsedDebounce, falling back to the package
-// default for stores built via a struct literal that never set it (e.g.
-// StoreManager's init* helpers before this field existed, or a future one
-// added the same way — see the "watch for bypass construction" note in
-// .design/hot-path-db-access.md).
+// default for any store built without going through newAPITokenStoreOverDB.
 func (s *APITokenStore) debounceWindow() time.Duration {
 	if s.lastUsedDebounce > 0 {
 		return s.lastUsedDebounce
@@ -325,14 +307,10 @@ func (s *APITokenStore) debounceWindow() time.Duration {
 	return defaultLastUsedDebounce
 }
 
-// UpdateLastUsed updates the last_used_at timestamp for a token.
-//
-// Called on every authenticated request (see AuthMiddleware.ModelAuthMiddleware
-// in internal/middleware/auth.go), but the column is only ever read for "last
-// used" display in the token admin UI, which doesn't need per-request
-// precision. Writes within debounceWindow() of the last persisted value are
-// coalesced away — cheap under the read lock, so a hot token pays almost
-// nothing between flushes instead of one SQLite UPDATE per request.
+// UpdateLastUsed updates the last_used_at timestamp for a token. Called on
+// every authenticated request, so writes within debounceWindow() of the
+// last persisted value are coalesced away instead of costing one SQLite
+// UPDATE per request.
 func (s *APITokenStore) UpdateLastUsed(tokenID string) error {
 	now := time.Now()
 	window := s.debounceWindow()

--- a/internal/db/api_token_store_test.go
+++ b/internal/db/api_token_store_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -33,4 +34,64 @@ func TestAPITokenStore_RevokeToken_NotFound(t *testing.T) {
 
 	err := store.RevokeToken("non-existent", "reason")
 	assert.Error(t, err)
+}
+
+func TestAPITokenStore_UpdateLastUsed_FirstCallPersists(t *testing.T) {
+	store, _ := setupTestAPITokenStore(t)
+	defer store.Close()
+
+	_, err := store.CreateTokenWithTokenID("user-1", "token-1", "display", "admin", nil)
+	assert.NoError(t, err)
+
+	assert.NoError(t, store.UpdateLastUsed("token-1"))
+
+	cached, err := store.GetToken("token-1")
+	assert.NoError(t, err)
+	assert.NotNil(t, cached.LastUsedAt)
+
+	// Confirm it was actually persisted to SQLite, not just cached.
+	var dbRecord APITokenRecord
+	assert.NoError(t, store.db.Where("token_id = ?", "token-1").First(&dbRecord).Error)
+	assert.NotNil(t, dbRecord.LastUsedAt)
+}
+
+func TestAPITokenStore_UpdateLastUsed_DebouncesWithinWindow(t *testing.T) {
+	store, _ := setupTestAPITokenStore(t)
+	defer store.Close()
+
+	_, err := store.CreateTokenWithTokenID("user-1", "token-1", "display", "admin", nil)
+	assert.NoError(t, err)
+
+	assert.NoError(t, store.UpdateLastUsed("token-1"))
+	first, err := store.GetToken("token-1")
+	assert.NoError(t, err)
+
+	// A second call inside the debounce window must not move last_used_at —
+	// this is what turns "one SQLite write per request" into "one write per
+	// debounce window per token".
+	assert.NoError(t, store.UpdateLastUsed("token-1"))
+	second, err := store.GetToken("token-1")
+	assert.NoError(t, err)
+
+	assert.True(t, first.LastUsedAt.Equal(*second.LastUsedAt))
+}
+
+func TestAPITokenStore_UpdateLastUsed_WritesAgainAfterWindow(t *testing.T) {
+	store, _ := setupTestAPITokenStore(t)
+	defer store.Close()
+
+	_, err := store.CreateTokenWithTokenID("user-1", "token-1", "display", "admin", nil)
+	assert.NoError(t, err)
+	assert.NoError(t, store.UpdateLastUsed("token-1"))
+
+	// Simulate the debounce window having elapsed without sleeping in the test.
+	store.mu.Lock()
+	stale := time.Now().Add(-2 * defaultLastUsedDebounce)
+	store.cache["token-1"].LastUsedAt = &stale
+	store.mu.Unlock()
+
+	assert.NoError(t, store.UpdateLastUsed("token-1"))
+	refreshed, err := store.GetToken("token-1")
+	assert.NoError(t, err)
+	assert.True(t, refreshed.LastUsedAt.After(stale))
 }

--- a/internal/db/api_token_store_test.go
+++ b/internal/db/api_token_store_test.go
@@ -66,9 +66,7 @@ func TestAPITokenStore_UpdateLastUsed_DebouncesWithinWindow(t *testing.T) {
 	first, err := store.GetToken("token-1")
 	assert.NoError(t, err)
 
-	// A second call inside the debounce window must not move last_used_at —
-	// this is what turns "one SQLite write per request" into "one write per
-	// debounce window per token".
+	// A second call inside the debounce window must not move last_used_at.
 	assert.NoError(t, store.UpdateLastUsed("token-1"))
 	second, err := store.GetToken("token-1")
 	assert.NoError(t, err)

--- a/internal/db/provider_store.go
+++ b/internal/db/provider_store.go
@@ -375,11 +375,16 @@ func (ps *ProviderStore) Save(provider *typ.Provider) error {
 	defer ps.mu.Unlock()
 
 	if existing, ok := ps.cache[provider.UUID]; ok {
-		// Update existing record
-		updateRecordFromProvider(existing, provider)
-		if err := ps.db.Save(existing).Error; err != nil {
+		// Update a copy first -- only replace the cached record once the
+		// SQLite write actually succeeds, so a failed Save can't leave the
+		// cache holding data that was never persisted (see UpdateOAuthAccessToken
+		// below for the same write-then-cache ordering).
+		updated := *existing
+		updateRecordFromProvider(&updated, provider)
+		if err := ps.db.Save(&updated).Error; err != nil {
 			return fmt.Errorf("failed to update provider record: %w", err)
 		}
+		ps.cache[provider.UUID] = &updated
 		logrus.Debugf("Updated provider: %s (%s)", provider.Name, provider.UUID)
 	} else {
 		// Create new record
@@ -502,32 +507,37 @@ func (ps *ProviderStore) UpdateCredential(uuid string, token string, oauthDetail
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	record, ok := ps.cache[uuid]
+	existing, ok := ps.cache[uuid]
 	if !ok {
 		return fmt.Errorf("provider with UUID '%s' not found", uuid)
 	}
 
+	// Update a copy first -- see Save's comment on why the cache is only
+	// replaced after the SQLite write succeeds.
+	updated := *existing
+
 	// Update credential fields based on auth type
-	if record.AuthType == string(typ.AuthTypeOAuth) && oauthDetail != nil {
-		record.Token = oauthDetail.AccessToken
-		record.OAuthProviderType = string(oauthDetail.GetIssuer())
-		record.OAuthUserID = oauthDetail.UserID
-		record.OAuthRefreshToken = oauthDetail.RefreshToken
-		record.OAuthExpiresAt = oauthDetail.ExpiresAt
+	if updated.AuthType == string(typ.AuthTypeOAuth) && oauthDetail != nil {
+		updated.Token = oauthDetail.AccessToken
+		updated.OAuthProviderType = string(oauthDetail.GetIssuer())
+		updated.OAuthUserID = oauthDetail.UserID
+		updated.OAuthRefreshToken = oauthDetail.RefreshToken
+		updated.OAuthExpiresAt = oauthDetail.ExpiresAt
 		if oauthDetail.ExtraFields != nil {
 			extraJSON, _ := json.Marshal(oauthDetail.ExtraFields)
-			record.OAuthExtraFields = string(extraJSON)
+			updated.OAuthExtraFields = string(extraJSON)
 		}
 	} else {
-		record.Token = token
+		updated.Token = token
 	}
 
-	record.UpdatedAt = time.Now()
+	updated.UpdatedAt = time.Now()
 
-	if err := ps.db.Save(record).Error; err != nil {
+	if err := ps.db.Save(&updated).Error; err != nil {
 		return fmt.Errorf("failed to update provider credential: %w", err)
 	}
 
+	ps.cache[uuid] = &updated
 	logrus.Debugf("Updated credential for provider: %s", uuid)
 	return nil
 }
@@ -539,23 +549,27 @@ func (ps *ProviderStore) UpdateCredentialBundle(uuid string, bundle *typ.Credent
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	record, ok := ps.cache[uuid]
+	existing, ok := ps.cache[uuid]
 	if !ok {
 		return fmt.Errorf("provider with UUID '%s' not found", uuid)
 	}
 
+	// Update a copy first -- see Save's comment on why the cache is only
+	// replaced after the SQLite write succeeds.
+	updated := *existing
 	if bundle != nil {
 		credJSON, _ := json.Marshal(bundle)
-		record.Credential = string(credJSON)
+		updated.Credential = string(credJSON)
 	} else {
-		record.Credential = ""
+		updated.Credential = ""
 	}
-	record.UpdatedAt = time.Now()
+	updated.UpdatedAt = time.Now()
 
-	if err := ps.db.Save(record).Error; err != nil {
+	if err := ps.db.Save(&updated).Error; err != nil {
 		return fmt.Errorf("failed to update provider credential bundle: %w", err)
 	}
 
+	ps.cache[uuid] = &updated
 	logrus.Debugf("Updated credential bundle for provider: %s", uuid)
 	return nil
 }

--- a/internal/db/provider_store.go
+++ b/internal/db/provider_store.go
@@ -278,11 +278,30 @@ func updateRecordFromProvider(record *ProviderRecord, p *typ.Provider) {
 	}
 }
 
-// ProviderStore manages providers as complete units (configuration + credentials)
+// ProviderStore manages providers as complete units (configuration + credentials).
+//
+// Providers are read on the request hot path (ServiceSelector.Select resolves
+// one per routed request — see internal/routing/selector.go) but change
+// rarely (admin CRUD only). A pprof of BenchmarkSelect_Plain showed
+// GetByUUID's SQLite round-trip (cgo call + gorm scan), serialized behind a
+// plain sync.Mutex that blocked concurrent readers too, accounting for ~47%
+// of Select()'s CPU time. ProviderStore now keeps every record mirrored in
+// an in-memory cache: all reads are served from the cache under an RWMutex
+// (concurrent, lock-free-ish, no SQLite call), while writes go to SQLite
+// first (for durability) and then update the cache — SQLite remains the
+// source of truth, the cache is just a write-through mirror of it.
 type ProviderStore struct {
 	db     *gorm.DB
 	dbPath string
-	mu     sync.Mutex
+	mu     sync.RWMutex
+
+	// cache mirrors the providers table, keyed by UUID. order preserves
+	// insertion order (List/ListOAuth/ListEnabled otherwise depend on
+	// SQLite's implicit rowid order, which callers such as the provider
+	// table UI rely on for a stable listing) since Go map iteration is
+	// randomized.
+	cache map[string]*ProviderRecord
+	order []string
 }
 
 // NewProviderStore creates or loads a provider store using SQLite database.
@@ -312,15 +331,35 @@ func NewProviderStore(baseDir string) (*ProviderStore, error) {
 	store := &ProviderStore{
 		db:     db,
 		dbPath: dbPath,
+		cache:  make(map[string]*ProviderRecord),
 	}
 
 	// Auto-migrate schema
 	if err := db.AutoMigrate(&ProviderRecord{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate provider database: %w", err)
 	}
+
+	if err := store.loadCache(); err != nil {
+		return nil, fmt.Errorf("failed to load provider cache: %w", err)
+	}
 	logrus.Debugf("Provider store initialization completed")
 
 	return store, nil
+}
+
+// loadCache populates the in-memory mirror from SQLite. Called once at
+// construction, before the store is shared with any other goroutine.
+func (ps *ProviderStore) loadCache() error {
+	var records []ProviderRecord
+	if err := ps.db.Find(&records).Error; err != nil {
+		return err
+	}
+	for i := range records {
+		r := records[i]
+		ps.cache[r.UUID] = &r
+		ps.order = append(ps.order, r.UUID)
+	}
+	return nil
 }
 
 // Save saves a provider (create or update)
@@ -335,25 +374,22 @@ func (ps *ProviderStore) Save(provider *typ.Provider) error {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	var existing ProviderRecord
-	err := ps.db.Where("uuid = ?", provider.UUID).First(&existing).Error
-
-	if errors.Is(err, gorm.ErrRecordNotFound) {
+	if existing, ok := ps.cache[provider.UUID]; ok {
+		// Update existing record
+		updateRecordFromProvider(existing, provider)
+		if err := ps.db.Save(existing).Error; err != nil {
+			return fmt.Errorf("failed to update provider record: %w", err)
+		}
+		logrus.Debugf("Updated provider: %s (%s)", provider.Name, provider.UUID)
+	} else {
 		// Create new record
 		record := toRecord(provider)
 		if err := ps.db.Create(record).Error; err != nil {
 			return fmt.Errorf("failed to create provider record: %w", err)
 		}
+		ps.cache[provider.UUID] = record
+		ps.order = append(ps.order, provider.UUID)
 		logrus.Debugf("Created new provider: %s (%s)", provider.Name, provider.UUID)
-	} else if err != nil {
-		return fmt.Errorf("failed to query existing provider: %w", err)
-	} else {
-		// Update existing record
-		updateRecordFromProvider(&existing, provider)
-		if err := ps.db.Save(&existing).Error; err != nil {
-			return fmt.Errorf("failed to update provider record: %w", err)
-		}
-		logrus.Debugf("Updated provider: %s (%s)", provider.Name, provider.UUID)
 	}
 
 	return nil
@@ -361,15 +397,12 @@ func (ps *ProviderStore) Save(provider *typ.Provider) error {
 
 // GetByUUID returns a provider by UUID
 func (ps *ProviderStore) GetByUUID(uuid string) (*typ.Provider, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var record ProviderRecord
-	if err := ps.db.Where("uuid = ?", uuid).First(&record).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("provider with UUID '%s' not found", uuid)
-		}
-		return nil, fmt.Errorf("failed to get provider: %w", err)
+	record, ok := ps.cache[uuid]
+	if !ok {
+		return nil, fmt.Errorf("provider with UUID '%s' not found", uuid)
 	}
 
 	return record.toProvider(), nil
@@ -377,33 +410,26 @@ func (ps *ProviderStore) GetByUUID(uuid string) (*typ.Provider, error) {
 
 // GetByName returns a provider by name
 func (ps *ProviderStore) GetByName(name string) (*typ.Provider, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var record ProviderRecord
-	if err := ps.db.Where("name = ?", name).First(&record).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("provider with name '%s' not found", name)
+	for _, uuid := range ps.order {
+		if record := ps.cache[uuid]; record.Name == name {
+			return record.toProvider(), nil
 		}
-		return nil, fmt.Errorf("failed to get provider: %w", err)
 	}
 
-	return record.toProvider(), nil
+	return nil, fmt.Errorf("provider with name '%s' not found", name)
 }
 
 // List returns all providers
 func (ps *ProviderStore) List() ([]*typ.Provider, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var records []ProviderRecord
-	if err := ps.db.Find(&records).Error; err != nil {
-		return nil, fmt.Errorf("failed to list providers: %w", err)
-	}
-
-	providers := make([]*typ.Provider, 0, len(records))
-	for _, record := range records {
-		providers = append(providers, record.toProvider())
+	providers := make([]*typ.Provider, 0, len(ps.order))
+	for _, uuid := range ps.order {
+		providers = append(providers, ps.cache[uuid].toProvider())
 	}
 
 	return providers, nil
@@ -411,17 +437,15 @@ func (ps *ProviderStore) List() ([]*typ.Provider, error) {
 
 // ListOAuth returns all OAuth-enabled providers
 func (ps *ProviderStore) ListOAuth() ([]*typ.Provider, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var records []ProviderRecord
-	if err := ps.db.Where("auth_type = ?", typ.AuthTypeOAuth).Find(&records).Error; err != nil {
-		return nil, fmt.Errorf("failed to list oauth providers: %w", err)
-	}
-
-	providers := make([]*typ.Provider, 0, len(records))
-	for _, record := range records {
-		providers = append(providers, record.toProvider())
+	providers := make([]*typ.Provider, 0)
+	for _, uuid := range ps.order {
+		record := ps.cache[uuid]
+		if record.AuthType == string(typ.AuthTypeOAuth) {
+			providers = append(providers, record.toProvider())
+		}
 	}
 
 	return providers, nil
@@ -432,6 +456,10 @@ func (ps *ProviderStore) Delete(uuid string) error {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
+	if _, ok := ps.cache[uuid]; !ok {
+		return fmt.Errorf("provider with UUID '%s' not found", uuid)
+	}
+
 	result := ps.db.Where("uuid = ?", uuid).Delete(&ProviderRecord{})
 	if result.Error != nil {
 		return fmt.Errorf("failed to delete provider: %w", result.Error)
@@ -440,34 +468,33 @@ func (ps *ProviderStore) Delete(uuid string) error {
 		return fmt.Errorf("provider with UUID '%s' not found", uuid)
 	}
 
+	delete(ps.cache, uuid)
+	for i, id := range ps.order {
+		if id == uuid {
+			ps.order = append(ps.order[:i], ps.order[i+1:]...)
+			break
+		}
+	}
+
 	logrus.Debugf("Deleted provider: %s", uuid)
 	return nil
 }
 
 // Exists checks if a provider exists by UUID
 func (ps *ProviderStore) Exists(uuid string) bool {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var count int64
-	if err := ps.db.Model(&ProviderRecord{}).Where("uuid = ?", uuid).Count(&count).Error; err != nil {
-		return false
-	}
-
-	return count > 0
+	_, ok := ps.cache[uuid]
+	return ok
 }
 
 // Count returns the total number of providers
 func (ps *ProviderStore) Count() (int64, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var count int64
-	if err := ps.db.Model(&ProviderRecord{}).Count(&count).Error; err != nil {
-		return 0, fmt.Errorf("failed to count providers: %w", err)
-	}
-
-	return count, nil
+	return int64(len(ps.cache)), nil
 }
 
 // UpdateCredential updates only the credential fields of a provider
@@ -475,12 +502,9 @@ func (ps *ProviderStore) UpdateCredential(uuid string, token string, oauthDetail
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	var record ProviderRecord
-	if err := ps.db.Where("uuid = ?", uuid).First(&record).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("provider with UUID '%s' not found", uuid)
-		}
-		return fmt.Errorf("failed to get provider: %w", err)
+	record, ok := ps.cache[uuid]
+	if !ok {
+		return fmt.Errorf("provider with UUID '%s' not found", uuid)
 	}
 
 	// Update credential fields based on auth type
@@ -500,7 +524,7 @@ func (ps *ProviderStore) UpdateCredential(uuid string, token string, oauthDetail
 
 	record.UpdatedAt = time.Now()
 
-	if err := ps.db.Save(&record).Error; err != nil {
+	if err := ps.db.Save(record).Error; err != nil {
 		return fmt.Errorf("failed to update provider credential: %w", err)
 	}
 
@@ -515,12 +539,9 @@ func (ps *ProviderStore) UpdateCredentialBundle(uuid string, bundle *typ.Credent
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	var record ProviderRecord
-	if err := ps.db.Where("uuid = ?", uuid).First(&record).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("provider with UUID '%s' not found", uuid)
-		}
-		return fmt.Errorf("failed to get provider: %w", err)
+	record, ok := ps.cache[uuid]
+	if !ok {
+		return fmt.Errorf("provider with UUID '%s' not found", uuid)
 	}
 
 	if bundle != nil {
@@ -531,7 +552,7 @@ func (ps *ProviderStore) UpdateCredentialBundle(uuid string, bundle *typ.Credent
 	}
 	record.UpdatedAt = time.Now()
 
-	if err := ps.db.Save(&record).Error; err != nil {
+	if err := ps.db.Save(record).Error; err != nil {
 		return fmt.Errorf("failed to update provider credential bundle: %w", err)
 	}
 
@@ -541,12 +562,12 @@ func (ps *ProviderStore) UpdateCredentialBundle(uuid string, bundle *typ.Credent
 
 // GetAccessToken returns the access token for a provider (convenience method)
 func (ps *ProviderStore) GetAccessToken(uuid string) (string, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var record ProviderRecord
-	if err := ps.db.Where("uuid = ?", uuid).First(&record).Error; err != nil {
-		return "", fmt.Errorf("failed to get provider: %w", err)
+	record, ok := ps.cache[uuid]
+	if !ok {
+		return "", fmt.Errorf("failed to get provider: provider with UUID '%s' not found", uuid)
 	}
 
 	return record.Token, nil
@@ -556,6 +577,11 @@ func (ps *ProviderStore) GetAccessToken(uuid string) (string, error) {
 func (ps *ProviderStore) UpdateOAuthAccessToken(uuid, accessToken string) error {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
+
+	record, ok := ps.cache[uuid]
+	if !ok {
+		return fmt.Errorf("provider with UUID '%s' not found", uuid)
+	}
 
 	result := ps.db.Model(&ProviderRecord{}).
 		Where("uuid = ?", uuid).
@@ -568,21 +594,21 @@ func (ps *ProviderStore) UpdateOAuthAccessToken(uuid, accessToken string) error 
 		return fmt.Errorf("provider with UUID '%s' not found", uuid)
 	}
 
+	record.Token = accessToken
+	record.UpdatedAt = time.Now()
+
 	logrus.Debugf("Updated OAuth access token for provider: %s", uuid)
 	return nil
 }
 
 // IsOAuthExpired checks if the OAuth token for a provider is expired
 func (ps *ProviderStore) IsOAuthExpired(uuid string) (bool, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var record ProviderRecord
-	if err := ps.db.Where("uuid = ?", uuid).First(&record).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return false, fmt.Errorf("provider with UUID '%s' not found", uuid)
-		}
-		return false, fmt.Errorf("failed to get provider: %w", err)
+	record, ok := ps.cache[uuid]
+	if !ok {
+		return false, fmt.Errorf("provider with UUID '%s' not found", uuid)
 	}
 
 	if record.AuthType != string(typ.AuthTypeOAuth) || record.OAuthExpiresAt == "" {
@@ -600,17 +626,15 @@ func (ps *ProviderStore) IsOAuthExpired(uuid string) (bool, error) {
 
 // ListEnabled returns all enabled providers
 func (ps *ProviderStore) ListEnabled() ([]*typ.Provider, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var records []ProviderRecord
-	if err := ps.db.Where("enabled = ?", true).Find(&records).Error; err != nil {
-		return nil, fmt.Errorf("failed to list enabled providers: %w", err)
-	}
-
-	providers := make([]*typ.Provider, 0, len(records))
-	for _, record := range records {
-		providers = append(providers, record.toProvider())
+	providers := make([]*typ.Provider, 0)
+	for _, uuid := range ps.order {
+		record := ps.cache[uuid]
+		if record.Enabled {
+			providers = append(providers, record.toProvider())
+		}
 	}
 
 	return providers, nil

--- a/internal/db/provider_store.go
+++ b/internal/db/provider_store.go
@@ -280,27 +280,18 @@ func updateRecordFromProvider(record *ProviderRecord, p *typ.Provider) {
 
 // ProviderStore manages providers as complete units (configuration + credentials).
 //
-// Providers are read on the request hot path (ServiceSelector.Select resolves
-// one per routed request — see internal/routing/selector.go) but change
-// rarely (admin CRUD only). A pprof of BenchmarkSelect_Plain showed
-// GetByUUID's SQLite round-trip (cgo call + gorm scan), serialized behind a
-// plain sync.Mutex that blocked concurrent readers too, accounting for ~47%
-// of Select()'s CPU time. ProviderStore now keeps every record mirrored in
-// an in-memory cache: all reads are served from the cache under an RWMutex
-// (concurrent, lock-free-ish, no SQLite call), while writes go to SQLite
-// first (for durability) and then update the cache — SQLite remains the
-// source of truth, the cache is just a write-through mirror of it.
+// Reads are served from an in-memory cache (write-through: SQLite is still
+// the source of truth) instead of hitting SQLite per call — GetByUUID is on
+// the request hot path (see internal/routing/selector.go) and used to
+// account for ~47% of Select()'s CPU time.
 type ProviderStore struct {
 	db     *gorm.DB
 	dbPath string
 	mu     sync.RWMutex
 
-	// cache mirrors the providers table, keyed by UUID. order preserves
-	// insertion order (List/ListOAuth/ListEnabled otherwise depend on
-	// SQLite's implicit rowid order, which callers such as the provider
-	// table UI rely on for a stable listing) since Go map iteration is
-	// randomized.
 	cache map[string]*ProviderRecord
+	// order preserves insertion order for List/ListOAuth/ListEnabled, since
+	// map iteration is randomized in Go.
 	order []string
 }
 
@@ -337,15 +328,10 @@ func NewProviderStore(baseDir string) (*ProviderStore, error) {
 	return store, nil
 }
 
-// newProviderStoreOverDB finishes setting up a ProviderStore (schema
-// migration + cache load) over an already-open *gorm.DB, whether that
-// connection is NewProviderStore's own or StoreManager's shared one. Having
-// both construction paths funnel through this single function is what makes
-// the cache-init wiring impossible to duplicate-and-drift between them --
-// see StoreManager.initProviderStore, and the "watch for bypass
-// construction" note in .design/hot-path-db-access.md, which is exactly the
-// class of bug this consolidation closes off for any future field added to
-// ProviderStore's construction.
+// newProviderStoreOverDB finishes setting up a ProviderStore (migrate +
+// cache load) over an already-open *gorm.DB, shared by NewProviderStore and
+// StoreManager.initProviderStore so the cache-init wiring can't drift
+// between them.
 func newProviderStoreOverDB(db *gorm.DB, dbPath string) (*ProviderStore, error) {
 	if err := db.AutoMigrate(&ProviderRecord{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate provider database: %w", err)
@@ -411,14 +397,9 @@ func (ps *ProviderStore) Save(provider *typ.Provider) error {
 	return nil
 }
 
-// writeThroughLocked applies mutate to a copy of the cached record for uuid,
-// persists the copy to SQLite, and only swaps it into ps.cache once that
-// write succeeds -- so a failed write can never leave the cache holding data
-// that was never persisted (in contrast to mutating the cached pointer
-// in-place before the write, which a failed Save can't undo). Shared by
-// Save's update path, UpdateCredential, and UpdateCredentialBundle, which
-// otherwise each duplicated this exact clone-mutate-save-swap shape.
-// Callers must hold ps.mu.Lock().
+// writeThroughLocked mutates a copy of the cached record for uuid, persists
+// it, and only then swaps it into ps.cache -- so a failed write can't leave
+// the cache holding unpersisted data. Callers must hold ps.mu.Lock().
 func (ps *ProviderStore) writeThroughLocked(uuid string, mutate func(*ProviderRecord)) (*ProviderRecord, error) {
 	existing, ok := ps.cache[uuid]
 	if !ok {

--- a/internal/db/provider_store.go
+++ b/internal/db/provider_store.go
@@ -328,21 +328,37 @@ func NewProviderStore(baseDir string) (*ProviderStore, error) {
 	}
 	logrus.Debugf("SQLite database opened successfully for provider store")
 
+	store, err := newProviderStoreOverDB(db, dbPath)
+	if err != nil {
+		return nil, err
+	}
+	logrus.Debugf("Provider store initialization completed")
+
+	return store, nil
+}
+
+// newProviderStoreOverDB finishes setting up a ProviderStore (schema
+// migration + cache load) over an already-open *gorm.DB, whether that
+// connection is NewProviderStore's own or StoreManager's shared one. Having
+// both construction paths funnel through this single function is what makes
+// the cache-init wiring impossible to duplicate-and-drift between them --
+// see StoreManager.initProviderStore, and the "watch for bypass
+// construction" note in .design/hot-path-db-access.md, which is exactly the
+// class of bug this consolidation closes off for any future field added to
+// ProviderStore's construction.
+func newProviderStoreOverDB(db *gorm.DB, dbPath string) (*ProviderStore, error) {
+	if err := db.AutoMigrate(&ProviderRecord{}); err != nil {
+		return nil, fmt.Errorf("failed to migrate provider database: %w", err)
+	}
+
 	store := &ProviderStore{
 		db:     db,
 		dbPath: dbPath,
 		cache:  make(map[string]*ProviderRecord),
 	}
-
-	// Auto-migrate schema
-	if err := db.AutoMigrate(&ProviderRecord{}); err != nil {
-		return nil, fmt.Errorf("failed to migrate provider database: %w", err)
-	}
-
 	if err := store.loadCache(); err != nil {
 		return nil, fmt.Errorf("failed to load provider cache: %w", err)
 	}
-	logrus.Debugf("Provider store initialization completed")
 
 	return store, nil
 }
@@ -374,17 +390,12 @@ func (ps *ProviderStore) Save(provider *typ.Provider) error {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	if existing, ok := ps.cache[provider.UUID]; ok {
-		// Update a copy first -- only replace the cached record once the
-		// SQLite write actually succeeds, so a failed Save can't leave the
-		// cache holding data that was never persisted (see UpdateOAuthAccessToken
-		// below for the same write-then-cache ordering).
-		updated := *existing
-		updateRecordFromProvider(&updated, provider)
-		if err := ps.db.Save(&updated).Error; err != nil {
+	if _, ok := ps.cache[provider.UUID]; ok {
+		if _, err := ps.writeThroughLocked(provider.UUID, func(r *ProviderRecord) {
+			updateRecordFromProvider(r, provider)
+		}); err != nil {
 			return fmt.Errorf("failed to update provider record: %w", err)
 		}
-		ps.cache[provider.UUID] = &updated
 		logrus.Debugf("Updated provider: %s (%s)", provider.Name, provider.UUID)
 	} else {
 		// Create new record
@@ -398,6 +409,31 @@ func (ps *ProviderStore) Save(provider *typ.Provider) error {
 	}
 
 	return nil
+}
+
+// writeThroughLocked applies mutate to a copy of the cached record for uuid,
+// persists the copy to SQLite, and only swaps it into ps.cache once that
+// write succeeds -- so a failed write can never leave the cache holding data
+// that was never persisted (in contrast to mutating the cached pointer
+// in-place before the write, which a failed Save can't undo). Shared by
+// Save's update path, UpdateCredential, and UpdateCredentialBundle, which
+// otherwise each duplicated this exact clone-mutate-save-swap shape.
+// Callers must hold ps.mu.Lock().
+func (ps *ProviderStore) writeThroughLocked(uuid string, mutate func(*ProviderRecord)) (*ProviderRecord, error) {
+	existing, ok := ps.cache[uuid]
+	if !ok {
+		return nil, fmt.Errorf("provider with UUID '%s' not found", uuid)
+	}
+
+	updated := *existing
+	mutate(&updated)
+
+	if err := ps.db.Save(&updated).Error; err != nil {
+		return nil, err
+	}
+
+	ps.cache[uuid] = &updated
+	return &updated, nil
 }
 
 // GetByUUID returns a provider by UUID
@@ -445,7 +481,7 @@ func (ps *ProviderStore) ListOAuth() ([]*typ.Provider, error) {
 	ps.mu.RLock()
 	defer ps.mu.RUnlock()
 
-	providers := make([]*typ.Provider, 0)
+	providers := make([]*typ.Provider, 0, len(ps.order))
 	for _, uuid := range ps.order {
 		record := ps.cache[uuid]
 		if record.AuthType == string(typ.AuthTypeOAuth) {
@@ -507,37 +543,26 @@ func (ps *ProviderStore) UpdateCredential(uuid string, token string, oauthDetail
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	existing, ok := ps.cache[uuid]
-	if !ok {
-		return fmt.Errorf("provider with UUID '%s' not found", uuid)
-	}
-
-	// Update a copy first -- see Save's comment on why the cache is only
-	// replaced after the SQLite write succeeds.
-	updated := *existing
-
-	// Update credential fields based on auth type
-	if updated.AuthType == string(typ.AuthTypeOAuth) && oauthDetail != nil {
-		updated.Token = oauthDetail.AccessToken
-		updated.OAuthProviderType = string(oauthDetail.GetIssuer())
-		updated.OAuthUserID = oauthDetail.UserID
-		updated.OAuthRefreshToken = oauthDetail.RefreshToken
-		updated.OAuthExpiresAt = oauthDetail.ExpiresAt
-		if oauthDetail.ExtraFields != nil {
-			extraJSON, _ := json.Marshal(oauthDetail.ExtraFields)
-			updated.OAuthExtraFields = string(extraJSON)
+	_, err := ps.writeThroughLocked(uuid, func(r *ProviderRecord) {
+		if r.AuthType == string(typ.AuthTypeOAuth) && oauthDetail != nil {
+			r.Token = oauthDetail.AccessToken
+			r.OAuthProviderType = string(oauthDetail.GetIssuer())
+			r.OAuthUserID = oauthDetail.UserID
+			r.OAuthRefreshToken = oauthDetail.RefreshToken
+			r.OAuthExpiresAt = oauthDetail.ExpiresAt
+			if oauthDetail.ExtraFields != nil {
+				extraJSON, _ := json.Marshal(oauthDetail.ExtraFields)
+				r.OAuthExtraFields = string(extraJSON)
+			}
+		} else {
+			r.Token = token
 		}
-	} else {
-		updated.Token = token
-	}
-
-	updated.UpdatedAt = time.Now()
-
-	if err := ps.db.Save(&updated).Error; err != nil {
+		r.UpdatedAt = time.Now()
+	})
+	if err != nil {
 		return fmt.Errorf("failed to update provider credential: %w", err)
 	}
 
-	ps.cache[uuid] = &updated
 	logrus.Debugf("Updated credential for provider: %s", uuid)
 	return nil
 }
@@ -549,27 +574,19 @@ func (ps *ProviderStore) UpdateCredentialBundle(uuid string, bundle *typ.Credent
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	existing, ok := ps.cache[uuid]
-	if !ok {
-		return fmt.Errorf("provider with UUID '%s' not found", uuid)
-	}
-
-	// Update a copy first -- see Save's comment on why the cache is only
-	// replaced after the SQLite write succeeds.
-	updated := *existing
-	if bundle != nil {
-		credJSON, _ := json.Marshal(bundle)
-		updated.Credential = string(credJSON)
-	} else {
-		updated.Credential = ""
-	}
-	updated.UpdatedAt = time.Now()
-
-	if err := ps.db.Save(&updated).Error; err != nil {
+	_, err := ps.writeThroughLocked(uuid, func(r *ProviderRecord) {
+		if bundle != nil {
+			credJSON, _ := json.Marshal(bundle)
+			r.Credential = string(credJSON)
+		} else {
+			r.Credential = ""
+		}
+		r.UpdatedAt = time.Now()
+	})
+	if err != nil {
 		return fmt.Errorf("failed to update provider credential bundle: %w", err)
 	}
 
-	ps.cache[uuid] = &updated
 	logrus.Debugf("Updated credential bundle for provider: %s", uuid)
 	return nil
 }
@@ -643,7 +660,7 @@ func (ps *ProviderStore) ListEnabled() ([]*typ.Provider, error) {
 	ps.mu.RLock()
 	defer ps.mu.RUnlock()
 
-	providers := make([]*typ.Provider, 0)
+	providers := make([]*typ.Provider, 0, len(ps.order))
 	for _, uuid := range ps.order {
 		record := ps.cache[uuid]
 		if record.Enabled {

--- a/internal/db/provider_store_test.go
+++ b/internal/db/provider_store_test.go
@@ -699,3 +699,102 @@ func TestProviderCredentialBundleRoundTrip(t *testing.T) {
 		t.Errorf("region after update: got %q, want %q", got2.Credential.Field("region"), "eu-west-1")
 	}
 }
+
+// TestProviderStore_FailedWriteDoesNotCorruptCache covers Save, UpdateCredential,
+// and UpdateCredentialBundle: each must not let a failed SQLite write leave the
+// in-memory cache holding data that was never persisted. Forces the write to
+// fail by closing the underlying *sql.DB after seeding a provider.
+func TestProviderStore_FailedWriteDoesNotCorruptCache(t *testing.T) {
+	seed := func(t *testing.T) *ProviderStore {
+		t.Helper()
+		store, _ := setupTestProviderStore(t)
+		provider := &typ.Provider{
+			UUID:     "test-cache-integrity-uuid",
+			Name:     "original-name",
+			APIBase:  "https://api.example.com",
+			APIStyle: protocol.APIStyleOpenAI,
+			AuthType: typ.AuthTypeAPIKey,
+			Token:    "original-token",
+			Enabled:  true,
+		}
+		if err := store.Save(provider); err != nil {
+			t.Fatalf("seed Save: %v", err)
+		}
+		return store
+	}
+
+	closeUnderlyingDB := func(t *testing.T, store *ProviderStore) {
+		t.Helper()
+		sqlDB, err := store.db.DB()
+		if err != nil {
+			t.Fatalf("store.db.DB(): %v", err)
+		}
+		if err := sqlDB.Close(); err != nil {
+			t.Fatalf("closing underlying db: %v", err)
+		}
+	}
+
+	t.Run("Save", func(t *testing.T) {
+		store := seed(t)
+		closeUnderlyingDB(t, store)
+
+		err := store.Save(&typ.Provider{
+			UUID:     "test-cache-integrity-uuid",
+			Name:     "corrupted-name",
+			APIBase:  "https://api.example.com",
+			APIStyle: protocol.APIStyleOpenAI,
+			AuthType: typ.AuthTypeAPIKey,
+			Token:    "corrupted-token",
+			Enabled:  true,
+		})
+		if err == nil {
+			t.Fatal("expected Save to fail against a closed db")
+		}
+
+		got, getErr := store.GetByUUID("test-cache-integrity-uuid")
+		if getErr != nil {
+			t.Fatalf("GetByUUID: %v", getErr)
+		}
+		if got.Name != "original-name" || got.Token != "original-token" {
+			t.Errorf("cache reflects a failed write: got name=%q token=%q, want the pre-failure values", got.Name, got.Token)
+		}
+	})
+
+	t.Run("UpdateCredential", func(t *testing.T) {
+		store := seed(t)
+		closeUnderlyingDB(t, store)
+
+		err := store.UpdateCredential("test-cache-integrity-uuid", "corrupted-token", nil)
+		if err == nil {
+			t.Fatal("expected UpdateCredential to fail against a closed db")
+		}
+
+		token, getErr := store.GetAccessToken("test-cache-integrity-uuid")
+		if getErr != nil {
+			t.Fatalf("GetAccessToken: %v", getErr)
+		}
+		if token != "original-token" {
+			t.Errorf("cache reflects a failed write: got token=%q, want %q", token, "original-token")
+		}
+	})
+
+	t.Run("UpdateCredentialBundle", func(t *testing.T) {
+		store := seed(t)
+		closeUnderlyingDB(t, store)
+
+		err := store.UpdateCredentialBundle("test-cache-integrity-uuid", &typ.CredentialBundle{
+			Fields: map[string]string{"region": "corrupted-region"},
+		})
+		if err == nil {
+			t.Fatal("expected UpdateCredentialBundle to fail against a closed db")
+		}
+
+		got, getErr := store.GetByUUID("test-cache-integrity-uuid")
+		if getErr != nil {
+			t.Fatalf("GetByUUID: %v", getErr)
+		}
+		if got.Credential != nil {
+			t.Errorf("cache reflects a failed write: got Credential=%v, want nil (seed provider has no credential bundle)", got.Credential)
+		}
+	})
+}

--- a/internal/db/provider_store_test.go
+++ b/internal/db/provider_store_test.go
@@ -700,10 +700,9 @@ func TestProviderCredentialBundleRoundTrip(t *testing.T) {
 	}
 }
 
-// TestProviderStore_FailedWriteDoesNotCorruptCache covers Save, UpdateCredential,
-// and UpdateCredentialBundle: each must not let a failed SQLite write leave the
-// in-memory cache holding data that was never persisted. Forces the write to
-// fail by closing the underlying *sql.DB after seeding a provider.
+// TestProviderStore_FailedWriteDoesNotCorruptCache checks that Save,
+// UpdateCredential, and UpdateCredentialBundle don't leave the cache holding
+// unpersisted data when the SQLite write fails (forced by closing the DB).
 func TestProviderStore_FailedWriteDoesNotCorruptCache(t *testing.T) {
 	seed := func(t *testing.T) *ProviderStore {
 		t.Helper()

--- a/internal/db/record_outcome.go
+++ b/internal/db/record_outcome.go
@@ -1,0 +1,72 @@
+package db
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+// RecordRequestOutcome persists a service's updated stats (StatsStore) and a
+// usage audit row (UsageStore) together, in a single SQLite transaction,
+// instead of each store committing independently -- halving the per-request
+// COMMIT count on the path ProtocolHandler.trackUsageWithTokenUsage /
+// trackUsageFromContext take before responding to the client. See
+// .design/hot-path-db-access.md, which also has the pprof/benchmark
+// evidence this follows up on (BenchmarkStatsAndUsage_Combined).
+//
+// service and/or usage may be nil (only one side has something to persist);
+// statsStore and/or usageStore may be nil (store not initialized). Both
+// stores share the same *gorm.DB in production -- StoreManager wires every
+// store to one shared connection -- so this is always able to combine the
+// two writes there. The db != db fallback exists only for direct NewXStore
+// construction (outside StoreManager, e.g. a future standalone tool),
+// which is never mixed with StoreManager-built stores in production today.
+func RecordRequestOutcome(statsStore *StatsStore, usageStore *UsageStore, service *loadbalance.Service, usage *UsageRecord) error {
+	if statsStore == nil {
+		if usageStore == nil {
+			return nil
+		}
+		return usageStore.RecordUsage(usage)
+	}
+	if usageStore == nil {
+		return statsStore.UpdateFromService(service)
+	}
+
+	if statsStore.db != usageStore.db {
+		statsErr := statsStore.UpdateFromService(service)
+		usageErr := usageStore.RecordUsage(usage)
+		if statsErr != nil {
+			return statsErr
+		}
+		return usageErr
+	}
+
+	// Lock order (stats then usage) is arbitrary but fixed, matching the only
+	// other place these two stores could ever be locked together -- nowhere
+	// else today, so there's no existing convention to conflict with.
+	statsStore.mu.Lock()
+	defer statsStore.mu.Unlock()
+	usageStore.mu.Lock()
+	defer usageStore.mu.Unlock()
+
+	statsRecord := buildStatsRecordFromService(service)
+	if usage != nil {
+		prepareUsageRecord(usage)
+	}
+
+	return statsStore.db.Transaction(func(tx *gorm.DB) error {
+		if statsRecord != nil {
+			if err := tx.Save(statsRecord).Error; err != nil {
+				return fmt.Errorf("failed to save service stats: %w", err)
+			}
+		}
+		if usage != nil {
+			if err := tx.Create(usage).Error; err != nil {
+				return fmt.Errorf("failed to create usage record: %w", err)
+			}
+		}
+		return nil
+	})
+}

--- a/internal/db/record_outcome.go
+++ b/internal/db/record_outcome.go
@@ -9,19 +9,13 @@ import (
 )
 
 // RecordRequestOutcome persists a service's updated stats (StatsStore) and a
-// usage audit row (UsageStore) together, in a single SQLite transaction,
-// instead of each store committing independently -- halving the per-request
-// COMMIT count on the path ProtocolHandler.trackUsageWithTokenUsage /
-// trackUsageFromContext take before responding to the client. See
-// .design/hot-path-db-access.md, which also has the pprof/benchmark
-// evidence this follows up on (BenchmarkStatsAndUsage_Combined).
+// usage audit row (UsageStore) together in one SQLite transaction, instead
+// of each store committing independently. Assumes both stores share the
+// same *gorm.DB, true of every production call site (StoreManager wires
+// every store to one shared connection). See .design/hot-path-db-access.md.
 //
 // service and/or usage may be nil (only one side has something to persist);
-// statsStore and/or usageStore may be nil (store not initialized). Both
-// stores are assumed to share the same *gorm.DB, true of every production
-// call site -- StoreManager wires every store to one shared connection (see
-// its initProviderStore/initAPITokenStore-style init* helpers) -- so the
-// transaction below always covers both writes there.
+// statsStore and/or usageStore may be nil (store not initialized).
 func RecordRequestOutcome(statsStore *StatsStore, usageStore *UsageStore, service *loadbalance.Service, usage *UsageRecord) error {
 	if statsStore == nil {
 		if usageStore == nil || usage == nil {
@@ -33,18 +27,13 @@ func RecordRequestOutcome(statsStore *StatsStore, usageStore *UsageStore, servic
 		return statsStore.UpdateFromService(service)
 	}
 
-	// Build both records before taking any lock: buildStatsRecordFromService
-	// only mutates the caller's *loadbalance.Service and prepareUsageRecord
-	// only mutates its own argument, neither touches store state, so there's
-	// no reason to hold statsStore.mu/usageStore.mu for this in-memory work.
+	// Build both records before taking any lock -- neither builder touches
+	// store state, only its own argument.
 	statsRecord := buildStatsRecordFromService(service)
 	if usage != nil {
 		prepareUsageRecord(usage)
 	}
 
-	// Lock order (stats then usage) is arbitrary but fixed, matching the only
-	// other place these two stores could ever be locked together -- nowhere
-	// else today, so there's no existing convention to conflict with.
 	statsStore.mu.Lock()
 	defer statsStore.mu.Unlock()
 	usageStore.mu.Lock()

--- a/internal/db/record_outcome.go
+++ b/internal/db/record_outcome.go
@@ -18,11 +18,10 @@ import (
 //
 // service and/or usage may be nil (only one side has something to persist);
 // statsStore and/or usageStore may be nil (store not initialized). Both
-// stores share the same *gorm.DB in production -- StoreManager wires every
-// store to one shared connection -- so this is always able to combine the
-// two writes there. The db != db fallback exists only for direct NewXStore
-// construction (outside StoreManager, e.g. a future standalone tool),
-// which is never mixed with StoreManager-built stores in production today.
+// stores are assumed to share the same *gorm.DB, true of every production
+// call site -- StoreManager wires every store to one shared connection (see
+// its initProviderStore/initAPITokenStore-style init* helpers) -- so the
+// transaction below always covers both writes there.
 func RecordRequestOutcome(statsStore *StatsStore, usageStore *UsageStore, service *loadbalance.Service, usage *UsageRecord) error {
 	if statsStore == nil {
 		if usageStore == nil || usage == nil {
@@ -34,16 +33,13 @@ func RecordRequestOutcome(statsStore *StatsStore, usageStore *UsageStore, servic
 		return statsStore.UpdateFromService(service)
 	}
 
-	if statsStore.db != usageStore.db {
-		statsErr := statsStore.UpdateFromService(service)
-		var usageErr error
-		if usage != nil {
-			usageErr = usageStore.RecordUsage(usage)
-		}
-		if statsErr != nil {
-			return statsErr
-		}
-		return usageErr
+	// Build both records before taking any lock: buildStatsRecordFromService
+	// only mutates the caller's *loadbalance.Service and prepareUsageRecord
+	// only mutates its own argument, neither touches store state, so there's
+	// no reason to hold statsStore.mu/usageStore.mu for this in-memory work.
+	statsRecord := buildStatsRecordFromService(service)
+	if usage != nil {
+		prepareUsageRecord(usage)
 	}
 
 	// Lock order (stats then usage) is arbitrary but fixed, matching the only
@@ -53,11 +49,6 @@ func RecordRequestOutcome(statsStore *StatsStore, usageStore *UsageStore, servic
 	defer statsStore.mu.Unlock()
 	usageStore.mu.Lock()
 	defer usageStore.mu.Unlock()
-
-	statsRecord := buildStatsRecordFromService(service)
-	if usage != nil {
-		prepareUsageRecord(usage)
-	}
 
 	return statsStore.db.Transaction(func(tx *gorm.DB) error {
 		if statsRecord != nil {

--- a/internal/db/record_outcome.go
+++ b/internal/db/record_outcome.go
@@ -25,7 +25,7 @@ import (
 // which is never mixed with StoreManager-built stores in production today.
 func RecordRequestOutcome(statsStore *StatsStore, usageStore *UsageStore, service *loadbalance.Service, usage *UsageRecord) error {
 	if statsStore == nil {
-		if usageStore == nil {
+		if usageStore == nil || usage == nil {
 			return nil
 		}
 		return usageStore.RecordUsage(usage)
@@ -36,7 +36,10 @@ func RecordRequestOutcome(statsStore *StatsStore, usageStore *UsageStore, servic
 
 	if statsStore.db != usageStore.db {
 		statsErr := statsStore.UpdateFromService(service)
-		usageErr := usageStore.RecordUsage(usage)
+		var usageErr error
+		if usage != nil {
+			usageErr = usageStore.RecordUsage(usage)
+		}
 		if statsErr != nil {
 			return statsErr
 		}

--- a/internal/db/record_outcome_test.go
+++ b/internal/db/record_outcome_test.go
@@ -54,6 +54,36 @@ func TestRecordRequestOutcome_NilUsageStore(t *testing.T) {
 	assert.True(t, found)
 }
 
+// TestRecordRequestOutcome_NilStatsStore_NilUsage covers the branch where
+// statsStore is nil and usage is also nil: RecordUsage(nil) errors ("record
+// cannot be nil"), so this must short-circuit before calling it rather than
+// surfacing that as a spurious failure for a legitimate no-op call.
+func TestRecordRequestOutcome_NilStatsStore_NilUsage(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	require.NoError(t, err)
+	defer sm.Close()
+
+	assert.NoError(t, RecordRequestOutcome(nil, sm.Usage(), nil, nil))
+}
+
+// TestRecordRequestOutcome_DifferentDB_NilUsage covers the same "nil usage
+// must not reach UsageStore.RecordUsage" requirement on the statsStore.db !=
+// usageStore.db fallback path (stores backed by independently constructed
+// *gorm.DBs, e.g. built via NewStatsStore/NewUsageStore directly rather than
+// StoreManager).
+func TestRecordRequestOutcome_DifferentDB_NilUsage(t *testing.T) {
+	statsStore, err := NewStatsStore(t.TempDir())
+	require.NoError(t, err)
+	usageStore, err := NewUsageStore(t.TempDir())
+	require.NoError(t, err)
+
+	service := &loadbalance.Service{Provider: "p1", Model: "m1", Active: true}
+	assert.NoError(t, RecordRequestOutcome(statsStore, usageStore, service, nil))
+
+	_, found := statsStore.Get("p1", "m1")
+	assert.True(t, found)
+}
+
 // TestRecordRequestOutcome_AtomicRollback confirms the stats write and the
 // usage write share one transaction: a usage row that fails to persist (a
 // deliberate primary-key collision here) must roll back the stats write from

--- a/internal/db/record_outcome_test.go
+++ b/internal/db/record_outcome_test.go
@@ -66,24 +66,6 @@ func TestRecordRequestOutcome_NilStatsStore_NilUsage(t *testing.T) {
 	assert.NoError(t, RecordRequestOutcome(nil, sm.Usage(), nil, nil))
 }
 
-// TestRecordRequestOutcome_DifferentDB_NilUsage covers the same "nil usage
-// must not reach UsageStore.RecordUsage" requirement on the statsStore.db !=
-// usageStore.db fallback path (stores backed by independently constructed
-// *gorm.DBs, e.g. built via NewStatsStore/NewUsageStore directly rather than
-// StoreManager).
-func TestRecordRequestOutcome_DifferentDB_NilUsage(t *testing.T) {
-	statsStore, err := NewStatsStore(t.TempDir())
-	require.NoError(t, err)
-	usageStore, err := NewUsageStore(t.TempDir())
-	require.NoError(t, err)
-
-	service := &loadbalance.Service{Provider: "p1", Model: "m1", Active: true}
-	assert.NoError(t, RecordRequestOutcome(statsStore, usageStore, service, nil))
-
-	_, found := statsStore.Get("p1", "m1")
-	assert.True(t, found)
-}
-
 // TestRecordRequestOutcome_AtomicRollback confirms the stats write and the
 // usage write share one transaction: a usage row that fails to persist (a
 // deliberate primary-key collision here) must roll back the stats write from

--- a/internal/db/record_outcome_test.go
+++ b/internal/db/record_outcome_test.go
@@ -54,10 +54,8 @@ func TestRecordRequestOutcome_NilUsageStore(t *testing.T) {
 	assert.True(t, found)
 }
 
-// TestRecordRequestOutcome_NilStatsStore_NilUsage covers the branch where
-// statsStore is nil and usage is also nil: RecordUsage(nil) errors ("record
-// cannot be nil"), so this must short-circuit before calling it rather than
-// surfacing that as a spurious failure for a legitimate no-op call.
+// TestRecordRequestOutcome_NilStatsStore_NilUsage: with usage nil too, this
+// must short-circuit rather than call RecordUsage(nil), which errors.
 func TestRecordRequestOutcome_NilStatsStore_NilUsage(t *testing.T) {
 	sm, err := NewStoreManager(t.TempDir())
 	require.NoError(t, err)
@@ -66,10 +64,8 @@ func TestRecordRequestOutcome_NilStatsStore_NilUsage(t *testing.T) {
 	assert.NoError(t, RecordRequestOutcome(nil, sm.Usage(), nil, nil))
 }
 
-// TestRecordRequestOutcome_AtomicRollback confirms the stats write and the
-// usage write share one transaction: a usage row that fails to persist (a
-// deliberate primary-key collision here) must roll back the stats write from
-// the same call too, not leave it half-committed.
+// TestRecordRequestOutcome_AtomicRollback: a usage write that fails (a
+// deliberate primary-key collision) must roll back the stats write too.
 func TestRecordRequestOutcome_AtomicRollback(t *testing.T) {
 	sm, err := NewStoreManager(t.TempDir())
 	require.NoError(t, err)

--- a/internal/db/record_outcome_test.go
+++ b/internal/db/record_outcome_test.go
@@ -1,0 +1,77 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+func TestRecordRequestOutcome_SavesBoth(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	require.NoError(t, err)
+	defer sm.Close()
+
+	service := &loadbalance.Service{Provider: "p1", Model: "m1", Active: true}
+	usage := &UsageRecord{ProviderUUID: "p1", ProviderName: "p1", Model: "m1", Scenario: "openai"}
+
+	require.NoError(t, RecordRequestOutcome(sm.Stats(), sm.Usage(), service, usage))
+
+	_, found := sm.Stats().Get("p1", "m1")
+	assert.True(t, found)
+
+	records, total, err := sm.Usage().GetRecords(usage.Timestamp.Add(-1), usage.Timestamp.Add(1), nil, 10, 0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, total)
+	require.Len(t, records, 1)
+	assert.Equal(t, "p1", records[0].ProviderUUID)
+}
+
+func TestRecordRequestOutcome_NilStatsStore(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	require.NoError(t, err)
+	defer sm.Close()
+
+	usage := &UsageRecord{ProviderUUID: "p1", ProviderName: "p1", Model: "m1", Scenario: "openai"}
+	require.NoError(t, RecordRequestOutcome(nil, sm.Usage(), nil, usage))
+
+	_, total, err := sm.Usage().GetRecords(usage.Timestamp.Add(-1), usage.Timestamp.Add(1), nil, 10, 0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, total)
+}
+
+func TestRecordRequestOutcome_NilUsageStore(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	require.NoError(t, err)
+	defer sm.Close()
+
+	service := &loadbalance.Service{Provider: "p1", Model: "m1", Active: true}
+	require.NoError(t, RecordRequestOutcome(sm.Stats(), nil, service, nil))
+
+	_, found := sm.Stats().Get("p1", "m1")
+	assert.True(t, found)
+}
+
+// TestRecordRequestOutcome_AtomicRollback confirms the stats write and the
+// usage write share one transaction: a usage row that fails to persist (a
+// deliberate primary-key collision here) must roll back the stats write from
+// the same call too, not leave it half-committed.
+func TestRecordRequestOutcome_AtomicRollback(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	require.NoError(t, err)
+	defer sm.Close()
+
+	statsStore, usageStore := sm.Stats(), sm.Usage()
+	require.NoError(t, usageStore.RecordUsage(&UsageRecord{ID: 999, ProviderUUID: "seed", ProviderName: "seed", Model: "seed", Scenario: "openai"}))
+
+	service := &loadbalance.Service{Provider: "p1", Model: "m1", Active: true}
+	conflicting := &UsageRecord{ID: 999, ProviderUUID: "p1", ProviderName: "p1", Model: "m1", Scenario: "openai"}
+
+	err = RecordRequestOutcome(statsStore, usageStore, service, conflicting)
+	assert.Error(t, err)
+
+	_, found := statsStore.Get("p1", "m1")
+	assert.False(t, found, "stats write from the same call must have rolled back with the failed usage write")
+}

--- a/internal/db/service_stat.go
+++ b/internal/db/service_stat.go
@@ -145,11 +145,9 @@ func (ss *StatsStore) UpdateFromService(service *loadbalance.Service) error {
 }
 
 // buildStatsRecordFromService builds the ServiceStatsRecord UpdateFromService
-// persists, without touching the database. Split out so RecordRequestOutcome
-// (record_outcome.go) can build it and save it in the same transaction as a
-// UsageStore write, instead of paying for two independent commits on the
-// request hot path -- see .design/hot-path-db-access.md. Still mutates
-// service.Stats via InitializeStats/GetStats, same as before extraction.
+// persists, without touching the database -- split out so
+// RecordRequestOutcome can save it in the same transaction as a UsageStore
+// write. Still mutates service.Stats via InitializeStats/GetStats.
 func buildStatsRecordFromService(service *loadbalance.Service) *ServiceStatsRecord {
 	if service == nil {
 		return nil

--- a/internal/db/service_stat.go
+++ b/internal/db/service_stat.go
@@ -133,17 +133,32 @@ func (ss *StatsStore) Get(provider, model string) (loadbalance.ServiceStats, boo
 
 // UpdateFromService stores the current stats from a service into the store.
 func (ss *StatsStore) UpdateFromService(service *loadbalance.Service) error {
-	if service == nil {
+	record := buildStatsRecordFromService(service)
+	if record == nil {
 		return nil
 	}
 
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
 
+	return ss.db.Save(record).Error
+}
+
+// buildStatsRecordFromService builds the ServiceStatsRecord UpdateFromService
+// persists, without touching the database. Split out so RecordRequestOutcome
+// (record_outcome.go) can build it and save it in the same transaction as a
+// UsageStore write, instead of paying for two independent commits on the
+// request hot path -- see .design/hot-path-db-access.md. Still mutates
+// service.Stats via InitializeStats/GetStats, same as before extraction.
+func buildStatsRecordFromService(service *loadbalance.Service) *ServiceStatsRecord {
+	if service == nil {
+		return nil
+	}
+
 	service.InitializeStats()
 	stat := service.Stats.GetStats()
 
-	record := ServiceStatsRecord{
+	record := &ServiceStatsRecord{
 		Provider:             service.Provider,
 		Model:                service.Model,
 		ServiceID:            stat.ServiceID,
@@ -172,7 +187,7 @@ func (ss *StatsStore) UpdateFromService(service *loadbalance.Service) error {
 		record.WindowStart = time.Now()
 	}
 
-	return ss.db.Save(&record).Error
+	return record
 }
 
 // RecordUsage records usage for a service and persists the updated stats.

--- a/internal/db/stats_usage_bench_test.go
+++ b/internal/db/stats_usage_bench_test.go
@@ -8,10 +8,6 @@ import (
 )
 
 // newUsageStoreForBench builds a UsageStore for a fresh temp dir.
-// NewUsageStore is never called in production (StoreManager builds
-// UsageStore directly over its own already-open *gorm.DB instead), so this
-// benchmark suite is its only real caller -- see NewUsageStore's directory
-// setup, which this relies on.
 func newUsageStoreForBench(b *testing.B) *UsageStore {
 	b.Helper()
 	store, err := NewUsageStore(b.TempDir())
@@ -21,16 +17,9 @@ func newUsageStoreForBench(b *testing.B) *UsageStore {
 	return store
 }
 
-// Benchmarks for the two stores that internal/protocolserver/usage_tracking.go
-// writes to synchronously, once per completed LLM request (both streaming and
-// non-streaming, success and error paths), before the response is handed back
-// to the client -- see ProtocolHandler.trackUsageWithTokenUsage, which calls
-// updateServiceStats (-> StatsStore.UpdateFromService) and
-// recordDetailedUsageWithTokenUsage (-> UsageStore.RecordUsage) inline in the
-// request goroutine. Unlike ProviderStore.GetByUUID or
-// APITokenStore.ValidateToken, these are writes, not reads that can be
-// served from a cache -- there's a real row to persist every request. See
-// .design/hot-path-db-access.md for the read-path fixes this follows up on.
+// Benchmarks for StatsStore/UsageStore, both written synchronously once per
+// completed LLM request by ProtocolHandler.trackUsageWithTokenUsage -- see
+// .design/hot-path-db-access.md.
 //
 // Run: go test ./internal/db/... -bench 'StatsStore|UsageStore' -benchmem -run '^$'
 
@@ -89,11 +78,9 @@ func BenchmarkUsageStore_RecordUsage(b *testing.B) {
 	}
 }
 
-// BenchmarkStatsAndUsage_Combined runs both writes back to back via two
-// separate stores (each with its own *gorm.DB and its own implicit
-// transaction) -- this was the only shape available before
-// RecordRequestOutcome and stays here as the "before" baseline for
-// BenchmarkStatsAndUsage_RecordRequestOutcome below to be compared against.
+// BenchmarkStatsAndUsage_Combined runs both writes via two separate stores
+// (two independent transactions) -- the "before" baseline for
+// BenchmarkStatsAndUsage_RecordRequestOutcome below.
 func BenchmarkStatsAndUsage_Combined(b *testing.B) {
 	statsStore, err := NewStatsStore(b.TempDir())
 	if err != nil {
@@ -136,10 +123,8 @@ func BenchmarkStatsAndUsage_Combined(b *testing.B) {
 	}
 }
 
-// BenchmarkStatsAndUsage_RecordRequestOutcome exercises RecordRequestOutcome
-// with both stores wired exactly as production does -- sharing one *gorm.DB
-// via StoreManager, the precondition for the two writes to land in a single
-// SQLite transaction/commit instead of BenchmarkStatsAndUsage_Combined's two.
+// BenchmarkStatsAndUsage_RecordRequestOutcome wires both stores through
+// StoreManager (shared *gorm.DB), so the two writes land in one transaction.
 func BenchmarkStatsAndUsage_RecordRequestOutcome(b *testing.B) {
 	sm, err := NewStoreManager(b.TempDir())
 	if err != nil {

--- a/internal/db/stats_usage_bench_test.go
+++ b/internal/db/stats_usage_bench_test.go
@@ -89,10 +89,11 @@ func BenchmarkUsageStore_RecordUsage(b *testing.B) {
 	}
 }
 
-// BenchmarkStatsAndUsage_Combined runs both writes back to back, mirroring
-// trackUsageWithTokenUsage's per-request sequence (updateServiceStats then
-// recordDetailedUsageWithTokenUsage) so the combined per-request SQLite cost
-// on the client-visible latency path can be read off directly.
+// BenchmarkStatsAndUsage_Combined runs both writes back to back via two
+// separate stores (each with its own *gorm.DB and its own implicit
+// transaction) -- this was the only shape available before
+// RecordRequestOutcome and stays here as the "before" baseline for
+// BenchmarkStatsAndUsage_RecordRequestOutcome below to be compared against.
 func BenchmarkStatsAndUsage_Combined(b *testing.B) {
 	statsStore, err := NewStatsStore(b.TempDir())
 	if err != nil {
@@ -130,6 +131,50 @@ func BenchmarkStatsAndUsage_Combined(b *testing.B) {
 			LatencyMs:    120,
 		}
 		if err := usageStore.RecordUsage(record); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkStatsAndUsage_RecordRequestOutcome exercises RecordRequestOutcome
+// with both stores wired exactly as production does -- sharing one *gorm.DB
+// via StoreManager, the precondition for the two writes to land in a single
+// SQLite transaction/commit instead of BenchmarkStatsAndUsage_Combined's two.
+func BenchmarkStatsAndUsage_RecordRequestOutcome(b *testing.B) {
+	sm, err := NewStoreManager(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = sm.Close() })
+
+	statsStore, usageStore := sm.Stats(), sm.Usage()
+
+	service := &loadbalance.Service{
+		Provider: "bench-provider",
+		Model:    "bench-model",
+		Weight:   1,
+		Active:   true,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		service.RecordUsage(10, 20)
+		record := &UsageRecord{
+			ProviderUUID: "bench-provider",
+			ProviderName: "bench-provider",
+			Model:        "bench-model",
+			Scenario:     "openai",
+			RuleUUID:     "bench-rule",
+			UserID:       DefaultAdminUserID,
+			RequestModel: "bench-model",
+			Timestamp:    time.Now(),
+			InputTokens:  10,
+			OutputTokens: 20,
+			Status:       "success",
+			LatencyMs:    120,
+		}
+		if err := RecordRequestOutcome(statsStore, usageStore, service, record); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/db/stats_usage_bench_test.go
+++ b/internal/db/stats_usage_bench_test.go
@@ -1,28 +1,20 @@
 package db
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 )
 
-// newUsageStoreForBench works around NewUsageStore never being called in
-// production (StoreManager builds UsageStore directly over its own already-open
-// *gorm.DB instead) -- as its first-ever caller, this benchmark tripped a
-// latent bug: NewUsageStore never creates the "db" subdirectory GetDBFile
-// expects, unlike every other NewXStore constructor in this package. Worked
-// around here rather than fixed, since it's an unrelated pre-existing issue.
+// newUsageStoreForBench builds a UsageStore for a fresh temp dir.
+// NewUsageStore is never called in production (StoreManager builds
+// UsageStore directly over its own already-open *gorm.DB instead), so this
+// benchmark suite is its only real caller -- see NewUsageStore's directory
+// setup, which this relies on.
 func newUsageStoreForBench(b *testing.B) *UsageStore {
 	b.Helper()
-	dir := b.TempDir()
-	if err := os.MkdirAll(filepath.Join(dir, constant.DBDirName), 0700); err != nil {
-		b.Fatal(err)
-	}
-	store, err := NewUsageStore(dir)
+	store, err := NewUsageStore(b.TempDir())
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/db/stats_usage_bench_test.go
+++ b/internal/db/stats_usage_bench_test.go
@@ -1,0 +1,144 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+// newUsageStoreForBench works around NewUsageStore never being called in
+// production (StoreManager builds UsageStore directly over its own already-open
+// *gorm.DB instead) -- as its first-ever caller, this benchmark tripped a
+// latent bug: NewUsageStore never creates the "db" subdirectory GetDBFile
+// expects, unlike every other NewXStore constructor in this package. Worked
+// around here rather than fixed, since it's an unrelated pre-existing issue.
+func newUsageStoreForBench(b *testing.B) *UsageStore {
+	b.Helper()
+	dir := b.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, constant.DBDirName), 0700); err != nil {
+		b.Fatal(err)
+	}
+	store, err := NewUsageStore(dir)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return store
+}
+
+// Benchmarks for the two stores that internal/protocolserver/usage_tracking.go
+// writes to synchronously, once per completed LLM request (both streaming and
+// non-streaming, success and error paths), before the response is handed back
+// to the client -- see ProtocolHandler.trackUsageWithTokenUsage, which calls
+// updateServiceStats (-> StatsStore.UpdateFromService) and
+// recordDetailedUsageWithTokenUsage (-> UsageStore.RecordUsage) inline in the
+// request goroutine. Unlike ProviderStore.GetByUUID or
+// APITokenStore.ValidateToken, these are writes, not reads that can be
+// served from a cache -- there's a real row to persist every request. See
+// .design/hot-path-db-access.md for the read-path fixes this follows up on.
+//
+// Run: go test ./internal/db/... -bench 'StatsStore|UsageStore' -benchmem -run '^$'
+
+// BenchmarkStatsStore_UpdateFromService exercises the exact call
+// updateServiceStats makes: an upsert (gorm Save, no prior read) of a
+// service's current in-memory stats snapshot.
+func BenchmarkStatsStore_UpdateFromService(b *testing.B) {
+	store, err := NewStatsStore(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	service := &loadbalance.Service{
+		Provider: "bench-provider",
+		Model:    "bench-model",
+		Weight:   1,
+		Active:   true,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		service.RecordUsage(10, 20)
+		if err := store.UpdateFromService(service); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkUsageStore_RecordUsage exercises the exact call
+// recordDetailedUsageWithTokenUsage makes: a single-row INSERT per
+// completed request (the proxy's usage audit log).
+func BenchmarkUsageStore_RecordUsage(b *testing.B) {
+	store := newUsageStoreForBench(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		record := &UsageRecord{
+			ProviderUUID: "bench-provider",
+			ProviderName: "bench-provider",
+			Model:        "bench-model",
+			Scenario:     "openai",
+			RuleUUID:     "bench-rule",
+			UserID:       DefaultAdminUserID,
+			RequestModel: "bench-model",
+			Timestamp:    time.Now(),
+			InputTokens:  10,
+			OutputTokens: 20,
+			Status:       "success",
+			LatencyMs:    120,
+		}
+		if err := store.RecordUsage(record); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkStatsAndUsage_Combined runs both writes back to back, mirroring
+// trackUsageWithTokenUsage's per-request sequence (updateServiceStats then
+// recordDetailedUsageWithTokenUsage) so the combined per-request SQLite cost
+// on the client-visible latency path can be read off directly.
+func BenchmarkStatsAndUsage_Combined(b *testing.B) {
+	statsStore, err := NewStatsStore(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	usageStore := newUsageStoreForBench(b)
+
+	service := &loadbalance.Service{
+		Provider: "bench-provider",
+		Model:    "bench-model",
+		Weight:   1,
+		Active:   true,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		service.RecordUsage(10, 20)
+		if err := statsStore.UpdateFromService(service); err != nil {
+			b.Fatal(err)
+		}
+		record := &UsageRecord{
+			ProviderUUID: "bench-provider",
+			ProviderName: "bench-provider",
+			Model:        "bench-model",
+			Scenario:     "openai",
+			RuleUUID:     "bench-rule",
+			UserID:       DefaultAdminUserID,
+			RequestModel: "bench-model",
+			Timestamp:    time.Now(),
+			InputTokens:  10,
+			OutputTokens: 20,
+			Status:       "success",
+			LatencyMs:    120,
+		}
+		if err := usageStore.RecordUsage(record); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/db/store_manager.go
+++ b/internal/db/store_manager.go
@@ -263,10 +263,15 @@ func (sm *StoreManager) initAPITokenStore() error {
 	if err := sm.db.AutoMigrate(&APITokenRecord{}); err != nil {
 		return err
 	}
-	sm.apiTokenStore = &APITokenStore{
+	store := &APITokenStore{
 		db:     sm.db,
 		dbPath: constant.GetDBFile(sm.baseDir),
+		cache:  make(map[string]*APITokenRecord),
 	}
+	if err := store.loadCache(); err != nil {
+		return fmt.Errorf("failed to load API token cache: %w", err)
+	}
+	sm.apiTokenStore = store
 	return nil
 }
 

--- a/internal/db/store_manager.go
+++ b/internal/db/store_manager.go
@@ -200,16 +200,9 @@ func (sm *StoreManager) initUsageStore() error {
 
 // initProviderStore initializes the ProviderStore.
 func (sm *StoreManager) initProviderStore() error {
-	if err := sm.db.AutoMigrate(&ProviderRecord{}); err != nil {
+	store, err := newProviderStoreOverDB(sm.db, constant.GetDBFile(sm.baseDir))
+	if err != nil {
 		return err
-	}
-	store := &ProviderStore{
-		db:     sm.db,
-		dbPath: constant.GetDBFile(sm.baseDir),
-		cache:  make(map[string]*ProviderRecord),
-	}
-	if err := store.loadCache(); err != nil {
-		return fmt.Errorf("failed to load provider cache: %w", err)
 	}
 	sm.providerStore = store
 	return nil
@@ -260,17 +253,9 @@ func (sm *StoreManager) initModelStore() error {
 
 // initAPITokenStore initializes the APITokenStore.
 func (sm *StoreManager) initAPITokenStore() error {
-	if err := sm.db.AutoMigrate(&APITokenRecord{}); err != nil {
+	store, err := newAPITokenStoreOverDB(sm.db, constant.GetDBFile(sm.baseDir))
+	if err != nil {
 		return err
-	}
-	store := &APITokenStore{
-		db:               sm.db,
-		dbPath:           constant.GetDBFile(sm.baseDir),
-		cache:            make(map[string]*APITokenRecord),
-		lastUsedDebounce: defaultLastUsedDebounce,
-	}
-	if err := store.loadCache(); err != nil {
-		return fmt.Errorf("failed to load API token cache: %w", err)
 	}
 	sm.apiTokenStore = store
 	return nil

--- a/internal/db/store_manager.go
+++ b/internal/db/store_manager.go
@@ -203,10 +203,15 @@ func (sm *StoreManager) initProviderStore() error {
 	if err := sm.db.AutoMigrate(&ProviderRecord{}); err != nil {
 		return err
 	}
-	sm.providerStore = &ProviderStore{
+	store := &ProviderStore{
 		db:     sm.db,
 		dbPath: constant.GetDBFile(sm.baseDir),
+		cache:  make(map[string]*ProviderRecord),
 	}
+	if err := store.loadCache(); err != nil {
+		return fmt.Errorf("failed to load provider cache: %w", err)
+	}
+	sm.providerStore = store
 	return nil
 }
 

--- a/internal/db/store_manager.go
+++ b/internal/db/store_manager.go
@@ -264,9 +264,10 @@ func (sm *StoreManager) initAPITokenStore() error {
 		return err
 	}
 	store := &APITokenStore{
-		db:     sm.db,
-		dbPath: constant.GetDBFile(sm.baseDir),
-		cache:  make(map[string]*APITokenRecord),
+		db:               sm.db,
+		dbPath:           constant.GetDBFile(sm.baseDir),
+		cache:            make(map[string]*APITokenRecord),
+		lastUsedDebounce: defaultLastUsedDebounce,
 	}
 	if err := store.loadCache(); err != nil {
 		return fmt.Errorf("failed to load API token cache: %w", err)

--- a/internal/db/usage_record.go
+++ b/internal/db/usage_record.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"sync"
 	"time"
@@ -155,6 +156,17 @@ func NewUsageStore(baseDir string) (*UsageStore, error) {
 	}
 
 	dbPath := constant.GetDBFile(baseDir)
+	// Ensure the db subdirectory exists -- unlike every other NewXStore
+	// constructor in this package, this was missing until now, so the first
+	// real caller (a benchmark, see stats_usage_bench_test.go) failed with
+	// "unable to open database file" on a fresh directory. Production never
+	// hit this: StoreManager builds UsageStore directly over its own
+	// already-open *gorm.DB, whose NewStoreManagerWithConfig creates this
+	// directory itself before opening anything.
+	dbDir := filepath.Dir(dbPath)
+	if err := os.MkdirAll(dbDir, 0700); err != nil {
+		return nil, fmt.Errorf("failed to create db directory: %w", err)
+	}
 	logrus.Printf("Opening SQLite database for usage store: %s", dbPath)
 	dsn := dbPath + "?_busy_timeout=5000&_journal_mode=WAL&_foreign_keys=1"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{

--- a/internal/db/usage_record.go
+++ b/internal/db/usage_record.go
@@ -284,6 +284,16 @@ func (us *UsageStore) RecordUsage(record *UsageRecord) error {
 	us.mu.Lock()
 	defer us.mu.Unlock()
 
+	prepareUsageRecord(record)
+
+	return us.db.Create(record).Error
+}
+
+// prepareUsageRecord fills in RecordUsage's defaults without touching the
+// database. Split out so RecordRequestOutcome (record_outcome.go) can
+// prepare it and create it in the same transaction as a StatsStore write --
+// see .design/hot-path-db-access.md.
+func prepareUsageRecord(record *UsageRecord) {
 	if record.Timestamp.IsZero() {
 		record.Timestamp = time.Now()
 	}
@@ -292,8 +302,6 @@ func (us *UsageStore) RecordUsage(record *UsageRecord) error {
 	if record.Status == "" {
 		record.Status = "success"
 	}
-
-	return us.db.Create(record).Error
 }
 
 // RenameRuleUUID re-attributes historical usage records from oldUUID to

--- a/internal/db/usage_record.go
+++ b/internal/db/usage_record.go
@@ -156,13 +156,7 @@ func NewUsageStore(baseDir string) (*UsageStore, error) {
 	}
 
 	dbPath := constant.GetDBFile(baseDir)
-	// Ensure the db subdirectory exists -- unlike every other NewXStore
-	// constructor in this package, this was missing until now, so the first
-	// real caller (a benchmark, see stats_usage_bench_test.go) failed with
-	// "unable to open database file" on a fresh directory. Production never
-	// hit this: StoreManager builds UsageStore directly over its own
-	// already-open *gorm.DB, whose NewStoreManagerWithConfig creates this
-	// directory itself before opening anything.
+	// Ensure the db subdirectory exists (matches every other NewXStore constructor).
 	dbDir := filepath.Dir(dbPath)
 	if err := os.MkdirAll(dbDir, 0700); err != nil {
 		return nil, fmt.Errorf("failed to create db directory: %w", err)
@@ -290,9 +284,8 @@ func (us *UsageStore) RecordUsage(record *UsageRecord) error {
 }
 
 // prepareUsageRecord fills in RecordUsage's defaults without touching the
-// database. Split out so RecordRequestOutcome (record_outcome.go) can
-// prepare it and create it in the same transaction as a StatsStore write --
-// see .design/hot-path-db-access.md.
+// database -- split out so RecordRequestOutcome can create it in the same
+// transaction as a StatsStore write.
 func prepareUsageRecord(record *UsageRecord) {
 	if record.Timestamp.IsZero() {
 		record.Timestamp = time.Now()

--- a/internal/middleware/auth_bench_test.go
+++ b/internal/middleware/auth_bench_test.go
@@ -13,13 +13,7 @@ import (
 
 // Benchmarks for AuthMiddleware.ModelAuthMiddleware's multi-tenant
 // "tb-share-" API-token path, wired against a real db.APITokenStore
-// (SQLite-backed, exactly as internal/server/server.go constructs it)
-// instead of a mock. Mirrors internal/routing/pipeline_bench_test.go's
-// approach — benchmark the production wiring and read pprof, rather than
-// reason about the DB-lock cost from first principles — for
-// APITokenStore.ValidateToken, which internal/db/provider_store.go's
-// GetByUUID turned out to share its lock+query-on-every-read shape with
-// (see .design/hot-path-db-access.md).
+// (SQLite-backed) instead of a mock. See .design/hot-path-db-access.md.
 //
 // Run: go test ./internal/middleware/... -bench . -benchmem -run '^$'
 
@@ -39,9 +33,7 @@ func benchAPITokenStore(b *testing.B) (*db.APITokenStore, string) {
 }
 
 // BenchmarkAPITokenStore_ValidateToken isolates the store call the auth
-// middleware makes on every "tb-share-"-prefixed request, the same way
-// pipeline_bench_test.go's BenchmarkHealthFilter_Filter isolates a single
-// routing stage from the full pipeline benchmark.
+// middleware makes on every "tb-share-"-prefixed request.
 func BenchmarkAPITokenStore_ValidateToken(b *testing.B) {
 	store, token := benchAPITokenStore(b)
 	b.ReportAllocs()
@@ -54,11 +46,8 @@ func BenchmarkAPITokenStore_ValidateToken(b *testing.B) {
 }
 
 // BenchmarkModelAuthMiddleware_APIToken exercises the full production gin
-// middleware chain for a multi-tenant "tb-share-" request. UpdateLastUsed's
-// fire-and-forget write (see ModelAuthMiddleware in auth.go) runs on its own
-// goroutine exactly as in production, so this also reflects the write-lock
-// contention a real deployment would see between concurrent validations and
-// last-used updates.
+// middleware chain for a multi-tenant "tb-share-" request, including
+// UpdateLastUsed's fire-and-forget write on its own goroutine.
 func BenchmarkModelAuthMiddleware_APIToken(b *testing.B) {
 	gin.SetMode(gin.TestMode)
 	store, token := benchAPITokenStore(b)

--- a/internal/middleware/auth_bench_test.go
+++ b/internal/middleware/auth_bench_test.go
@@ -1,0 +1,87 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tingly-dev/tingly-box/internal/db"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+)
+
+// Benchmarks for AuthMiddleware.ModelAuthMiddleware's multi-tenant
+// "tb-share-" API-token path, wired against a real db.APITokenStore
+// (SQLite-backed, exactly as internal/server/server.go constructs it)
+// instead of a mock. Mirrors internal/routing/pipeline_bench_test.go's
+// approach — benchmark the production wiring and read pprof, rather than
+// reason about the DB-lock cost from first principles — for
+// APITokenStore.ValidateToken, which internal/db/provider_store.go's
+// GetByUUID turned out to share its lock+query-on-every-read shape with
+// (see .design/hot-path-db-access.md).
+//
+// Run: go test ./internal/middleware/... -bench . -benchmem -run '^$'
+
+func benchAPITokenStore(b *testing.B) (*db.APITokenStore, string) {
+	b.Helper()
+	store, err := db.NewAPITokenStore(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = store.Close() })
+
+	token := "tb-share-benchtoken0000000000000000000000000000"
+	if _, err := store.CreateTokenWithTokenID("bench-user", token, "bench", "bench", nil); err != nil {
+		b.Fatal(err)
+	}
+	return store, token
+}
+
+// BenchmarkAPITokenStore_ValidateToken isolates the store call the auth
+// middleware makes on every "tb-share-"-prefixed request, the same way
+// pipeline_bench_test.go's BenchmarkHealthFilter_Filter isolates a single
+// routing stage from the full pipeline benchmark.
+func BenchmarkAPITokenStore_ValidateToken(b *testing.B) {
+	store, token := benchAPITokenStore(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := store.ValidateToken(token); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkModelAuthMiddleware_APIToken exercises the full production gin
+// middleware chain for a multi-tenant "tb-share-" request. UpdateLastUsed's
+// fire-and-forget write (see ModelAuthMiddleware in auth.go) runs on its own
+// goroutine exactly as in production, so this also reflects the write-lock
+// contention a real deployment would see between concurrent validations and
+// last-used updates.
+func BenchmarkModelAuthMiddleware_APIToken(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	store, token := benchAPITokenStore(b)
+
+	cfg := &config.Config{}
+	cfg.MultiTenantConfig.Enabled = true
+
+	am := NewAuthMiddleware(cfg, nil, nil, store)
+	r := gin.New()
+	r.POST("/v1/chat/completions", am.ModelAuthMiddleware(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			b.Fatalf("unexpected status %d: %s", w.Code, w.Body.String())
+		}
+	}
+}

--- a/internal/protocolserver/usage_tracking.go
+++ b/internal/protocolserver/usage_tracking.go
@@ -340,9 +340,8 @@ func isRateLimitError(err error) bool {
 }
 
 // recordDetailedUsage builds the detailed usage record for the analytics
-// dashboard. Building is separate from persisting (see persistRequestOutcome)
-// so it can be saved together with the matching StatsStore update in one
-// SQLite transaction instead of two -- see .design/hot-path-db-access.md.
+// dashboard; persistRequestOutcome saves it together with the matching
+// StatsStore update.
 func (ph *ProtocolHandler) recordDetailedUsage(c *gin.Context, rule *typ.Rule, provider *typ.Provider, model, requestModel, scenario string, inputTokens, outputTokens int, streamed bool, status, errorCode string, latencyMs int) *db.UsageRecord {
 	ttftMs := CalculateTTFT(c)
 
@@ -370,9 +369,8 @@ func (ph *ProtocolHandler) recordDetailedUsage(c *gin.Context, rule *typ.Rule, p
 	return record
 }
 
-// recordDetailedUsageWithTokenUsage builds a detailed usage record with
-// comprehensive token data. Building is separate from persisting (see
-// persistRequestOutcome) for the same reason as recordDetailedUsage.
+// recordDetailedUsageWithTokenUsage is recordDetailedUsage with comprehensive
+// token data (cache/system tokens).
 func (ph *ProtocolHandler) recordDetailedUsageWithTokenUsage(c *gin.Context, rule *typ.Rule, provider *typ.Provider, model, requestModel, scenario string, usage *protocol.TokenUsage, streamed bool, status, errorCode string, latencyMs int) *db.UsageRecord {
 	if usage == nil {
 		return nil
@@ -407,11 +405,9 @@ func (ph *ProtocolHandler) recordDetailedUsageWithTokenUsage(c *gin.Context, rul
 	return record
 }
 
-// updateServiceStats updates the in-memory service-level statistics for load
-// balancing (tokens, latency, TTFT, cache, TPS) and returns the matched
-// service. Updating is separate from persisting (see persistRequestOutcome)
-// so the caller can save it together with the matching usage record in one
-// SQLite transaction instead of two -- see .design/hot-path-db-access.md.
+// updateServiceStats updates the in-memory service-level stats (tokens,
+// latency, TTFT, cache, TPS) and returns the matched service for
+// persistRequestOutcome to save.
 func (ph *ProtocolHandler) updateServiceStats(rule *typ.Rule, provider *typ.Provider, model string, metrics MetricsData) *loadbalance.Service {
 	if rule == nil || provider == nil {
 		return nil
@@ -449,11 +445,7 @@ func (ph *ProtocolHandler) updateServiceStats(rule *typ.Rule, provider *typ.Prov
 }
 
 // persistRequestOutcome saves service and usage (either may be nil) via
-// db.RecordRequestOutcome, which commits both to SQLite in a single
-// transaction when both stores share one *gorm.DB (always true in
-// production, see StoreManager) instead of updateServiceStats and
-// recordDetailedUsage[WithTokenUsage] each committing their own -- see
-// .design/hot-path-db-access.md for the pprof/benchmark evidence.
+// db.RecordRequestOutcome, which commits both in a single transaction.
 func (ph *ProtocolHandler) persistRequestOutcome(service *loadbalance.Service, usage *db.UsageRecord) {
 	if ph.deps.Config == nil {
 		return

--- a/internal/protocolserver/usage_tracking.go
+++ b/internal/protocolserver/usage_tracking.go
@@ -110,8 +110,8 @@ func (ph *ProtocolHandler) trackUsageFromContext(c *gin.Context, inputTokens, ou
 		TPS:          tps,
 	}
 
-	// 1. Update service stats with comprehensive metrics
-	ph.updateServiceStats(rule, provider, model, metrics)
+	// 1. Update in-memory service stats with comprehensive metrics
+	service := ph.updateServiceStats(rule, provider, model, metrics)
 
 	// 2. Record to OTel (primary path for metrics)
 	if ph.deps.TokenTracker != nil {
@@ -138,8 +138,9 @@ func (ph *ProtocolHandler) trackUsageFromContext(c *gin.Context, inputTokens, ou
 		})
 	}
 
-	// 3. Record detailed usage (for analytics/dashboard)
-	ph.recordDetailedUsage(c, rule, provider, model, requestModel, scenario, inputTokens, outputTokens, streamed, status, errorCode, latencyMs)
+	// 3. Persist service stats and detailed usage together in one transaction
+	usageRecord := ph.recordDetailedUsage(c, rule, provider, model, requestModel, scenario, inputTokens, outputTokens, streamed, status, errorCode, latencyMs)
+	ph.persistRequestOutcome(service, usageRecord)
 
 	// 4. Report to health monitor for service health tracking
 	ph.ReportHealthStatus(provider, model, err, errorCode)
@@ -227,8 +228,8 @@ func (ph *ProtocolHandler) trackUsageWithTokenUsage(c *gin.Context, usage *proto
 		TPS:          tps,
 	}
 
-	// 1. Update service stats with comprehensive metrics
-	ph.updateServiceStats(rule, provider, model, metrics)
+	// 1. Update in-memory service stats with comprehensive metrics
+	service := ph.updateServiceStats(rule, provider, model, metrics)
 
 	// 2. Record to OTel with comprehensive usage data
 	if ph.deps.TokenTracker != nil {
@@ -253,8 +254,9 @@ func (ph *ProtocolHandler) trackUsageWithTokenUsage(c *gin.Context, usage *proto
 		})
 	}
 
-	// 3. Record detailed usage with comprehensive token data
-	ph.recordDetailedUsageWithTokenUsage(c, rule, provider, model, requestModel, scenario, usage, streamed, status, errorCode, latencyMs)
+	// 3. Persist service stats and detailed usage together in one transaction
+	usageRecord := ph.recordDetailedUsageWithTokenUsage(c, rule, provider, model, requestModel, scenario, usage, streamed, status, errorCode, latencyMs)
+	ph.persistRequestOutcome(service, usageRecord)
 
 	// 4. Report to health monitor for service health tracking
 	ph.ReportHealthStatus(provider, model, err, errorCode)
@@ -337,22 +339,11 @@ func isRateLimitError(err error) bool {
 		strings.Contains(errStr, "1302")
 }
 
-// recordDetailedUsage writes a detailed usage record to the database.
-// This maintains the detailed analytics tracking for the dashboard.
-func (ph *ProtocolHandler) recordDetailedUsage(c *gin.Context, rule *typ.Rule, provider *typ.Provider, model, requestModel, scenario string, inputTokens, outputTokens int, streamed bool, status, errorCode string, latencyMs int) {
-	if ph.deps.Config == nil {
-		return
-	}
-
-	sm := ph.deps.Config.StoreManager()
-	if sm == nil {
-		return
-	}
-	usageStore := sm.Usage()
-	if usageStore == nil {
-		return
-	}
-
+// recordDetailedUsage builds the detailed usage record for the analytics
+// dashboard. Building is separate from persisting (see persistRequestOutcome)
+// so it can be saved together with the matching StatsStore update in one
+// SQLite transaction instead of two -- see .design/hot-path-db-access.md.
+func (ph *ProtocolHandler) recordDetailedUsage(c *gin.Context, rule *typ.Rule, provider *typ.Provider, model, requestModel, scenario string, inputTokens, outputTokens int, streamed bool, status, errorCode string, latencyMs int) *db.UsageRecord {
 	ttftMs := CalculateTTFT(c)
 
 	record := &db.UsageRecord{
@@ -376,22 +367,15 @@ func (ph *ProtocolHandler) recordDetailedUsage(c *gin.Context, rule *typ.Rule, p
 		record.RuleUUID = rule.UUID
 	}
 
-	_ = usageStore.RecordUsage(record)
+	return record
 }
 
-// recordDetailedUsageWithTokenUsage writes a detailed usage record with comprehensive token data.
-func (ph *ProtocolHandler) recordDetailedUsageWithTokenUsage(c *gin.Context, rule *typ.Rule, provider *typ.Provider, model, requestModel, scenario string, usage *protocol.TokenUsage, streamed bool, status, errorCode string, latencyMs int) {
-	if ph.deps.Config == nil || usage == nil {
-		return
-	}
-
-	sm := ph.deps.Config.StoreManager()
-	if sm == nil {
-		return
-	}
-	usageStore := sm.Usage()
-	if usageStore == nil {
-		return
+// recordDetailedUsageWithTokenUsage builds a detailed usage record with
+// comprehensive token data. Building is separate from persisting (see
+// persistRequestOutcome) for the same reason as recordDetailedUsage.
+func (ph *ProtocolHandler) recordDetailedUsageWithTokenUsage(c *gin.Context, rule *typ.Rule, provider *typ.Provider, model, requestModel, scenario string, usage *protocol.TokenUsage, streamed bool, status, errorCode string, latencyMs int) *db.UsageRecord {
+	if usage == nil {
+		return nil
 	}
 
 	ttftMs := CalculateTTFT(c)
@@ -420,14 +404,17 @@ func (ph *ProtocolHandler) recordDetailedUsageWithTokenUsage(c *gin.Context, rul
 		record.RuleUUID = rule.UUID
 	}
 
-	_ = usageStore.RecordUsage(record)
+	return record
 }
 
-// updateServiceStats updates the service-level statistics for load balancing.
-// This function records comprehensive metrics including tokens, latency, TTFT, cache, and TPS.
-func (ph *ProtocolHandler) updateServiceStats(rule *typ.Rule, provider *typ.Provider, model string, metrics MetricsData) {
-	if rule == nil || provider == nil || ph.deps.Config == nil {
-		return
+// updateServiceStats updates the in-memory service-level statistics for load
+// balancing (tokens, latency, TTFT, cache, TPS) and returns the matched
+// service. Updating is separate from persisting (see persistRequestOutcome)
+// so the caller can save it together with the matching usage record in one
+// SQLite transaction instead of two -- see .design/hot-path-db-access.md.
+func (ph *ProtocolHandler) updateServiceStats(rule *typ.Rule, provider *typ.Provider, model string, metrics MetricsData) *loadbalance.Service {
+	if rule == nil || provider == nil {
+		return nil
 	}
 
 	// Find the matching service in the rule and update its stats
@@ -455,16 +442,27 @@ func (ph *ProtocolHandler) updateServiceStats(rule *typ.Rule, provider *typ.Prov
 				service.Stats.RecordTokenSpeed(metrics.TPS, 100)
 			}
 
-			// Persist to stats store
-			sm := ph.deps.Config.StoreManager()
-			if sm != nil {
-				if statsStore := sm.Stats(); statsStore != nil {
-					_ = statsStore.UpdateFromService(service)
-				}
-			}
-			return
+			return service
 		}
 	}
+	return nil
+}
+
+// persistRequestOutcome saves service and usage (either may be nil) via
+// db.RecordRequestOutcome, which commits both to SQLite in a single
+// transaction when both stores share one *gorm.DB (always true in
+// production, see StoreManager) instead of updateServiceStats and
+// recordDetailedUsage[WithTokenUsage] each committing their own -- see
+// .design/hot-path-db-access.md for the pprof/benchmark evidence.
+func (ph *ProtocolHandler) persistRequestOutcome(service *loadbalance.Service, usage *db.UsageRecord) {
+	if ph.deps.Config == nil {
+		return
+	}
+	sm := ph.deps.Config.StoreManager()
+	if sm == nil {
+		return
+	}
+	_ = db.RecordRequestOutcome(sm.Stats(), sm.Usage(), service, usage)
 }
 
 // reportHealthStatus reports the health status of a service based on request outcome.

--- a/internal/routing/pipeline_bench_test.go
+++ b/internal/routing/pipeline_bench_test.go
@@ -1,0 +1,229 @@
+package routing_test
+
+// Benchmarks for the production ServiceSelector pipeline (health → smart →
+// affinity → load_balancer), wired exactly as internal/server/server.go does
+// (protocolserver.LoadBalancer + routing.ServiceSelector), minus the HTTP
+// layer. They exist to put real numbers behind "is the multi-stage pipeline
+// (and its known double active/health filtering — see
+// internal/protocolserver/load_balance.go's selectService, which re-filters
+// candidates HealthStage already filtered) worth optimizing", rather than
+// reasoning about it from first principles.
+//
+// Run: go test ./internal/routing/... -bench . -benchmem -run '^$'
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+
+	"github.com/tingly-dev/tingly-box/internal/config"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/protocolserver"
+	"github.com/tingly-dev/tingly-box/internal/routing"
+	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// benchSelector wires the real production pipeline. cfg's rule list is left
+// empty on purpose — Select() takes the *typ.Rule directly via
+// SelectionContext, so benchmarks build rules in-memory without paying for
+// AddRequestConfig's persisted-config write path.
+func benchSelector(b *testing.B) (*routing.ServiceSelector, *config.AppConfig) {
+	b.Helper()
+	appConfig, err := config.NewAppConfig(config.WithConfigDir(b.TempDir()))
+	if err != nil {
+		b.Fatal(err)
+	}
+	cfg := appConfig.GetGlobalConfig()
+
+	healthMonitor := loadbalance.NewHealthMonitor(cfg.HealthMonitor)
+	healthFilter := routing.NewHealthFilter(healthMonitor)
+	lb := protocolserver.NewLoadBalancer(cfg, healthFilter)
+	affinityStore := protocolserver.NewAffinityStore(0)
+	sel := routing.NewServiceSelector(cfg, affinityStore, lb)
+	return sel, appConfig
+}
+
+func benchProvider(b *testing.B, appConfig *config.AppConfig, uuid string) {
+	b.Helper()
+	p := &typ.Provider{UUID: uuid, Name: uuid, APIBase: "http://bench.invalid", Enabled: true}
+	if err := appConfig.GetGlobalConfig().AddProvider(p); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func benchService(provider, model string) *loadbalance.Service {
+	return &loadbalance.Service{Provider: provider, Model: model, Weight: 1, Active: true}
+}
+
+func benchRequest() *openai.ChatCompletionNewParams {
+	return &openai.ChatCompletionNewParams{
+		Model: "bench-model",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.UserMessage("benchmark probe request"),
+		},
+	}
+}
+
+func runSelectBench(b *testing.B, sel *routing.ServiceSelector, ctx *routing.SelectionContext) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := sel.Select(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkSelect_Plain is the simplest shape: no smart routing, no
+// affinity, N services under the (default) random tactic. This isolates the
+// pipeline's fixed per-request overhead — including the double active/health
+// filter (once in HealthStage, once again inside LoadBalancer.SelectService)
+// — from smart-routing/affinity-specific work.
+func BenchmarkSelect_Plain(b *testing.B) {
+	sel, appConfig := benchSelector(b)
+	benchProvider(b, appConfig, "bench-a")
+	benchProvider(b, appConfig, "bench-b")
+	benchProvider(b, appConfig, "bench-c")
+
+	rule := &typ.Rule{
+		UUID:         "bench-rule-plain",
+		RequestModel: "bench-model",
+		Scenario:     typ.ScenarioOpenAI,
+		Active:       true,
+		Services: []*loadbalance.Service{
+			benchService("bench-a", "m"),
+			benchService("bench-b", "m"),
+			benchService("bench-c", "m"),
+		},
+	}
+	ctx := &routing.SelectionContext{
+		Rule:                  rule,
+		Request:               benchRequest(),
+		SessionID:             typ.SessionID{Source: typ.SessionSourceIP, Value: "127.0.0.1"},
+		Scenario:              typ.ScenarioOpenAI,
+		MatchedSmartRuleIndex: -1,
+	}
+	runSelectBench(b, sel, ctx)
+}
+
+// BenchmarkSelect_SmartMatch narrows via a matching smart-routing partition
+// on every request — the common "content routing hit" case.
+func BenchmarkSelect_SmartMatch(b *testing.B) {
+	sel, appConfig := benchSelector(b)
+	benchProvider(b, appConfig, "bench-base")
+	benchProvider(b, appConfig, "bench-smart")
+
+	rule := &typ.Rule{
+		UUID:         "bench-rule-smart-match",
+		RequestModel: "bench-model",
+		Scenario:     typ.ScenarioOpenAI,
+		Active:       true,
+		SmartEnabled: true,
+		Services:     []*loadbalance.Service{benchService("bench-base", "m")},
+		SmartRouting: []smartrouting.SmartRouting{{
+			Description: "always",
+			Ops: []smartrouting.SmartOp{{
+				Position:  smartrouting.PositionModel,
+				Operation: smartrouting.OpModelContains,
+				Value:     "bench",
+			}},
+			Services: []*loadbalance.Service{benchService("bench-smart", "m")},
+		}},
+	}
+	ctx := &routing.SelectionContext{
+		Rule:                  rule,
+		Request:               benchRequest(),
+		SessionID:             typ.SessionID{Source: typ.SessionSourceIP, Value: "127.0.0.1"},
+		Scenario:              typ.ScenarioOpenAI,
+		MatchedSmartRuleIndex: -1,
+	}
+	runSelectBench(b, sel, ctx)
+}
+
+// BenchmarkSelect_SmartNoMatch exercises the lazy basePool fallback path in
+// SmartRoutingStage: the partition never matches, so every request falls
+// back to IntersectServices(candidates, rule.Services).
+func BenchmarkSelect_SmartNoMatch(b *testing.B) {
+	sel, appConfig := benchSelector(b)
+	benchProvider(b, appConfig, "bench-base")
+	benchProvider(b, appConfig, "bench-smart")
+
+	rule := &typ.Rule{
+		UUID:         "bench-rule-smart-nomatch",
+		RequestModel: "bench-model",
+		Scenario:     typ.ScenarioOpenAI,
+		Active:       true,
+		SmartEnabled: true,
+		Services:     []*loadbalance.Service{benchService("bench-base", "m")},
+		SmartRouting: []smartrouting.SmartRouting{{
+			Description: "never",
+			Ops: []smartrouting.SmartOp{{
+				Position:  smartrouting.PositionModel,
+				Operation: smartrouting.OpModelContains,
+				Value:     "never-matches-this-request",
+			}},
+			Services: []*loadbalance.Service{benchService("bench-smart", "m")},
+		}},
+	}
+	ctx := &routing.SelectionContext{
+		Rule:                  rule,
+		Request:               benchRequest(),
+		SessionID:             typ.SessionID{Source: typ.SessionSourceIP, Value: "127.0.0.1"},
+		Scenario:              typ.ScenarioOpenAI,
+		MatchedSmartRuleIndex: -1,
+	}
+	runSelectBench(b, sel, ctx)
+}
+
+// BenchmarkSelect_Affinity exercises the affinity-hit short-circuit: the pin
+// is written once (via a real Select() call, so it's locked exactly as
+// production would), then every subsequent iteration returns from
+// AffinityStage before HealthStage's sibling filter in LoadBalancer runs.
+func BenchmarkSelect_Affinity(b *testing.B) {
+	sel, appConfig := benchSelector(b)
+	benchProvider(b, appConfig, "bench-pinned")
+	benchProvider(b, appConfig, "bench-other")
+
+	rule := &typ.Rule{
+		UUID:         "bench-rule-affinity",
+		RequestModel: "bench-model",
+		Scenario:     typ.ScenarioOpenAI,
+		Active:       true,
+		Services:     []*loadbalance.Service{benchService("bench-pinned", "m"), benchService("bench-other", "m")},
+	}
+	rule.Flags.SessionAffinity = 3600
+
+	ctx := &routing.SelectionContext{
+		Rule:                  rule,
+		Request:               benchRequest(),
+		SessionID:             typ.SessionID{Source: typ.SessionSourceHeader, Value: "bench-session"},
+		Scenario:              typ.ScenarioOpenAI,
+		MatchedSmartRuleIndex: -1,
+	}
+	if _, err := sel.Select(ctx); err != nil {
+		b.Fatal(err)
+	}
+	runSelectBench(b, sel, ctx)
+}
+
+// BenchmarkHealthFilter_Filter isolates a single health-filter pass so the
+// double-filtering cost visible in BenchmarkSelect_Plain (HealthStage, then
+// again inside LoadBalancer.SelectService) can be read off directly: each
+// BenchmarkSelect_Plain op should cost roughly the pipeline's fixed overhead
+// plus ~2x this number's ns/op and allocs/op.
+func BenchmarkHealthFilter_Filter(b *testing.B) {
+	monitor := loadbalance.NewHealthMonitor(loadbalance.DefaultHealthMonitorConfig())
+	filter := routing.NewHealthFilter(monitor)
+	services := []*loadbalance.Service{
+		benchService("bench-a", "m"),
+		benchService("bench-b", "m"),
+		benchService("bench-c", "m"),
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = filter.Filter(services)
+	}
+}

--- a/internal/routing/pipeline_bench_test.go
+++ b/internal/routing/pipeline_bench_test.go
@@ -24,6 +24,18 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+// benchService and benchRequest are thin aliases over routing's exported
+// test fixtures (ServiceForTest/OpenAIRequestForTest) — kept as local
+// wrappers only to fix the benchmark's request model/weight/active shape
+// once, not to reimplement the fixtures themselves.
+func benchService(provider, model string) *loadbalance.Service {
+	return routing.ServiceForTest(provider, model, true)
+}
+
+func benchRequest() *openai.ChatCompletionNewParams {
+	return routing.OpenAIRequestForTest("bench-model")
+}
+
 // benchSelector wires the real production pipeline. cfg's rule list is left
 // empty on purpose — Select() takes the *typ.Rule directly via
 // SelectionContext, so benchmarks build rules in-memory without paying for
@@ -49,19 +61,6 @@ func benchProvider(b *testing.B, appConfig *config.AppConfig, uuid string) {
 	p := &typ.Provider{UUID: uuid, Name: uuid, APIBase: "http://bench.invalid", Enabled: true}
 	if err := appConfig.GetGlobalConfig().AddProvider(p); err != nil {
 		b.Fatal(err)
-	}
-}
-
-func benchService(provider, model string) *loadbalance.Service {
-	return &loadbalance.Service{Provider: provider, Model: model, Weight: 1, Active: true}
-}
-
-func benchRequest() *openai.ChatCompletionNewParams {
-	return &openai.ChatCompletionNewParams{
-		Model: "bench-model",
-		Messages: []openai.ChatCompletionMessageParamUnion{
-			openai.UserMessage("benchmark probe request"),
-		},
 	}
 }
 

--- a/internal/routing/test_helpers.go
+++ b/internal/routing/test_helpers.go
@@ -23,6 +23,19 @@ func testService(provider, model string, active bool) *loadbalance.Service {
 	}
 }
 
+// ServiceForTest and OpenAIRequestForTest are exported wrappers around this
+// package's own fixtures, for external test packages (e.g. routing_test's
+// benchmarks, which must live outside package routing to import
+// protocolserver without an import cycle) that need identical shapes without
+// reimplementing them.
+func ServiceForTest(provider, model string, active bool) *loadbalance.Service {
+	return testService(provider, model, active)
+}
+
+func OpenAIRequestForTest(model string) *openai.ChatCompletionNewParams {
+	return testOpenAIRequest(model)
+}
+
 func testProvider(uuid, name string, enabled bool) *typ.Provider {
 	return &typ.Provider{
 		UUID:    uuid,


### PR DESCRIPTION
## Summary

pprof on the real routing pipeline (`internal/routing/pipeline_bench_test.go`) showed `ServiceSelector.Select` spending 47.5% of its CPU in `ProviderStore.GetByUUID` — a SQLite round-trip on every routed request, serialized behind a plain `sync.Mutex` that blocked concurrent readers too. `APITokenStore.ValidateToken` (auth middleware) and `StatsStore`/`UsageStore`'s per-request writes had the same shape. Every fix below was benchmarked before/after; see `.design/hot-path-db-access.md` for the full writeup, including a rejected approach (`PRAGMA synchronous=NORMAL` — the driver already applies it, so it measured as a no-op) kept there so it isn't retried.

- **`ProviderStore`/`APITokenStore`**: write-through in-memory cache instead of a SQLite round-trip per read. `BenchmarkSelect_Plain` 59.7µs→5.8µs/op (10.2×), `ValidateToken` 30.0µs→119ns/op (~251×). `UpdateLastUsed` debounced to once/minute per token, taking the full auth middleware path to ~75× total.
- **`StatsStore`/`UsageStore`**: both are per-request writes, not reads, so no cache applies — `RecordRequestOutcome` merges their two independent transactions into one (~4–8%, plus atomicity: the stats and usage rows can no longer partially persist).
- Fixed a latent bug found along the way: `NewUsageStore` never created its `db` subdirectory (every other `NewXStore` does) — never hit in production since `StoreManager` never calls it directly.
- Code review + a 4-angle simplify pass on top: fixed two real bugs (cache mutated before a SQLite write succeeded; a nil-usage fallback that surfaced a spurious error), removed a speculative-generality fallback branch three independent reviewers flagged, and factored duplicated cache-write/store-construction logic into shared helpers.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (whole repo, green throughout)
- [x] Every perf claim backed by a `go test -bench` run before/after (tables in `.design/hot-path-db-access.md`)
- [x] Regression tests: cache-not-corrupted-on-failed-write, atomic transaction rollback, debounce behavior

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_015x1eojavC1neC8U2GnLzLo