### PR TITLE
fix(quota): tolerate transient refresh failures

### DIFF
--- a/ai/quota/manager.go
+++ b/ai/quota/manager.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"math/rand/v2"
 	"net"
 	"net/url"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -19,6 +22,13 @@ const maxConcurrentRefreshes = 5
 // warningUsedPercent is where a provider counts as close to running out.
 const warningUsedPercent = 80
 
+const (
+	initialRetryDelay = 200 * time.Millisecond
+	maxRetryDelay     = 2 * time.Second
+	retryJitter       = 100 * time.Millisecond
+	failedRefreshTTL  = time.Minute
+)
+
 // Manager coordinates quota fetching, storage, and refreshes.
 type Manager struct {
 	config      *Config
@@ -27,6 +37,8 @@ type Manager struct {
 	providerMgr ProviderManager
 	logger      *logrus.Logger
 	refresher   *Refresher
+	retryDelay  func(attempt int) time.Duration
+	refreshes   sync.Map // provider UUID -> chan struct{}
 }
 
 // ProviderManager provides access to configured providers.
@@ -47,6 +59,7 @@ func NewManager(config *Config, store Store, providerMgr ProviderManager, logger
 		registry:    NewRegistry(),
 		providerMgr: providerMgr,
 		logger:      logger,
+		retryDelay:  quotaRetryDelay,
 	}
 
 	// Create the background refresher.
@@ -261,6 +274,45 @@ func (m *Manager) IsProviderSupported(providerUUID string) bool {
 // fetchProviderQuota fetches and stores quota data for one provider.
 // It always returns ProviderUsage, either successful or containing error details.
 func (m *Manager) fetchProviderQuota(ctx context.Context, provider *typ.Provider) (*ProviderUsage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	requestedAt := time.Now()
+	gate := m.providerRefreshGate(provider.UUID)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case gate <- struct{}{}:
+	}
+	defer func() { <-gate }()
+
+	// A refresh that started after this caller arrived may have completed while
+	// it waited for the gate. Reuse that result rather than repeating the same
+	// upstream call. Each caller retains its own context; one canceled request
+	// cannot abort another caller's refresh.
+	if usage, err := m.store.Get(ctx, provider.UUID); err == nil && refreshedSince(usage, requestedAt) {
+		return usage, nil
+	}
+
+	return m.fetchProviderQuotaOnce(ctx, provider)
+}
+
+func (m *Manager) providerRefreshGate(providerUUID string) chan struct{} {
+	gate, _ := m.refreshes.LoadOrStore(providerUUID, make(chan struct{}, 1))
+	return gate.(chan struct{})
+}
+
+func refreshedSince(usage *ProviderUsage, requestedAt time.Time) bool {
+	if usage == nil {
+		return false
+	}
+	if !usage.FetchedAt.Before(requestedAt) {
+		return true
+	}
+	return usage.LastErrorAt != nil && !usage.LastErrorAt.Before(requestedAt)
+}
+
+func (m *Manager) fetchProviderQuotaOnce(ctx context.Context, provider *typ.Provider) (*ProviderUsage, error) {
 	providerType := inferProviderType(provider)
 	now := time.Now()
 
@@ -295,16 +347,29 @@ func (m *Manager) fetchProviderQuota(ctx context.Context, provider *typ.Provider
 		return usage, nil
 	}
 
-	// Fetch quota data.
+	// Read the fallback before the remote call while the request context is
+	// still usable. If the fetch later exhausts that context, stale quota can
+	// still be returned without replacing it with an empty error record.
+	cached, cachedErr := m.store.Get(ctx, provider.UUID)
+
+	// Fetch quota data. Quota reads are idempotent, so retry only transient
+	// transport failures and keep the retry local to this provider.
 	start := time.Now()
-	usage, err := f.Fetch(ctx, provider)
+	usage, err := m.fetchWithRetry(ctx, f, provider, log)
 	elapsed := time.Since(start)
 	if err != nil {
+		failedAt := time.Now()
 		log.WithFields(logrus.Fields{
 			"duration_ms": elapsed.Milliseconds(),
 			"error":       err.Error(),
 		}).Warn("quota fetch failed")
-		usage = m.unreadable(provider, providerType, now, err.Error())
+		if ctx.Err() != nil {
+			return cached, ctx.Err()
+		}
+		if cachedErr != nil && !errors.Is(cachedErr, ErrUsageNotFound) {
+			return nil, fmt.Errorf("load cached quota after fetch failure: %w", cachedErr)
+		}
+		usage = m.preserveLastSuccess(cached, provider, providerType, failedAt, err)
 	} else {
 		fields := logrus.Fields{
 			"duration_ms": elapsed.Milliseconds(),
@@ -322,6 +387,94 @@ func (m *Manager) fetchProviderQuota(ctx context.Context, provider *typ.Provider
 	}
 
 	return usage, nil
+}
+
+func (m *Manager) fetchWithRetry(ctx context.Context, f Fetcher, provider *typ.Provider, log *logrus.Entry) (*ProviderUsage, error) {
+	attempts := 1
+	if m.config.RetryOnFailure && m.config.MaxRetries > 0 {
+		attempts += m.config.MaxRetries
+	}
+
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		var usage *ProviderUsage
+		usage, err = f.Fetch(ctx, provider)
+		if err == nil {
+			return usage, nil
+		}
+		if attempt == attempts || !isTransientQuotaError(err) || ctx.Err() != nil {
+			return nil, err
+		}
+
+		delay := m.retryDelay(attempt)
+		log.WithFields(logrus.Fields{
+			"attempt":      attempt,
+			"max_attempts": attempts,
+			"retry_in_ms":  delay.Milliseconds(),
+			"error":        err.Error(),
+		}).Warn("transient quota fetch failure; retrying")
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return nil, err
+}
+
+func isTransientQuotaError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && (netErr.Timeout() || netErr.Temporary())
+}
+
+func quotaRetryDelay(attempt int) time.Duration {
+	delay := initialRetryDelay
+	for step := 1; step < attempt && delay < maxRetryDelay; step++ {
+		delay = min(delay*2, maxRetryDelay)
+	}
+	return delay + time.Duration(rand.Int64N(int64(retryJitter)+1))
+}
+
+// preserveLastSuccess keeps the last readable snapshot visible while recording
+// why its refresh failed. FetchedAt and the quota payload remain untouched, so
+// callers can distinguish stale data from a successful refresh.
+func (m *Manager) preserveLastSuccess(usage *ProviderUsage, provider *typ.Provider, providerType ProviderType, now time.Time, fetchErr error) *ProviderUsage {
+	if !hasSuccessfulSnapshot(usage) {
+		return m.unreadable(provider, providerType, now, fetchErr.Error())
+	}
+
+	usage.MarkUnreadable(fetchErr.Error(), now)
+	retryTTL := min(m.config.CacheTTL, failedRefreshTTL)
+	if retryTTL <= 0 {
+		retryTTL = failedRefreshTTL
+	}
+	usage.ExpiresAt = now.Add(retryTTL)
+	return usage
+}
+
+func hasSuccessfulSnapshot(usage *ProviderUsage) bool {
+	if usage == nil || usage.FetchedAt.IsZero() {
+		return false
+	}
+	if usage.LastErrorAt == nil {
+		return usage.LastError == ""
+	}
+	return usage.FetchedAt.Before(*usage.LastErrorAt)
 }
 
 // unreadable records a provider whose quota could not be read.

--- a/ai/quota/manager_test.go
+++ b/ai/quota/manager_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -183,18 +185,336 @@ func TestUnreadableProvidersReportWhyAndNothingElse(t *testing.T) {
 // recordingStore reports what a fetch attempt left behind.
 type recordingStore struct {
 	managerTestStore
+	current *ProviderUsage
+	getErr  error
 	saved   []*ProviderUsage
 	deleted []string
 }
 
 func (s *recordingStore) Save(_ context.Context, usage *ProviderUsage) error {
 	s.saved = append(s.saved, usage)
+	s.current = usage
 	return nil
+}
+
+func (s *recordingStore) Get(_ context.Context, _ string) (*ProviderUsage, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	if s.current == nil {
+		return nil, ErrUsageNotFound
+	}
+	return s.current, nil
 }
 
 func (s *recordingStore) Delete(_ context.Context, uuid string) error {
 	s.deleted = append(s.deleted, uuid)
 	return nil
+}
+
+type sequenceFetcher struct {
+	errs  []error
+	usage *ProviderUsage
+	calls int
+}
+
+func (*sequenceFetcher) Name() string                 { return "sequence-test" }
+func (*sequenceFetcher) ProviderType() ProviderType   { return ProviderTypeCodex }
+func (*sequenceFetcher) Validate(*typ.Provider) error { return nil }
+func (*sequenceFetcher) RequiresAuth() typ.AuthType   { return typ.AuthTypeOAuth }
+func (f *sequenceFetcher) Fetch(context.Context, *typ.Provider) (*ProviderUsage, error) {
+	f.calls++
+	if f.calls <= len(f.errs) {
+		return nil, f.errs[f.calls-1]
+	}
+	return f.usage, nil
+}
+
+type cancelingFetcher struct {
+	cancel context.CancelFunc
+}
+
+func (*cancelingFetcher) Name() string                 { return "canceling-test" }
+func (*cancelingFetcher) ProviderType() ProviderType   { return ProviderTypeCodex }
+func (*cancelingFetcher) Validate(*typ.Provider) error { return nil }
+func (*cancelingFetcher) RequiresAuth() typ.AuthType   { return typ.AuthTypeOAuth }
+func (f *cancelingFetcher) Fetch(context.Context, *typ.Provider) (*ProviderUsage, error) {
+	f.cancel()
+	return nil, context.Canceled
+}
+
+type serializedFetcher struct {
+	current atomic.Int32
+	maximum atomic.Int32
+	calls   atomic.Int32
+}
+
+func (*serializedFetcher) Name() string                 { return "serialized-test" }
+func (*serializedFetcher) ProviderType() ProviderType   { return ProviderTypeCodex }
+func (*serializedFetcher) Validate(*typ.Provider) error { return nil }
+func (*serializedFetcher) RequiresAuth() typ.AuthType   { return typ.AuthTypeOAuth }
+func (f *serializedFetcher) Fetch(_ context.Context, provider *typ.Provider) (*ProviderUsage, error) {
+	f.calls.Add(1)
+	current := f.current.Add(1)
+	defer f.current.Add(-1)
+	for {
+		maximum := f.maximum.Load()
+		if current <= maximum || f.maximum.CompareAndSwap(maximum, current) {
+			break
+		}
+	}
+	time.Sleep(10 * time.Millisecond)
+	return &ProviderUsage{
+		ProviderUUID: provider.UUID,
+		FetchedAt:    time.Now(),
+		ExpiresAt:    time.Now().Add(time.Minute),
+	}, nil
+}
+
+func newRetryTestManager(t *testing.T, config *Config, store Store, fetcher Fetcher) (*Manager, *typ.Provider) {
+	t.Helper()
+	provider := &typ.Provider{
+		UUID:    "codex-1",
+		Name:    "Codex",
+		APIBase: "https://chatgpt.com/backend-api",
+		Enabled: true,
+	}
+	manager := NewManager(config, store, managerTestProviderManager{providers: []*typ.Provider{provider}}, logrus.New())
+	manager.retryDelay = func(int) time.Duration { return 0 }
+	if err := manager.RegisterFetcher(fetcher); err != nil {
+		t.Fatal(err)
+	}
+	return manager, provider
+}
+
+func TestFetchProviderQuotaRetriesTransientErrors(t *testing.T) {
+	config := DefaultConfig()
+	config.MaxRetries = 2
+	want := &ProviderUsage{
+		ProviderUUID: "codex-1",
+		ProviderName: "Codex",
+		ProviderType: ProviderTypeCodex,
+		FetchedAt:    time.Now(),
+		ExpiresAt:    time.Now().Add(time.Minute),
+	}
+	fetcher := &sequenceFetcher{errs: []error{io.EOF, io.ErrUnexpectedEOF}, usage: want}
+	store := &recordingStore{}
+	manager, provider := newRetryTestManager(t, config, store, fetcher)
+
+	got, err := manager.fetchProviderQuota(context.Background(), provider)
+	if err != nil {
+		t.Fatalf("fetchProviderQuota() error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("fetchProviderQuota() = %p, want %p", got, want)
+	}
+	if fetcher.calls != 3 {
+		t.Fatalf("Fetch() calls = %d, want 3", fetcher.calls)
+	}
+	if len(store.saved) != 1 || store.saved[0] != want {
+		t.Fatalf("saved = %#v, want the successful usage once", store.saved)
+	}
+}
+
+func TestFetchProviderQuotaDoesNotRetryPermanentErrors(t *testing.T) {
+	config := DefaultConfig()
+	config.MaxRetries = 2
+	fetcher := &sequenceFetcher{errs: []error{errors.New("status 401")}}
+	store := &recordingStore{}
+	manager, provider := newRetryTestManager(t, config, store, fetcher)
+
+	usage, err := manager.fetchProviderQuota(context.Background(), provider)
+	if err != nil {
+		t.Fatalf("fetchProviderQuota() error: %v", err)
+	}
+	if fetcher.calls != 1 {
+		t.Fatalf("Fetch() calls = %d, want 1", fetcher.calls)
+	}
+	if usage.LastError != "status 401" {
+		t.Fatalf("LastError = %q, want status 401", usage.LastError)
+	}
+}
+
+func TestFetchProviderQuotaDoesNotRetryCanceledContext(t *testing.T) {
+	config := DefaultConfig()
+	config.MaxRetries = 2
+	fetcher := &sequenceFetcher{errs: []error{context.Canceled}}
+	store := &recordingStore{}
+	manager, provider := newRetryTestManager(t, config, store, fetcher)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := manager.fetchProviderQuota(ctx, provider)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("fetchProviderQuota() error = %v, want context.Canceled", err)
+	}
+	if fetcher.calls != 0 {
+		t.Fatalf("Fetch() calls = %d, want 0 for an already-canceled request", fetcher.calls)
+	}
+}
+
+func TestFetchProviderQuotaStopsWithoutSavingWhenContextIsCanceled(t *testing.T) {
+	config := DefaultConfig()
+	fetchedAt := time.Now().Add(-time.Hour)
+	cached := &ProviderUsage{
+		ProviderUUID: "codex-1",
+		ProviderName: "Codex",
+		ProviderType: ProviderTypeCodex,
+		FetchedAt:    fetchedAt,
+		ExpiresAt:    time.Now().Add(-time.Minute),
+		Windows:      []*UsageWindow{{Key: "current", Limit: 100, Used: 20}},
+	}
+	store := &recordingStore{current: cached}
+	ctx, cancel := context.WithCancel(context.Background())
+	fetcher := &cancelingFetcher{cancel: cancel}
+	manager, provider := newRetryTestManager(t, config, store, fetcher)
+
+	usage, err := manager.fetchProviderQuota(ctx, provider)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("fetchProviderQuota() error = %v, want context.Canceled", err)
+	}
+	if usage != cached {
+		t.Fatal("context cancellation replaced the cached quota")
+	}
+	if !usage.FetchedAt.Equal(fetchedAt) || len(usage.Windows) != 1 {
+		t.Fatal("cached quota payload was not preserved")
+	}
+	if len(store.saved) != 0 {
+		t.Fatalf("saved %d records with a canceled context, want none", len(store.saved))
+	}
+}
+
+func TestFetchProviderQuotaRetriesTimeout(t *testing.T) {
+	config := DefaultConfig()
+	config.MaxRetries = 1
+	fetcher := &sequenceFetcher{
+		errs:  []error{context.DeadlineExceeded},
+		usage: &ProviderUsage{ProviderUUID: "codex-1", FetchedAt: time.Now()},
+	}
+	store := &recordingStore{}
+	manager, provider := newRetryTestManager(t, config, store, fetcher)
+
+	if _, err := manager.fetchProviderQuota(context.Background(), provider); err != nil {
+		t.Fatalf("fetchProviderQuota() error: %v", err)
+	}
+	if fetcher.calls != 2 {
+		t.Fatalf("Fetch() calls = %d, want 2", fetcher.calls)
+	}
+}
+
+func TestFetchProviderQuotaCoalescesSameProvider(t *testing.T) {
+	fetcher := &serializedFetcher{}
+	store := &recordingStore{}
+	manager, provider := newRetryTestManager(t, DefaultConfig(), store, fetcher)
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			<-start
+			_, err := manager.fetchProviderQuota(context.Background(), provider)
+			errs <- err
+		}()
+	}
+	close(start)
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatalf("fetchProviderQuota() error: %v", err)
+		}
+	}
+	if got := fetcher.maximum.Load(); got != 1 {
+		t.Fatalf("maximum concurrent fetches for one provider = %d, want 1", got)
+	}
+	if got := fetcher.calls.Load(); got != 1 {
+		t.Fatalf("Fetch() calls = %d, want 1 coalesced request", got)
+	}
+}
+
+func TestFetchProviderQuotaStopsAtRetryLimit(t *testing.T) {
+	config := DefaultConfig()
+	config.MaxRetries = 2
+	fetcher := &sequenceFetcher{errs: []error{io.EOF, io.EOF, io.EOF, io.EOF}}
+	store := &recordingStore{}
+	manager, provider := newRetryTestManager(t, config, store, fetcher)
+
+	usage, err := manager.fetchProviderQuota(context.Background(), provider)
+	if err != nil {
+		t.Fatalf("fetchProviderQuota() error: %v", err)
+	}
+	if fetcher.calls != 3 {
+		t.Fatalf("Fetch() calls = %d, want 3 (initial request plus 2 retries)", fetcher.calls)
+	}
+	if usage.LastError != io.EOF.Error() {
+		t.Fatalf("LastError = %q, want EOF", usage.LastError)
+	}
+}
+
+func TestFetchProviderQuotaPreservesLastSuccessfulSnapshot(t *testing.T) {
+	config := DefaultConfig()
+	config.RetryOnFailure = false
+	fetchedAt := time.Now().Add(-time.Hour)
+	cached := &ProviderUsage{
+		ProviderUUID: "codex-1",
+		ProviderName: "Codex",
+		ProviderType: ProviderTypeCodex,
+		FetchedAt:    fetchedAt,
+		ExpiresAt:    time.Now().Add(-time.Minute),
+		Windows: []*UsageWindow{{
+			Key:         "current",
+			Type:        WindowTypeSession,
+			Used:        25,
+			Limit:       100,
+			UsedPercent: 25,
+		}},
+		RawResponse: []byte(`{"plan_type":"plus"}`),
+	}
+	store := &recordingStore{current: cached}
+	fetcher := &sequenceFetcher{errs: []error{io.EOF}}
+	manager, provider := newRetryTestManager(t, config, store, fetcher)
+	before := time.Now()
+
+	usage, err := manager.fetchProviderQuota(context.Background(), provider)
+	if err != nil {
+		t.Fatalf("fetchProviderQuota() error: %v", err)
+	}
+	if usage != cached {
+		t.Fatal("fetch failure replaced the last successful snapshot")
+	}
+	if !usage.FetchedAt.Equal(fetchedAt) {
+		t.Fatalf("FetchedAt = %v, want last successful time %v", usage.FetchedAt, fetchedAt)
+	}
+	if len(usage.Windows) != 1 || string(usage.RawResponse) != `{"plan_type":"plus"}` {
+		t.Fatal("cached quota data was not preserved")
+	}
+	if usage.LastError != io.EOF.Error() || usage.LastErrorAt == nil {
+		t.Fatalf("refresh error not recorded: %#v", usage)
+	}
+	wantRetryAt := before.Add(min(config.CacheTTL, failedRefreshTTL))
+	if usage.ExpiresAt.Before(wantRetryAt.Add(-time.Second)) || usage.ExpiresAt.After(wantRetryAt.Add(time.Second)) {
+		t.Fatalf("ExpiresAt = %v, want a bounded retry delay", usage.ExpiresAt)
+	}
+	if len(store.saved) != 1 || store.saved[0] != cached {
+		t.Fatalf("saved = %#v, want updated cached snapshot", store.saved)
+	}
+}
+
+func TestFetchProviderQuotaDoesNotOverwriteWhenCacheReadFails(t *testing.T) {
+	config := DefaultConfig()
+	config.RetryOnFailure = false
+	store := &recordingStore{getErr: errors.New("database is busy")}
+	fetcher := &sequenceFetcher{errs: []error{io.EOF}}
+	manager, provider := newRetryTestManager(t, config, store, fetcher)
+
+	usage, err := manager.fetchProviderQuota(context.Background(), provider)
+	if err == nil || !strings.Contains(err.Error(), "load cached quota after fetch failure") {
+		t.Fatalf("fetchProviderQuota() error = %v, want cache read error", err)
+	}
+	if usage != nil {
+		t.Fatalf("usage = %#v, want nil", usage)
+	}
+	if len(store.saved) != 0 {
+		t.Fatalf("saved %d records after uncertain cache read, want none", len(store.saved))
+	}
 }
 
 // Most providers have no quota fetcher, which is ordinary rather than broken.

--- a/ai/quota/types.go
+++ b/ai/quota/types.go
@@ -259,7 +259,7 @@ type Config struct {
 	RefreshInterval time.Duration                  `json:"refresh_interval"` // refresh interval (default 5 minutes)
 	CacheTTL        time.Duration                  `json:"cache_ttl"`        // cache validity period (default 10 minutes)
 	RetryOnFailure  bool                           `json:"retry_on_failure"` // whether to retry on failure
-	MaxRetries      int                            `json:"max_retries"`      // maximum retry attempts
+	MaxRetries      int                            `json:"max_retries"`      // maximum retries after the initial request
 	Providers       map[string]ProviderUsageConfig `json:"providers"`        // provider-specific configuration
 }
 
@@ -270,7 +270,7 @@ func DefaultConfig() *Config {
 		RefreshInterval: 15 * time.Minute,
 		CacheTTL:        20 * time.Minute,
 		RetryOnFailure:  true,
-		MaxRetries:      3,
+		MaxRetries:      2,
 		Providers:       make(map[string]ProviderUsageConfig),
 	}
 }


### PR DESCRIPTION
## Summary

- Retry quota fetches only for transient transport failures (EOF, unexpected EOF, connection errors, and timeouts) with bounded exponential backoff and jitter
- Keep the last successful quota snapshot when a refresh fails, while recording the refresh error and scheduling a near-term retry
- Coalesce concurrent refreshes for the same provider without coupling callers' contexts
- Avoid overwriting cached quota when persistence reads are uncertain or the request is canceled

## Test plan

- [x] `go test ./...` (`ai` module)
- [x] `go test -race ./quota/...`
- [x] `go vet ./quota/...`
- [x] `go build ./...`
- [x] `go test ./internal/server/module/providerquota/...`
