### PR TITLE
perf(db): cache ProviderStore reads, cutting Select() latency 6-10x

### DIFF
--- a/internal/db/provider_store.go
+++ b/internal/db/provider_store.go
@@ -278,11 +278,21 @@ func updateRecordFromProvider(record *ProviderRecord, p *typ.Provider) {
 	}
 }
 
-// ProviderStore manages providers as complete units (configuration + credentials)
+// ProviderStore manages providers as complete units (configuration + credentials).
+//
+// Reads are served from an in-memory cache (write-through: SQLite is still
+// the source of truth) instead of hitting SQLite per call — GetByUUID is on
+// the request hot path (see internal/routing/selector.go) and used to
+// account for ~47% of Select()'s CPU time.
 type ProviderStore struct {
 	db     *gorm.DB
 	dbPath string
-	mu     sync.Mutex
+	mu     sync.RWMutex
+
+	cache map[string]*ProviderRecord
+	// order preserves insertion order for List/ListOAuth/ListEnabled, since
+	// map iteration is randomized in Go.
+	order []string
 }
 
 // NewProviderStore creates or loads a provider store using SQLite database.
@@ -309,18 +319,49 @@ func NewProviderStore(baseDir string) (*ProviderStore, error) {
 	}
 	logrus.Debugf("SQLite database opened successfully for provider store")
 
-	store := &ProviderStore{
-		db:     db,
-		dbPath: dbPath,
-	}
-
-	// Auto-migrate schema
-	if err := db.AutoMigrate(&ProviderRecord{}); err != nil {
-		return nil, fmt.Errorf("failed to migrate provider database: %w", err)
+	store, err := newProviderStoreOverDB(db, dbPath)
+	if err != nil {
+		return nil, err
 	}
 	logrus.Debugf("Provider store initialization completed")
 
 	return store, nil
+}
+
+// newProviderStoreOverDB finishes setting up a ProviderStore (migrate +
+// cache load) over an already-open *gorm.DB, shared by NewProviderStore and
+// StoreManager.initProviderStore so the cache-init wiring can't drift
+// between them.
+func newProviderStoreOverDB(db *gorm.DB, dbPath string) (*ProviderStore, error) {
+	if err := db.AutoMigrate(&ProviderRecord{}); err != nil {
+		return nil, fmt.Errorf("failed to migrate provider database: %w", err)
+	}
+
+	store := &ProviderStore{
+		db:     db,
+		dbPath: dbPath,
+		cache:  make(map[string]*ProviderRecord),
+	}
+	if err := store.loadCache(); err != nil {
+		return nil, fmt.Errorf("failed to load provider cache: %w", err)
+	}
+
+	return store, nil
+}
+
+// loadCache populates the in-memory mirror from SQLite. Called once at
+// construction, before the store is shared with any other goroutine.
+func (ps *ProviderStore) loadCache() error {
+	var records []ProviderRecord
+	if err := ps.db.Find(&records).Error; err != nil {
+		return err
+	}
+	for i := range records {
+		r := records[i]
+		ps.cache[r.UUID] = &r
+		ps.order = append(ps.order, r.UUID)
+	}
+	return nil
 }
 
 // Save saves a provider (create or update)
@@ -335,41 +376,55 @@ func (ps *ProviderStore) Save(provider *typ.Provider) error {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	var existing ProviderRecord
-	err := ps.db.Where("uuid = ?", provider.UUID).First(&existing).Error
-
-	if errors.Is(err, gorm.ErrRecordNotFound) {
+	if _, ok := ps.cache[provider.UUID]; ok {
+		if _, err := ps.writeThroughLocked(provider.UUID, func(r *ProviderRecord) {
+			updateRecordFromProvider(r, provider)
+		}); err != nil {
+			return fmt.Errorf("failed to update provider record: %w", err)
+		}
+		logrus.Debugf("Updated provider: %s (%s)", provider.Name, provider.UUID)
+	} else {
 		// Create new record
 		record := toRecord(provider)
 		if err := ps.db.Create(record).Error; err != nil {
 			return fmt.Errorf("failed to create provider record: %w", err)
 		}
+		ps.cache[provider.UUID] = record
+		ps.order = append(ps.order, provider.UUID)
 		logrus.Debugf("Created new provider: %s (%s)", provider.Name, provider.UUID)
-	} else if err != nil {
-		return fmt.Errorf("failed to query existing provider: %w", err)
-	} else {
-		// Update existing record
-		updateRecordFromProvider(&existing, provider)
-		if err := ps.db.Save(&existing).Error; err != nil {
-			return fmt.Errorf("failed to update provider record: %w", err)
-		}
-		logrus.Debugf("Updated provider: %s (%s)", provider.Name, provider.UUID)
 	}
 
 	return nil
 }
 
+// writeThroughLocked mutates a copy of the cached record for uuid, persists
+// it, and only then swaps it into ps.cache -- so a failed write can't leave
+// the cache holding unpersisted data. Callers must hold ps.mu.Lock().
+func (ps *ProviderStore) writeThroughLocked(uuid string, mutate func(*ProviderRecord)) (*ProviderRecord, error) {
+	existing, ok := ps.cache[uuid]
+	if !ok {
+		return nil, fmt.Errorf("provider with UUID '%s' not found", uuid)
+	}
+
+	updated := *existing
+	mutate(&updated)
+
+	if err := ps.db.Save(&updated).Error; err != nil {
+		return nil, err
+	}
+
+	ps.cache[uuid] = &updated
+	return &updated, nil
+}
+
 // GetByUUID returns a provider by UUID
 func (ps *ProviderStore) GetByUUID(uuid string) (*typ.Provider, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var record ProviderRecord
-	if err := ps.db.Where("uuid = ?", uuid).First(&record).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("provider with UUID '%s' not found", uuid)
-		}
-		return nil, fmt.Errorf("failed to get provider: %w", err)
+	record, ok := ps.cache[uuid]
+	if !ok {
+		return nil, fmt.Errorf("provider with UUID '%s' not found", uuid)
 	}
 
 	return record.toProvider(), nil
@@ -377,33 +432,26 @@ func (ps *ProviderStore) GetByUUID(uuid string) (*typ.Provider, error) {
 
 // GetByName returns a provider by name
 func (ps *ProviderStore) GetByName(name string) (*typ.Provider, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var record ProviderRecord
-	if err := ps.db.Where("name = ?", name).First(&record).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("provider with name '%s' not found", name)
+	for _, uuid := range ps.order {
+		if record := ps.cache[uuid]; record.Name == name {
+			return record.toProvider(), nil
 		}
-		return nil, fmt.Errorf("failed to get provider: %w", err)
 	}
 
-	return record.toProvider(), nil
+	return nil, fmt.Errorf("provider with name '%s' not found", name)
 }
 
 // List returns all providers
 func (ps *ProviderStore) List() ([]*typ.Provider, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var records []ProviderRecord
-	if err := ps.db.Find(&records).Error; err != nil {
-		return nil, fmt.Errorf("failed to list providers: %w", err)
-	}
-
-	providers := make([]*typ.Provider, 0, len(records))
-	for _, record := range records {
-		providers = append(providers, record.toProvider())
+	providers := make([]*typ.Provider, 0, len(ps.order))
+	for _, uuid := range ps.order {
+		providers = append(providers, ps.cache[uuid].toProvider())
 	}
 
 	return providers, nil
@@ -411,17 +459,15 @@ func (ps *ProviderStore) List() ([]*typ.Provider, error) {
 
 // ListOAuth returns all OAuth-enabled providers
 func (ps *ProviderStore) ListOAuth() ([]*typ.Provider, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var records []ProviderRecord
-	if err := ps.db.Where("auth_type = ?", typ.AuthTypeOAuth).Find(&records).Error; err != nil {
-		return nil, fmt.Errorf("failed to list oauth providers: %w", err)
-	}
-
-	providers := make([]*typ.Provider, 0, len(records))
-	for _, record := range records {
-		providers = append(providers, record.toProvider())
+	providers := make([]*typ.Provider, 0, len(ps.order))
+	for _, uuid := range ps.order {
+		record := ps.cache[uuid]
+		if record.AuthType == string(typ.AuthTypeOAuth) {
+			providers = append(providers, record.toProvider())
+		}
 	}
 
 	return providers, nil
@@ -432,6 +478,10 @@ func (ps *ProviderStore) Delete(uuid string) error {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
+	if _, ok := ps.cache[uuid]; !ok {
+		return fmt.Errorf("provider with UUID '%s' not found", uuid)
+	}
+
 	result := ps.db.Where("uuid = ?", uuid).Delete(&ProviderRecord{})
 	if result.Error != nil {
 		return fmt.Errorf("failed to delete provider: %w", result.Error)
@@ -440,34 +490,33 @@ func (ps *ProviderStore) Delete(uuid string) error {
 		return fmt.Errorf("provider with UUID '%s' not found", uuid)
 	}
 
+	delete(ps.cache, uuid)
+	for i, id := range ps.order {
+		if id == uuid {
+			ps.order = append(ps.order[:i], ps.order[i+1:]...)
+			break
+		}
+	}
+
 	logrus.Debugf("Deleted provider: %s", uuid)
 	return nil
 }
 
 // Exists checks if a provider exists by UUID
 func (ps *ProviderStore) Exists(uuid string) bool {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var count int64
-	if err := ps.db.Model(&ProviderRecord{}).Where("uuid = ?", uuid).Count(&count).Error; err != nil {
-		return false
-	}
-
-	return count > 0
+	_, ok := ps.cache[uuid]
+	return ok
 }
 
 // Count returns the total number of providers
 func (ps *ProviderStore) Count() (int64, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var count int64
-	if err := ps.db.Model(&ProviderRecord{}).Count(&count).Error; err != nil {
-		return 0, fmt.Errorf("failed to count providers: %w", err)
-	}
-
-	return count, nil
+	return int64(len(ps.cache)), nil
 }
 
 // UpdateCredential updates only the credential fields of a provider
@@ -475,32 +524,23 @@ func (ps *ProviderStore) UpdateCredential(uuid string, token string, oauthDetail
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	var record ProviderRecord
-	if err := ps.db.Where("uuid = ?", uuid).First(&record).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("provider with UUID '%s' not found", uuid)
+	_, err := ps.writeThroughLocked(uuid, func(r *ProviderRecord) {
+		if r.AuthType == string(typ.AuthTypeOAuth) && oauthDetail != nil {
+			r.Token = oauthDetail.AccessToken
+			r.OAuthProviderType = string(oauthDetail.GetIssuer())
+			r.OAuthUserID = oauthDetail.UserID
+			r.OAuthRefreshToken = oauthDetail.RefreshToken
+			r.OAuthExpiresAt = oauthDetail.ExpiresAt
+			if oauthDetail.ExtraFields != nil {
+				extraJSON, _ := json.Marshal(oauthDetail.ExtraFields)
+				r.OAuthExtraFields = string(extraJSON)
+			}
+		} else {
+			r.Token = token
 		}
-		return fmt.Errorf("failed to get provider: %w", err)
-	}
-
-	// Update credential fields based on auth type
-	if record.AuthType == string(typ.AuthTypeOAuth) && oauthDetail != nil {
-		record.Token = oauthDetail.AccessToken
-		record.OAuthProviderType = string(oauthDetail.GetIssuer())
-		record.OAuthUserID = oauthDetail.UserID
-		record.OAuthRefreshToken = oauthDetail.RefreshToken
-		record.OAuthExpiresAt = oauthDetail.ExpiresAt
-		if oauthDetail.ExtraFields != nil {
-			extraJSON, _ := json.Marshal(oauthDetail.ExtraFields)
-			record.OAuthExtraFields = string(extraJSON)
-		}
-	} else {
-		record.Token = token
-	}
-
-	record.UpdatedAt = time.Now()
-
-	if err := ps.db.Save(&record).Error; err != nil {
+		r.UpdatedAt = time.Now()
+	})
+	if err != nil {
 		return fmt.Errorf("failed to update provider credential: %w", err)
 	}
 
@@ -515,23 +555,16 @@ func (ps *ProviderStore) UpdateCredentialBundle(uuid string, bundle *typ.Credent
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
-	var record ProviderRecord
-	if err := ps.db.Where("uuid = ?", uuid).First(&record).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("provider with UUID '%s' not found", uuid)
+	_, err := ps.writeThroughLocked(uuid, func(r *ProviderRecord) {
+		if bundle != nil {
+			credJSON, _ := json.Marshal(bundle)
+			r.Credential = string(credJSON)
+		} else {
+			r.Credential = ""
 		}
-		return fmt.Errorf("failed to get provider: %w", err)
-	}
-
-	if bundle != nil {
-		credJSON, _ := json.Marshal(bundle)
-		record.Credential = string(credJSON)
-	} else {
-		record.Credential = ""
-	}
-	record.UpdatedAt = time.Now()
-
-	if err := ps.db.Save(&record).Error; err != nil {
+		r.UpdatedAt = time.Now()
+	})
+	if err != nil {
 		return fmt.Errorf("failed to update provider credential bundle: %w", err)
 	}
 
@@ -541,12 +574,12 @@ func (ps *ProviderStore) UpdateCredentialBundle(uuid string, bundle *typ.Credent
 
 // GetAccessToken returns the access token for a provider (convenience method)
 func (ps *ProviderStore) GetAccessToken(uuid string) (string, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var record ProviderRecord
-	if err := ps.db.Where("uuid = ?", uuid).First(&record).Error; err != nil {
-		return "", fmt.Errorf("failed to get provider: %w", err)
+	record, ok := ps.cache[uuid]
+	if !ok {
+		return "", fmt.Errorf("failed to get provider: provider with UUID '%s' not found", uuid)
 	}
 
 	return record.Token, nil
@@ -556,6 +589,11 @@ func (ps *ProviderStore) GetAccessToken(uuid string) (string, error) {
 func (ps *ProviderStore) UpdateOAuthAccessToken(uuid, accessToken string) error {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
+
+	record, ok := ps.cache[uuid]
+	if !ok {
+		return fmt.Errorf("provider with UUID '%s' not found", uuid)
+	}
 
 	result := ps.db.Model(&ProviderRecord{}).
 		Where("uuid = ?", uuid).
@@ -568,21 +606,21 @@ func (ps *ProviderStore) UpdateOAuthAccessToken(uuid, accessToken string) error 
 		return fmt.Errorf("provider with UUID '%s' not found", uuid)
 	}
 
+	record.Token = accessToken
+	record.UpdatedAt = time.Now()
+
 	logrus.Debugf("Updated OAuth access token for provider: %s", uuid)
 	return nil
 }
 
 // IsOAuthExpired checks if the OAuth token for a provider is expired
 func (ps *ProviderStore) IsOAuthExpired(uuid string) (bool, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var record ProviderRecord
-	if err := ps.db.Where("uuid = ?", uuid).First(&record).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return false, fmt.Errorf("provider with UUID '%s' not found", uuid)
-		}
-		return false, fmt.Errorf("failed to get provider: %w", err)
+	record, ok := ps.cache[uuid]
+	if !ok {
+		return false, fmt.Errorf("provider with UUID '%s' not found", uuid)
 	}
 
 	if record.AuthType != string(typ.AuthTypeOAuth) || record.OAuthExpiresAt == "" {
@@ -600,17 +638,15 @@ func (ps *ProviderStore) IsOAuthExpired(uuid string) (bool, error) {
 
 // ListEnabled returns all enabled providers
 func (ps *ProviderStore) ListEnabled() ([]*typ.Provider, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
 
-	var records []ProviderRecord
-	if err := ps.db.Where("enabled = ?", true).Find(&records).Error; err != nil {
-		return nil, fmt.Errorf("failed to list enabled providers: %w", err)
-	}
-
-	providers := make([]*typ.Provider, 0, len(records))
-	for _, record := range records {
-		providers = append(providers, record.toProvider())
+	providers := make([]*typ.Provider, 0, len(ps.order))
+	for _, uuid := range ps.order {
+		record := ps.cache[uuid]
+		if record.Enabled {
+			providers = append(providers, record.toProvider())
+		}
 	}
 
 	return providers, nil

--- a/internal/db/provider_store_test.go
+++ b/internal/db/provider_store_test.go
@@ -699,3 +699,101 @@ func TestProviderCredentialBundleRoundTrip(t *testing.T) {
 		t.Errorf("region after update: got %q, want %q", got2.Credential.Field("region"), "eu-west-1")
 	}
 }
+
+// TestProviderStore_FailedWriteDoesNotCorruptCache checks that Save,
+// UpdateCredential, and UpdateCredentialBundle don't leave the cache holding
+// unpersisted data when the SQLite write fails (forced by closing the DB).
+func TestProviderStore_FailedWriteDoesNotCorruptCache(t *testing.T) {
+	seed := func(t *testing.T) *ProviderStore {
+		t.Helper()
+		store, _ := setupTestProviderStore(t)
+		provider := &typ.Provider{
+			UUID:     "test-cache-integrity-uuid",
+			Name:     "original-name",
+			APIBase:  "https://api.example.com",
+			APIStyle: protocol.APIStyleOpenAI,
+			AuthType: typ.AuthTypeAPIKey,
+			Token:    "original-token",
+			Enabled:  true,
+		}
+		if err := store.Save(provider); err != nil {
+			t.Fatalf("seed Save: %v", err)
+		}
+		return store
+	}
+
+	closeUnderlyingDB := func(t *testing.T, store *ProviderStore) {
+		t.Helper()
+		sqlDB, err := store.db.DB()
+		if err != nil {
+			t.Fatalf("store.db.DB(): %v", err)
+		}
+		if err := sqlDB.Close(); err != nil {
+			t.Fatalf("closing underlying db: %v", err)
+		}
+	}
+
+	t.Run("Save", func(t *testing.T) {
+		store := seed(t)
+		closeUnderlyingDB(t, store)
+
+		err := store.Save(&typ.Provider{
+			UUID:     "test-cache-integrity-uuid",
+			Name:     "corrupted-name",
+			APIBase:  "https://api.example.com",
+			APIStyle: protocol.APIStyleOpenAI,
+			AuthType: typ.AuthTypeAPIKey,
+			Token:    "corrupted-token",
+			Enabled:  true,
+		})
+		if err == nil {
+			t.Fatal("expected Save to fail against a closed db")
+		}
+
+		got, getErr := store.GetByUUID("test-cache-integrity-uuid")
+		if getErr != nil {
+			t.Fatalf("GetByUUID: %v", getErr)
+		}
+		if got.Name != "original-name" || got.Token != "original-token" {
+			t.Errorf("cache reflects a failed write: got name=%q token=%q, want the pre-failure values", got.Name, got.Token)
+		}
+	})
+
+	t.Run("UpdateCredential", func(t *testing.T) {
+		store := seed(t)
+		closeUnderlyingDB(t, store)
+
+		err := store.UpdateCredential("test-cache-integrity-uuid", "corrupted-token", nil)
+		if err == nil {
+			t.Fatal("expected UpdateCredential to fail against a closed db")
+		}
+
+		token, getErr := store.GetAccessToken("test-cache-integrity-uuid")
+		if getErr != nil {
+			t.Fatalf("GetAccessToken: %v", getErr)
+		}
+		if token != "original-token" {
+			t.Errorf("cache reflects a failed write: got token=%q, want %q", token, "original-token")
+		}
+	})
+
+	t.Run("UpdateCredentialBundle", func(t *testing.T) {
+		store := seed(t)
+		closeUnderlyingDB(t, store)
+
+		err := store.UpdateCredentialBundle("test-cache-integrity-uuid", &typ.CredentialBundle{
+			Fields: map[string]string{"region": "corrupted-region"},
+		})
+		if err == nil {
+			t.Fatal("expected UpdateCredentialBundle to fail against a closed db")
+		}
+
+		got, getErr := store.GetByUUID("test-cache-integrity-uuid")
+		if getErr != nil {
+			t.Fatalf("GetByUUID: %v", getErr)
+		}
+		if got.Credential != nil {
+			t.Errorf("cache reflects a failed write: got Credential=%v, want nil (seed provider has no credential bundle)", got.Credential)
+		}
+	})
+}

--- a/internal/db/store_manager.go
+++ b/internal/db/store_manager.go
@@ -200,13 +200,11 @@ func (sm *StoreManager) initUsageStore() error {
 
 // initProviderStore initializes the ProviderStore.
 func (sm *StoreManager) initProviderStore() error {
-	if err := sm.db.AutoMigrate(&ProviderRecord{}); err != nil {
+	store, err := newProviderStoreOverDB(sm.db, constant.GetDBFile(sm.baseDir))
+	if err != nil {
 		return err
 	}
-	sm.providerStore = &ProviderStore{
-		db:     sm.db,
-		dbPath: constant.GetDBFile(sm.baseDir),
-	}
+	sm.providerStore = store
 	return nil
 }
 

--- a/internal/routing/pipeline_bench_test.go
+++ b/internal/routing/pipeline_bench_test.go
@@ -1,0 +1,228 @@
+package routing_test
+
+// Benchmarks for the production ServiceSelector pipeline (health → smart →
+// affinity → load_balancer), wired exactly as internal/server/server.go does
+// (protocolserver.LoadBalancer + routing.ServiceSelector), minus the HTTP
+// layer. They exist to put real numbers behind "is the multi-stage pipeline
+// (and its known double active/health filtering — see
+// internal/protocolserver/load_balance.go's selectService, which re-filters
+// candidates HealthStage already filtered) worth optimizing", rather than
+// reasoning about it from first principles.
+//
+// Run: go test ./internal/routing/... -bench . -benchmem -run '^$'
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+
+	"github.com/tingly-dev/tingly-box/internal/config"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/protocolserver"
+	"github.com/tingly-dev/tingly-box/internal/routing"
+	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// benchService and benchRequest are thin aliases over routing's exported
+// test fixtures (ServiceForTest/OpenAIRequestForTest) — kept as local
+// wrappers only to fix the benchmark's request model/weight/active shape
+// once, not to reimplement the fixtures themselves.
+func benchService(provider, model string) *loadbalance.Service {
+	return routing.ServiceForTest(provider, model, true)
+}
+
+func benchRequest() *openai.ChatCompletionNewParams {
+	return routing.OpenAIRequestForTest("bench-model")
+}
+
+// benchSelector wires the real production pipeline. cfg's rule list is left
+// empty on purpose — Select() takes the *typ.Rule directly via
+// SelectionContext, so benchmarks build rules in-memory without paying for
+// AddRequestConfig's persisted-config write path.
+func benchSelector(b *testing.B) (*routing.ServiceSelector, *config.AppConfig) {
+	b.Helper()
+	appConfig, err := config.NewAppConfig(config.WithConfigDir(b.TempDir()))
+	if err != nil {
+		b.Fatal(err)
+	}
+	cfg := appConfig.GetGlobalConfig()
+
+	healthMonitor := loadbalance.NewHealthMonitor(cfg.HealthMonitor)
+	healthFilter := routing.NewHealthFilter(healthMonitor)
+	lb := protocolserver.NewLoadBalancer(cfg, healthFilter)
+	affinityStore := protocolserver.NewAffinityStore(0)
+	sel := routing.NewServiceSelector(cfg, affinityStore, lb)
+	return sel, appConfig
+}
+
+func benchProvider(b *testing.B, appConfig *config.AppConfig, uuid string) {
+	b.Helper()
+	p := &typ.Provider{UUID: uuid, Name: uuid, APIBase: "http://bench.invalid", Enabled: true}
+	if err := appConfig.GetGlobalConfig().AddProvider(p); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func runSelectBench(b *testing.B, sel *routing.ServiceSelector, ctx *routing.SelectionContext) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := sel.Select(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkSelect_Plain is the simplest shape: no smart routing, no
+// affinity, N services under the (default) random tactic. This isolates the
+// pipeline's fixed per-request overhead — including the double active/health
+// filter (once in HealthStage, once again inside LoadBalancer.SelectService)
+// — from smart-routing/affinity-specific work.
+func BenchmarkSelect_Plain(b *testing.B) {
+	sel, appConfig := benchSelector(b)
+	benchProvider(b, appConfig, "bench-a")
+	benchProvider(b, appConfig, "bench-b")
+	benchProvider(b, appConfig, "bench-c")
+
+	rule := &typ.Rule{
+		UUID:         "bench-rule-plain",
+		RequestModel: "bench-model",
+		Scenario:     typ.ScenarioOpenAI,
+		Active:       true,
+		Services: []*loadbalance.Service{
+			benchService("bench-a", "m"),
+			benchService("bench-b", "m"),
+			benchService("bench-c", "m"),
+		},
+	}
+	ctx := &routing.SelectionContext{
+		Rule:                  rule,
+		Request:               benchRequest(),
+		SessionID:             typ.SessionID{Source: typ.SessionSourceIP, Value: "127.0.0.1"},
+		Scenario:              typ.ScenarioOpenAI,
+		MatchedSmartRuleIndex: -1,
+	}
+	runSelectBench(b, sel, ctx)
+}
+
+// BenchmarkSelect_SmartMatch narrows via a matching smart-routing partition
+// on every request — the common "content routing hit" case.
+func BenchmarkSelect_SmartMatch(b *testing.B) {
+	sel, appConfig := benchSelector(b)
+	benchProvider(b, appConfig, "bench-base")
+	benchProvider(b, appConfig, "bench-smart")
+
+	rule := &typ.Rule{
+		UUID:         "bench-rule-smart-match",
+		RequestModel: "bench-model",
+		Scenario:     typ.ScenarioOpenAI,
+		Active:       true,
+		SmartEnabled: true,
+		Services:     []*loadbalance.Service{benchService("bench-base", "m")},
+		SmartRouting: []smartrouting.SmartRouting{{
+			Description: "always",
+			Ops: []smartrouting.SmartOp{{
+				Position:  smartrouting.PositionModel,
+				Operation: smartrouting.OpModelContains,
+				Value:     "bench",
+			}},
+			Services: []*loadbalance.Service{benchService("bench-smart", "m")},
+		}},
+	}
+	ctx := &routing.SelectionContext{
+		Rule:                  rule,
+		Request:               benchRequest(),
+		SessionID:             typ.SessionID{Source: typ.SessionSourceIP, Value: "127.0.0.1"},
+		Scenario:              typ.ScenarioOpenAI,
+		MatchedSmartRuleIndex: -1,
+	}
+	runSelectBench(b, sel, ctx)
+}
+
+// BenchmarkSelect_SmartNoMatch exercises the lazy basePool fallback path in
+// SmartRoutingStage: the partition never matches, so every request falls
+// back to IntersectServices(candidates, rule.Services).
+func BenchmarkSelect_SmartNoMatch(b *testing.B) {
+	sel, appConfig := benchSelector(b)
+	benchProvider(b, appConfig, "bench-base")
+	benchProvider(b, appConfig, "bench-smart")
+
+	rule := &typ.Rule{
+		UUID:         "bench-rule-smart-nomatch",
+		RequestModel: "bench-model",
+		Scenario:     typ.ScenarioOpenAI,
+		Active:       true,
+		SmartEnabled: true,
+		Services:     []*loadbalance.Service{benchService("bench-base", "m")},
+		SmartRouting: []smartrouting.SmartRouting{{
+			Description: "never",
+			Ops: []smartrouting.SmartOp{{
+				Position:  smartrouting.PositionModel,
+				Operation: smartrouting.OpModelContains,
+				Value:     "never-matches-this-request",
+			}},
+			Services: []*loadbalance.Service{benchService("bench-smart", "m")},
+		}},
+	}
+	ctx := &routing.SelectionContext{
+		Rule:                  rule,
+		Request:               benchRequest(),
+		SessionID:             typ.SessionID{Source: typ.SessionSourceIP, Value: "127.0.0.1"},
+		Scenario:              typ.ScenarioOpenAI,
+		MatchedSmartRuleIndex: -1,
+	}
+	runSelectBench(b, sel, ctx)
+}
+
+// BenchmarkSelect_Affinity exercises the affinity-hit short-circuit: the pin
+// is written once (via a real Select() call, so it's locked exactly as
+// production would), then every subsequent iteration returns from
+// AffinityStage before HealthStage's sibling filter in LoadBalancer runs.
+func BenchmarkSelect_Affinity(b *testing.B) {
+	sel, appConfig := benchSelector(b)
+	benchProvider(b, appConfig, "bench-pinned")
+	benchProvider(b, appConfig, "bench-other")
+
+	rule := &typ.Rule{
+		UUID:         "bench-rule-affinity",
+		RequestModel: "bench-model",
+		Scenario:     typ.ScenarioOpenAI,
+		Active:       true,
+		Services:     []*loadbalance.Service{benchService("bench-pinned", "m"), benchService("bench-other", "m")},
+	}
+	rule.Flags.SessionAffinity = 3600
+
+	ctx := &routing.SelectionContext{
+		Rule:                  rule,
+		Request:               benchRequest(),
+		SessionID:             typ.SessionID{Source: typ.SessionSourceHeader, Value: "bench-session"},
+		Scenario:              typ.ScenarioOpenAI,
+		MatchedSmartRuleIndex: -1,
+	}
+	if _, err := sel.Select(ctx); err != nil {
+		b.Fatal(err)
+	}
+	runSelectBench(b, sel, ctx)
+}
+
+// BenchmarkHealthFilter_Filter isolates a single health-filter pass so the
+// double-filtering cost visible in BenchmarkSelect_Plain (HealthStage, then
+// again inside LoadBalancer.SelectService) can be read off directly: each
+// BenchmarkSelect_Plain op should cost roughly the pipeline's fixed overhead
+// plus ~2x this number's ns/op and allocs/op.
+func BenchmarkHealthFilter_Filter(b *testing.B) {
+	monitor := loadbalance.NewHealthMonitor(loadbalance.DefaultHealthMonitorConfig())
+	filter := routing.NewHealthFilter(monitor)
+	services := []*loadbalance.Service{
+		benchService("bench-a", "m"),
+		benchService("bench-b", "m"),
+		benchService("bench-c", "m"),
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = filter.Filter(services)
+	}
+}

--- a/internal/routing/test_helpers.go
+++ b/internal/routing/test_helpers.go
@@ -23,6 +23,19 @@ func testService(provider, model string, active bool) *loadbalance.Service {
 	}
 }
 
+// ServiceForTest and OpenAIRequestForTest are exported wrappers around this
+// package's own fixtures, for external test packages (e.g. routing_test's
+// benchmarks, which must live outside package routing to import
+// protocolserver without an import cycle) that need identical shapes without
+// reimplementing them.
+func ServiceForTest(provider, model string, active bool) *loadbalance.Service {
+	return testService(provider, model, active)
+}
+
+func OpenAIRequestForTest(model string) *openai.ChatCompletionNewParams {
+	return testOpenAIRequest(model)
+}
+
 func testProvider(uuid, name string, enabled bool) *typ.Provider {
 	return &typ.Provider{
 		UUID:    uuid,


### PR DESCRIPTION
## Summary

pprof of `internal/routing/pipeline_bench_test.go` (the production `ServiceSelector` + `LoadBalancer` pipeline) showed 47.5% of total CPU time inside `GetProviderByUUID` → `ProviderStore.GetByUUID`: a SQLite round-trip via cgo, serialized behind a plain `sync.Mutex` that blocked concurrent readers too, paid on every routed request even though provider data only changes on admin CRUD.

- `ProviderStore` now keeps a write-through in-memory mirror of the `providers` table (map + insertion-order slice, `RWMutex`): reads serve from the cache, writes hit SQLite first (durability) then update the cache. Write methods mutate a copy and only swap it into the cache once the SQLite write succeeds (`writeThroughLocked`, shared by `Save`'s update path, `UpdateCredential`, `UpdateCredentialBundle`), so a failed write can't leave the cache holding unpersisted data.
- `StoreManager` built `ProviderStore` via a struct literal bypassing the constructor, so its cache init needed the same treatment — both `NewProviderStore` and `StoreManager.initProviderStore` now funnel through one `newProviderStoreOverDB` helper so this can't drift out of sync again.
- `BenchmarkSelect_Plain`: 59.7µs → 5.8µs/op (**10.2×**), 236 → 76 allocs/op. Other `Select` benchmarks: 5.9–7.9×.

See `.design/db.md` (#1556) for the full pprof writeup.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (whole repo, green)
- [x] `TestProviderStore_FailedWriteDoesNotCorruptCache` — forces a write failure by closing the underlying `*sql.DB`, confirms the cache still reflects the pre-failure state

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_015x1eojavC1neC8U2GnLzLo
