### PR TITLE
perf(db): merge StatsStore+UsageStore writes into one transaction

### DIFF
--- a/internal/db/record_outcome.go
+++ b/internal/db/record_outcome.go
@@ -1,0 +1,55 @@
+package db
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+// RecordRequestOutcome persists a service's updated stats (StatsStore) and a
+// usage audit row (UsageStore) together in one SQLite transaction, instead
+// of each store committing independently. Assumes both stores share the
+// same *gorm.DB, true of every production call site (StoreManager wires
+// every store to one shared connection). See .design/hot-path-db-access.md.
+//
+// service and/or usage may be nil (only one side has something to persist);
+// statsStore and/or usageStore may be nil (store not initialized).
+func RecordRequestOutcome(statsStore *StatsStore, usageStore *UsageStore, service *loadbalance.Service, usage *UsageRecord) error {
+	if statsStore == nil {
+		if usageStore == nil || usage == nil {
+			return nil
+		}
+		return usageStore.RecordUsage(usage)
+	}
+	if usageStore == nil {
+		return statsStore.UpdateFromService(service)
+	}
+
+	// Build both records before taking any lock -- neither builder touches
+	// store state, only its own argument.
+	statsRecord := buildStatsRecordFromService(service)
+	if usage != nil {
+		prepareUsageRecord(usage)
+	}
+
+	statsStore.mu.Lock()
+	defer statsStore.mu.Unlock()
+	usageStore.mu.Lock()
+	defer usageStore.mu.Unlock()
+
+	return statsStore.db.Transaction(func(tx *gorm.DB) error {
+		if statsRecord != nil {
+			if err := tx.Save(statsRecord).Error; err != nil {
+				return fmt.Errorf("failed to save service stats: %w", err)
+			}
+		}
+		if usage != nil {
+			if err := tx.Create(usage).Error; err != nil {
+				return fmt.Errorf("failed to create usage record: %w", err)
+			}
+		}
+		return nil
+	})
+}

--- a/internal/db/record_outcome_test.go
+++ b/internal/db/record_outcome_test.go
@@ -1,0 +1,85 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+func TestRecordRequestOutcome_SavesBoth(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	require.NoError(t, err)
+	defer sm.Close()
+
+	service := &loadbalance.Service{Provider: "p1", Model: "m1", Active: true}
+	usage := &UsageRecord{ProviderUUID: "p1", ProviderName: "p1", Model: "m1", Scenario: "openai"}
+
+	require.NoError(t, RecordRequestOutcome(sm.Stats(), sm.Usage(), service, usage))
+
+	_, found := sm.Stats().Get("p1", "m1")
+	assert.True(t, found)
+
+	records, total, err := sm.Usage().GetRecords(usage.Timestamp.Add(-1), usage.Timestamp.Add(1), nil, 10, 0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, total)
+	require.Len(t, records, 1)
+	assert.Equal(t, "p1", records[0].ProviderUUID)
+}
+
+func TestRecordRequestOutcome_NilStatsStore(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	require.NoError(t, err)
+	defer sm.Close()
+
+	usage := &UsageRecord{ProviderUUID: "p1", ProviderName: "p1", Model: "m1", Scenario: "openai"}
+	require.NoError(t, RecordRequestOutcome(nil, sm.Usage(), nil, usage))
+
+	_, total, err := sm.Usage().GetRecords(usage.Timestamp.Add(-1), usage.Timestamp.Add(1), nil, 10, 0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, total)
+}
+
+func TestRecordRequestOutcome_NilUsageStore(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	require.NoError(t, err)
+	defer sm.Close()
+
+	service := &loadbalance.Service{Provider: "p1", Model: "m1", Active: true}
+	require.NoError(t, RecordRequestOutcome(sm.Stats(), nil, service, nil))
+
+	_, found := sm.Stats().Get("p1", "m1")
+	assert.True(t, found)
+}
+
+// TestRecordRequestOutcome_NilStatsStore_NilUsage: with usage nil too, this
+// must short-circuit rather than call RecordUsage(nil), which errors.
+func TestRecordRequestOutcome_NilStatsStore_NilUsage(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	require.NoError(t, err)
+	defer sm.Close()
+
+	assert.NoError(t, RecordRequestOutcome(nil, sm.Usage(), nil, nil))
+}
+
+// TestRecordRequestOutcome_AtomicRollback: a usage write that fails (a
+// deliberate primary-key collision) must roll back the stats write too.
+func TestRecordRequestOutcome_AtomicRollback(t *testing.T) {
+	sm, err := NewStoreManager(t.TempDir())
+	require.NoError(t, err)
+	defer sm.Close()
+
+	statsStore, usageStore := sm.Stats(), sm.Usage()
+	require.NoError(t, usageStore.RecordUsage(&UsageRecord{ID: 999, ProviderUUID: "seed", ProviderName: "seed", Model: "seed", Scenario: "openai"}))
+
+	service := &loadbalance.Service{Provider: "p1", Model: "m1", Active: true}
+	conflicting := &UsageRecord{ID: 999, ProviderUUID: "p1", ProviderName: "p1", Model: "m1", Scenario: "openai"}
+
+	err = RecordRequestOutcome(statsStore, usageStore, service, conflicting)
+	assert.Error(t, err)
+
+	_, found := statsStore.Get("p1", "m1")
+	assert.False(t, found, "stats write from the same call must have rolled back with the failed usage write")
+}

--- a/internal/db/service_stat.go
+++ b/internal/db/service_stat.go
@@ -133,17 +133,30 @@ func (ss *StatsStore) Get(provider, model string) (loadbalance.ServiceStats, boo
 
 // UpdateFromService stores the current stats from a service into the store.
 func (ss *StatsStore) UpdateFromService(service *loadbalance.Service) error {
-	if service == nil {
+	record := buildStatsRecordFromService(service)
+	if record == nil {
 		return nil
 	}
 
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
 
+	return ss.db.Save(record).Error
+}
+
+// buildStatsRecordFromService builds the ServiceStatsRecord UpdateFromService
+// persists, without touching the database -- split out so
+// RecordRequestOutcome can save it in the same transaction as a UsageStore
+// write. Still mutates service.Stats via InitializeStats/GetStats.
+func buildStatsRecordFromService(service *loadbalance.Service) *ServiceStatsRecord {
+	if service == nil {
+		return nil
+	}
+
 	service.InitializeStats()
 	stat := service.Stats.GetStats()
 
-	record := ServiceStatsRecord{
+	record := &ServiceStatsRecord{
 		Provider:             service.Provider,
 		Model:                service.Model,
 		ServiceID:            stat.ServiceID,
@@ -172,7 +185,7 @@ func (ss *StatsStore) UpdateFromService(service *loadbalance.Service) error {
 		record.WindowStart = time.Now()
 	}
 
-	return ss.db.Save(&record).Error
+	return record
 }
 
 // RecordUsage records usage for a service and persists the updated stats.

--- a/internal/db/stats_usage_bench_test.go
+++ b/internal/db/stats_usage_bench_test.go
@@ -1,0 +1,166 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+// newUsageStoreForBench builds a UsageStore for a fresh temp dir.
+func newUsageStoreForBench(b *testing.B) *UsageStore {
+	b.Helper()
+	store, err := NewUsageStore(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	return store
+}
+
+// Benchmarks for StatsStore/UsageStore, both written synchronously once per
+// completed LLM request by ProtocolHandler.trackUsageWithTokenUsage -- see
+// .design/hot-path-db-access.md.
+//
+// Run: go test ./internal/db/... -bench 'StatsStore|UsageStore' -benchmem -run '^$'
+
+// BenchmarkStatsStore_UpdateFromService exercises the exact call
+// updateServiceStats makes: an upsert (gorm Save, no prior read) of a
+// service's current in-memory stats snapshot.
+func BenchmarkStatsStore_UpdateFromService(b *testing.B) {
+	store, err := NewStatsStore(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	service := &loadbalance.Service{
+		Provider: "bench-provider",
+		Model:    "bench-model",
+		Weight:   1,
+		Active:   true,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		service.RecordUsage(10, 20)
+		if err := store.UpdateFromService(service); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkUsageStore_RecordUsage exercises the exact call
+// recordDetailedUsageWithTokenUsage makes: a single-row INSERT per
+// completed request (the proxy's usage audit log).
+func BenchmarkUsageStore_RecordUsage(b *testing.B) {
+	store := newUsageStoreForBench(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		record := &UsageRecord{
+			ProviderUUID: "bench-provider",
+			ProviderName: "bench-provider",
+			Model:        "bench-model",
+			Scenario:     "openai",
+			RuleUUID:     "bench-rule",
+			UserID:       DefaultAdminUserID,
+			RequestModel: "bench-model",
+			Timestamp:    time.Now(),
+			InputTokens:  10,
+			OutputTokens: 20,
+			Status:       "success",
+			LatencyMs:    120,
+		}
+		if err := store.RecordUsage(record); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkStatsAndUsage_Combined runs both writes via two separate stores
+// (two independent transactions) -- the "before" baseline for
+// BenchmarkStatsAndUsage_RecordRequestOutcome below.
+func BenchmarkStatsAndUsage_Combined(b *testing.B) {
+	statsStore, err := NewStatsStore(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	usageStore := newUsageStoreForBench(b)
+
+	service := &loadbalance.Service{
+		Provider: "bench-provider",
+		Model:    "bench-model",
+		Weight:   1,
+		Active:   true,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		service.RecordUsage(10, 20)
+		if err := statsStore.UpdateFromService(service); err != nil {
+			b.Fatal(err)
+		}
+		record := &UsageRecord{
+			ProviderUUID: "bench-provider",
+			ProviderName: "bench-provider",
+			Model:        "bench-model",
+			Scenario:     "openai",
+			RuleUUID:     "bench-rule",
+			UserID:       DefaultAdminUserID,
+			RequestModel: "bench-model",
+			Timestamp:    time.Now(),
+			InputTokens:  10,
+			OutputTokens: 20,
+			Status:       "success",
+			LatencyMs:    120,
+		}
+		if err := usageStore.RecordUsage(record); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkStatsAndUsage_RecordRequestOutcome wires both stores through
+// StoreManager (shared *gorm.DB), so the two writes land in one transaction.
+func BenchmarkStatsAndUsage_RecordRequestOutcome(b *testing.B) {
+	sm, err := NewStoreManager(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = sm.Close() })
+
+	statsStore, usageStore := sm.Stats(), sm.Usage()
+
+	service := &loadbalance.Service{
+		Provider: "bench-provider",
+		Model:    "bench-model",
+		Weight:   1,
+		Active:   true,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		service.RecordUsage(10, 20)
+		record := &UsageRecord{
+			ProviderUUID: "bench-provider",
+			ProviderName: "bench-provider",
+			Model:        "bench-model",
+			Scenario:     "openai",
+			RuleUUID:     "bench-rule",
+			UserID:       DefaultAdminUserID,
+			RequestModel: "bench-model",
+			Timestamp:    time.Now(),
+			InputTokens:  10,
+			OutputTokens: 20,
+			Status:       "success",
+			LatencyMs:    120,
+		}
+		if err := RecordRequestOutcome(statsStore, usageStore, service, record); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/db/usage_record.go
+++ b/internal/db/usage_record.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"sync"
 	"time"
@@ -155,6 +156,11 @@ func NewUsageStore(baseDir string) (*UsageStore, error) {
 	}
 
 	dbPath := constant.GetDBFile(baseDir)
+	// Ensure the db subdirectory exists (matches every other NewXStore constructor).
+	dbDir := filepath.Dir(dbPath)
+	if err := os.MkdirAll(dbDir, 0700); err != nil {
+		return nil, fmt.Errorf("failed to create db directory: %w", err)
+	}
 	logrus.Printf("Opening SQLite database for usage store: %s", dbPath)
 	dsn := dbPath + "?_busy_timeout=5000&_journal_mode=WAL&_foreign_keys=1"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
@@ -272,6 +278,15 @@ func (us *UsageStore) RecordUsage(record *UsageRecord) error {
 	us.mu.Lock()
 	defer us.mu.Unlock()
 
+	prepareUsageRecord(record)
+
+	return us.db.Create(record).Error
+}
+
+// prepareUsageRecord fills in RecordUsage's defaults without touching the
+// database -- split out so RecordRequestOutcome can create it in the same
+// transaction as a StatsStore write.
+func prepareUsageRecord(record *UsageRecord) {
 	if record.Timestamp.IsZero() {
 		record.Timestamp = time.Now()
 	}
@@ -280,8 +295,6 @@ func (us *UsageStore) RecordUsage(record *UsageRecord) error {
 	if record.Status == "" {
 		record.Status = "success"
 	}
-
-	return us.db.Create(record).Error
 }
 
 // RenameRuleUUID re-attributes historical usage records from oldUUID to

--- a/internal/protocolserver/usage_tracking.go
+++ b/internal/protocolserver/usage_tracking.go
@@ -110,8 +110,8 @@ func (ph *ProtocolHandler) trackUsageFromContext(c *gin.Context, inputTokens, ou
 		TPS:          tps,
 	}
 
-	// 1. Update service stats with comprehensive metrics
-	ph.updateServiceStats(rule, provider, model, metrics)
+	// 1. Update in-memory service stats with comprehensive metrics
+	service := ph.updateServiceStats(rule, provider, model, metrics)
 
 	// 2. Record to OTel (primary path for metrics)
 	if ph.deps.TokenTracker != nil {
@@ -138,8 +138,9 @@ func (ph *ProtocolHandler) trackUsageFromContext(c *gin.Context, inputTokens, ou
 		})
 	}
 
-	// 3. Record detailed usage (for analytics/dashboard)
-	ph.recordDetailedUsage(c, rule, provider, model, requestModel, scenario, inputTokens, outputTokens, streamed, status, errorCode, latencyMs)
+	// 3. Persist service stats and detailed usage together in one transaction
+	usageRecord := ph.recordDetailedUsage(c, rule, provider, model, requestModel, scenario, inputTokens, outputTokens, streamed, status, errorCode, latencyMs)
+	ph.persistRequestOutcome(service, usageRecord)
 
 	// 4. Report to health monitor for service health tracking
 	ph.ReportHealthStatus(provider, model, err, errorCode)
@@ -227,8 +228,8 @@ func (ph *ProtocolHandler) trackUsageWithTokenUsage(c *gin.Context, usage *proto
 		TPS:          tps,
 	}
 
-	// 1. Update service stats with comprehensive metrics
-	ph.updateServiceStats(rule, provider, model, metrics)
+	// 1. Update in-memory service stats with comprehensive metrics
+	service := ph.updateServiceStats(rule, provider, model, metrics)
 
 	// 2. Record to OTel with comprehensive usage data
 	if ph.deps.TokenTracker != nil {
@@ -253,8 +254,9 @@ func (ph *ProtocolHandler) trackUsageWithTokenUsage(c *gin.Context, usage *proto
 		})
 	}
 
-	// 3. Record detailed usage with comprehensive token data
-	ph.recordDetailedUsageWithTokenUsage(c, rule, provider, model, requestModel, scenario, usage, streamed, status, errorCode, latencyMs)
+	// 3. Persist service stats and detailed usage together in one transaction
+	usageRecord := ph.recordDetailedUsageWithTokenUsage(c, rule, provider, model, requestModel, scenario, usage, streamed, status, errorCode, latencyMs)
+	ph.persistRequestOutcome(service, usageRecord)
 
 	// 4. Report to health monitor for service health tracking
 	ph.ReportHealthStatus(provider, model, err, errorCode)
@@ -337,22 +339,10 @@ func isRateLimitError(err error) bool {
 		strings.Contains(errStr, "1302")
 }
 
-// recordDetailedUsage writes a detailed usage record to the database.
-// This maintains the detailed analytics tracking for the dashboard.
-func (ph *ProtocolHandler) recordDetailedUsage(c *gin.Context, rule *typ.Rule, provider *typ.Provider, model, requestModel, scenario string, inputTokens, outputTokens int, streamed bool, status, errorCode string, latencyMs int) {
-	if ph.deps.Config == nil {
-		return
-	}
-
-	sm := ph.deps.Config.StoreManager()
-	if sm == nil {
-		return
-	}
-	usageStore := sm.Usage()
-	if usageStore == nil {
-		return
-	}
-
+// recordDetailedUsage builds the detailed usage record for the analytics
+// dashboard; persistRequestOutcome saves it together with the matching
+// StatsStore update.
+func (ph *ProtocolHandler) recordDetailedUsage(c *gin.Context, rule *typ.Rule, provider *typ.Provider, model, requestModel, scenario string, inputTokens, outputTokens int, streamed bool, status, errorCode string, latencyMs int) *db.UsageRecord {
 	ttftMs := CalculateTTFT(c)
 
 	record := &db.UsageRecord{
@@ -376,22 +366,14 @@ func (ph *ProtocolHandler) recordDetailedUsage(c *gin.Context, rule *typ.Rule, p
 		record.RuleUUID = rule.UUID
 	}
 
-	_ = usageStore.RecordUsage(record)
+	return record
 }
 
-// recordDetailedUsageWithTokenUsage writes a detailed usage record with comprehensive token data.
-func (ph *ProtocolHandler) recordDetailedUsageWithTokenUsage(c *gin.Context, rule *typ.Rule, provider *typ.Provider, model, requestModel, scenario string, usage *protocol.TokenUsage, streamed bool, status, errorCode string, latencyMs int) {
-	if ph.deps.Config == nil || usage == nil {
-		return
-	}
-
-	sm := ph.deps.Config.StoreManager()
-	if sm == nil {
-		return
-	}
-	usageStore := sm.Usage()
-	if usageStore == nil {
-		return
+// recordDetailedUsageWithTokenUsage is recordDetailedUsage with comprehensive
+// token data (cache/system tokens).
+func (ph *ProtocolHandler) recordDetailedUsageWithTokenUsage(c *gin.Context, rule *typ.Rule, provider *typ.Provider, model, requestModel, scenario string, usage *protocol.TokenUsage, streamed bool, status, errorCode string, latencyMs int) *db.UsageRecord {
+	if usage == nil {
+		return nil
 	}
 
 	ttftMs := CalculateTTFT(c)
@@ -420,14 +402,15 @@ func (ph *ProtocolHandler) recordDetailedUsageWithTokenUsage(c *gin.Context, rul
 		record.RuleUUID = rule.UUID
 	}
 
-	_ = usageStore.RecordUsage(record)
+	return record
 }
 
-// updateServiceStats updates the service-level statistics for load balancing.
-// This function records comprehensive metrics including tokens, latency, TTFT, cache, and TPS.
-func (ph *ProtocolHandler) updateServiceStats(rule *typ.Rule, provider *typ.Provider, model string, metrics MetricsData) {
-	if rule == nil || provider == nil || ph.deps.Config == nil {
-		return
+// updateServiceStats updates the in-memory service-level stats (tokens,
+// latency, TTFT, cache, TPS) and returns the matched service for
+// persistRequestOutcome to save.
+func (ph *ProtocolHandler) updateServiceStats(rule *typ.Rule, provider *typ.Provider, model string, metrics MetricsData) *loadbalance.Service {
+	if rule == nil || provider == nil {
+		return nil
 	}
 
 	// Find the matching service in the rule and update its stats
@@ -455,16 +438,23 @@ func (ph *ProtocolHandler) updateServiceStats(rule *typ.Rule, provider *typ.Prov
 				service.Stats.RecordTokenSpeed(metrics.TPS, 100)
 			}
 
-			// Persist to stats store
-			sm := ph.deps.Config.StoreManager()
-			if sm != nil {
-				if statsStore := sm.Stats(); statsStore != nil {
-					_ = statsStore.UpdateFromService(service)
-				}
-			}
-			return
+			return service
 		}
 	}
+	return nil
+}
+
+// persistRequestOutcome saves service and usage (either may be nil) via
+// db.RecordRequestOutcome, which commits both in a single transaction.
+func (ph *ProtocolHandler) persistRequestOutcome(service *loadbalance.Service, usage *db.UsageRecord) {
+	if ph.deps.Config == nil {
+		return
+	}
+	sm := ph.deps.Config.StoreManager()
+	if sm == nil {
+		return
+	}
+	_ = db.RecordRequestOutcome(sm.Stats(), sm.Usage(), service, usage)
 }
 
 // reportHealthStatus reports the health status of a service based on request outcome.


### PR DESCRIPTION
## Summary

`StatsStore.UpdateFromService` and `UsageStore.RecordUsage` are called synchronously once per completed LLM request, before the response reaches the client. Unlike `ProviderStore`/`APITokenStore`, both are genuine per-request writes with no prior read, so no cache applies — benchmarked first (`internal/db/stats_usage_bench_test.go`), pprof showed both dominated by gorm's implicit transaction wrapper around each write.

Two directions were evaluated:
- **`PRAGMA synchronous=NORMAL`** — implemented, benchmarked, **reverted**: the `mattn/go-sqlite3` driver already forces `synchronous=NORMAL` whenever `_journal_mode=WAL` is set (every store here already does), so the DSN change measured as a no-op. Full writeup in `.design/db.md` (#1556), including the isolated raw-driver test that confirms the pragma itself is real — that headroom just wasn't available here.
- **Merge the two writes into one transaction** (`db.RecordRequestOutcome`) — implemented. `UpdateFromService`/`RecordUsage` were split into a pure record-builder and the DB write, so `RecordRequestOutcome` builds both records and saves them inside one `gorm.DB.Transaction`. `internal/protocolserver/usage_tracking.go`'s `updateServiceStats`/`recordDetailedUsage[WithTokenUsage]` now build-and-return instead of persisting inline.
  `BenchmarkStatsAndUsage_Combined` vs. `_RecordRequestOutcome`: ~440µs/op, 246 allocs → ~420µs/op, 235 allocs (**~4–8%**, noisy). Modest but real, plus a genuine correctness improvement: `TestRecordRequestOutcome_AtomicRollback` proves the stats and usage rows for one request can no longer partially persist.

Also fixed: `NewUsageStore` never created the `db` subdirectory `GetDBFile` expects, unlike every other `NewXStore` constructor — never hit in production since `StoreManager` builds `UsageStore` directly over its own already-open `*gorm.DB`; surfaced when the new benchmark became its first-ever caller.

Still open (tracked in `.design/db.md`): batching multiple requests' stats/usage writes into fewer, larger transactions — the actual lever for the remaining per-statement cost.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (whole repo, green)
- [x] `TestRecordRequestOutcome_AtomicRollback` — a usage write that fails (deliberate primary-key collision) rolls back the stats write from the same call too

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_015x1eojavC1neC8U2GnLzLo
