### PR TITLE
fix(harness): insert codex builtin rule if missing in replay setup

### DIFF
--- a/internal/protocoltest/replay.go
+++ b/internal/protocoltest/replay.go
@@ -76,6 +76,11 @@ func StreamShapeForAgent(at AgentType) Assertion {
 // RequestModel routes to a single service{providerUUID, upstreamModel}.
 // It is the shared core of every AgentTestEnv setup path (virtual scenario,
 // vmodel, real provider, mock agent).
+//
+// Uses add-or-update rather than update-only: some scenarios (e.g. Codex,
+// see internal/server/config/init.go) intentionally have no seeded
+// DefaultRules entry, so their builtin rule UUID won't exist yet on a fresh
+// AgentTestEnv and must be inserted here rather than found.
 func (env *AgentTestEnv) repointBuiltinRule(agentType AgentType, providerUUID, upstreamModel string) error {
 	builtinUUID, requestModel, err := BuiltinRuleRef(agentType)
 	if err != nil {
@@ -85,7 +90,7 @@ func (env *AgentTestEnv) repointBuiltinRule(agentType AgentType, providerUUID, u
 	rule := newHarnessRule(builtinUUID, agentType.Scenario(), requestModel, upstreamModel,
 		harnessService(providerUUID, upstreamModel))
 
-	if err := env.appConfig.GetGlobalConfig().UpdateRequestConfigByUUID(builtinUUID, rule); err != nil {
+	if err := env.appConfig.GetGlobalConfig().AddOrUpdateRequestConfigByRequestModel(rule); err != nil {
 		return fmt.Errorf("update rule: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary
`replay-vmodel` and `replay-virtual` were failing CI ([run 31678936951](https://github.com/tingly-dev/tingly-box/actions/runs/31678936951)) because #1544 removed the Codex builtin rule from `DefaultRules`, but the replay harness still assumed it pre-existed.

## Key Changes

- **Harness replay setup**: `repointBuiltinRule` now uses `AddOrUpdateRequestConfigByRequestModel` (insert-or-update) instead of update-only `UpdateRequestConfigByUUID`, so agents without a seeded default rule (Codex) get one created on first use, matching production behavior.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] Reproduced CI failure locally, confirmed fix: `go run ./cli/harness replay batch --upstream=vmodel` and `--upstream=virtual` now both pass (8 Pass / 0 Fail / 1 Skip, matching the pre-existing `tool_use` skip)
- [x] Ran all 15 harness-matrix.yml legs locally (matrix single/transitive/idempotent/flags/content_shapes × http/gosdk/python/node/aisdk, replay×2, lb, duo-functional, routing) — all pass, no regressions
- [x] `go test ./internal/protocoltest/... ./internal/server/config/...`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoDv9GxEoaA3nHuGv2vgYs)_