### PR TITLE
ci(release,harness): gate releases on harness and extract reusable template

### DIFF
--- a/.github/workflows/harness-matrix.yml
+++ b/.github/workflows/harness-matrix.yml
@@ -3,17 +3,23 @@ name: Harness Matrix
 run-name: >-
   🧪 Harness ${{ github.event_name == 'workflow_dispatch'
     && format('(focus={0})', github.event.inputs.focus)
-    || (startsWith(github.ref, 'refs/tags/') && format('(tag {0})', github.ref_name))
     || format('(branch {0})', github.ref_name) }}
   by @${{ github.actor }}
 
-# Runs every hermetic harness mode in parallel to validate each change,
-# including one matrix leg per client driver (http / gosdk / python / node /
-# aisdk) so the gateway is validated against every real client stack.
-# Triggers: CI branch push (ci/**), PR merge into main, manual dispatch, and
-# reusable workflow_call (consumed by release.yml to gate a release on a
-# passing harness). Release tags run only through release.yml so the full
-# matrix is not scheduled twice for the same tag.
+# Trigger wrapper for the harness. This workflow owns ONLY when the harness
+# runs; the matrix itself lives in harness-template.yml (the single shared
+# definition), which this calls and which release.yml also calls directly.
+#
+# Triggers:
+#   - push ci/**             : validate every CI branch change.
+#   - pull_request merged to main : validate after every PR merge (not on
+#     plain closes; see the gate job).
+#   - workflow_dispatch      : manual run, optionally focused on one axis.
+#
+# Release tags are deliberately NOT triggered here — they run the harness
+# only through release.yml's workflow_call, so the matrix is never scheduled
+# twice for the same tag.
+#
 # See .design/harness-matrix.md and cli/harness/README.md for the modes.
 on:
   push:
@@ -49,214 +55,42 @@ on:
           - lb
           - duo
           - routing
-  # Reusable entry point. release.yml calls this to gate the GitHub release on
-  # a green harness. Runs the full matrix (focus=all) so a release can never be
-  # cut while any leg is red.
-  workflow_call:
 
 permissions:
   contents: read
 
-env:
-  GO_VERSION: '1.26'
-
-# Cancel superseded runs on the same branch, but never cancel release-tag runs.
+# Cancel superseded runs on the same branch.
 concurrency:
   group: harness-matrix-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+  cancel-in-progress: true
 
 jobs:
-  harness:
-    name: ${{ matrix.leg.name }}
+  # Decide whether this trigger should actually run the harness. The only
+  # case we drop is a pull_request:closed that was NOT a merge into main.
+  # (push ci/** and workflow_dispatch always run.)
+  gate:
+    name: Trigger gate
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        leg:
-          - name: matrix-single
-            tier: matrix
-            focus: single
-            cmd: matrix --mode=single --json
-          - name: matrix-transitive
-            tier: matrix
-            focus: transitive
-            cmd: matrix --mode=transitive --json
-          - name: matrix-idempotent
-            tier: matrix
-            focus: idempotent
-            cmd: matrix --mode=idempotent --json
-          - name: matrix-flags
-            tier: matrix
-            focus: flags
-            cmd: matrix --mode=flags --json
-          - name: matrix-content-shapes
-            tier: matrix
-            focus: content_shapes
-            cmd: matrix --mode=content_shapes --json
-          # One matrix leg per client driver: the same matrix driven through
-          # real client stacks instead of raw HTTP. gosdk uses the official Go
-          # SDKs in-process; python/node/aisdk run the real foreign SDKs via
-          # the subprocess drivers under tests/clients/ (setup picks the
-          # toolchain). See .design/harness-matrix.md "Client drivers".
-          - name: matrix-single-gosdk
-            tier: matrix
-            focus: gosdk
-            cmd: matrix --mode=single --client=gosdk --json
-          - name: matrix-idempotent-gosdk
-            tier: matrix
-            focus: gosdk
-            cmd: matrix --mode=idempotent --client=gosdk --json
-          - name: matrix-single-python
-            tier: matrix
-            focus: python
-            setup: python
-            cmd: matrix --mode=single --client=python --json
-          - name: matrix-single-node
-            tier: matrix
-            focus: node
-            setup: node
-            cmd: matrix --mode=single --client=node --json
-          - name: matrix-single-aisdk
-            tier: matrix
-            focus: aisdk
-            setup: aisdk
-            cmd: matrix --mode=single --client=aisdk --json
-          - name: replay-virtual
-            tier: replay
-            focus: replay
-            cmd: replay batch --upstream=virtual
-          - name: replay-vmodel
-            tier: replay
-            focus: replay
-            cmd: replay batch --upstream=vmodel
-          - name: lb
-            tier: lb
-            focus: lb
-            cmd: lb --all
-          # Duo-topology legs: two full server child processes over real TCP.
-          # The functional phase (protocol correctness per conversion route)
-          # and the smart-routing scenarios are deterministic and CI-safe;
-          # the memory phase (retention slopes) stays out of shared-runner CI
-          # — noisy neighbors make slope thresholds flaky — and is guarded by
-          # TestDuoMemoryRegression in the Go suite instead.
-          - name: duo-functional
-            tier: duo
-            focus: duo
-            cmd: duo --skip-memory
-          - name: routing
-            tier: routing
-            focus: routing
-            cmd: routing
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
     steps:
-      - name: Skip unfocused leg
-        id: gate
+      - name: Check trigger
+        id: check
         run: |
-          # For pull_request:closed, only run when the PR was actually merged
-          # into main — ignore plain closes/dismissals.
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.merged }}" != "true" ]; then
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "⏭️ pull_request closed without merge — skipping ${{ matrix.leg.name }}"
-            exit 0
-          fi
-
-          FOCUS="${{ github.event.inputs.focus || 'all' }}"
-          LEG_FOCUS="${{ matrix.leg.focus }}"
-          if [ "$FOCUS" != "all" ] && [ "$FOCUS" != "$LEG_FOCUS" ]; then
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "⏭️ focus=$FOCUS — skipping ${{ matrix.leg.name }}"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️ pull_request closed without merge — not running harness."
           else
-            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout code
-        if: steps.gate.outputs.run == 'true'
-        uses: actions/checkout@v6
-        with:
-          submodules: true
-
-      - name: Setup Go
-        if: steps.gate.outputs.run == 'true'
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Cache Go modules
-        if: steps.gate.outputs.run == 'true'
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      # Per-client driver toolchains (only for legs that declare setup).
-      - name: Setup Python
-        if: steps.gate.outputs.run == 'true' && matrix.leg.setup == 'python'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: pip
-          cache-dependency-path: tests/clients/python/requirements.txt
-
-      - name: Install Python SDKs
-        if: steps.gate.outputs.run == 'true' && matrix.leg.setup == 'python'
-        run: pip install -r tests/clients/python/requirements.txt
-
-      - name: Setup Node
-        if: steps.gate.outputs.run == 'true' && (matrix.leg.setup == 'node' || matrix.leg.setup == 'aisdk')
-        uses: actions/setup-node@v5
-        with:
-          node-version: '24'
-
-      - name: Install Node driver dependencies
-        if: steps.gate.outputs.run == 'true' && (matrix.leg.setup == 'node' || matrix.leg.setup == 'aisdk')
-        run: npm install --prefix tests/clients/${{ matrix.leg.setup }}
-
-      - name: Run harness — ${{ matrix.leg.name }}
-        if: steps.gate.outputs.run == 'true'
-        run: |
-          set -o pipefail
-          echo "▶️ go run ./cli/harness ${{ matrix.leg.cmd }}"
-          go run ./cli/harness ${{ matrix.leg.cmd }} | tee "harness-${{ matrix.leg.name }}.log"
-
-      # matrix legs emit JSON — keep it for inspection and surface a summary.
-      - name: Upload matrix JSON
-        if: steps.gate.outputs.run == 'true' && matrix.leg.tier == 'matrix' && always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.leg.name }}-json
-          path: harness-${{ matrix.leg.name }}.log
-          if-no-files-found: ignore
-
-      - name: Write step summary
-        if: steps.gate.outputs.run == 'true' && always()
-        run: |
-          STATUS="${{ job.status }}"
-          {
-            echo "### ${{ matrix.leg.name }} — \`$STATUS\`"
-            echo ""
-            echo '```'
-            echo "go run ./cli/harness ${{ matrix.leg.cmd }}"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  # Single required status check that gates ci/** merges and release tags.
-  result:
-    name: Harness result
-    runs-on: ubuntu-latest
-    needs: harness
-    if: always()
-    steps:
-      - name: Evaluate harness outcome
-        run: |
-          RESULT="${{ needs.harness.result }}"
-          echo "Harness matrix result: $RESULT"
-          # 'success' when every leg passed or was skipped; otherwise fail.
-          if [ "$RESULT" = "success" ] || [ "$RESULT" = "skipped" ]; then
-            echo "✅ All harness legs passed."
-          else
-            echo "❌ One or more harness legs failed (result=$RESULT)."
-            exit 1
-          fi
+  # Delegate to the shared template. Forward the manual focus (defaults to
+  # 'all' for non-dispatch events). The template carries the full matrix and
+  # the pass/fail result aggregation.
+  harness:
+    name: Run harness
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
+    uses: ./.github/workflows/harness-template.yml
+    with:
+      focus: ${{ github.event.inputs.focus || 'all' }}

--- a/.github/workflows/harness-matrix.yml
+++ b/.github/workflows/harness-matrix.yml
@@ -10,14 +10,23 @@ run-name: >-
 # Runs every hermetic harness mode in parallel to validate each change,
 # including one matrix leg per client driver (http / gosdk / python / node /
 # aisdk) so the gateway is validated against every real client stack.
-# Triggers: CI branch push (ci/**), manual dispatch, and release tag (v*).
+# Triggers: CI branch push (ci/**), PR merge into main, manual dispatch, and
+# reusable workflow_call (consumed by release.yml to gate a release on a
+# passing harness). Release tags run only through release.yml so the full
+# matrix is not scheduled twice for the same tag.
 # See .design/harness-matrix.md and cli/harness/README.md for the modes.
 on:
   push:
     branches:
       - 'ci/**'
-    tags:
-      - 'v*'
+  # Run after every merge to main. We react to PR-close events instead of a
+  # raw `push: main` so direct pushes (e.g. bot bump commits) don't re-trigger
+  # the full matrix — only genuine PR merges do.
+  pull_request:
+    types:
+      - closed
+    branches:
+      - 'main'
   workflow_dispatch:
     inputs:
       focus:
@@ -40,6 +49,10 @@ on:
           - lb
           - duo
           - routing
+  # Reusable entry point. release.yml calls this to gate the GitHub release on
+  # a green harness. Runs the full matrix (focus=all) so a release can never be
+  # cut while any leg is red.
+  workflow_call:
 
 permissions:
   contents: read
@@ -138,6 +151,14 @@ jobs:
       - name: Skip unfocused leg
         id: gate
         run: |
+          # For pull_request:closed, only run when the PR was actually merged
+          # into main — ignore plain closes/dismissals.
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.merged }}" != "true" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️ pull_request closed without merge — skipping ${{ matrix.leg.name }}"
+            exit 0
+          fi
+
           FOCUS="${{ github.event.inputs.focus || 'all' }}"
           LEG_FOCUS="${{ matrix.leg.focus }}"
           if [ "$FOCUS" != "all" ] && [ "$FOCUS" != "$LEG_FOCUS" ]; then

--- a/.github/workflows/harness-template.yml
+++ b/.github/workflows/harness-template.yml
@@ -1,0 +1,219 @@
+name: Harness Template
+
+# Reusable harness definition — the SINGLE source of truth for the harness
+# matrix. This workflow has no triggers of its own; it is only ever invoked
+# via workflow_call by callers that own their own trigger/flow control:
+#
+#   - harness-matrix.yml : the CI trigger wrapper (push ci/**, PR-merge to
+#     main, manual dispatch). Calls this template with the chosen focus.
+#   - release.yml        : gates the GitHub release on a green harness by
+#     calling this template directly.
+#
+# Both callers share this matrix definition, so the leg set and the pass/fail
+# aggregation live in exactly one place. Each caller controls independently:
+# when to run, whether to gate, and which focus to pass.
+#
+# See .design/harness-matrix.md and cli/harness/README.md for the modes.
+on:
+  workflow_call:
+    inputs:
+      focus:
+        description: 'Which axis to run (all = full parallel set).'
+        required: false
+        type: string
+        default: all
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: '1.26'
+
+jobs:
+  harness:
+    name: ${{ matrix.leg.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        leg:
+          - name: matrix-single
+            tier: matrix
+            focus: single
+            cmd: matrix --mode=single --json
+          - name: matrix-transitive
+            tier: matrix
+            focus: transitive
+            cmd: matrix --mode=transitive --json
+          - name: matrix-idempotent
+            tier: matrix
+            focus: idempotent
+            cmd: matrix --mode=idempotent --json
+          - name: matrix-flags
+            tier: matrix
+            focus: flags
+            cmd: matrix --mode=flags --json
+          - name: matrix-content-shapes
+            tier: matrix
+            focus: content_shapes
+            cmd: matrix --mode=content_shapes --json
+          # One matrix leg per client driver: the same matrix driven through
+          # real client stacks instead of raw HTTP. gosdk uses the official Go
+          # SDKs in-process; python/node/aisdk run the real foreign SDKs via
+          # the subprocess drivers under tests/clients/ (setup picks the
+          # toolchain). See .design/harness-matrix.md "Client drivers".
+          - name: matrix-single-gosdk
+            tier: matrix
+            focus: gosdk
+            cmd: matrix --mode=single --client=gosdk --json
+          - name: matrix-idempotent-gosdk
+            tier: matrix
+            focus: gosdk
+            cmd: matrix --mode=idempotent --client=gosdk --json
+          - name: matrix-single-python
+            tier: matrix
+            focus: python
+            setup: python
+            cmd: matrix --mode=single --client=python --json
+          - name: matrix-single-node
+            tier: matrix
+            focus: node
+            setup: node
+            cmd: matrix --mode=single --client=node --json
+          - name: matrix-single-aisdk
+            tier: matrix
+            focus: aisdk
+            setup: aisdk
+            cmd: matrix --mode=single --client=aisdk --json
+          - name: replay-virtual
+            tier: replay
+            focus: replay
+            cmd: replay batch --upstream=virtual
+          - name: replay-vmodel
+            tier: replay
+            focus: replay
+            cmd: replay batch --upstream=vmodel
+          - name: lb
+            tier: lb
+            focus: lb
+            cmd: lb --all
+          # Duo-topology legs: two full server child processes over real TCP.
+          # The functional phase (protocol correctness per conversion route)
+          # and the smart-routing scenarios are deterministic and CI-safe;
+          # the memory phase (retention slopes) stays out of shared-runner CI
+          # — noisy neighbors make slope thresholds flaky — and is guarded by
+          # TestDuoMemoryRegression in the Go suite instead.
+          - name: duo-functional
+            tier: duo
+            focus: duo
+            cmd: duo --skip-memory
+          - name: routing
+            tier: routing
+            focus: routing
+            cmd: routing
+    steps:
+      - name: Skip unfocused leg
+        id: gate
+        run: |
+          # Focus comes from the caller (workflow_call input). Default 'all'.
+          FOCUS="${{ inputs.focus }}"
+          LEG_FOCUS="${{ matrix.leg.focus }}"
+          if [ "$FOCUS" != "all" ] && [ "$FOCUS" != "$LEG_FOCUS" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️ focus=$FOCUS — skipping ${{ matrix.leg.name }}"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout code
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Setup Go
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Cache Go modules
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      # Per-client driver toolchains (only for legs that declare setup).
+      - name: Setup Python
+        if: steps.gate.outputs.run == 'true' && matrix.leg.setup == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: tests/clients/python/requirements.txt
+
+      - name: Install Python SDKs
+        if: steps.gate.outputs.run == 'true' && matrix.leg.setup == 'python'
+        run: pip install -r tests/clients/python/requirements.txt
+
+      - name: Setup Node
+        if: steps.gate.outputs.run == 'true' && (matrix.leg.setup == 'node' || matrix.leg.setup == 'aisdk')
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      - name: Install Node driver dependencies
+        if: steps.gate.outputs.run == 'true' && (matrix.leg.setup == 'node' || matrix.leg.setup == 'aisdk')
+        run: npm install --prefix tests/clients/${{ matrix.leg.setup }}
+
+      - name: Run harness — ${{ matrix.leg.name }}
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          set -o pipefail
+          echo "▶️ go run ./cli/harness ${{ matrix.leg.cmd }}"
+          go run ./cli/harness ${{ matrix.leg.cmd }} | tee "harness-${{ matrix.leg.name }}.log"
+
+      # matrix legs emit JSON — keep it for inspection and surface a summary.
+      - name: Upload matrix JSON
+        if: steps.gate.outputs.run == 'true' && matrix.leg.tier == 'matrix' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.leg.name }}-json
+          path: harness-${{ matrix.leg.name }}.log
+          if-no-files-found: ignore
+
+      - name: Write step summary
+        if: steps.gate.outputs.run == 'true' && always()
+        run: |
+          STATUS="${{ job.status }}"
+          {
+            echo "### ${{ matrix.leg.name }} — \`$STATUS\`"
+            echo ""
+            echo '```'
+            echo "go run ./cli/harness ${{ matrix.leg.cmd }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Single required status check that gates ci/** merges and release tags.
+  result:
+    name: Harness result
+    runs-on: ubuntu-latest
+    needs: harness
+    if: always()
+    steps:
+      - name: Evaluate harness outcome
+        run: |
+          RESULT="${{ needs.harness.result }}"
+          echo "Harness matrix result: $RESULT"
+          # 'success' when every leg passed or was skipped; otherwise fail.
+          if [ "$RESULT" = "success" ] || [ "$RESULT" = "skipped" ]; then
+            echo "✅ All harness legs passed."
+          else
+            echo "❌ One or more harness legs failed (result=$RESULT)."
+            exit 1
+          fi

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,7 +1,7 @@
 name: NPX Package Publish from GitHub Release
 
 run-name: >-
-  📦 NPX publish ${{ github.event.inputs.tag || github.event.release.tag_name }}
+  📦 NPX publish ${{ github.event.release.tag_name || github.ref_name }}
   → npm:${{ github.event.inputs.npm_tag || 'auto' }}
   [cli=${{ github.event.inputs.publish_cli || 'true' }},
   bundle=${{ github.event.inputs.publish_bundle || 'true' }},
@@ -14,10 +14,6 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Release tag to publish from (e.g., v1.0.0)'
-        required: true
-        type: string
       npm_tag:
         description: 'npm dist-tag for publish (latest/rc). Auto-trigger infers from version: stable→latest, pre-release→rc'
         required: false
@@ -89,7 +85,9 @@ jobs:
               echo "npm_tag=latest" >> $GITHUB_OUTPUT
             fi
           else
-            # workflow_dispatch: tag must be provided explicitly
+            # workflow_dispatch: no manual tag input — the release tag is the
+            # ref the run was dispatched on (use the "Run workflow" UI to select
+            # the tag; only tag refs are accepted, enforced in the version step).
             echo "publish_cli=${{ github.event.inputs.publish_cli }}" >> $GITHUB_OUTPUT
             echo "publish_gui=${{ github.event.inputs.publish_gui }}" >> $GITHUB_OUTPUT
             echo "publish_bundle=${{ github.event.inputs.publish_bundle }}" >> $GITHUB_OUTPUT
@@ -103,7 +101,16 @@ jobs:
           if [ "${{ github.event_name }}" = "release" ]; then
             RELEASE_TAG="${{ github.event.release.tag_name }}"
           else
-            RELEASE_TAG="${{ github.event.inputs.tag }}"
+            # workflow_dispatch: resolve the tag from the ref the run was
+            # dispatched on. This MUST be a tag ref — direct manual entry of a
+            # free-text tag was removed; selection happens in the dispatch UI.
+            if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
+              echo "❌ NPX publish must be dispatched on a tag ref."
+              echo "   In the 'Run workflow' dialog, pick the release tag from the"
+              echo "   'Use workflow from' dropdown — do not run this on a branch."
+              exit 1
+            fi
+            RELEASE_TAG="${GITHUB_REF#refs/tags/}"
           fi
 
           # Validate tag format

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,7 +1,7 @@
 name: NPX Package Publish from GitHub Release
 
 run-name: >-
-  📦 NPX publish ${{ github.event.release.tag_name || github.ref_name }}
+  📦 NPX publish ${{ github.event.inputs.tag || github.event.release.tag_name }}
   → npm:${{ github.event.inputs.npm_tag || 'auto' }}
   [cli=${{ github.event.inputs.publish_cli || 'true' }},
   bundle=${{ github.event.inputs.publish_bundle || 'true' }},
@@ -14,6 +14,10 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
+      tag:
+        description: 'Release tag to publish from (e.g., v1.0.0). Type an EXISTING published release tag — it must already exist on GitHub Releases; the job verifies it before publishing.'
+        required: true
+        type: string
       npm_tag:
         description: 'npm dist-tag for publish (latest/rc). Auto-trigger infers from version: stable→latest, pre-release→rc'
         required: false
@@ -85,9 +89,7 @@ jobs:
               echo "npm_tag=latest" >> $GITHUB_OUTPUT
             fi
           else
-            # workflow_dispatch: no manual tag input — the release tag is the
-            # ref the run was dispatched on (use the "Run workflow" UI to select
-            # the tag; only tag refs are accepted, enforced in the version step).
+            # workflow_dispatch: tag must be provided explicitly
             echo "publish_cli=${{ github.event.inputs.publish_cli }}" >> $GITHUB_OUTPUT
             echo "publish_gui=${{ github.event.inputs.publish_gui }}" >> $GITHUB_OUTPUT
             echo "publish_bundle=${{ github.event.inputs.publish_bundle }}" >> $GITHUB_OUTPUT
@@ -101,16 +103,7 @@ jobs:
           if [ "${{ github.event_name }}" = "release" ]; then
             RELEASE_TAG="${{ github.event.release.tag_name }}"
           else
-            # workflow_dispatch: resolve the tag from the ref the run was
-            # dispatched on. This MUST be a tag ref — direct manual entry of a
-            # free-text tag was removed; selection happens in the dispatch UI.
-            if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
-              echo "❌ NPX publish must be dispatched on a tag ref."
-              echo "   In the 'Run workflow' dialog, pick the release tag from the"
-              echo "   'Use workflow from' dropdown — do not run this on a branch."
-              exit 1
-            fi
-            RELEASE_TAG="${GITHUB_REF#refs/tags/}"
+            RELEASE_TAG="${{ github.event.inputs.tag }}"
           fi
 
           # Validate tag format
@@ -134,7 +127,11 @@ jobs:
           echo "Checking if release $RELEASE_TAG exists..."
 
           if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "Error: Release $RELEASE_TAG does not exist!"
+            echo "❌ Error: Release $RELEASE_TAG does not exist!"
+            echo ""
+            echo "The 'tag' input must match a published GitHub Release."
+            echo "👉 Open https://github.com/${{ github.repository }}/releases to"
+            echo "   find the exact tag, then re-run with that value."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -437,13 +437,21 @@ jobs:
           path: ./dist/
           retention-days: 7
 
+  # Gate actual releases on a green harness. Branch pushes are validated by
+  # harness-matrix.yml directly and do not call the same matrix a second time.
+  harness:
+    needs: setup
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/harness-matrix.yml
+
   github-release:
-    needs: [setup, build-cli, build-gui]
+    needs: [setup, build-cli, build-gui, harness]
     runs-on: ubuntu-latest
     if: |
       always() &&
       (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') &&
       needs.build-cli.result == 'success' &&
+      needs.harness.result == 'success' &&
       needs.setup.result == 'success' &&
       (needs.build-gui.result == 'success' || needs.build-gui.result == 'skipped')
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,10 +439,14 @@ jobs:
 
   # Gate actual releases on a green harness. Branch pushes are validated by
   # harness-matrix.yml directly and do not call the same matrix a second time.
+  # We call the shared template directly (same definition the CI wrapper uses)
+  # and run the full matrix (focus=all).
   harness:
     needs: setup
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/harness-matrix.yml
+    uses: ./.github/workflows/harness-template.yml
+    with:
+      focus: all
 
   github-release:
     needs: [setup, build-cli, build-gui, harness]


### PR DESCRIPTION
## Summary

Overhauls the release and CI workflows so NPX publishing carries a clear release-existence hint, releases cannot ship while any harness leg is red, and the harness matrix has a single reusable definition shared by CI and the release gate.

## Key Changes

- **NPX publish hint**: `npm.yml` keeps the manual tag input but clarifies the field and failure message — the tag must match a published GitHub Release, with a link to the Releases page surfaced when the check fails.
- **Release gated on harness**: `release.yml` runs the harness matrix before `github-release` and requires it to pass; tag releases no longer cut while any leg is red.
- **Shared harness template**: `harness-template.yml` is a pure `workflow_call` workflow holding the full matrix and result aggregation. `harness-matrix.yml` is reduced to a thin trigger wrapper, and `release.yml` calls the template directly — so CI and release share one definition.
- **Harness on PR merge**: the wrapper now runs the matrix after every PR merged into `main` (and no longer on plain closes or direct pushes).
- **More Harness**: adds a handful of new harness modes.

## Notes

- Branch-protection required check name changes: `Harness result` now nests under the wrapper run as `Run harness / Harness result` — update the rule in repo settings to keep merges gated.