### PR TITLE
fix(frontend): improve theme contrast in probe results and Image Playground

### DIFF
--- a/frontend/src/components/probe/ProbeDialog.tsx
+++ b/frontend/src/components/probe/ProbeDialog.tsx
@@ -642,7 +642,8 @@ export const ProbeDialog: React.FC<ProbeDialogProps> = ({
                                 <Box
                                     sx={{
                                         p: 1.5,
-                                        bgcolor: 'grey.50',
+                                        bgcolor: 'background.default',
+                                        color: 'text.primary',
                                         borderRadius: 1.5,
                                         fontFamily: 'monospace',
                                         fontSize: '0.8rem',
@@ -662,7 +663,8 @@ export const ProbeDialog: React.FC<ProbeDialogProps> = ({
                                 <Box
                                     sx={{
                                         p: 1.5,
-                                        bgcolor: 'grey.50',
+                                        bgcolor: 'background.default',
+                                        color: 'text.primary',
                                         borderRadius: 1.5,
                                         fontFamily: 'monospace',
                                         fontSize: '0.72rem',

--- a/frontend/src/pages/scenario/components/ImageGenPlaygroundCard.tsx
+++ b/frontend/src/pages/scenario/components/ImageGenPlaygroundCard.tsx
@@ -288,6 +288,11 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
                             startIcon={pendingCount > 0
                                 ? <CircularProgress size={18} color="inherit" />
                                 : <AutoAwesome />}
+                            sx={{
+                                '&.Mui-disabled': {
+                                    color: 'common.white',
+                                },
+                            }}
                         >
                             {pendingCount > 0
                                 ? t('playground.generateAnother', {


### PR DESCRIPTION
## Summary
Fix unreadable probe output and disabled Image Playground button labels in Dark and Sunlit themes.

## Key Changes
- **Probe result contrast**: Use theme-aware surfaces and foreground colors for Response and Raw JSON.
- **Playground button contrast**: Keep existing button backgrounds while forcing disabled Generate text to white.

## Screenshots

### Dark theme
<img width="600" alt="response font color in dark mode" src="https://github.com/user-attachments/assets/0ffea526-a683-411c-86ec-f2f94d514f15" />


### Sunlit theme

<img width="600" alt="image" alt="button text color in different theme mode" src="https://github.com/user-attachments/assets/5ccc1a5a-d70e-4405-a540-08b8e297ee77" />

## Validation
- `pnpm exec oxlint src/components/probe/ProbeDialog.tsx src/pages/scenario/components/ImageGenPlaygroundCard.tsx`
- `pnpm build`
- `pnpm test` (59 tests passed)
- `pnpm typecheck` remains blocked by existing generated API type errors outside these files.