### PR TITLE
feat(scenario): add DeepSeek Harness (dsh) scenario with self-hosted Web UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,7 @@ const UseTeamPage = lazy(() => import('./pages/scenario/UseTeamPage'));
 const AgentOverviewPage = lazy(() => import('./pages/scenario/AgentOverviewPage'));
 const UseOpenCodePage = lazy(() => import('./pages/scenario/UseOpenCodePage'));
 const UsePiPage = lazy(() => import('./pages/scenario/UsePiPage'));
+const UseDshPage = lazy(() => import('./pages/scenario/UseDshPage'));
 const UseXcodePage = lazy(() => import('./pages/scenario/UseXcodePage'));
 const UseVSCodePage = lazy(() => import('./pages/scenario/UseVSCodePage'));
 const UseEmbedPage = lazy(() => import('./pages/scenario/UseEmbedPage'));
@@ -238,6 +239,7 @@ function AppContent() {
                     <Route path="/agent/team" element={<UseTeamPage />} />
                     <Route path="/agent/opencode" element={<UseOpenCodePage />} />
                     <Route path="/agent/pi" element={<UsePiPage />} />
+                    <Route path="/agent/dsh" element={<UseDshPage />} />
                     <Route path="/agent/xcode" element={<UseXcodePage />} />
                     <Route path="/agent/vscode" element={<UseVSCodePage />} />
                     <Route path="/agent/embed" element={<UseEmbedPage />} />

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -45,6 +45,7 @@ export default {
       "useClaudeDesktop": "Claude Desktop",
       "useOpenCode": "OpenCode",
       "usePi": "Pi",
+      "useDsh": "DeepSeek",
       "useXcode": "Xcode",
       "useVSCode": "VS Code",
       "useEmbed": "Embedding",
@@ -1584,6 +1585,7 @@ export default {
       "xcode": "Xcode AI coding assistant through Tingly Box proxy for iOS/macOS development",
       "vscode": "Bring Your Own Key: Use your own API keys with VS Code Copilot through Tingly Box proxy",
       "pi": "Pi coding agent through Tingly Box proxy",
+      "dsh": "DeepSeek Harness (dsh) agent harness through Tingly Box proxy",
       "imagegen": "AI-powered image generation through Tingly Box proxy with multiple model support"
     },
     "vscode": {
@@ -1604,6 +1606,16 @@ export default {
       "openGuide": "View Config",
       "configTitle": "Configure Pi",
       "modalDescription": "Point pi's provider base URL and API key at the values shown on this page, then check the repo below for pi's exact configuration options."
+    },
+    "dsh": {
+      "openWebUi": "Open Web UI",
+      "installDescription": "Run DeepSeek Harness locally with `npx @deepseek-ai/dsh web` (requires Node.js) — the Web UI serves at http://127.0.0.1:3080. Tingly Box does not launch dsh for you; use the button below to jump to it once it's running. Note: dsh is in developer preview and its config may change.",
+      "viewRepo": "View on GitHub",
+      "applyStepLabel": "Configure DSH",
+      "applyStepDescription": "Point dsh's model provider plugin base URL and API key at the values above — see the dsh docs for the exact plugin config.",
+      "openGuide": "View Config",
+      "configTitle": "Configure DSH",
+      "modalDescription": "Point dsh's model provider plugin at the base URL and API key shown on this page, then check the repo below for dsh's plugin configuration options."
     }
   },
   "scenarioOverview": {
@@ -1624,6 +1636,7 @@ export default {
       "xcode": "Bring your model into Xcode's coding intelligence.",
       "vscode": "Power VS Code Copilot Chat through Tingly Box.",
       "pi": "Route the pi coding agent through your provider.",
+      "dsh": "Route DeepSeek Harness (dsh) through your provider.",
       "openai": "Drop-in OpenAI-compatible SDK endpoint.",
       "anthropic": "Drop-in Anthropic-compatible SDK endpoint.",
       "embed": "Route embedding requests to your provider.",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1531,6 +1531,8 @@ export default {
     "model": {
       "label": "Select a Model",
       "configured": "Configured",
+      "skipped": "Skipped",
+      "skip": "Skip",
       "choose": "Choose Model",
       "change": "Change",
       "tooltip": "Choose which model {{agent}} will use in the Model Rules section below."

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1531,6 +1531,8 @@ export default {
     "model": {
       "label": "选择模型",
       "configured": "已配置",
+      "skipped": "已跳过",
+      "skip": "跳过",
       "choose": "选择模型",
       "change": "更换",
       "tooltip": "在下方的模型规则中选择 {{agent}} 使用的模型。",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -47,6 +47,7 @@ export default {
       "useClaudeDesktop": "Claude Desktop",
       "useOpenCode": "OpenCode",
       "usePi": "Pi",
+      "useDsh": "DeepSeek",
       "useXcode": "Xcode",
       "useVSCode": "VS Code",
       "useEmbed": "Embedding",
@@ -1584,6 +1585,7 @@ export default {
       "xcode": "通过 Tingly Box 代理，在 Xcode 中用于 iOS/macOS 开发的 AI 编码助手",
       "vscode": "自带密钥：通过 Tingly Box 代理，在 VS Code Copilot 中使用你自己的 API Key",
       "pi": "通过 Tingly Box 代理使用 pi 编码 Agent",
+      "dsh": "通过 Tingly Box 代理使用 DeepSeek Harness (dsh) 智能体框架",
       "imagegen": "通过 Tingly Box 代理进行 AI 图像生成，支持多种模型",
     },
     "vscode": {
@@ -1604,6 +1606,16 @@ export default {
       "openGuide": "查看配置",
       "configTitle": "配置 Pi",
       "modalDescription": "把 pi 的 provider base URL 和 API Key 配置为本页面上方显示的值，具体配置项请参考下方仓库中的说明。",
+    },
+    "dsh": {
+      "openWebUi": "打开 Web UI",
+      "installDescription": "在本机运行 `npx @deepseek-ai/dsh web`（需要 Node.js），Web UI 默认地址为 http://127.0.0.1:3080。出于安全考虑 Tingly Box 不会代为启动 dsh，运行后可用下方按钮一键跳转。注意：dsh 处于开发者预览阶段，配置可能变化。",
+      "viewRepo": "在 GitHub 上查看",
+      "applyStepLabel": "配置 DSH",
+      "applyStepDescription": "把 dsh 模型 provider 插件的 base URL 和 API Key 配置为上方的值 —— 具体插件配置请参考 dsh 文档。",
+      "openGuide": "查看配置",
+      "configTitle": "配置 DSH",
+      "modalDescription": "把 dsh 的模型 provider 插件指向本页面上方显示的 base URL 和 API Key，具体插件配置请参考下方仓库中的说明。",
     },
   },
   "scenarioOverview": {

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getHiddenScenarios } from '@/pages/scenario/scenarioRegistry';
-import { OpenAI, Anthropic, Claude, OpenCode, Pi, Xcode, VSCode, Codex, ClaudeDesktop } from '../components/BrandIcons';
+import { OpenAI, Anthropic, Claude, DeepSeek, OpenCode, Pi, Xcode, VSCode, Codex, ClaudeDesktop } from '../components/BrandIcons';
 import {
     SettingsApplications,
     BarChart as IconChartBar,
@@ -104,6 +104,7 @@ export function useActivityItems(): ActivityItem[] {
             { id: 'codex', nav: { path: '/agent/codex', label: t('layout.nav.useCodex', { defaultValue: 'Codex' }), icon: <Codex size={20} /> } },
             { id: 'opencode', nav: { path: '/agent/opencode', label: t('layout.nav.useOpenCode', { defaultValue: 'OpenCode' }), icon: <OpenCode size={20} /> } },
             { id: 'pi', nav: { path: '/agent/pi', label: t('layout.nav.usePi', { defaultValue: 'Pi' }), icon: <Pi size={20} /> } },
+            { id: 'dsh', nav: { path: '/agent/dsh', label: t('layout.nav.useDsh', { defaultValue: 'DeepSeek' }), icon: <DeepSeek size={20} /> } },
             { id: 'xcode', nav: { path: '/agent/xcode', label: t('layout.nav.useXcode', { defaultValue: 'Xcode' }), icon: <Xcode size={20} /> } },
             { id: 'vscode', nav: { path: '/agent/vscode', label: t('layout.nav.useVSCode', { defaultValue: 'VS Code' }), icon: <VSCode size={20} /> } },
             // "custom" (bring-your-own-request-model) closes out the coding

--- a/frontend/src/pages/scenario/UseDshPage.tsx
+++ b/frontend/src/pages/scenario/UseDshPage.tsx
@@ -1,0 +1,127 @@
+import CardGrid from "@/components/CardGrid.tsx";
+import UnifiedCard from "@/components/UnifiedCard.tsx";
+import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
+import AgentSetupCard, { hasModelOnAnyRule, scrollToModelsCard } from './components/AgentSetupCard';
+import ConnectAIDialogs from '@/components/ConnectAIDialogs';
+import {useProviderDialog} from '@/hooks/useProviderDialog';
+import { Box, Button, Tooltip, IconButton } from '@mui/material';
+import { Info as InfoIcon } from '@/components/icons';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import PageLayout from '@/components/PageLayout';
+import ScenarioPageSkeleton from './components/ScenarioPageSkeleton';
+import TemplatePage from './components/TemplatePage.tsx';
+import DshConfigModal from './components/DshConfigModal';
+import { useScenarioPageInternal } from '@/pages/scenario/hooks/useScenarioPageInternal.ts';
+import { ScenarioPageModalProvider } from '@/pages/scenario/context/ScenarioPageContext';
+const scenario = "dsh";
+const DSH_REPO_URL = 'https://github.com/deepseek-ai/deepseek-harness';
+// dsh serves a local Web UI; tingly-box does not launch it (security), the
+// frontend only offers a jump to the default address.
+const DSH_WEB_UI_URL = 'http://127.0.0.1:3080';
+const UseDshPageContent: React.FC = () => {
+    const { t } = useTranslation();
+    const {
+        isLoading,
+        notification,
+        showNotification,
+        copyToClipboard,
+        baseUrl,
+        rules,
+    } = useScenarioPageInternal(scenario);
+    const [configModalOpen, setConfigModalOpen] = useState(false);
+    // Unified Connect AI add flow (picker + form/OAuth/paste/import dialogs).
+    const connectAI = useProviderDialog(showNotification, {
+        onProviderAdded: () => window.location.reload(),
+    });
+    const handleOpenConfigModal = () => {
+        setConfigModalOpen(true);
+    };
+    return (
+        <PageLayout loading={isLoading} loadingContent={<ScenarioPageSkeleton />} notification={notification}>
+            <CardGrid>
+                <UnifiedCard
+                    titleHeadingLevel={1}
+                    title={
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <span>DeepSeek Harness</span>
+                            <Tooltip title={t('scenarioPage.tooltip.dsh')}>
+                                <IconButton size="small" sx={{ ml: 0.5 }}>
+                                    <InfoIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+                                </IconButton>
+                            </Tooltip>
+                        </Box>
+                    }
+                    size="full"
+                    rightAction={
+                        <Box sx={{ display: 'flex', gap: 1 }}>
+                            <Tooltip title={DSH_WEB_UI_URL}>
+                                <Button
+                                    href={DSH_WEB_UI_URL}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    variant="contained"
+                                    size="small"
+                                >
+                                    {t('scenarioPage.dsh.openWebUi')}
+                                </Button>
+                            </Tooltip>
+                            <Button
+                                onClick={handleOpenConfigModal}
+                                variant="outlined"
+                                size="small"
+                            >
+                                {t('scenarioPage.config')}
+                            </Button>
+                        </Box>
+                    }
+                >
+                    <ProviderConfigCard
+                        title="DeepSeek Harness"
+                        baseUrlPath="/tingly/dsh"
+                        baseUrl={baseUrl}
+                        onCopy={copyToClipboard}
+                        scenario={scenario}
+                        showApiKeyRow={true}
+                        compact={true}
+                    />
+                </UnifiedCard>
+                <AgentSetupCard
+                    agentKey={scenario}
+                    agentName="DeepSeek Harness"
+                    installCommand="npx @deepseek-ai/dsh web"
+                    installStepDescription={t('scenarioPage.dsh.installDescription')}
+                    installActions={[
+                        { label: t('scenarioPage.dsh.openWebUi'), href: DSH_WEB_UI_URL, variant: 'contained', external: true },
+                        { label: t('scenarioPage.dsh.viewRepo'), href: DSH_REPO_URL, variant: 'outlined', external: true },
+                    ]}
+                    onViewConfig={handleOpenConfigModal}
+                    applyStepLabel={t('scenarioPage.dsh.applyStepLabel')}
+                    applyStepDescription={t('scenarioPage.dsh.applyStepDescription')}
+                    viewConfigButtonLabel={t('scenarioPage.dsh.openGuide')}
+                    hasModelSelected={hasModelOnAnyRule(rules)}
+                    onSelectModel={scrollToModelsCard}
+                    onConnectProvider={connectAI.handleConnectAIClick}
+                />
+                <TemplatePage
+                    scenario={scenario}
+                    collapsible={true}
+                    allowDeleteRule={true}
+                />
+                <DshConfigModal
+                    open={configModalOpen}
+                    onClose={() => setConfigModalOpen(false)}
+                />
+                <ConnectAIDialogs flow={connectAI}/>
+            </CardGrid>
+        </PageLayout>
+    );
+};
+const UseDshPage: React.FC = () => {
+    return (
+        <ScenarioPageModalProvider>
+            <UseDshPageContent />
+        </ScenarioPageModalProvider>
+    );
+};
+export default UseDshPage;

--- a/frontend/src/pages/scenario/components/AgentSetupCard.tsx
+++ b/frontend/src/pages/scenario/components/AgentSetupCard.tsx
@@ -60,6 +60,9 @@ export interface AgentSetupCardProps {
 const COLLAPSED_KEY = (agentKey: string) => `setup-card-collapsed-${agentKey}`;
 const INSTALL_DONE_KEY = (agentKey: string) => `setup-card-step2-done-${agentKey}`;
 const APPLY_DONE_KEY = (agentKey: string) => `setup-card-step3-done-${agentKey}`;
+// Step 2 (model) can be skipped, mirroring Step 4's skip. Skipping marks the
+// step done so the wizard advances, without claiming a model was configured.
+const MODEL_SKIPPED_KEY = (agentKey: string) => `setup-card-step2-skipped-${agentKey}`;
 const TOTAL_STEPS = 4;
 
 /** True iff at least one rule has a service with both a non-empty provider and model. */
@@ -133,6 +136,9 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     const [applyDone, setApplyDone] = useState(
         () => localStorage.getItem(APPLY_DONE_KEY(agentKey)) === 'true'
     );
+    const [modelSkipped, setModelSkipped] = useState(
+        () => localStorage.getItem(MODEL_SKIPPED_KEY(agentKey)) === 'true'
+    );
     const [hasProvider, setHasProvider] = useState(false);
     const [providerCount, setProviderCount] = useState(0);
     const [providerLoading, setProviderLoading] = useState(true);
@@ -167,7 +173,11 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     }, []);
 
     const providerDone = hasProvider;
-    const modelDone = hasModelSelected;
+    const modelSelected = hasModelSelected;
+    // The step counts as done either when a model is really configured (the
+    // provider actually routes a model on some rule) or when the user chose to
+    // skip it. "Configured" vs "skipped" stays distinct on the row itself.
+    const modelDone = modelSelected || modelSkipped;
     const allDone = providerDone && modelDone && installDone && applyDone;
     const doneCount = [providerDone, modelDone, installDone, applyDone].filter(Boolean).length;
 
@@ -207,6 +217,22 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         setInstallDone(true);
     };
 
+    const markModelSkipped = () => {
+        localStorage.setItem(MODEL_SKIPPED_KEY(agentKey), 'true');
+        setModelSkipped(true);
+    };
+
+    // Re-entry after a skip: opening the model picker drops the skipped mark
+    // (progress still stands on the already-selected model / provider), so the
+    // row flips back to the real "configured" state as soon as a model is set.
+    const handleChooseModel = () => {
+        if (modelSkipped) {
+            localStorage.removeItem(MODEL_SKIPPED_KEY(agentKey));
+            setModelSkipped(false);
+        }
+        onSelectModel?.();
+    };
+
     const handleApplyWithStatusLine = async () => {
         if (!onApplyWithStatusLine) return;
         const result = await onApplyWithStatusLine();
@@ -221,9 +247,11 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         localStorage.removeItem(COLLAPSED_KEY(agentKey));
         localStorage.removeItem(INSTALL_DONE_KEY(agentKey));
         localStorage.removeItem(APPLY_DONE_KEY(agentKey));
+        localStorage.removeItem(MODEL_SKIPPED_KEY(agentKey));
         setCollapsed(false);
         setInstallDone(false);
         setApplyDone(false);
+        setModelSkipped(false);
         setApplyResult(null);
         setCopied(false);
         setCopiedMirror(false);
@@ -283,11 +311,24 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                 </Stack>
             }
             rightAction={
-                <Tooltip title={collapsed ? t('agentSetup.expand') : t('agentSetup.collapse')}>
-                    <IconButton size="small" onClick={toggleCollapsed}>
-                        {collapsed ? <ExpandMoreIcon fontSize="small" /> : <ExpandLessIcon fontSize="small" />}
-                    </IconButton>
-                </Tooltip>
+                <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                    {/* Reset is always reachable from the header (not buried at the
+                        bottom of an expanded card), so it works whether the card is
+                        open, closed, or mid-flow. */}
+                    <Button
+                        size="small"
+                        variant="text"
+                        onClick={handleReset}
+                        sx={{ py: 0, textTransform: 'none', color: 'text.secondary', minWidth: 0, fontSize: '0.75rem' }}
+                    >
+                        {t('agentSetup.resetProgress')}
+                    </Button>
+                    <Tooltip title={collapsed ? t('agentSetup.expand') : t('agentSetup.collapse')}>
+                        <IconButton size="small" onClick={toggleCollapsed}>
+                            {collapsed ? <ExpandMoreIcon fontSize="small" /> : <ExpandLessIcon fontSize="small" />}
+                        </IconButton>
+                    </Tooltip>
+                </Stack>
             }
         >
             <Collapse in={!collapsed} unmountOnExit={false}>
@@ -349,10 +390,15 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                 }}>
                                 {t('agentSetup.model.label')}
                             </Typography>
-                            {modelDone && (
+                            {modelSelected && (
                                 <Typography variant="body2" sx={{
                                     color: "text.secondary"
                                 }}>{t('agentSetup.model.configured')}</Typography>
+                            )}
+                            {modelSkipped && !modelSelected && (
+                                <Typography variant="body2" sx={{
+                                    color: "text.secondary"
+                                }}>{t('agentSetup.model.skipped')}</Typography>
                             )}
                             {onSelectModel && (
                                 <Tooltip title={modelDone ? '' : t('agentSetup.model.tooltip', { agent: agentName })}>
@@ -361,13 +407,20 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                                             size="small"
                                             variant={modelDone ? 'text' : 'contained'}
                                             disabled={!modelDone && !providerDone}
-                                            onClick={onSelectModel}
+                                            onClick={handleChooseModel}
                                             sx={modelDone ? { py: 0, textTransform: 'none', minWidth: 0 } : { py: 0.25 }}
                                         >
-                                            {modelDone ? t('agentSetup.model.change') : t('agentSetup.model.choose')}
+                                            {modelSelected ? t('agentSetup.model.change') : t('agentSetup.model.choose')}
                                         </Button>
                                     </span>
                                 </Tooltip>
+                            )}
+                            {firstIncomplete === 1 && (
+                                <Button variant="text" size="small"
+                                    onClick={(e) => { e.stopPropagation(); markModelSkipped(); }}
+                                    sx={{ py: 0, textTransform: 'none', color: 'text.disabled', minWidth: 0 }}>
+                                    {t('agentSetup.model.skip')}
+                                </Button>
                             )}
                         </Stack>
                     </Box>
@@ -583,15 +636,6 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                             </Stack>
                         </Collapse>
                     </Box>
-
-                    {/* Reset link — only visible when something has been manually completed */}
-                    {(installDone || applyDone) && (
-                        <Box sx={{ pt: 0.5, pl: 1.5 }}>
-                            <Button size="small" variant="text" onClick={handleReset} sx={{ py: 0, textTransform: 'none', color: 'text.disabled', fontSize: '0.75rem' }}>
-                                {t('agentSetup.resetProgress')}
-                            </Button>
-                        </Box>
-                    )}
                 </Stack>
             </Collapse>
         </UnifiedCard>

--- a/frontend/src/pages/scenario/components/AgentSetupCard.tsx
+++ b/frontend/src/pages/scenario/components/AgentSetupCard.tsx
@@ -2,6 +2,7 @@ import { ContentCopy as ContentCopyIcon } from '@/components/icons';
 import { CheckCircle as CheckCircleIcon } from '@/components/icons';
 import { ExpandLess as ExpandLessIcon } from '@/components/icons';
 import { ExpandMore as ExpandMoreIcon } from '@/components/icons';
+import { HelpOutline as HelpOutlineIcon } from '@/components/icons';
 import {
     Alert,
     Box,
@@ -19,6 +20,7 @@ import { useTranslation } from 'react-i18next';
 import UnifiedCard from '@/components/UnifiedCard';
 import { api } from '@/services/api';
 import { SPOTLIGHT_ADD_MODEL_EVENT } from '@/components/nodes/ActionAddNode';
+import { EntryGuideDialog } from '@/components/tier/EntryGuideDialog';
 
 export interface AgentApplyResult {
     success: boolean;
@@ -55,6 +57,8 @@ export interface AgentSetupCardProps {
     hasModelSelected?: boolean;
     onSelectModel?: () => void;
     onConnectProvider?: () => void;
+    /** Opened by the header "How routing works" help button. */
+    onShowGuide?: () => void;
 }
 
 const COLLAPSED_KEY = (agentKey: string) => `setup-card-collapsed-${agentKey}`;
@@ -121,6 +125,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     hasModelSelected = false,
     onSelectModel,
     onConnectProvider,
+    onShowGuide,
 }) => {
     const { t } = useTranslation();
     // Pages may override these; otherwise fall back to the translated defaults.
@@ -145,6 +150,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     const [applyResult, setApplyResult] = useState<AgentApplyResult | null>(null);
     const [copied, setCopied] = useState(false);
     const [copiedMirror, setCopiedMirror] = useState(false);
+    const [showGuide, setShowGuide] = useState(false);
     // Tracks which completed steps the user has manually expanded
     const [expandedDoneSteps, setExpandedDoneSteps] = useState<Set<number>>(new Set());
 
@@ -278,6 +284,7 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     });
 
     return (
+        <>
         <UnifiedCard
             size="header"
             titleMarginBottom={collapsed ? 0 : 2}
@@ -323,6 +330,16 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                     >
                         {t('agentSetup.resetProgress')}
                     </Button>
+                    <Tooltip title={t('templateActions.howRoutingWorks', { defaultValue: 'How routing works' })}>
+                        <IconButton
+                            size="small"
+                            aria-label={t('templateActions.howRoutingWorks', { defaultValue: 'How routing works' })}
+                            onClick={() => { if (onShowGuide) onShowGuide(); else setShowGuide(true); }}
+                            sx={{ color: 'text.secondary', '&:hover': { color: 'primary.main' } }}
+                        >
+                            <HelpOutlineIcon fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
                     <Tooltip title={collapsed ? t('agentSetup.expand') : t('agentSetup.collapse')}>
                         <IconButton size="small" onClick={toggleCollapsed}>
                             {collapsed ? <ExpandMoreIcon fontSize="small" /> : <ExpandLessIcon fontSize="small" />}
@@ -639,6 +656,18 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
                 </Stack>
             </Collapse>
         </UnifiedCard>
+
+        {/* Self-hosted "How routing works" guide — only when the page didn't
+            hand in its own `onShowGuide` (in which case the page owns the
+            dialog). */}
+        {!onShowGuide && (
+            <EntryGuideDialog
+                open={showGuide}
+                onClose={() => setShowGuide(false)}
+                mode="direct"
+            />
+        )}
+        </>
     );
 };
 

--- a/frontend/src/pages/scenario/components/DshConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/DshConfigModal.tsx
@@ -1,0 +1,65 @@
+import { Dialog, DialogActions, DialogContent, DialogTitle, Button, Typography, Stack, Link } from '@mui/material';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface DshConfigModalProps {
+    open: boolean;
+    onClose: () => void;
+}
+
+const DSH_REPO_URL = 'https://github.com/deepseek-ai/deepseek-harness';
+
+const DshConfigModal: React.FC<DshConfigModalProps> = ({
+    open,
+    onClose,
+}) => {
+    const { t } = useTranslation();
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            maxWidth="sm"
+            fullWidth
+            slotProps={{
+                paper: {
+                    sx: {
+                        borderRadius: 3,
+                    }
+                }
+            }}
+        >
+            <DialogTitle sx={{ pb: 1 }}>
+                <Typography variant="h6" sx={{
+                    fontWeight: 600
+                }}>
+                    {t('scenarioPage.dsh.configTitle')}
+                </Typography>
+            </DialogTitle>
+            <DialogContent sx={{ pt: 1 }}>
+                <Stack spacing={2}>
+                    <Typography variant="body2" sx={{
+                        color: "text.secondary"
+                    }}>
+                        {t('scenarioPage.dsh.modalDescription')}
+                    </Typography>
+                    <Button
+                        component={Link}
+                        href={DSH_REPO_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        variant="outlined"
+                    >
+                        {t('scenarioPage.dsh.viewRepo')}
+                    </Button>
+                </Stack>
+            </DialogContent>
+            <DialogActions sx={{ px: 3, pb: 2, pt: 1 }}>
+                <Button onClick={onClose} variant="contained">
+                    {t('common.done')}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default DshConfigModal;

--- a/frontend/src/pages/scenario/scenarioRegistry.tsx
+++ b/frontend/src/pages/scenario/scenarioRegistry.tsx
@@ -15,6 +15,7 @@ import {
     Claude,
     ClaudeDesktop,
     Codex,
+    DeepSeek,
     OpenAI,
     OpenCode,
     Pi,
@@ -71,6 +72,14 @@ export const SCENARIOS: ScenarioDescriptor[] = [
         descKey: 'scenarioOverview.descriptions.pi',
         path: '/agent/pi',
         icon: (size) => <Pi size={size} />,
+        hideable: true,
+    },
+    {
+        id: 'dsh',
+        labelKey: 'layout.nav.useDsh',
+        descKey: 'scenarioOverview.descriptions.dsh',
+        path: '/agent/dsh',
+        icon: (size) => <DeepSeek size={size} />,
         hideable: true,
     },
     {

--- a/internal/tbclient/tb_client.go
+++ b/internal/tbclient/tb_client.go
@@ -403,6 +403,8 @@ func (c *TBClientImpl) GetScenarioEndpointPath(scenario typ.RuleScenario) string
 		return "/tingly/opencode"
 	case typ.ScenarioPi:
 		return "/tingly/pi"
+	case typ.ScenarioDsh:
+		return "/tingly/dsh"
 	case typ.ScenarioXcode:
 		return "/tingly/xcode"
 	case typ.ScenarioVSCode:

--- a/internal/typ/scenario_registry.go
+++ b/internal/typ/scenario_registry.go
@@ -106,6 +106,15 @@ func builtinScenarioDescriptorFor(scenario RuleScenario) ScenarioDescriptor {
 			AllowRuleBinding:   true,
 			AllowDirectPathUse: true,
 		}
+	case ScenarioDsh:
+		// DeepSeek Harness: the provider layer is a plugin, so the emitted
+		// protocol is not fixed — accept both OpenAI and Anthropic transports.
+		return ScenarioDescriptor{
+			ID:                 scenario,
+			SupportedTransport: []ScenarioTransport{TransportOpenAI, TransportAnthropic},
+			AllowRuleBinding:   true,
+			AllowDirectPathUse: true,
+		}
 	case ScenarioClaudeCode:
 		return ScenarioDescriptor{
 			ID:                 scenario,

--- a/internal/typ/scenario_registry_test.go
+++ b/internal/typ/scenario_registry_test.go
@@ -152,6 +152,24 @@ func TestTeamScenarioDescriptor(t *testing.T) {
 	}
 }
 
+func TestDshScenarioDescriptor(t *testing.T) {
+	d, ok := GetScenarioDescriptor(ScenarioDsh)
+	if !ok {
+		t.Fatal("dsh descriptor not found")
+	}
+	if !d.AllowRuleBinding {
+		t.Error("dsh should allow rule binding")
+	}
+	if !d.AllowDirectPathUse {
+		t.Error("dsh should allow direct path use")
+	}
+	for _, transport := range []ScenarioTransport{TransportOpenAI, TransportAnthropic} {
+		if !ScenarioSupportsTransport(ScenarioDsh, transport) {
+			t.Errorf("dsh should support transport %q", transport)
+		}
+	}
+}
+
 func TestResolveScenarioAlias(t *testing.T) {
 	canonical, ok := ResolveScenarioAlias(ScenarioAgent)
 	if !ok {

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -63,7 +63,8 @@ const (
 	ScenarioCodex         RuleScenario = "codex"
 	ScenarioClaudeCode    RuleScenario = "claude_code"
 	ScenarioOpenCode      RuleScenario = "opencode"
-	ScenarioPi            RuleScenario = "pi" // Pi agent (https://github.com/earendil-works/pi)
+	ScenarioPi            RuleScenario = "pi"  // Pi agent (https://github.com/earendil-works/pi)
+	ScenarioDsh           RuleScenario = "dsh" // DeepSeek Harness (https://github.com/deepseek-ai/deepseek-harness)
 	ScenarioXcode         RuleScenario = "xcode"
 	ScenarioVSCode        RuleScenario = "vscode"
 	ScenarioClaudeDesktop RuleScenario = "claude_desktop"
@@ -83,6 +84,7 @@ func BuiltinScenarios() []RuleScenario {
 		ScenarioClaudeCode,
 		ScenarioOpenCode,
 		ScenarioPi,
+		ScenarioDsh,
 		ScenarioXcode,
 		ScenarioVSCode,
 		ScenarioClaudeDesktop,


### PR DESCRIPTION
## Summary
Adds DeepSeek Harness (`dsh`) as a first-class scenario, so users can route the agent through Tingly Box's proxy — accepting either OpenAI or Anthropic transport, since dsh's provider is a plugin with no fixed protocol.

## Key Changes

- **dsh scenario**: registers the `dsh` backend scenario and `scenarioOverview`/nav/frontend route, emitting a `/tingly/dsh` base URL with a config modal and repo/Web-UI jump links; the transport is left open (OpenAI + Anthropic) because the provider layer is a plugin.
- **Self-hosted Web UI**: Tingly Box never launches dsh for the user (security); the page instead offers a jump to the default `http://127.0.0.1:3080` once the user runs it locally.

## Minor

- **Quick-start Model skip**: the Model step can now be skipped and still advance the wizard, mirroring step 4, with a distinct "Skipped" vs "Configured" state.
- **Reset moved to header**: the Reset control is now reachable regardless of card state; a "How routing works" help button is added alongside it.
