### PR TITLE
fix(deepseek,kimi): forward reasoning_effort onto the low/high/max tiers both vendors support

### DIFF
--- a/internal/protocol/ops/request_openai_deepseek.go
+++ b/internal/protocol/ops/request_openai_deepseek.go
@@ -5,13 +5,19 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 )
 
+// deepSeekEffortTiers is DeepSeek's own reasoning_effort tier map, built
+// fresh so it can diverge from kimiEffortTiers without touching the shared
+// transform (they hold equal but independent maps — not the same map value,
+// which sharing a Go map reference would make them, silently coupling any
+// future edit to one into the other).
+var deepSeekEffortTiers = lowHighMaxEffortTiers()
+
 // applyDeepSeekTransform applies DeepSeek's request shaping: the
 // reasoning_content message conversion shared with Moonshot/Kimi (see
 // convertThinkingToReasoningContent), plus DeepSeek's own reasoning_effort
-// forwarding onto the low/high/max tiers its V4-Flash/V4-Pro thinking mode
-// accepts (see applyLowHighMaxReasoningEffort).
+// forwarding through deepSeekEffortTiers.
 func applyDeepSeekTransform(req *openai.ChatCompletionNewParams, providerURL, model string, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
-	applyLowHighMaxReasoningEffort(req, config)
+	applyReasoningEffortTier(req, config, deepSeekEffortTiers)
 	convertThinkingToReasoningContent(req)
 	return req
 }

--- a/internal/protocol/ops/request_openai_deepseek.go
+++ b/internal/protocol/ops/request_openai_deepseek.go
@@ -1,14 +1,22 @@
 package ops
 
 import (
+	"strings"
+
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/shared"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/thinking"
 )
 
 // applyDeepSeekTransform converts x_thinking field to reasoning_content for DeepSeek/Moonshot
 // This is required by DeepSeek's and Moonshot's reasoning models
 // The base conversion preserves thinking content in "x_thinking" field
 func applyDeepSeekTransform(req *openai.ChatCompletionNewParams, providerURL, model string, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
+	if isDeepSeekVendor(providerURL, model) {
+		applyDeepSeekReasoningEffort(req, config)
+	}
+
 	for i := range req.Messages {
 		if req.Messages[i].OfAssistant != nil {
 			// Read/write extra fields on OfAssistant (variant level) for consistency.
@@ -35,4 +43,66 @@ func applyDeepSeekTransform(req *openai.ChatCompletionNewParams, providerURL, mo
 		}
 	}
 	return req
+}
+
+// isDeepSeekVendor reports whether the request targets DeepSeek proper (as
+// opposed to Moonshot/Kimi, which share the reasoning_content message shape
+// but not DeepSeek's reasoning_effort ladder).
+func isDeepSeekVendor(providerURL, model string) bool {
+	return strings.Contains(strings.ToLower(providerURL), "deepseek.com") ||
+		strings.Contains(strings.ToLower(model), "deepseek")
+}
+
+// applyDeepSeekReasoningEffort forwards the resolved thinking-effort signal
+// to DeepSeek as reasoning_effort, collapsed onto the three tiers DeepSeek's
+// V4-Flash/V4-Pro thinking mode actually accepts: low/high/max. Earlier
+// DeepSeek models had no effort dial at all (thinking was an on/off switch
+// baked into the model alias, deepseek-chat vs deepseek-reasoner), so this
+// value was previously dropped on the floor for every DeepSeek request.
+//
+// No actionable signal leaves reasoning_effort unset — DeepSeek keeps its
+// own default rather than being forced into thinking mode.
+func applyDeepSeekReasoningEffort(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig) {
+	effort := resolveDeepSeekEffort(req, config)
+	if effort == "" {
+		req.ReasoningEffort = ""
+		return
+	}
+	req.ReasoningEffort = shared.ReasoningEffort(deepSeekReasoningEffortTier(effort))
+}
+
+// resolveDeepSeekEffort picks the effort level driving the DeepSeek request,
+// mirroring the Gemini resolution order (see resolveGeminiEffort):
+//  1. req.ReasoningEffort — set by a forced thinking_effort rule flag, or by
+//     an OpenAI-native client sending reasoning_effort directly.
+//  2. config.ReasoningEffort — derived during Anthropic→OpenAI conversion
+//     (explicit output_config.effort, or budget_tokens tiered onto the
+//     ladder).
+//
+// "none" (explicit disable) and "" (no signal) both resolve to "" so thinking
+// is left at DeepSeek's own default rather than forced on.
+func resolveDeepSeekEffort(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig) string {
+	if effort := string(req.ReasoningEffort); effort != "" && effort != "none" {
+		return effort
+	}
+	if config != nil && config.HasThinking && config.ReasoningEffort != "" && config.ReasoningEffort != "none" {
+		return string(config.ReasoningEffort)
+	}
+	return ""
+}
+
+// deepSeekReasoningEffortTier collapses the canonical six-level thinking
+// ladder onto DeepSeek's three reasoning_effort tiers:
+//   - minimal/low  -> "low"  (everyday, non-agentic use)
+//   - medium/high  -> "high" (everyday agent tasks)
+//   - xhigh/max    -> "max"  (harder, more complex tasks)
+func deepSeekReasoningEffortTier(effort string) string {
+	switch effort {
+	case thinking.LevelXHigh, thinking.LevelMax:
+		return "max"
+	case thinking.LevelMedium, thinking.LevelHigh:
+		return "high"
+	default: // minimal, low, or an unrecognized value
+		return "low"
+	}
 }

--- a/internal/protocol/ops/request_openai_deepseek.go
+++ b/internal/protocol/ops/request_openai_deepseek.go
@@ -1,22 +1,26 @@
 package ops
 
 import (
-	"strings"
-
 	"github.com/openai/openai-go/v3"
-	"github.com/openai/openai-go/v3/shared"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
-	"github.com/tingly-dev/tingly-box/internal/protocol/thinking"
 )
 
-// applyDeepSeekTransform converts x_thinking field to reasoning_content for DeepSeek/Moonshot
-// This is required by DeepSeek's and Moonshot's reasoning models
-// The base conversion preserves thinking content in "x_thinking" field
+// applyDeepSeekTransform applies DeepSeek's request shaping: the
+// reasoning_content message conversion shared with Moonshot/Kimi (see
+// convertThinkingToReasoningContent), plus DeepSeek's own reasoning_effort
+// forwarding onto the low/high/max tiers its V4-Flash/V4-Pro thinking mode
+// accepts (see applyLowHighMaxReasoningEffort).
 func applyDeepSeekTransform(req *openai.ChatCompletionNewParams, providerURL, model string, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
-	if isDeepSeekVendor(providerURL, model) {
-		applyDeepSeekReasoningEffort(req, config)
-	}
+	applyLowHighMaxReasoningEffort(req, config)
+	convertThinkingToReasoningContent(req)
+	return req
+}
 
+// convertThinkingToReasoningContent converts the x_thinking field to
+// reasoning_content on assistant messages. Required by both DeepSeek's and
+// Moonshot/Kimi's reasoning models, so it's shared by applyDeepSeekTransform
+// and applyKimiTransform.
+func convertThinkingToReasoningContent(req *openai.ChatCompletionNewParams) {
 	for i := range req.Messages {
 		if req.Messages[i].OfAssistant != nil {
 			// Read/write extra fields on OfAssistant (variant level) for consistency.
@@ -26,8 +30,8 @@ func applyDeepSeekTransform(req *openai.ChatCompletionNewParams, providerURL, mo
 			}
 
 			// Extract x_thinking and convert to reasoning_content
-			if thinking, hasThinking := msgMap["x_thinking"]; hasThinking {
-				if thinkingStr, ok := thinking.(string); ok {
+			if val, hasThinking := msgMap["x_thinking"]; hasThinking {
+				if thinkingStr, ok := val.(string); ok {
 					msgMap["reasoning_content"] = thinkingStr
 				}
 				delete(msgMap, "x_thinking")
@@ -41,68 +45,5 @@ func applyDeepSeekTransform(req *openai.ChatCompletionNewParams, providerURL, mo
 
 			req.Messages[i].OfAssistant.SetExtraFields(msgMap)
 		}
-	}
-	return req
-}
-
-// isDeepSeekVendor reports whether the request targets DeepSeek proper (as
-// opposed to Moonshot/Kimi, which share the reasoning_content message shape
-// but not DeepSeek's reasoning_effort ladder).
-func isDeepSeekVendor(providerURL, model string) bool {
-	return strings.Contains(strings.ToLower(providerURL), "deepseek.com") ||
-		strings.Contains(strings.ToLower(model), "deepseek")
-}
-
-// applyDeepSeekReasoningEffort forwards the resolved thinking-effort signal
-// to DeepSeek as reasoning_effort, collapsed onto the three tiers DeepSeek's
-// V4-Flash/V4-Pro thinking mode actually accepts: low/high/max. Earlier
-// DeepSeek models had no effort dial at all (thinking was an on/off switch
-// baked into the model alias, deepseek-chat vs deepseek-reasoner), so this
-// value was previously dropped on the floor for every DeepSeek request.
-//
-// No actionable signal leaves reasoning_effort unset — DeepSeek keeps its
-// own default rather than being forced into thinking mode.
-func applyDeepSeekReasoningEffort(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig) {
-	effort := resolveDeepSeekEffort(req, config)
-	if effort == "" {
-		req.ReasoningEffort = ""
-		return
-	}
-	req.ReasoningEffort = shared.ReasoningEffort(deepSeekReasoningEffortTier(effort))
-}
-
-// resolveDeepSeekEffort picks the effort level driving the DeepSeek request,
-// mirroring the Gemini resolution order (see resolveGeminiEffort):
-//  1. req.ReasoningEffort — set by a forced thinking_effort rule flag, or by
-//     an OpenAI-native client sending reasoning_effort directly.
-//  2. config.ReasoningEffort — derived during Anthropic→OpenAI conversion
-//     (explicit output_config.effort, or budget_tokens tiered onto the
-//     ladder).
-//
-// "none" (explicit disable) and "" (no signal) both resolve to "" so thinking
-// is left at DeepSeek's own default rather than forced on.
-func resolveDeepSeekEffort(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig) string {
-	if effort := string(req.ReasoningEffort); effort != "" && effort != "none" {
-		return effort
-	}
-	if config != nil && config.HasThinking && config.ReasoningEffort != "" && config.ReasoningEffort != "none" {
-		return string(config.ReasoningEffort)
-	}
-	return ""
-}
-
-// deepSeekReasoningEffortTier collapses the canonical six-level thinking
-// ladder onto DeepSeek's three reasoning_effort tiers:
-//   - minimal/low  -> "low"  (everyday, non-agentic use)
-//   - medium/high  -> "high" (everyday agent tasks)
-//   - xhigh/max    -> "max"  (harder, more complex tasks)
-func deepSeekReasoningEffortTier(effort string) string {
-	switch effort {
-	case thinking.LevelXHigh, thinking.LevelMax:
-		return "max"
-	case thinking.LevelMedium, thinking.LevelHigh:
-		return "high"
-	default: // minimal, low, or an unrecognized value
-		return "low"
 	}
 }

--- a/internal/protocol/ops/request_openai_deepseek_test.go
+++ b/internal/protocol/ops/request_openai_deepseek_test.go
@@ -142,6 +142,86 @@ func TestAnthropicConversionStoresXThinkingOnOfAssistant(t *testing.T) {
 		"x_thinking stored at OfAssistant level must appear in JSON")
 }
 
+// TestDeepSeekReasoningEffortCollapsesOntoThreeTiers proves that the six-level
+// canonical thinking ladder is collapsed onto the three reasoning_effort
+// tiers DeepSeek's V4-Flash/V4-Pro thinking mode accepts (low/high/max),
+// rather than being passed through verbatim (which V4-Flash would reject for
+// minimal/medium/xhigh).
+func TestDeepSeekReasoningEffortCollapsesOntoThreeTiers(t *testing.T) {
+	tests := []struct {
+		ladderEffort string
+		want         string
+	}{
+		{"minimal", "low"},
+		{"low", "low"},
+		{"medium", "high"},
+		{"high", "high"},
+		{"xhigh", "max"},
+		{"max", "max"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ladderEffort, func(t *testing.T) {
+			req := &openai.ChatCompletionNewParams{
+				Model:           openai.ChatModel("deepseek-v4-flash"),
+				ReasoningEffort: openai.ReasoningEffort(tt.ladderEffort),
+			}
+
+			ApplyProviderTransforms(req, "https://api.deepseek.com/v1", string(req.Model), &protocol.OpenAIConfig{})
+
+			assert.Equal(t, tt.want, string(req.ReasoningEffort))
+		})
+	}
+}
+
+// TestDeepSeekReasoningEffortFromConfigDefault proves that when no rule flag
+// forces req.ReasoningEffort directly, the effort derived during the
+// Anthropic→OpenAI conversion (carried on config.ReasoningEffort) still
+// reaches DeepSeek — previously this was silently dropped for every DeepSeek
+// request.
+func TestDeepSeekReasoningEffortFromConfigDefault(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model: openai.ChatModel("deepseek-v4-flash"),
+	}
+
+	ApplyProviderTransforms(req, "https://api.deepseek.com/v1", string(req.Model), &protocol.OpenAIConfig{
+		HasThinking:     true,
+		ReasoningEffort: "medium",
+	})
+
+	assert.Equal(t, "high", string(req.ReasoningEffort))
+}
+
+// TestDeepSeekReasoningEffortNoSignalLeavesUnset proves that DeepSeek is not
+// forced into thinking mode when neither the request nor the config carries
+// an actionable thinking signal.
+func TestDeepSeekReasoningEffortNoSignalLeavesUnset(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model: openai.ChatModel("deepseek-v4-flash"),
+	}
+
+	ApplyProviderTransforms(req, "https://api.deepseek.com/v1", string(req.Model), &protocol.OpenAIConfig{})
+
+	assert.Equal(t, "", string(req.ReasoningEffort))
+}
+
+// TestDeepSeekReasoningEffortNotAppliedToMoonshot proves the reasoning_effort
+// collapse is scoped to DeepSeek proper — Moonshot/Kimi share the
+// reasoning_content message shape but not DeepSeek's effort ladder, so a
+// stray reasoning_effort must not be invented for them.
+func TestDeepSeekReasoningEffortNotAppliedToMoonshot(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model: openai.ChatModel("moonshot-v1-8k"),
+	}
+
+	ApplyProviderTransforms(req, "https://api.moonshot.cn/v1", string(req.Model), &protocol.OpenAIConfig{
+		HasThinking:     true,
+		ReasoningEffort: "medium",
+	})
+
+	assert.Equal(t, "", string(req.ReasoningEffort))
+}
+
 // --- helpers ---
 
 func assistantToolCallMessage(t *testing.T) openai.ChatCompletionMessageParamUnion {

--- a/internal/protocol/ops/request_openai_deepseek_test.go
+++ b/internal/protocol/ops/request_openai_deepseek_test.go
@@ -205,6 +205,26 @@ func TestDeepSeekReasoningEffortNoSignalLeavesUnset(t *testing.T) {
 	assert.Equal(t, "", string(req.ReasoningEffort))
 }
 
+// TestDeepSeekReasoningEffortExplicitNoneWinsOverConfig proves that an
+// explicit "none" on the request (a forced thinking_effort=off rule flag, or
+// an OpenAI-native client disabling reasoning directly) short-circuits to no
+// signal rather than falling through to a competing config.ReasoningEffort —
+// otherwise a disable request would be silently overridden by whatever
+// effort the Anthropic→OpenAI conversion happened to derive.
+func TestDeepSeekReasoningEffortExplicitNoneWinsOverConfig(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model:           openai.ChatModel("deepseek-v4-flash"),
+		ReasoningEffort: "none",
+	}
+
+	ApplyProviderTransforms(req, "https://api.deepseek.com/v1", string(req.Model), &protocol.OpenAIConfig{
+		HasThinking:     true,
+		ReasoningEffort: "high",
+	})
+
+	assert.Equal(t, "", string(req.ReasoningEffort))
+}
+
 // --- helpers ---
 
 func assistantToolCallMessage(t *testing.T) openai.ChatCompletionMessageParamUnion {

--- a/internal/protocol/ops/request_openai_deepseek_test.go
+++ b/internal/protocol/ops/request_openai_deepseek_test.go
@@ -205,23 +205,6 @@ func TestDeepSeekReasoningEffortNoSignalLeavesUnset(t *testing.T) {
 	assert.Equal(t, "", string(req.ReasoningEffort))
 }
 
-// TestDeepSeekReasoningEffortNotAppliedToMoonshot proves the reasoning_effort
-// collapse is scoped to DeepSeek proper — Moonshot/Kimi share the
-// reasoning_content message shape but not DeepSeek's effort ladder, so a
-// stray reasoning_effort must not be invented for them.
-func TestDeepSeekReasoningEffortNotAppliedToMoonshot(t *testing.T) {
-	req := &openai.ChatCompletionNewParams{
-		Model: openai.ChatModel("moonshot-v1-8k"),
-	}
-
-	ApplyProviderTransforms(req, "https://api.moonshot.cn/v1", string(req.Model), &protocol.OpenAIConfig{
-		HasThinking:     true,
-		ReasoningEffort: "medium",
-	})
-
-	assert.Equal(t, "", string(req.ReasoningEffort))
-}
-
 // --- helpers ---
 
 func assistantToolCallMessage(t *testing.T) openai.ChatCompletionMessageParamUnion {

--- a/internal/protocol/ops/request_openai_extensions.go
+++ b/internal/protocol/ops/request_openai_extensions.go
@@ -26,11 +26,13 @@ func ApplyProviderTransforms(req *openai.ChatCompletionNewParams, providerURL, m
 
 	switch {
 	case strings.Contains(url, "api.deepseek.com"),
-		strings.Contains(url, "api.moonshot.cn"),
-		strings.Contains(url, "api.moonshot.ai"),
-		strings.Contains(url, "api.kimi.com/coding/v1"),
 		strings.Contains(url, "opencode.ai/zen/go") && strings.Contains(modelLower, "deepseek"):
 		return applyDeepSeekTransform(req, providerURL, model, config)
+
+	case strings.Contains(url, "api.moonshot.cn"),
+		strings.Contains(url, "api.moonshot.ai"),
+		strings.Contains(url, "api.kimi.com/coding/v1"):
+		return applyKimiTransform(req, providerURL, model, config)
 
 	case strings.Contains(url, "generativelanguage.googleapis.com") && strings.Contains(modelLower, "gemini"):
 		return applyGeminiTransform(req, providerURL, model, config)

--- a/internal/protocol/ops/request_openai_kimi.go
+++ b/internal/protocol/ops/request_openai_kimi.go
@@ -1,0 +1,17 @@
+package ops
+
+import (
+	"github.com/openai/openai-go/v3"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+// applyKimiTransform applies Moonshot/Kimi's request shaping: the
+// reasoning_content message conversion shared with DeepSeek (see
+// convertThinkingToReasoningContent), plus Kimi K3's own reasoning_effort
+// forwarding onto the same low/high/max tiers DeepSeek uses (see
+// applyLowHighMaxReasoningEffort).
+func applyKimiTransform(req *openai.ChatCompletionNewParams, providerURL, model string, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
+	applyLowHighMaxReasoningEffort(req, config)
+	convertThinkingToReasoningContent(req)
+	return req
+}

--- a/internal/protocol/ops/request_openai_kimi.go
+++ b/internal/protocol/ops/request_openai_kimi.go
@@ -5,13 +5,18 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 )
 
+// kimiEffortTiers is Moonshot/Kimi's own reasoning_effort tier map (K3
+// documents the same low/high/max scheme as DeepSeek V4 today), built fresh
+// so it holds an independent map from deepSeekEffortTiers rather than an
+// alias of the same one — see deepSeekEffortTiers for why that matters.
+var kimiEffortTiers = lowHighMaxEffortTiers()
+
 // applyKimiTransform applies Moonshot/Kimi's request shaping: the
 // reasoning_content message conversion shared with DeepSeek (see
-// convertThinkingToReasoningContent), plus Kimi K3's own reasoning_effort
-// forwarding onto the same low/high/max tiers DeepSeek uses (see
-// applyLowHighMaxReasoningEffort).
+// convertThinkingToReasoningContent), plus Kimi's own reasoning_effort
+// forwarding through kimiEffortTiers.
 func applyKimiTransform(req *openai.ChatCompletionNewParams, providerURL, model string, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
-	applyLowHighMaxReasoningEffort(req, config)
+	applyReasoningEffortTier(req, config, kimiEffortTiers)
 	convertThinkingToReasoningContent(req)
 	return req
 }

--- a/internal/protocol/ops/request_openai_kimi_test.go
+++ b/internal/protocol/ops/request_openai_kimi_test.go
@@ -8,6 +8,22 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 )
 
+// TestDeepSeekAndKimiEffortTiersAreIndependentMaps proves deepSeekEffortTiers
+// and kimiEffortTiers are distinct map values, not two variables aliasing
+// the same underlying Go map (lowHighMaxEffortTiers() returns a fresh map on
+// each call precisely to guarantee this) — mutating one must never affect
+// the other, since the whole point of splitting them was to let either
+// vendor's tier scheme diverge independently.
+func TestDeepSeekAndKimiEffortTiersAreIndependentMaps(t *testing.T) {
+	original := kimiEffortTiers["max"]
+	kimiEffortTiers["max"] = "high" // simulate Kimi-only divergence
+	defer func() { kimiEffortTiers["max"] = original }()
+
+	assert.Equal(t, "high", kimiEffortTiers["max"])
+	assert.NotEqual(t, "high", deepSeekEffortTiers["max"],
+		"mutating kimiEffortTiers must not affect deepSeekEffortTiers")
+}
+
 // TestKimiTransformReasoningContentConversion proves that Moonshot/Kimi gets
 // the same x_thinking -> reasoning_content message-shape conversion as
 // DeepSeek.

--- a/internal/protocol/ops/request_openai_kimi_test.go
+++ b/internal/protocol/ops/request_openai_kimi_test.go
@@ -1,0 +1,97 @@
+package ops
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+// TestKimiTransformReasoningContentConversion proves that Moonshot/Kimi gets
+// the same x_thinking -> reasoning_content message-shape conversion as
+// DeepSeek.
+func TestKimiTransformReasoningContentConversion(t *testing.T) {
+	msg := assistantToolCallMessage(t)
+	msg.OfAssistant.SetExtraFields(map[string]any{"x_thinking": "reasoning for kimi"})
+
+	req := &openai.ChatCompletionNewParams{
+		Model:    openai.ChatModel("kimi-k3"),
+		Messages: []openai.ChatCompletionMessageParamUnion{msg},
+	}
+
+	ApplyProviderTransforms(req, "https://api.moonshot.cn/v1", string(req.Model), &protocol.OpenAIConfig{})
+
+	raw := marshalMessage(t, req.Messages[0])
+	assert.Equal(t, "reasoning for kimi", raw["reasoning_content"],
+		"x_thinking should be converted to reasoning_content")
+	assert.NotContains(t, raw, "x_thinking",
+		"x_thinking should be removed after conversion")
+}
+
+// TestKimiReasoningEffortCollapsesOntoThreeTiers proves that Kimi K3 gets
+// the same low/high/max reasoning_effort collapse as DeepSeek, since both
+// vendors document the identical three-tier scheme.
+func TestKimiReasoningEffortCollapsesOntoThreeTiers(t *testing.T) {
+	tests := []struct {
+		ladderEffort string
+		want         string
+	}{
+		{"minimal", "low"},
+		{"low", "low"},
+		{"medium", "high"},
+		{"high", "high"},
+		{"xhigh", "max"},
+		{"max", "max"},
+	}
+
+	urls := []string{
+		"https://api.moonshot.cn/v1",
+		"https://api.moonshot.ai/v1",
+		"https://api.kimi.com/coding/v1",
+	}
+
+	for _, url := range urls {
+		for _, tt := range tests {
+			t.Run(url+"/"+tt.ladderEffort, func(t *testing.T) {
+				req := &openai.ChatCompletionNewParams{
+					Model:           openai.ChatModel("kimi-k3"),
+					ReasoningEffort: openai.ReasoningEffort(tt.ladderEffort),
+				}
+
+				ApplyProviderTransforms(req, url, string(req.Model), &protocol.OpenAIConfig{})
+
+				assert.Equal(t, tt.want, string(req.ReasoningEffort))
+			})
+		}
+	}
+}
+
+// TestKimiReasoningEffortFromConfigDefault proves that the effort derived
+// during Anthropic→OpenAI conversion (config.ReasoningEffort) reaches Kimi
+// the same way it reaches DeepSeek.
+func TestKimiReasoningEffortFromConfigDefault(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model: openai.ChatModel("kimi-k3"),
+	}
+
+	ApplyProviderTransforms(req, "https://api.moonshot.cn/v1", string(req.Model), &protocol.OpenAIConfig{
+		HasThinking:     true,
+		ReasoningEffort: "medium",
+	})
+
+	assert.Equal(t, "high", string(req.ReasoningEffort))
+}
+
+// TestKimiReasoningEffortNoSignalLeavesUnset proves that Kimi is not forced
+// into thinking mode when neither the request nor the config carries an
+// actionable thinking signal.
+func TestKimiReasoningEffortNoSignalLeavesUnset(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model: openai.ChatModel("kimi-k3"),
+	}
+
+	ApplyProviderTransforms(req, "https://api.moonshot.cn/v1", string(req.Model), &protocol.OpenAIConfig{})
+
+	assert.Equal(t, "", string(req.ReasoningEffort))
+}

--- a/internal/protocol/ops/request_openai_reasoning_tier.go
+++ b/internal/protocol/ops/request_openai_reasoning_tier.go
@@ -1,0 +1,63 @@
+package ops
+
+import (
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/shared"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/protocol/thinking"
+)
+
+// applyLowHighMaxReasoningEffort forwards the resolved thinking-effort
+// signal as reasoning_effort, collapsed onto the low/high/max tiers shared
+// by DeepSeek's V4-Flash/V4-Pro and Moonshot/Kimi's K3 thinking modes.
+// Earlier models in both families had no effort dial at all (thinking was
+// an on/off switch baked into the model alias), so this value used to be
+// dropped on the floor for every request to either vendor.
+//
+// No actionable signal leaves reasoning_effort unset — the vendor keeps its
+// own default rather than being forced into thinking mode.
+func applyLowHighMaxReasoningEffort(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig) {
+	effort := resolveReasoningEffort(req, config)
+	if effort == "" {
+		req.ReasoningEffort = ""
+		return
+	}
+	req.ReasoningEffort = shared.ReasoningEffort(lowHighMaxTier(effort))
+}
+
+// resolveReasoningEffort picks the effort level driving the request,
+// mirroring the Gemini resolution order (see resolveGeminiEffort):
+//  1. req.ReasoningEffort — set by a forced thinking_effort rule flag, or by
+//     an OpenAI-native client sending reasoning_effort directly.
+//  2. config.ReasoningEffort — derived during Anthropic→OpenAI conversion
+//     (explicit output_config.effort, or budget_tokens tiered onto the
+//     ladder).
+//
+// "none" (explicit disable) and "" (no signal) both resolve to "" so
+// thinking is left at the vendor's own default rather than forced on.
+func resolveReasoningEffort(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig) string {
+	if effort := string(req.ReasoningEffort); effort != "" && effort != "none" {
+		return effort
+	}
+	if config != nil && config.HasThinking && config.ReasoningEffort != "" && config.ReasoningEffort != "none" {
+		return string(config.ReasoningEffort)
+	}
+	return ""
+}
+
+// lowHighMaxTier collapses the canonical six-level thinking ladder onto the
+// low/high/max reasoning_effort scheme DeepSeek V4 and Moonshot/Kimi K3 both
+// use:
+//   - minimal/low  -> "low"  (everyday, non-agentic use)
+//   - medium/high  -> "high" (everyday agent tasks)
+//   - xhigh/max    -> "max"  (harder, more complex tasks)
+func lowHighMaxTier(effort string) string {
+	switch effort {
+	case thinking.LevelXHigh, thinking.LevelMax:
+		return "max"
+	case thinking.LevelMedium, thinking.LevelHigh:
+		return "high"
+	default: // minimal, low, or an unrecognized value
+		return "low"
+	}
+}

--- a/internal/protocol/ops/request_openai_reasoning_tier.go
+++ b/internal/protocol/ops/request_openai_reasoning_tier.go
@@ -7,22 +7,51 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/protocol/thinking"
 )
 
-// applyLowHighMaxReasoningEffort forwards the resolved thinking-effort
-// signal as reasoning_effort, collapsed onto the low/high/max tiers shared
-// by DeepSeek's V4-Flash/V4-Pro and Moonshot/Kimi's K3 thinking modes.
-// Earlier models in both families had no effort dial at all (thinking was
-// an on/off switch baked into the model alias), so this value used to be
-// dropped on the floor for every request to either vendor.
+// reasoningEffortTierMap collapses the canonical six-level thinking-effort
+// ladder (internal/protocol/thinking) onto a vendor's own reasoning_effort
+// enum. Each vendor family that needs this keeps its own map (see
+// deepSeekEffortTiers, kimiEffortTiers) even where the values happen to
+// match today — a future vendor, or a future divergence between existing
+// ones (e.g. Kimi's rollout only accepting a subset at first), is then just
+// a different map, not a new hand-rolled transform.
+type reasoningEffortTierMap map[string]string
+
+// lowHighMaxEffortTiers is the low/high/max scheme DeepSeek's
+// V4-Flash/V4-Pro and Moonshot/Kimi's K3 both document today:
+//   - minimal/low  -> "low"  (everyday, non-agentic use)
+//   - medium/high  -> "high" (everyday agent tasks)
+//   - xhigh/max    -> "max"  (harder, more complex tasks)
+func lowHighMaxEffortTiers() reasoningEffortTierMap {
+	return reasoningEffortTierMap{
+		thinking.LevelMinimal: "low",
+		thinking.LevelLow:     "low",
+		thinking.LevelMedium:  "high",
+		thinking.LevelHigh:    "high",
+		thinking.LevelXHigh:   "max",
+		thinking.LevelMax:     "max",
+	}
+}
+
+// applyReasoningEffortTier forwards the resolved thinking-effort signal as
+// reasoning_effort, collapsed through the given tier map. Earlier models in
+// the DeepSeek/Kimi family had no effort dial at all (thinking was an on/off
+// switch baked into the model alias), so this value used to be dropped on
+// the floor for every request to either vendor.
 //
 // No actionable signal leaves reasoning_effort unset — the vendor keeps its
-// own default rather than being forced into thinking mode.
-func applyLowHighMaxReasoningEffort(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig) {
+// own default rather than being forced into thinking mode. A signal with no
+// entry in tiers (an already vendor-native value, or an unrecognized one)
+// passes through unchanged rather than being silently dropped.
+func applyReasoningEffortTier(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig, tiers reasoningEffortTierMap) {
 	effort := resolveReasoningEffort(req, config)
 	if effort == "" {
 		req.ReasoningEffort = ""
 		return
 	}
-	req.ReasoningEffort = shared.ReasoningEffort(lowHighMaxTier(effort))
+	if mapped, ok := tiers[effort]; ok {
+		effort = mapped
+	}
+	req.ReasoningEffort = shared.ReasoningEffort(effort)
 }
 
 // resolveReasoningEffort picks the effort level driving the request,
@@ -43,21 +72,4 @@ func resolveReasoningEffort(req *openai.ChatCompletionNewParams, config *protoco
 		return string(config.ReasoningEffort)
 	}
 	return ""
-}
-
-// lowHighMaxTier collapses the canonical six-level thinking ladder onto the
-// low/high/max reasoning_effort scheme DeepSeek V4 and Moonshot/Kimi K3 both
-// use:
-//   - minimal/low  -> "low"  (everyday, non-agentic use)
-//   - medium/high  -> "high" (everyday agent tasks)
-//   - xhigh/max    -> "max"  (harder, more complex tasks)
-func lowHighMaxTier(effort string) string {
-	switch effort {
-	case thinking.LevelXHigh, thinking.LevelMax:
-		return "max"
-	case thinking.LevelMedium, thinking.LevelHigh:
-		return "high"
-	default: // minimal, low, or an unrecognized value
-		return "low"
-	}
 }

--- a/internal/protocol/ops/request_openai_reasoning_tier.go
+++ b/internal/protocol/ops/request_openai_reasoning_tier.go
@@ -65,7 +65,10 @@ func applyReasoningEffortTier(req *openai.ChatCompletionNewParams, config *proto
 // "none" (explicit disable) and "" (no signal) both resolve to "" so
 // thinking is left at the vendor's own default rather than forced on.
 func resolveReasoningEffort(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig) string {
-	if effort := string(req.ReasoningEffort); effort != "" && effort != "none" {
+	if effort := string(req.ReasoningEffort); effort != "" {
+		if effort == "none" {
+			return ""
+		}
 		return effort
 	}
 	if config != nil && config.HasThinking && config.ReasoningEffort != "" && config.ReasoningEffort != "none" {


### PR DESCRIPTION
## Summary
DeepSeek's V4-Flash/V4-Pro and Moonshot/Kimi's K3 now support a `reasoning_effort` dial (low/high/max), but the gateway's DeepSeek vendor transform never forwarded any effort signal at all — every `thinking_effort` request to either vendor was silently dropped.

## Key Changes

- **DeepSeek/Kimi reasoning_effort forwarding**: collapses the internal six-level thinking ladder (minimal/low/medium/high/xhigh/max) onto the low/high/max tiers both vendors document, instead of dropping the signal entirely.
- **Vendor split**: DeepSeek and Moonshot/Kimi now have their own transform functions and independent, configurable tier maps (previously one function was silently shared by both with no effort handling), sharing only the common `reasoning_content` message-shape conversion and effort-resolution logic.
- **Explicit disable fix**: `reasoning_effort=none` now short-circuits instead of being silently overridden by a competing config-derived default (caught in code review).

## Testing
- `go test ./internal/protocol/...` — all green, including new coverage for the effort-tier collapse, config fallback, explicit-none handling, and DeepSeek/Kimi tier-map independence.
