### PR TITLE
fix(db): five independent store-layer defects

### DIFF
--- a/internal/db/service_stat.go
+++ b/internal/db/service_stat.go
@@ -262,6 +262,11 @@ func (ss *StatsStore) HydrateRules(rules []typ.Rule) error {
 		statsMap[key] = record
 	}
 
+	// Collect rows for services with no stored stats and insert them in one
+	// batch at the end. HydrateRules runs on every config load and every
+	// hot-reload, and a per-row Create inside the loop made that an N+1
+	// insert over rules x services on first boot or after adding a rule.
+	var missing []*ServiceStatsRecord
 	for i := range rules {
 		rule := &rules[i]
 		for j := range rule.Services {
@@ -270,41 +275,21 @@ func (ss *StatsStore) HydrateRules(rules []typ.Rule) error {
 
 			if record, ok := statsMap[key]; ok {
 				service.Stats = record.toServiceStats()
-			} else {
-				service.InitializeStats()
-				statCopy := service.Stats.GetStats()
-				record := &ServiceStatsRecord{
-					Provider:             service.Provider,
-					Model:                service.Model,
-					ServiceID:            statCopy.ServiceID,
-					RequestCount:         statCopy.RequestCount,
-					LastUsed:             statCopy.LastUsed,
-					WindowStart:          statCopy.WindowStart,
-					WindowRequestCount:   statCopy.WindowRequestCount,
-					WindowTokensConsumed: statCopy.WindowTokensConsumed,
-					WindowInputTokens:    statCopy.WindowInputTokens,
-					WindowOutputTokens:   statCopy.WindowOutputTokens,
-					TimeWindow:           statCopy.TimeWindow,
-				}
-				if record.TimeWindow == 0 {
-					if service.TimeWindow > 0 {
-						record.TimeWindow = service.TimeWindow
-					} else {
-						record.TimeWindow = defaultServiceTimeWindow
-					}
-				}
-				if record.ServiceID == "" {
-					record.ServiceID = service.ServiceID()
-				}
-				if record.WindowStart.IsZero() {
-					record.WindowStart = time.Now()
-				}
-				if err := ss.db.Create(record).Error; err != nil {
-					return err
-				}
-				// Add to statsMap so other services with same provider:model find it
+			} else if record := buildStatsRecordFromService(service); record != nil {
+				// buildStatsRecordFromService initializes service.Stats and
+				// applies the same TimeWindow/ServiceID/WindowStart defaults
+				// this branch used to duplicate inline. Register the row in
+				// statsMap so other services with the same provider:model
+				// reuse it instead of inserting a duplicate.
 				statsMap[key] = record
+				missing = append(missing, record)
 			}
+		}
+	}
+
+	if len(missing) > 0 {
+		if err := ss.db.CreateInBatches(missing, 100).Error; err != nil {
+			return err
 		}
 	}
 

--- a/internal/db/store_manager.go
+++ b/internal/db/store_manager.go
@@ -460,6 +460,7 @@ func (sm *StoreManager) HealthCheck() (*HealthStatus, error) {
 		"tasks":          sm.taskStore,
 		"remoteChats":    sm.remoteChatStore,
 		"remoteSessions": sm.remoteSessionStore,
+		"botAccess":      sm.botAccessStore,
 	}
 
 	status := &HealthStatus{

--- a/internal/db/store_manager_test.go
+++ b/internal/db/store_manager_test.go
@@ -207,7 +207,7 @@ func TestStoreManager_HealthCheck(t *testing.T) {
 	expectedStores := []string{
 		"stats", "usage", "provider",
 		"toolConfig", "imbotSettings", "model", "apiToken",
-		"tasks", "remoteChats", "remoteSessions",
+		"tasks", "remoteChats", "remoteSessions", "botAccess",
 	}
 	for _, name := range expectedStores {
 		if status.StoreStatus[name] != HealthStatusOK {

--- a/internal/guardrails/utils/credential_store.go
+++ b/internal/guardrails/utils/credential_store.go
@@ -194,6 +194,25 @@ func (s *ProtectedCredentialStore) Resolve(ids []string) ([]guardrailscore.Prote
 	return resolved, nil
 }
 
+// Close releases the connection ensureDB opened, if any. Safe to call more
+// than once, and on a store that never opened one. With WAL enabled a live
+// connection holds three descriptors (db, -wal, -shm), so an owner that
+// never closes leaks all three for the process lifetime.
+func (s *ProtectedCredentialStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return nil
+	}
+	sqlDB, err := s.db.DB()
+	s.db = nil
+	if err != nil {
+		return fmt.Errorf("protected credential store: get database instance: %w", err)
+	}
+	return sqlDB.Close()
+}
+
 func (s *ProtectedCredentialStore) ensureDB() (*gorm.DB, error) {
 	if s.db != nil {
 		return s.db, nil

--- a/internal/guardrails/utils/credential_store.go
+++ b/internal/guardrails/utils/credential_store.go
@@ -205,7 +205,12 @@ func (s *ProtectedCredentialStore) ensureDB() (*gorm.DB, error) {
 		return nil, fmt.Errorf("create protected credential db dir: %w", err)
 	}
 
-	db, err := gorm.Open(sqlite.Open(s.path), &gorm.Config{
+	// Same connection options the tingly.db stores use: WAL journaling and a
+	// busy timeout, so concurrent writers back off instead of failing
+	// immediately with SQLITE_BUSY. This was the one SQLite open in the
+	// codebase with no options at all.
+	dsn := s.path + "?_busy_timeout=5000&_journal_mode=WAL&_foreign_keys=1"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
 	if err != nil {

--- a/internal/guardrails/utils/credential_store_test.go
+++ b/internal/guardrails/utils/credential_store_test.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestProtectedCredentialStore_CloseReleasesConnection: the store opens its
+// SQLite connection lazily and its owner is expected to release it. With WAL
+// enabled a live connection holds three descriptors, so an owner that cannot
+// close leaks all three for the process lifetime.
+func TestProtectedCredentialStore_CloseReleasesConnection(t *testing.T) {
+	store := NewProtectedCredentialStore(filepath.Join(t.TempDir(), "db", "guardrails.db"))
+
+	if _, err := store.List(); err != nil {
+		t.Fatalf("List (which opens the connection) failed: %v", err)
+	}
+	conn := store.db
+	if conn == nil {
+		t.Fatal("List should have opened a connection")
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+	if store.db != nil {
+		t.Error("Close should clear the handle")
+	}
+
+	sqlDB, err := conn.DB()
+	if err != nil {
+		t.Fatalf("failed to reach the underlying handle: %v", err)
+	}
+	if err := sqlDB.Ping(); err == nil {
+		t.Error("connection should be closed after Close")
+	}
+}
+
+// TestProtectedCredentialStore_CloseIsSafeWhenUnused: Close must not fail on
+// a store whose connection was never opened, or on a second call — its owner
+// (Config.CloseStores) is documented as safe to call more than once.
+func TestProtectedCredentialStore_CloseIsSafeWhenUnused(t *testing.T) {
+	store := NewProtectedCredentialStore(filepath.Join(t.TempDir(), "db", "guardrails.db"))
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close on an unused store failed: %v", err)
+	}
+
+	if _, err := store.List(); err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("first Close failed: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("second Close failed: %v", err)
+	}
+}

--- a/internal/protocolserver/guardrails_state.go
+++ b/internal/protocolserver/guardrails_state.go
@@ -130,7 +130,7 @@ func (g *GuardrailsState) RefreshCredentialCache() error {
 		return nil
 	}
 
-	store, err := config.CredentialStore(g.cfg.ConfigDir)
+	store, err := g.cfg.CredentialStore()
 	if err != nil {
 		return err
 	}

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/data"
 	"github.com/tingly-dev/tingly-box/internal/db"
+	guardrailsutils "github.com/tingly-dev/tingly-box/internal/guardrails/utils"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 	"github.com/tingly-dev/tingly-box/pkg/auth"
@@ -103,6 +104,11 @@ type Config struct {
 	toolConfigStore    *db.ToolConfigStore
 	imbotSettingsStore *db.ImBotSettingsStore
 	templateManager    *data.TemplateManager
+
+	// credentialStore backs the guardrails protected-credential database,
+	// which is a separate file from tingly.db. Built lazily by
+	// CredentialStore.
+	credentialStore *guardrailsutils.ProtectedCredentialStore
 
 	// Provider lifecycle hooks
 	providerUpdateHooks []ProviderUpdateHook
@@ -474,7 +480,9 @@ func (c *Config) StoreManager() *db.StoreManager {
 }
 
 // CloseStores releases every database handle the config owns: the shared
-// store-manager connection and the provider-model store. The long-lived
+// store-manager connection, the provider-model store, and the guardrails
+// credential store (a separate file, and with WAL on, three
+// descriptors). The long-lived
 // server closes the store manager from Stop; short-lived embedders (tests,
 // harness environments) call this so each instance does not leak SQLite
 // descriptors for the process lifetime. Safe to call more than once.
@@ -482,6 +490,7 @@ func (c *Config) CloseStores() error {
 	c.mu.Lock()
 	storeManager := c.storeManager
 	modelManager := c.modelManager
+	credentialStore := c.credentialStore
 	c.mu.Unlock()
 
 	var errs []error
@@ -490,6 +499,9 @@ func (c *Config) CloseStores() error {
 	}
 	if modelManager != nil {
 		errs = append(errs, modelManager.Close())
+	}
+	if credentialStore != nil {
+		errs = append(errs, credentialStore.Close())
 	}
 	return errors.Join(errs...)
 }

--- a/internal/server/config/guardrails.go
+++ b/internal/server/config/guardrails.go
@@ -137,14 +137,27 @@ func WriteFileAtomic(path string, data []byte) error {
 	return os.Rename(tmp, path)
 }
 
-// CredentialStore opens the protected-credential sqlite store shared by
+// CredentialStore returns the protected-credential sqlite store shared by
 // request-time masking (AI Model API) and the admin credential CRUD (WebUI
-// Management API).
-func CredentialStore(configDir string) (*guardrailsutils.ProtectedCredentialStore, error) {
-	if configDir == "" {
+// Management API), building it on first use.
+//
+// The Config owns it for the same reason it owns the other stores: the store
+// holds a lazily-opened SQLite connection, and something has to be able to
+// close it. This used to be a free function handing out a fresh store per
+// call, which left a new connection behind on every credential-cache
+// refresh — i.e. on the request path.
+func (c *Config) CredentialStore() (*guardrailsutils.ProtectedCredentialStore, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.credentialStore != nil {
+		return c.credentialStore, nil
+	}
+	if c.ConfigDir == "" {
 		return nil, errors.New("config directory not set")
 	}
-	return guardrailsutils.NewProtectedCredentialStore(DBPath(configDir)), nil
+	c.credentialStore = guardrailsutils.NewProtectedCredentialStore(DBPath(c.ConfigDir))
+	return c.credentialStore, nil
 }
 
 // applyGuardrailsDefaults ensures the global scenario has an extensions map so

--- a/internal/server/guardrails_handler.go
+++ b/internal/server/guardrails_handler.go
@@ -69,7 +69,7 @@ func NewGuardrailsHandler(deps GuardrailsDeps) *GuardrailsHandler {
 }
 
 func (h *GuardrailsHandler) credentialStore() (*guardrailsutils.ProtectedCredentialStore, error) {
-	return config.CredentialStore(h.deps.Config.ConfigDir)
+	return h.deps.Config.CredentialStore()
 }
 
 // Config/builtin handler payloads.

--- a/internal/server/load_balance_simulator.go
+++ b/internal/server/load_balance_simulator.go
@@ -130,6 +130,11 @@ func NewLBSimulatorWithSequences(rule *typ.Rule, faults map[string]vmodel.Sequen
 		runCleanup()
 		return nil, nil, fmt.Errorf("config: %w", err)
 	}
+	// The config owns a StoreManager holding an open SQLite handle. Without
+	// this every simulator run leaks one for the process lifetime.
+	// Registered after the temp-dir removal so it runs before it (cleanups
+	// unwind in reverse).
+	cleanups = append(cleanups, func() { _ = cfg.CloseStores() })
 
 	seen := map[string]bool{}
 	for _, svc := range rule.Services {


### PR DESCRIPTION
## Summary

An audit of the store layer turned up five unrelated defects, each pre-existing on `main` and each fixable on its own. One commit per defect — none depends on another.

## Key Changes

- **Health reporting**: `HealthCheck` enumerated 10 of 11 stores, so `TotalStores` was wrong and `botAccessStore` was never checked.
- **guardrails.db concurrency**: the store opened SQLite with no DSN options at all, so concurrent writers failed immediately with `SQLITE_BUSY` instead of backing off.
- **Credential-store lifetime**: `config.CredentialStore` built a fresh store per call, each lazily opening a connection nothing closed — including on the request-path cache refresh. `Config` now owns it, and the store gains the `Close` that ownership implies.
- **Config-reload cost**: `HydrateRules` issued one INSERT per service missing a stats row, inside a rules × services loop that runs on every config load and hot-reload.
- **Simulator cleanup**: `NewLBSimulatorWithSequences`' documented "must be called" cleanup never closed the config's stores, leaking a SQLite handle per run.

## Notes

- With WAL enabled a live guardrails connection holds three descriptors (db, `-wal`, `-shm`), so the credential-store leak was three per store; `Close` is covered by tests asserting the handle is actually released and that closing twice is safe.
- `HydrateRules` now reuses `buildStatsRecordFromService` instead of a second inline copy of its defaults. It has no test coverage in the repo, before or after — equivalence was verified manually against a 2-rule × 250-service fixture.