### PR TITLE
fix(db): hold one connection to tingly.db per process

### DIFF
--- a/ai/quota/store.go
+++ b/ai/quota/store.go
@@ -267,8 +267,26 @@ type Store interface {
 type GormStore struct {
 	db     *gorm.DB
 	dbPath string
+	// ownsDB records whether this store opened its own connection (and so
+	// must close it) or borrowed a shared handle from the caller.
+	ownsDB bool
 	mu     sync.RWMutex
 	logger *logrus.Logger
+}
+
+// NewGormStoreOverDB creates a quota store over an already-open shared
+// connection. The caller retains ownership of the handle: Close on the
+// returned store is a no-op.
+//
+// Prefer this inside the server process, where StoreManager already owns a
+// connection to the same file; NewGormStore is for standalone use (CLI
+// commands, tests) with no shared connection to borrow.
+func NewGormStoreOverDB(db *gorm.DB, logger *logrus.Logger) (*GormStore, error) {
+	store := &GormStore{db: db, logger: logger}
+	if err := store.migrate(); err != nil {
+		return nil, fmt.Errorf("failed to migrate quota database: %w", err)
+	}
+	return store, nil
 }
 
 // NewGormStore creates a GORM-backed quota store. dbPath is the full path to
@@ -293,6 +311,7 @@ func NewGormStore(dbPath string, logger *logrus.Logger) (*GormStore, error) {
 	store := &GormStore{
 		db:     db,
 		dbPath: dbPath,
+		ownsDB: true,
 		logger: logger,
 	}
 
@@ -373,6 +392,9 @@ func (s *GormStore) CleanupExpired(ctx context.Context) (int64, error) {
 }
 
 func (s *GormStore) Close() error {
+	if !s.ownsDB {
+		return nil
+	}
 	sqlDB, err := s.db.DB()
 	if err != nil {
 		return err

--- a/internal/data/model_list.go
+++ b/internal/data/model_list.go
@@ -2,8 +2,6 @@ package data
 
 import (
 	"encoding/json"
-	"fmt"
-	"os"
 	"time"
 
 	"github.com/tingly-dev/tingly-box/internal/db"
@@ -19,23 +17,13 @@ type ModelListManager struct {
 	modelStore *db.ModelStore
 }
 
-// NewProviderModelManager creates a new provider model manager with database backing
-func NewProviderModelManager(configDir string) (*ModelListManager, error) {
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create models directory: %w", err)
-	}
-
-	modelStore, err := db.NewModelStore(configDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize model store: %w", err)
-	}
-
-	return &ModelListManager{modelStore: modelStore}, nil
-}
-
-// Close releases the underlying model store's database connection.
-func (mm *ModelListManager) Close() error {
-	return mm.modelStore.Close()
+// NewModelListManager wraps the StoreManager's ModelStore. There is
+// deliberately no constructor that opens its own connection: this manager
+// used to do exactly that, giving the process a second connection pool (and
+// a second AutoMigrate over provider_models) against the same tingly.db
+// StoreManager had just opened. Closing is the StoreManager's job.
+func NewModelListManager(store *db.ModelStore) *ModelListManager {
+	return &ModelListManager{modelStore: store}
 }
 
 // SaveModels saves models for a provider by UUID to the database.

--- a/internal/db/store_manager.go
+++ b/internal/db/store_manager.go
@@ -403,6 +403,16 @@ func (sm *StoreManager) BaseDir() string {
 	return sm.baseDir
 }
 
+// DB returns the shared *gorm.DB every store runs on. Subsystems that keep
+// their own record types on the shared tingly.db borrow this handle instead
+// of opening a second connection to the same file — the process should hold
+// exactly one connection pool per database. Returns nil after Close().
+func (sm *StoreManager) DB() *gorm.DB {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.db
+}
+
 // Close closes all database connections and cleans up resources.
 // After Close() is called, all accessor methods will return nil.
 func (sm *StoreManager) Close() error {

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -371,12 +371,10 @@ func NewConfig(opts ...ConfigOption) (*Config, error) {
 		}
 	}
 
-	// Initialize provider model manager
-	providerModelManager, err := data.NewProviderModelManager(configDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize provider model manager: %w", err)
-	}
-	cfg.modelManager = providerModelManager
+	// Initialize provider model manager over the store manager's ModelStore,
+	// so the process keeps one connection to tingly.db instead of a second
+	// pool (with its own AutoMigrate) against the same file.
+	cfg.modelManager = data.NewModelListManager(storeManager.Model())
 
 	if err := cfg.RefreshStatsFromStore(); err != nil {
 		return nil, err
@@ -480,25 +478,21 @@ func (c *Config) StoreManager() *db.StoreManager {
 }
 
 // CloseStores releases every database handle the config owns: the shared
-// store-manager connection, the provider-model store, and the guardrails
-// credential store (a separate file, and with WAL on, three
-// descriptors). The long-lived
+// store-manager connection (which every store, including the one the
+// ModelListManager wraps, now runs on) and the guardrails credential store,
+// a separate file holding three descriptors with WAL on. The long-lived
 // server closes the store manager from Stop; short-lived embedders (tests,
 // harness environments) call this so each instance does not leak SQLite
 // descriptors for the process lifetime. Safe to call more than once.
 func (c *Config) CloseStores() error {
 	c.mu.Lock()
 	storeManager := c.storeManager
-	modelManager := c.modelManager
 	credentialStore := c.credentialStore
 	c.mu.Unlock()
 
 	var errs []error
 	if storeManager != nil {
 		errs = append(errs, storeManager.Close())
-	}
-	if modelManager != nil {
-		errs = append(errs, modelManager.Close())
 	}
 	if credentialStore != nil {
 		errs = append(errs, credentialStore.Close())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -18,7 +19,6 @@ import (
 	"github.com/tingly-dev/tingly-box/ai/quota"
 	"github.com/tingly-dev/tingly-box/ai/quota/fetcher"
 	"github.com/tingly-dev/tingly-box/internal/client"
-	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/data"
 	"github.com/tingly-dev/tingly-box/internal/db"
 	"github.com/tingly-dev/tingly-box/internal/guardrails"
@@ -627,8 +627,21 @@ func (s *Server) setupConfigWatcher() {
 
 // initQuotaManager initializes the provider quota manager
 func initQuotaManager(cfg *config.Config) (*quota.Manager, error) {
-	// Create quota store
-	store, err := quota.NewGormStore(constant.GetDBFile(cfg.ConfigDir), logrus.StandardLogger())
+	// Create the quota store over the StoreManager's shared connection to
+	// tingly.db, rather than opening (and leaking — nothing closed it) a
+	// second connection pool against the same file.
+	//
+	// There is no fallback on purpose: every Server is built from a
+	// config.NewConfig, which fails outright if the StoreManager cannot be
+	// created, so a missing one means something is wrong rather than
+	// something to route around. Opening a private connection here would
+	// resolve a relative path against the process CWD — a stray second
+	// database, which is the failure this is meant to prevent.
+	sm := cfg.StoreManager()
+	if sm == nil || sm.DB() == nil {
+		return nil, errors.New("quota manager requires an initialized store manager")
+	}
+	store, err := quota.NewGormStoreOverDB(sm.DB(), logrus.StandardLogger())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

A running server opened three independent GORM connection pools against the same `tingly.db`, two of which nothing ever closed.

## Key Changes

- **Single connection to tingly.db**: `ai/quota` and the model-list subsystem now borrow `StoreManager`'s handle instead of each opening (and leaking) a pool against the same file — the model list also re-ran `AutoMigrate` over a table `StoreManager` had just migrated.
- **`initQuotaManager` has no fallback on purpose**: every `Server` comes from `config.NewConfig`, which fails outright if the `StoreManager` cannot be created, so a missing one means something is wrong rather than something to route around. A private connection there would resolve a relative path against the process CWD — the exact stray-second-database failure this exists to prevent.

## Notes

An earlier version of this PR also switched on a usage-table schema-alignment step (`ensureUsageRecordSchema`) that had never run in production. That code has no live callers and no effect on current behavior — dropped from this PR rather than fixed, since there's nothing broken to fix.