### PR TITLE
refactor(db): unify store construction over one openDB seam

### DIFF
--- a/internal/db/api_token_store.go
+++ b/internal/db/api_token_store.go
@@ -3,17 +3,11 @@ package db
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
-
-	"github.com/tingly-dev/tingly-box/internal/constant"
 )
 
 // APITokenRecord represents a user API token for multi-tenant authentication
@@ -49,64 +43,39 @@ const defaultLastUsedDebounce = 10 * time.Minute
 // request, see internal/middleware/auth.go), so cache mirrors the
 // api_tokens table by TokenID the same way ProviderStore mirrors providers.
 type APITokenStore struct {
-	db     *gorm.DB
-	dbPath string
-	mu     sync.RWMutex
-	cache  map[string]*APITokenRecord
+	storeConn
+	mu    sync.RWMutex
+	cache map[string]*APITokenRecord
 
 	// lastUsedDebounce is the minimum interval between persisted
 	// last_used_at writes for the same token; see UpdateLastUsed.
 	lastUsedDebounce time.Duration
 }
 
-// NewAPITokenStore creates or loads an API token store using SQLite database.
+// NewAPITokenStore creates or loads an API token store over its own
+// connection to the shared tingly.db.
 func NewAPITokenStore(baseDir string) (*APITokenStore, error) {
-	logrus.Debugf("Initializing API token store in directory: %s", baseDir)
-	if err := os.MkdirAll(baseDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create API token store directory: %w", err)
-	}
-
-	dbPath := constant.GetDBFile(baseDir)
-	dbDir := filepath.Dir(dbPath)
-	if err := os.MkdirAll(dbDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create db directory: %w", err)
-	}
-
-	logrus.Debugf("Opening SQLite database for API token store: %s", dbPath)
-	dsn := dbPath + "?_busy_timeout=5000&_journal_mode=WAL&_foreign_keys=1"
-	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
+	db, err := openTinglyDB(baseDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open API token database: %w", err)
+		return nil, fmt.Errorf("api token store: %w", err)
 	}
-	logrus.Debugf("SQLite database opened successfully for API token store")
-
-	store, err := newAPITokenStoreOverDB(db, dbPath)
-	if err != nil {
-		return nil, err
-	}
-
-	logrus.Debugf("API token store initialization completed")
-	return store, nil
+	return newAPITokenStore(ownedConn(db))
 }
 
-// newAPITokenStoreOverDB finishes setting up an APITokenStore (migrate +
-// cache load) over an already-open *gorm.DB, shared by NewAPITokenStore and
-// StoreManager.initAPITokenStore -- see newProviderStoreOverDB.
-func newAPITokenStoreOverDB(db *gorm.DB, dbPath string) (*APITokenStore, error) {
-	if err := db.AutoMigrate(&APITokenRecord{}); err != nil {
+// newAPITokenStore finishes setting up an APITokenStore (migrate + cache
+// load) over an already-open connection -- see newProviderStore.
+func newAPITokenStore(conn storeConn) (*APITokenStore, error) {
+	if err := conn.db.AutoMigrate(&APITokenRecord{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate API token database: %w", err)
 	}
 
 	// Rename user_uuid column to user_id for consistency
-	if err := ensureAPITokenSchema(db); err != nil {
+	if err := ensureAPITokenSchema(conn.db); err != nil {
 		return nil, fmt.Errorf("failed to align API token schema: %w", err)
 	}
 
 	store := &APITokenStore{
-		db:               db,
-		dbPath:           dbPath,
+		storeConn:        conn,
 		cache:            make(map[string]*APITokenRecord),
 		lastUsedDebounce: defaultLastUsedDebounce,
 	}
@@ -445,13 +414,4 @@ func (s *APITokenStore) CleanupExpiredTokens(olderThan time.Duration) (int64, er
 // GetDB returns the underlying GORM DB instance (for testing)
 func (s *APITokenStore) GetDB() *gorm.DB {
 	return s.db
-}
-
-// Close closes the database connection
-func (s *APITokenStore) Close() error {
-	sqlDB, err := s.db.DB()
-	if err != nil {
-		return err
-	}
-	return sqlDB.Close()
 }

--- a/internal/db/imbot_settings_store.go
+++ b/internal/db/imbot_settings_store.go
@@ -4,17 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
-
-	"github.com/sirupsen/logrus"
-	"github.com/tingly-dev/tingly-box/internal/constant"
 )
 
 // Settings represents ImBot configuration (exported for use by remote_coder module)
@@ -46,44 +39,27 @@ type Settings struct {
 
 // ImBotSettingsStore persists ImBot settings in SQLite using GORM.
 type ImBotSettingsStore struct {
-	db     *gorm.DB
-	dbPath string
-	mu     sync.Mutex
+	storeConn
+	mu sync.Mutex
 }
 
-// NewImBotSettingsStore creates or loads an ImBot settings store using SQLite database.
+// NewImBotSettingsStore creates or loads an ImBot settings store over its
+// own connection to the shared tingly.db.
 func NewImBotSettingsStore(baseDir string) (*ImBotSettingsStore, error) {
-	logrus.Debugf("Initializing stats store in directory: %s", baseDir)
-	if err := os.MkdirAll(baseDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create stats store directory: %w", err)
-	}
-
-	dbPath := constant.GetDBFile(baseDir)
-	// Ensure the db subdirectory exists
-	dbDir := filepath.Dir(dbPath)
-	if err := os.MkdirAll(dbDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create db directory: %w", err)
-	}
-	// Configure SQLite with busy timeout and other settings
-	dsn := dbPath + "?_busy_timeout=5000&_journal_mode=WAL&_foreign_keys=1"
-	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
+	db, err := openTinglyDB(baseDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open imbot settings database: %w", err)
+		return nil, fmt.Errorf("imbot settings store: %w", err)
 	}
+	return newImBotSettingsStore(ownedConn(db))
+}
 
-	store := &ImBotSettingsStore{
-		db:     db,
-		dbPath: dbPath,
-	}
-
-	// Auto-migrate schema
-	if err := db.AutoMigrate(&ImBotSettingsRecord{}); err != nil {
+// newImBotSettingsStore finishes setting up an ImBotSettingsStore (migrate)
+// over an already-open connection.
+func newImBotSettingsStore(conn storeConn) (*ImBotSettingsStore, error) {
+	if err := conn.db.AutoMigrate(&ImBotSettingsRecord{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate imbot settings database: %w", err)
 	}
-
-	return store, nil
+	return &ImBotSettingsStore{storeConn: conn}, nil
 }
 
 // ListSettings returns all ImBot configurations.

--- a/internal/db/open.go
+++ b/internal/db/open.go
@@ -1,0 +1,92 @@
+package db
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
+)
+
+// defaultBusyTimeoutMs is the SQLite busy_timeout applied to every connection
+// this package opens. StoreManager makes it configurable; the standalone
+// NewXStore constructors use the default.
+const defaultBusyTimeoutMs = 5000
+
+// OpenSQLite opens a GORM handle on dbPath with the canonical options for
+// tingly's SQLite databases — WAL journaling (which also forces
+// synchronous=NORMAL in mattn/go-sqlite3), foreign keys on, and a busy
+// timeout so concurrent connections back off instead of failing with
+// SQLITE_BUSY — creating the parent directory first. A busyTimeoutMs of 0
+// takes the default.
+//
+// This is the only place the option set is spelled out. It is exported for
+// databases outside this package that are nonetheless tingly's own (the
+// guardrails credential store); everything on tingly.db should go through
+// StoreManager instead.
+func OpenSQLite(dbPath string, busyTimeoutMs int) (*gorm.DB, error) {
+	if busyTimeoutMs <= 0 {
+		busyTimeoutMs = defaultBusyTimeoutMs
+	}
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0700); err != nil {
+		return nil, fmt.Errorf("failed to create db directory: %w", err)
+	}
+	dsn := fmt.Sprintf("%s?_busy_timeout=%d&_journal_mode=WAL&_foreign_keys=1", dbPath, busyTimeoutMs)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database %s: %w", dbPath, err)
+	}
+	return db, nil
+}
+
+// openTinglyDB opens the shared tingly.db under baseDir for the standalone
+// NewXStore constructors. StoreManager opens the same file itself so it can
+// thread its configurable busy timeout through.
+//
+// Creating baseDir is left to OpenSQLite, which creates baseDir/db and so
+// baseDir along with it.
+func openTinglyDB(baseDir string) (*gorm.DB, error) {
+	return OpenSQLite(constant.GetDBFile(baseDir), defaultBusyTimeoutMs)
+}
+
+// storeConn is the connection half every store embeds: the *gorm.DB it runs
+// on, plus whether the store opened that connection itself (standalone
+// NewXStore constructors) or borrowed StoreManager's shared handle. Close is
+// a no-op for borrowed connections, so calling Close on a store can never
+// tear down the shared database out from under the other stores — a real
+// hazard in the previous per-store Close implementations.
+type storeConn struct {
+	db     *gorm.DB
+	ownsDB bool
+}
+
+// borrowedConn wraps a shared *gorm.DB the store must not close.
+func borrowedConn(db *gorm.DB) storeConn {
+	return storeConn{db: db}
+}
+
+// ownedConn wraps a *gorm.DB the store opened and is responsible for closing.
+func ownedConn(db *gorm.DB) storeConn {
+	return storeConn{db: db, ownsDB: true}
+}
+
+// Close closes the underlying connection if this store owns it; otherwise it
+// is a no-op (the owner — usually StoreManager — closes it).
+func (c *storeConn) Close() error {
+	if !c.ownsDB || c.db == nil {
+		return nil
+	}
+	sqlDB, err := c.db.DB()
+	if err != nil {
+		return err
+	}
+	// Leave c.db in place: GORM calls on a closed connection fail with a
+	// clean "database is closed" error rather than a nil-pointer panic.
+	return sqlDB.Close()
+}

--- a/internal/db/provider_model.go
+++ b/internal/db/provider_model.go
@@ -4,15 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 
-	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -53,55 +49,29 @@ func (ProviderModelRecord) TableName() string {
 
 // ModelStore persists provider model information in SQLite using GORM.
 type ModelStore struct {
-	db     *gorm.DB
-	dbPath string
-	mu     sync.RWMutex
+	storeConn
+	mu sync.RWMutex
 }
 
-// NewModelStore creates or loads a model store using SQLite database.
+// NewModelStore creates or loads a model store over its own connection to
+// the shared tingly.db. Short-lived embedders must Close, or each instance
+// leaks a SQLite handle for the process lifetime; a store borrowed from
+// StoreManager is closed by it instead.
 func NewModelStore(baseDir string) (*ModelStore, error) {
-	if err := os.MkdirAll(baseDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create model store directory: %w", err)
-	}
-
-	dbPath := constant.GetDBFile(baseDir)
-	// Configure SQLite with busy timeout and other settings
-	dsn := dbPath + "?_busy_timeout=5000&_journal_mode=WAL&_foreign_keys=1"
-	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
+	db, err := openTinglyDB(baseDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open models database: %w", err)
+		return nil, fmt.Errorf("model store: %w", err)
 	}
+	return newModelStore(ownedConn(db))
+}
 
-	store := &ModelStore{
-		db:     db,
-		dbPath: dbPath,
-	}
-
-	// Auto-migrate schema
-	if err := db.AutoMigrate(&ProviderModelRecord{}); err != nil {
+// newModelStore finishes setting up a ModelStore (migrate) over an
+// already-open connection.
+func newModelStore(conn storeConn) (*ModelStore, error) {
+	if err := conn.db.AutoMigrate(&ProviderModelRecord{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate models database: %w", err)
 	}
-
-	return store, nil
-}
-
-// Close releases the store's database connection. Safe to call more than
-// once. Short-lived embedders (tests, harness environments) must close, or
-// each instance leaks a SQLite handle for the process lifetime.
-func (s *ModelStore) Close() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.db == nil {
-		return nil
-	}
-	sqlDB, err := s.db.DB()
-	s.db = nil
-	if err != nil {
-		return fmt.Errorf("model store: get database instance: %w", err)
-	}
-	return sqlDB.Close()
+	return &ModelStore{storeConn: conn}, nil
 }
 
 // SaveModels saves models for a provider by UUID

--- a/internal/db/provider_store.go
+++ b/internal/db/provider_store.go
@@ -4,18 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/ai"
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 
-	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -285,9 +280,8 @@ func updateRecordFromProvider(record *ProviderRecord, p *typ.Provider) {
 // the request hot path (see internal/routing/selector.go) and used to
 // account for ~47% of Select()'s CPU time.
 type ProviderStore struct {
-	db     *gorm.DB
-	dbPath string
-	mu     sync.RWMutex
+	storeConn
+	mu sync.RWMutex
 
 	cache map[string]*ProviderRecord
 	// order preserves insertion order for List/ListOAuth/ListEnabled, since
@@ -295,52 +289,27 @@ type ProviderStore struct {
 	order []string
 }
 
-// NewProviderStore creates or loads a provider store using SQLite database.
+// NewProviderStore creates or loads a provider store over its own connection
+// to the shared tingly.db.
 func NewProviderStore(baseDir string) (*ProviderStore, error) {
-	logrus.Debugf("Initializing provider store in directory: %s", baseDir)
-	if err := os.MkdirAll(baseDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create provider store directory: %w", err)
-	}
-
-	dbPath := constant.GetDBFile(baseDir)
-	// Ensure the db subdirectory exists
-	dbDir := filepath.Dir(dbPath)
-	if err := os.MkdirAll(dbDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create db directory: %w", err)
-	}
-
-	logrus.Debugf("Opening SQLite database for provider store: %s", dbPath)
-	dsn := dbPath + "?_busy_timeout=5000&_journal_mode=WAL&_foreign_keys=1"
-	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
+	db, err := openTinglyDB(baseDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open provider database: %w", err)
+		return nil, fmt.Errorf("provider store: %w", err)
 	}
-	logrus.Debugf("SQLite database opened successfully for provider store")
-
-	store, err := newProviderStoreOverDB(db, dbPath)
-	if err != nil {
-		return nil, err
-	}
-	logrus.Debugf("Provider store initialization completed")
-
-	return store, nil
+	return newProviderStore(ownedConn(db))
 }
 
-// newProviderStoreOverDB finishes setting up a ProviderStore (migrate +
-// cache load) over an already-open *gorm.DB, shared by NewProviderStore and
-// StoreManager.initProviderStore so the cache-init wiring can't drift
-// between them.
-func newProviderStoreOverDB(db *gorm.DB, dbPath string) (*ProviderStore, error) {
-	if err := db.AutoMigrate(&ProviderRecord{}); err != nil {
+// newProviderStore finishes setting up a ProviderStore (migrate + cache load)
+// over an already-open connection, shared by NewProviderStore and
+// StoreManager so the cache-init wiring can't drift between them.
+func newProviderStore(conn storeConn) (*ProviderStore, error) {
+	if err := conn.db.AutoMigrate(&ProviderRecord{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate provider database: %w", err)
 	}
 
 	store := &ProviderStore{
-		db:     db,
-		dbPath: dbPath,
-		cache:  make(map[string]*ProviderRecord),
+		storeConn: conn,
+		cache:     make(map[string]*ProviderRecord),
 	}
 	if err := store.loadCache(); err != nil {
 		return nil, fmt.Errorf("failed to load provider cache: %w", err)
@@ -655,13 +624,4 @@ func (ps *ProviderStore) ListEnabled() ([]*typ.Provider, error) {
 // GetDB returns the underlying GORM DB instance (for testing/advanced usage)
 func (ps *ProviderStore) GetDB() *gorm.DB {
 	return ps.db
-}
-
-// Close closes the database connection
-func (ps *ProviderStore) Close() error {
-	sqlDB, err := ps.db.DB()
-	if err != nil {
-		return err
-	}
-	return sqlDB.Close()
 }

--- a/internal/db/service_stat.go
+++ b/internal/db/service_stat.go
@@ -3,17 +3,11 @@ package db
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 
-	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -43,49 +37,27 @@ func (ServiceStatsRecord) TableName() string {
 
 // StatsStore persists service usage statistics in SQLite using GORM.
 type StatsStore struct {
-	db     *gorm.DB
-	dbPath string
-	mu     sync.Mutex
+	storeConn
+	mu sync.Mutex
 }
 
-// NewStatsStore creates or loads a stats store using SQLite database.
+// NewStatsStore creates or loads a stats store over its own connection to
+// the shared tingly.db.
 func NewStatsStore(baseDir string) (*StatsStore, error) {
-	logrus.Debugf("Initializing stats store in directory: %s", baseDir)
-	if err := os.MkdirAll(baseDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create stats store directory: %w", err)
-	}
-
-	dbPath := constant.GetDBFile(baseDir)
-	// Ensure the db subdirectory exists
-	dbDir := filepath.Dir(dbPath)
-	if err := os.MkdirAll(dbDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create db directory: %w", err)
-	}
-
-	logrus.Debugf("Opening SQLite database: %s", dbPath)
-	// Configure SQLite with busy timeout and other settings to prevent hangs
-	// Use pure Go driver by ensuring modernc.org/sqlite is used
-	dsn := dbPath + "?_busy_timeout=5000&_journal_mode=WAL&_foreign_keys=1"
-	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent), // Disable verbose logging for now
-	})
+	db, err := openTinglyDB(baseDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open stats database: %w", err)
+		return nil, fmt.Errorf("stats store: %w", err)
 	}
-	logrus.Debugf("SQLite database opened successfully")
+	return newStatsStore(ownedConn(db))
+}
 
-	store := &StatsStore{
-		db:     db,
-		dbPath: dbPath,
-	}
-
-	// Auto-migrate schema, if we add column it would create or update the database table to match the struct definition
-	if err := db.AutoMigrate(&ServiceStatsRecord{}); err != nil {
+// newStatsStore finishes setting up a StatsStore (migrate) over an
+// already-open connection.
+func newStatsStore(conn storeConn) (*StatsStore, error) {
+	if err := conn.db.AutoMigrate(&ServiceStatsRecord{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate stats database: %w", err)
 	}
-	logrus.Debugf("Stats store initialization completed")
-
-	return store, nil
+	return &StatsStore{storeConn: conn}, nil
 }
 
 // ServiceKey builds a unique key for a provider/model combination.

--- a/internal/db/store_manager.go
+++ b/internal/db/store_manager.go
@@ -3,14 +3,10 @@ package db
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/sirupsen/logrus"
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/remote/session"
@@ -69,44 +65,22 @@ const (
 //	*StoreManager - Initialized store manager
 //	error - Error if any store fails to initialize
 func NewStoreManager(baseDir string) (*StoreManager, error) {
-	config := StoreManagerConfig{
-		BaseDir:     baseDir,
-		BusyTimeout: 5000,
-	}
-	return NewStoreManagerWithConfig(config)
+	return NewStoreManagerWithConfig(StoreManagerConfig{BaseDir: baseDir})
 }
 
 // NewStoreManagerWithConfig creates a StoreManager with custom configuration.
+// A zero BusyTimeout takes OpenSQLite's default.
 func NewStoreManagerWithConfig(config StoreManagerConfig) (*StoreManager, error) {
 	if config.BaseDir == "" {
 		return nil, errors.New("base directory cannot be empty")
 	}
 
-	// Create base directory if it doesn't exist
-	if err := os.MkdirAll(config.BaseDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create base directory: %w", err)
-	}
-
-	// Set default busy timeout
-	if config.BusyTimeout <= 0 {
-		config.BusyTimeout = 5000
-	}
-
-	// Get database path
+	// Open shared database connection. OpenSQLite creates baseDir/db, and
+	// baseDir with it.
 	dbPath := constant.GetDBFile(config.BaseDir)
-	dbDir := filepath.Dir(dbPath)
-	if err := os.MkdirAll(dbDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create db directory: %w", err)
-	}
-
-	// Open shared database connection
-	dsn := fmt.Sprintf("%s?_busy_timeout=%d&_journal_mode=WAL&_foreign_keys=1",
-		dbPath, config.BusyTimeout)
-	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
+	db, err := OpenSQLite(dbPath, config.BusyTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open database: %w", err)
+		return nil, err
 	}
 
 	logrus.Debugf("StoreManager: Opened database at %s", dbPath)
@@ -166,33 +140,29 @@ func (sm *StoreManager) initStores() error {
 	return nil
 }
 
-// initStatsStore initializes the StatsStore.
+// initStatsStore initializes the store over the shared connection.
 func (sm *StoreManager) initStatsStore() error {
-	if err := sm.db.AutoMigrate(&ServiceStatsRecord{}); err != nil {
+	store, err := newStatsStore(borrowedConn(sm.db))
+	if err != nil {
 		return err
 	}
-	sm.statsStore = &StatsStore{
-		db:     sm.db,
-		dbPath: constant.GetDBFile(sm.baseDir),
-	}
+	sm.statsStore = store
 	return nil
 }
 
-// initUsageStore initializes the UsageStore.
+// initUsageStore initializes the store over the shared connection.
 func (sm *StoreManager) initUsageStore() error {
-	if err := migrateUsageTables(sm.db); err != nil {
+	store, err := newUsageStore(borrowedConn(sm.db))
+	if err != nil {
 		return err
 	}
-	sm.usageStore = &UsageStore{
-		db:     sm.db,
-		dbPath: constant.GetDBFile(sm.baseDir),
-	}
+	sm.usageStore = store
 	return nil
 }
 
-// initProviderStore initializes the ProviderStore.
+// initProviderStore initializes the store over the shared connection.
 func (sm *StoreManager) initProviderStore() error {
-	store, err := newProviderStoreOverDB(sm.db, constant.GetDBFile(sm.baseDir))
+	store, err := newProviderStore(borrowedConn(sm.db))
 	if err != nil {
 		return err
 	}
@@ -200,15 +170,13 @@ func (sm *StoreManager) initProviderStore() error {
 	return nil
 }
 
-// initImBotSettingsStore initializes the ImBotSettingsStore.
+// initImBotSettingsStore initializes the store over the shared connection.
 func (sm *StoreManager) initImBotSettingsStore() error {
-	if err := sm.db.AutoMigrate(&ImBotSettingsRecord{}); err != nil {
+	store, err := newImBotSettingsStore(borrowedConn(sm.db))
+	if err != nil {
 		return err
 	}
-	sm.imbotSettingsStore = &ImBotSettingsStore{
-		db:     sm.db,
-		dbPath: constant.GetDBFile(sm.baseDir),
-	}
+	sm.imbotSettingsStore = store
 	return nil
 }
 
@@ -219,21 +187,19 @@ func (sm *StoreManager) dropDeprecatedModelCapabilities() error {
 	return sm.db.Exec("DROP TABLE IF EXISTS model_capabilities").Error
 }
 
-// initModelStore initializes the ModelStore.
+// initModelStore initializes the store over the shared connection.
 func (sm *StoreManager) initModelStore() error {
-	if err := sm.db.AutoMigrate(&ProviderModelRecord{}); err != nil {
+	store, err := newModelStore(borrowedConn(sm.db))
+	if err != nil {
 		return err
 	}
-	sm.modelStore = &ModelStore{
-		db:     sm.db,
-		dbPath: constant.GetDBFile(sm.baseDir),
-	}
+	sm.modelStore = store
 	return nil
 }
 
-// initAPITokenStore initializes the APITokenStore.
+// initAPITokenStore initializes the store over the shared connection.
 func (sm *StoreManager) initAPITokenStore() error {
-	store, err := newAPITokenStoreOverDB(sm.db, constant.GetDBFile(sm.baseDir))
+	store, err := newAPITokenStore(borrowedConn(sm.db))
 	if err != nil {
 		return err
 	}

--- a/internal/db/usage_record.go
+++ b/internal/db/usage_record.go
@@ -3,18 +3,11 @@ package db
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
-
-	"github.com/tingly-dev/tingly-box/internal/constant"
 )
 
 // UsageRecord is the GORM model for persisting individual usage records
@@ -95,8 +88,7 @@ func (UsageDailyRecord) TableName() string {
 
 // UsageStore persists usage records in SQLite using GORM.
 type UsageStore struct {
-	db     *gorm.DB
-	dbPath string
+	storeConn
 	// mu guards the database: writes take the write lock, queries the read
 	// lock (WAL mode supports concurrent readers), so dashboard queries do
 	// not serialize behind proxy usage writes or each other.
@@ -123,40 +115,23 @@ type PerformanceSummary struct {
 	Completion PerformanceMetricSummary
 }
 
-// NewUsageStore creates or loads a usage store using SQLite database.
+// NewUsageStore creates or loads a usage store over its own connection to
+// the shared tingly.db.
 func NewUsageStore(baseDir string) (*UsageStore, error) {
-	logrus.Printf("Initializing usage store in directory: %s", baseDir)
-	if err := os.MkdirAll(baseDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create usage store directory: %w", err)
-	}
-
-	dbPath := constant.GetDBFile(baseDir)
-	// Ensure the db subdirectory exists (matches every other NewXStore constructor).
-	dbDir := filepath.Dir(dbPath)
-	if err := os.MkdirAll(dbDir, 0700); err != nil {
-		return nil, fmt.Errorf("failed to create db directory: %w", err)
-	}
-	logrus.Printf("Opening SQLite database for usage store: %s", dbPath)
-	dsn := dbPath + "?_busy_timeout=5000&_journal_mode=WAL&_foreign_keys=1"
-	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
+	db, err := openTinglyDB(baseDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open usage database: %w", err)
+		return nil, fmt.Errorf("usage store: %w", err)
 	}
-	logrus.Debugf("SQLite database opened successfully for usage store")
+	return newUsageStore(ownedConn(db))
+}
 
-	store := &UsageStore{
-		db:     db,
-		dbPath: dbPath,
-	}
-
-	if err := migrateUsageTables(db); err != nil {
+// newUsageStore finishes setting up a UsageStore (migrate) over an
+// already-open connection.
+func newUsageStore(conn storeConn) (*UsageStore, error) {
+	if err := migrateUsageTables(conn.db); err != nil {
 		return nil, err
 	}
-	logrus.Debugf("Usage store initialization completed")
-
-	return store, nil
+	return &UsageStore{storeConn: conn}, nil
 }
 
 // migrateUsageTables aligns and auto-migrates usage_records and usage_daily.

--- a/internal/guardrails/utils/credential_store.go
+++ b/internal/guardrails/utils/credential_store.go
@@ -3,16 +3,13 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 
+	tinglydb "github.com/tingly-dev/tingly-box/internal/db"
 	guardrailscore "github.com/tingly-dev/tingly-box/internal/guardrails/core"
 )
 
@@ -220,26 +217,18 @@ func (s *ProtectedCredentialStore) ensureDB() (*gorm.DB, error) {
 	if s.path == "" {
 		return nil, fmt.Errorf("protected credential store path is empty")
 	}
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
-		return nil, fmt.Errorf("create protected credential db dir: %w", err)
-	}
-
-	// Same connection options the tingly.db stores use: WAL journaling and a
-	// busy timeout, so concurrent writers back off instead of failing
-	// immediately with SQLITE_BUSY. This was the one SQLite open in the
-	// codebase with no options at all.
-	dsn := s.path + "?_busy_timeout=5000&_journal_mode=WAL&_foreign_keys=1"
-	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
+	// guardrails.db is a separate file (separate security domain) but not a
+	// separate set of connection options: db.OpenSQLite owns those, and
+	// creates the directory.
+	conn, err := tinglydb.OpenSQLite(s.path, 0)
 	if err != nil {
 		return nil, fmt.Errorf("open protected credential db: %w", err)
 	}
-	if err := db.AutoMigrate(&protectedCredentialRecord{}); err != nil {
+	if err := conn.AutoMigrate(&protectedCredentialRecord{}); err != nil {
 		return nil, fmt.Errorf("migrate protected credential db: %w", err)
 	}
 
-	s.db = db
+	s.db = conn
 	return s.db, nil
 }
 


### PR DESCRIPTION
## Summary

Every standalone store constructor repeated the same open-connection boilerplate, with the DSN string spelled out nine times across the package. Collapsed onto one seam.

## Key Changes

- **Single DSN/connection helper**: `open.go` (`sqliteDSN`/`openSQLite`/`openTinglyDB`) is now the only place the SQLite option set and directory creation are spelled out — `StoreManager` and every standalone `NewXStore` constructor go through it, including the guardrails credential store (a different file, but not a different option set).
- **Explicit connection ownership**: `storeConn` records whether a store opened its own connection or borrowed `StoreManager`'s shared handle. `Close` on a borrowed connection is a no-op — previously `ProviderStore.Close`/`APITokenStore.Close` closed the shared database out from under every other store if called on a `StoreManager`-owned instance.
- **One construction path per store**: every store gets a `newXStore(conn)` seam that both `NewXStore` and `StoreManager` call, instead of `StoreManager` building several via bare struct literals (a drift hazard `.design/db.md` already documents).