### PR TITLE
feat(frontend): tighten dashboard filters and Connect AI dialog UX

### DIFF
--- a/frontend/src/components/OAuthDetailDialog.tsx
+++ b/frontend/src/components/OAuthDetailDialog.tsx
@@ -113,10 +113,18 @@ const OAuthDetailDialog = ({ open, provider, onClose, onSubmit, onNotification }
     if (!provider) return null;
 
     return (
-        <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-            <DialogTitle>Edit OAuth Provider</DialogTitle>
-            <form onSubmit={handleSubmit}>
-                <DialogContent sx={{ pb: 1 }}>
+        <Dialog
+            open={open}
+            onClose={onClose}
+            maxWidth="sm"
+            fullWidth
+            slotProps={{
+                paper: { sx: { maxHeight: '88vh', display: 'flex', flexDirection: 'column' } },
+            }}
+        >
+            <DialogTitle sx={{ flexShrink: 0 }}>Edit OAuth Provider</DialogTitle>
+            <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
+                <DialogContent sx={{ pb: 1, overflowY: 'auto', flex: 1 }}>
                     <Stack spacing={2.5}>
                         {/* OAuth Badge */}
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -345,7 +353,7 @@ const OAuthDetailDialog = ({ open, provider, onClose, onSubmit, onNotification }
                         )}
                     </Stack>
                 </DialogContent>
-                <DialogActions sx={{ px: 3, pb: 2, gap: 1 }}>
+                <DialogActions sx={{ px: 3, pb: 2, gap: 1, flexShrink: 0 }}>
                     <ProviderExportButton providerUuid={provider.uuid} onNotification={onNotification}/>
                     <Box sx={{ml: 'auto'}}>
                         <Button onClick={onClose} color="inherit">Cancel</Button>

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -189,7 +189,6 @@ const ProviderFormDialog = ({
 
         setVerificationResult(null);
         setBaseUrlError(false);
-        setAdvancedOpen(mode === 'edit');
         setShowNameField(mode === 'edit');
 
         const hasDualOpenAI = !!data.apiBaseOpenAI;
@@ -519,9 +518,18 @@ const ProviderFormDialog = ({
             <DialogTitle sx={{flexShrink: 0}}>
                 <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
                     {title || defaultTitle}
-                    <IconButton aria-label="close" onClick={onClose} sx={{ml: 2}} size="small">
-                        <Close/>
-                    </IconButton>
+                    <Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
+                        {mode === 'edit' && (
+                            <FormControlLabel
+                                sx={{ml: 0, mr: 0}}
+                                control={<Switch size="small" checked={data.enabled || false} onChange={(e) => onChange('enabled', e.target.checked)}/>}
+                                label={<Typography variant="body2" color="text.secondary">{t('providerDialog.enabled')}</Typography>}
+                            />
+                        )}
+                        <IconButton aria-label="close" onClick={onClose} sx={{ml: 1}} size="small">
+                            <Close/>
+                        </IconButton>
+                    </Box>
                 </Box>
             </DialogTitle>
             <form onSubmit={handleSubmit} style={{display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden'}}>
@@ -619,6 +627,21 @@ const ProviderFormDialog = ({
                             </Stack>
                         </Box>
 
+                        {/* ── Name ────────────────────────────── */}
+                        <KeyNameField
+                            showField={showNameField}
+                            onShowField={() => {
+                                if (!data.name) onChangeRef.current('name', computeAutoName());
+                                setShowNameField(true);
+                            }}
+                            name={data.name}
+                            autoName={computeAutoName()}
+                            onNameChange={(value) => {
+                                onChange('name', value);
+                                setNameIsAutoFilled(false);
+                            }}
+                        />
+
                         {/* ── API Key ─────────────────────────── */}
                         <ApiKeyField
                             mode={mode}
@@ -687,31 +710,13 @@ const ProviderFormDialog = ({
                                         color: "text.secondary",
                                         fontWeight: 600
                                     }}>
-                                    {t('providerDialog.advanced.label', {defaultValue: 'Advanced — user-agent, name'})}
+                                    {t('providerDialog.advanced.title')}
                                 </Typography>
                             </AccordionSummary>
+                            {/* Empty for now — reserved for future advanced options
+                                (enabled toggle moved to the dialog title). */}
                             <AccordionDetails sx={{px: 0, pb: 1}}>
-                                <Stack spacing={2.5}>
-                                    <KeyNameField
-                                        showField={showNameField}
-                                        onShowField={() => {
-                                            if (!data.name) onChangeRef.current('name', computeAutoName());
-                                            setShowNameField(true);
-                                        }}
-                                        name={data.name}
-                                        autoName={computeAutoName()}
-                                        onNameChange={(value) => {
-                                            onChange('name', value);
-                                            setNameIsAutoFilled(false);
-                                        }}
-                                    />
-                                    {mode === 'edit' && (
-                                        <FormControlLabel
-                                            control={<Switch size="small" checked={data.enabled || false} onChange={(e) => onChange('enabled', e.target.checked)}/>}
-                                            label={t('providerDialog.enabled')}
-                                        />
-                                    )}
-                                </Stack>
+                                <Stack spacing={2.5} />
                             </AccordionDetails>
                         </Accordion>
                     </Stack>

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -102,7 +102,7 @@ const ProviderFormDialog = ({
     const [verificationResult, setVerificationResult] = useState<VerificationResult | null>(null);
     const [selectedProvider, setSelectedProvider] = useState<UniqueProvider | null>(null);
     const [nameIsAutoFilled, setNameIsAutoFilled] = useState(true);
-    const [showNameField, setShowNameField] = useState(mode === 'edit');
+    const [showNameField, setShowNameField] = useState(false);
     const [useGlobalProxy, setUseGlobalProxy] = useState(false);
     const [globalProxyUrl, setGlobalProxyUrl] = useState('');
     const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -189,7 +189,7 @@ const ProviderFormDialog = ({
 
         setVerificationResult(null);
         setBaseUrlError(false);
-        setShowNameField(mode === 'edit');
+        setShowNameField(false);
 
         const hasDualOpenAI = !!data.apiBaseOpenAI;
         const hasDualAnthropic = !!data.apiBaseAnthropic;

--- a/frontend/src/components/provider-form-dialog/ApiKeyField.tsx
+++ b/frontend/src/components/provider-form-dialog/ApiKeyField.tsx
@@ -81,13 +81,18 @@ const ApiKeyField: React.FC<ApiKeyFieldProps> = ({
                 }}
             />
             {!hideCheckbox && !optionalEditable && (
-                <Box sx={{display: 'flex', justifyContent: 'flex-end', mt: 0.5, pr: 2}}>
+                <Box sx={{display: 'flex', justifyContent: 'flex-end', mt: 0.25, pr: 1}}>
                     <FormControlLabel
+                        sx={{
+                            mr: 0,
+                            '& .MuiFormControlLabel-label': {fontSize: '0.75rem', color: 'text.secondary'},
+                        }}
                         control={
                             <Checkbox
                                 size="small"
                                 checked={noApiKey}
                                 onChange={(e) => onNoApiKeyChange(e.target.checked)}
+                                sx={{p: 0.5}}
                             />
                         }
                         label="No API Key Required"

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -279,7 +279,7 @@ export default {
   "providerDialog": {
     "addTitle": "Connect AI",
     "addDescription": "Select a provider and enter your API key to connect AI services. Multiple protocols can be enabled for providers that support them.",
-    "editTitle": "Edit Connection",
+    "editTitle": "Edit AI Config",
     "addButton": "Connect",
     "protocol": {
       "label": "Protocols",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -281,7 +281,7 @@ export default {
   "providerDialog": {
     "addTitle": "连接 AI",
     "addDescription": "选择提供商并输入您的 API 密钥以连接 AI 服务。支持多种协议的提供商可以启用多个协议。",
-    "editTitle": "修改连接",
+    "editTitle": "编辑 AI 配置",
     "addButton": "连接",
     "protocol": {
       "label": "协议",

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -737,7 +737,7 @@ export default function DashboardPage() {
                     view can use the full pane height (the Activity grid
                     centers itself vertically in it). */}
                 <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-                    <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                    <Box sx={{ display: 'flex', justifyContent: 'center' }}>
                         <ToggleButtonGroup
                             value={effectiveViewMode}
                             exclusive

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -330,6 +330,19 @@ export default function DashboardPage() {
         }
     }, [isHourlyRange]);
 
+    // Provider/model options are snapshotted from the current range's stats, so a
+    // selection from one range can be stale (or simply absent) in another. Clear
+    // them when the user switches time range. The user filter is kept — it names
+    // whose usage you're looking at, which stays meaningful across ranges.
+    const prevTimeRangeRef = useRef(timeRange);
+    useEffect(() => {
+        if (prevTimeRangeRef.current !== timeRange) {
+            setSelectedProvider('all');
+            setSelectedModel('all');
+            prevTimeRangeRef.current = timeRange;
+        }
+    }, [timeRange]);
+
     // Load records when entering the requests view or when a dashboard load
     // publishes new query params (filters are carried inside recordsParams).
     useEffect(() => {


### PR DESCRIPTION
## Summary
Cleans up stale filter state on Dashboard and a cluttered/inconsistent Connect AI dialog.

## Key Changes

- **Dashboard filters**: time-range switch clears provider/model (kept user filter); view-mode toggle centered.
- **Connect AI**: name field always visible and locked by default; enable toggle moved to title bar; stale "Advanced" copy removed.
- **Edit OAuth Provider**: action buttons pinned to viewport instead of scrolling away.