### PR TITLE
refactor(db): adopt gorm serializer:json, shared query scopes, and batched actor reads

### DIFF
--- a/.design/db.md
+++ b/.design/db.md
@@ -465,12 +465,28 @@ belongs in its own ticket, not bundled with a codec change.
 
 ### Suggested order
 
+All three are done. Context propagation (below) is deliberately left for
+its own change.
+
 1. ~~`serializer:json`, one store per commit, each re-auditing that store's
    `WHERE` clauses over the converted columns.~~ Done for `provider_store`,
    `provider_model` and `imbot_settings_store`; `remote_chat_store`
    deliberately skipped. See **Outcome** above.
-2. `usage_record` filter scopes + the column whitelist.
-3. The `ListGroupActors` `IN` batching.
+2. ~~`usage_record` filter scopes + the column whitelist.~~ Done. Six
+   rebuilt-by-hand `WHERE` blocks (four in `usage_record.go`, two in
+   `usage_daily.go`) collapsed to `withinTimeRange` + `withColumnFilters`,
+   with the typed `UsageStatsQuery` and the map form rendering to the same
+   columns. Filter keys are validated against a closed column set — a
+   smaller one for `usage_daily`, which has fewer dimensions — and an
+   unknown key is an **error, not a dropped filter**: dropping one widens
+   the result set, and for `user_id` that means returning another user's
+   records. Keys are also sorted, so the generated SQL no longer varies
+   with Go's randomized map iteration.
+3. ~~The `ListGroupActors` `IN` batching.~~ Done: 2N+2 → 4 queries,
+   measured 42 → 4 at N=20. The test asserts the count via a counting gorm
+   logger rather than trusting the shape by inspection, so a future
+   per-actor query is caught. Associations were not used, for the
+   composite-key reasons above.
 
 Not recommended as part of this: removing the manual `CreatedAt`/`UpdatedAt`
 assignments. GORM does fill them (probed: `Create` sets both; `Updates(map)`,

--- a/.design/db.md
+++ b/.design/db.md
@@ -308,6 +308,61 @@ lives in the DDL, which GORM can't see. A nil `Config` would hit the NOT NULL
 constraint at write time. Leave `bot_access_store`'s `rawJSONOrObject` helper
 alone; it exists for this reason.
 
+#### Outcome
+
+Done for **`provider_store`** (tags, oauth_extra_fields, vmodel_detail,
+credential), **`provider_model`** (models) and **`imbot_settings_store`**
+(auth_config, bash_allowlist). Three things came out of doing it that the
+evaluation above did not anticipate:
+
+**1. It is a hot-path performance fix, not just a tidy-up.**
+`ProviderStore.GetByUUID` is served from the write-through cache, so its cost
+is whatever `toProvider()` does — which included decoding the JSON columns on
+every call, i.e. once per routed LLM request. Removing that:
+
+| Benchmark | before | after |
+|---|---|---|
+| `GetByUUID_Tagged` | 1637–1901 ns/op, 11 allocs | 369–386 ns/op, 2 allocs (**~4.5×**) |
+| `GetByUUID_OAuth` | 2671–2922 ns/op, 21 allocs | 718–838 ns/op, 5 allocs (**~3.5×**) |
+| `GetByUUID_NoJSON` (control) | ~253 ns/op | ~245 ns/op |
+
+**2. `Updates(map[string]any)` silently bypasses serializers.** GORM applies
+a field's serializer only when the value comes off the *model*. A map value
+reaches the driver raw: passing a `[]string` fails with SQLite's
+"row value misused", and — worse — an empty `[]string` **writes NULL with no
+error at all**. Every store whose write path used `Updates(map)` on a column
+being converted had to move to read-modify-write (`provider_model.saveModels`,
+`imbot_settings_store.UpdateSettings`). This is the single biggest trap in
+this migration: the failure is silent in exactly the case (empty collection)
+that a test is least likely to cover.
+
+**3. The string encoding was providing cache isolation by accident.**
+Unmarshalling allocated a fresh value per read, so no caller shared state
+with a cached record. `ProviderStore` caches `*ProviderRecord`, and the OAuth
+callback handler mutates `provider.OAuthDetail.ExtraFields` in place on a
+provider it read from the store — which, with typed fields, would write
+straight into the cache and persist even if the following `UpdateProvider`
+failed. Explicit clone helpers restore the isolation; `TestProviderStore_CacheIsolation`
+pins it. **Any cached store converted in future needs the same treatment.**
+
+#### Not done: `remote_chat_store.project_history`
+
+Deliberately left as hand-marshalled, reversing the evaluation above.
+
+The serializer turns a decode failure into a failed *query*. For provider
+config that is the right trade — silently loading a provider with no
+credentials is worse than a loud error. For `project_history` it is not:
+`decodeProjectHistory` deliberately logs and degrades to empty, and the
+column holds a best-effort MRU path list, not anything the bot needs to
+function.
+
+Hard-failing the read would also make the row **unrecoverable through the
+store**. `GetChat` gates the IM-bot message path, and every write path
+(`GetOrCreateChat` → `mutate` → `UpdateChat`) reads before it writes — so a
+column that fails to decode could no longer be overwritten by the next
+`BindProject`, where today it is simply replaced. Trading that for the
+removal of two helper functions is a bad deal.
+
 ### Yes: `Scopes` for the repeated usage filter blocks
 
 `usage_record.go` rebuilds the same time-range + filter-map `WHERE` block
@@ -410,10 +465,10 @@ belongs in its own ticket, not bundled with a codec change.
 
 ### Suggested order
 
-1. `serializer:json`, **one store per PR**, each PR re-auditing that store's
-   `WHERE` clauses over the converted columns (`GetAllProviders` is the
-   known one). Start with `provider_store` — most sites, and it fixes the
-   swallowed JSON errors.
+1. ~~`serializer:json`, one store per commit, each re-auditing that store's
+   `WHERE` clauses over the converted columns.~~ Done for `provider_store`,
+   `provider_model` and `imbot_settings_store`; `remote_chat_store`
+   deliberately skipped. See **Outcome** above.
 2. `usage_record` filter scopes + the column whitelist.
 3. The `ListGroupActors` `IN` batching.
 

--- a/.design/db.md
+++ b/.design/db.md
@@ -218,3 +218,203 @@ message path**:
 4. **Write the benchmark first**, against the real production wiring, and
    profile before touching any code — don't reason about the win from first
    principles; measure it.
+
+## GORM feature adoption
+
+Status: **evaluation only** — nothing in this section is implemented yet.
+After the performance rounds above, the remaining question is where the
+stores still hand-roll something GORM already does. Every claim below was
+checked against gorm v1.31.2 / gorm.io/driver/sqlite v1.6.0 with throwaway
+probe tests and benchmarks (deleted after the numbers were taken), not read
+off the GORM docs.
+
+The short version: **one clear win (`serializer:json`), two small ones
+(query `Scopes`, an N+1 fix), and four features worth explicitly *not*
+adopting.** The "not" list matters as much as the "yes" list — the stores
+hand-roll several things on purpose, and that intent isn't obvious from the
+code.
+
+### Yes: `serializer:json` for the JSON-in-TEXT columns
+
+Eight columns across five stores hold JSON in a `string` field, marshalled
+and unmarshalled by hand at **27 call sites**:
+
+| Store | Columns | Sites |
+|---|---|---|
+| `provider_store.go` | `tags`, `oauth_extra_fields`, `vmodel_detail`, `credential` | 14 |
+| `imbot_settings_store.go` | `auth_config`, `bash_allowlist` | 6 |
+| `provider_model.go` | `models` | 4 |
+| `remote_chat_store.go` | `project_history` | 2 |
+| `bot_access_store.go` | `event_filter` | 1 |
+
+GORM's `serializer:json` tag replaces all of it — the field becomes its real
+type (`[]string`, `map[string]string`, `*typ.VModelDetail`) and GORM
+marshals on write / unmarshals on read:
+
+```go
+Tags []string `gorm:"column:tags;type:text;serializer:json"`
+```
+
+The bigger win isn't line count, it's **error handling**. All 14 of
+`provider_store.go`'s sites discard the JSON error, in three flavours: two
+bare unmarshals with no check at all (`:93`, `:107`), two that check and then
+silently fall through leaving the field nil (`:112`, `:119`), and ten writes
+that swallow it with `_` (`:163`, `:174`, `:180`, `:185`, `:214`, `:230`,
+`:238`, `:252`, `:504`, `:529`). A provider whose tags fail to marshal is
+silently persisted with no tags. Under the serializer, the failure surfaces
+through the normal `.Error` path.
+
+**Reads migrate cleanly — verified.** The concern is legacy rows: the
+current code writes `""` for "absent", which is not valid JSON.
+`JSONSerializer.Scan` guards on `len(bytes) > 0`, so a probe reading
+existing `""` rows through a serializer model returned a nil slice with no
+error. No backfill needed.
+
+**Writes change the on-disk representation — verified, and this is the trap.**
+Probe results writing through the serializer:
+
+| Go value | column before | column after |
+|---|---|---|
+| `nil` | `""` | `NULL` |
+| `[]string{}` | `""` | `"[]"` |
+| `[]string{"x"}` | `"[\"x\"]"` | `"[\"x\"]"` |
+
+That breaks any predicate that tests these columns as strings.
+`ModelStore.GetAllProviders` (`provider_model.go:225`) does exactly that:
+
+```go
+ms.db.Where("models <> ''").Find(&records)
+```
+
+Against a mixed table the probe counted **3 of 5** rows — it excluded the
+`NULL` row (because `NULL <> ''` is `NULL`, not true) *and* wrongly matched
+the `"[]"` row, reporting a provider with an empty model list as having
+models. So the migration is mechanical per column but **every `WHERE` over a
+serialized column has to be re-audited**, not just the codec.
+
+**Scope it to the four AutoMigrate-owned stores.** `bot_access_store.go`
+declares its tables with hand-written DDL where the JSON columns are
+`JSON NOT NULL DEFAULT '{}'`. `JSONSerializer.Value` returns SQL `NULL` for a
+nil value unless `NOT NULL` is in the *GORM tag* — and here the constraint
+lives in the DDL, which GORM can't see. A nil `Config` would hit the NOT NULL
+constraint at write time. Leave `bot_access_store`'s `rawJSONOrObject` helper
+alone; it exists for this reason.
+
+### Yes: `Scopes` for the repeated usage filter blocks
+
+`usage_record.go` rebuilds the same time-range + filter-map `WHERE` block
+four times — `rawAggBuckets` (`:324`), `rawTimeSeries` (`:456`),
+`GetRecords` (`:531`), `GetPerformanceSummary` (`:585`). A pair of
+`func(*gorm.DB) *gorm.DB` scopes collapses them.
+
+It also closes a latent hole. All four do:
+
+```go
+for key, value := range filters {
+    q = q.Where(key+" = ?", value)
+}
+```
+
+The map *key* is interpolated into SQL. This is **not** exploitable today —
+every caller in `internal/server/module/usage/handler.go` builds the map with
+hardcoded keys (`provider_uuid`, `model`, `scenario`, `status`, `user_id`)
+and only takes the *value* from the request. But the store has no way to
+enforce that, and the next caller won't know. A scope that whitelists the
+allowed columns makes it structurally safe rather than safe-by-convention.
+
+### Yes: the `ListGroupActors` N+1 — but with `IN`, not associations
+
+`bot_access_store.go:646-655` issues two queries per binding inside the loop
+(one `remote_actors` lookup, one `group_actor_permissions` lookup), so
+listing a group with 20 actors costs 41 queries. Two batched `Find`s with
+`IN (...)` plus a group-by in Go fixes it.
+
+**Do not reach for `Preload`/associations for this.** It would mean adding
+`has-many`/`belongs-to` tags to records whose keys are composite —
+`group_actor_permissions` is keyed on `(group_id, actor_id, capability,
+action)` and referenced by a composite foreign key. Composite-key
+associations are the weakest part of GORM's association support, and the
+tags would have to agree with DDL that GORM doesn't generate. The batched
+query is less code and no new coupling.
+
+### No: `PrepareStmt` — measured, no win
+
+The obvious candidate for the "batching still open" item above. Benchmarked
+both ways on the real `RecordRequestOutcome` write path and a
+`GetRecords` read, 300 iterations × 3 runs:
+
+| Benchmark | `PrepareStmt: false` | `PrepareStmt: true` |
+|---|---|---|
+| stats+usage write | 365–396 µs/op, 235 allocs | 357–370 µs/op, 250 allocs |
+| `GetRecords` read | 990 µs–1.12 ms/op, 2217 allocs | 986 µs–1.04 ms/op, 2151 allocs |
+
+Both deltas sit inside run-to-run variance, and the write path *gains* 15
+allocs/op. Consistent with the profiling above: the cost is statement
+execution and index maintenance, not SQL parsing, so caching the parse
+buys nothing. It would also add a per-connection statement cache that has to
+be invalidated across migrations. Not worth it.
+
+### No: replacing `bot_access_store`'s hand-written DDL with AutoMigrate
+
+The nine `CREATE TABLE` statements in `migrateBotAccessTables`
+(`bot_access_store.go:153`) carry things AutoMigrate cannot produce on
+SQLite:
+
+- `CHECK(effect IN ('allow','deny'))` on five tables
+- `CHECK((direct_chat_id IS NOT NULL) != (group_id IS NOT NULL))` — the
+  route XOR invariant
+- a **composite** foreign key: `FOREIGN KEY(group_id, actor_id) REFERENCES
+  remote_group_actors(group_id, actor_id) ON DELETE CASCADE`
+- `ON DELETE CASCADE` throughout
+
+SQLite cannot `ALTER TABLE ADD CONSTRAINT`, so these can only be declared at
+`CREATE TABLE` time. Converting to AutoMigrate would silently drop the
+database-level enforcement of the access model's invariants. Keep the DDL.
+
+### No: the generics API (`gorm.G[T]`)
+
+v1.31.2 ships `gorm.G[T](db).Where(...).Find(ctx)`, which gives type-safe
+results and a mandatory `context.Context`. But the existing code already gets
+its type safety from `Find(&typedSlice)`, so the only real gain is the forced
+ctx — and adopting it means rewriting every call site in the package. Revisit
+only if the context work below happens anyway.
+
+### No: soft delete (`gorm.DeletedAt`)
+
+Nothing here wants tombstones. `usage_records` has an explicit retention
+path (`DeleteOlderThan`), and the access tables depend on `ON DELETE CASCADE`
+actually removing rows — soft delete would break the cascade semantics the
+DDL relies on.
+
+### Adjacent, bigger than "ORM features": context propagation
+
+Worth recording because it kept surfacing during this evaluation.
+`bot_access_store` threads `context.Context` into GORM at 37 call sites.
+**Every other store in the package ignores context entirely** — 0
+`WithContext` calls across `api_token_store`, `imbot_settings_store`,
+`provider_model`, `provider_store`, `remote_chat_store`,
+`remote_session_store`, `service_stat`, `usage_daily`, `usage_record`. A
+cancelled or timed-out HTTP request cannot cancel the DB work it started.
+
+This is the highest-value item found, but it is not a local refactor: it
+changes public method signatures across the package and every caller. It
+belongs in its own ticket, not bundled with a codec change.
+
+### Suggested order
+
+1. `serializer:json`, **one store per PR**, each PR re-auditing that store's
+   `WHERE` clauses over the converted columns (`GetAllProviders` is the
+   known one). Start with `provider_store` — most sites, and it fixes the
+   swallowed JSON errors.
+2. `usage_record` filter scopes + the column whitelist.
+3. The `ListGroupActors` `IN` batching.
+
+Not recommended as part of this: removing the manual `CreatedAt`/`UpdatedAt`
+assignments. GORM does fill them (probed: `Create` sets both; `Updates(map)`,
+`Update(col, val)` and `OnConflict{UpdateAll: true}` all bump `updated_at`
+and the last preserves `created_at`) — so roughly 15 assignments are indeed
+redundant. But `OnConflict` with an explicit `clause.AssignmentColumns` list
+does **not** auto-bump (probed), which is why `bot_access_store.go:226` must
+keep listing `updated_at` by hand; and `remote_chat_store.normalizeChat`
+deliberately stamps UTC where GORM would use local time. The cleanup is
+small, the ways to get it subtly wrong are not.

--- a/.design/db.md
+++ b/.design/db.md
@@ -279,18 +279,26 @@ Probe results writing through the serializer:
 | `[]string{}` | `""` | `"[]"` |
 | `[]string{"x"}` | `"[\"x\"]"` | `"[\"x\"]"` |
 
-That breaks any predicate that tests these columns as strings.
-`ModelStore.GetAllProviders` (`provider_model.go:225`) does exactly that:
+So **every predicate over a serialized column has to be re-audited** — but
+re-audited, not reflexively rewritten. `ModelStore.GetAllProviders`
+(`provider_model.go:225`) is the one that looked broken:
 
 ```go
 ms.db.Where("models <> ''").Find(&records)
 ```
 
-Against a mixed table the probe counted **3 of 5** rows — it excluded the
-`NULL` row (because `NULL <> ''` is `NULL`, not true) *and* wrongly matched
-the `"[]"` row, reporting a provider with an empty model list as having
-models. So the migration is mechanical per column but **every `WHERE` over a
-serialized column has to be re-audited**, not just the codec.
+On inspection it survives the encoding change untouched. SQL's three-valued
+logic excludes `NULL` from `<> ''` already (comparing `NULL` to anything
+yields `NULL`, not true), and `NULL` is exactly the new spelling of "absent"
+— so the rows it drops are the rows it should drop. A stored-but-empty
+`"[]"` still matches, as it did before. Verified by running both
+`models <> ''` and `models IS NOT NULL AND models <> ''` against a table
+holding all four values: identical result sets.
+
+The check that genuinely does break is the **Go-side** one. After decoding,
+a stored `"[]"` and a never-written column are both an empty slice, so
+`record.Models == ""` (`GetProviderInfo`) can no longer tell them apart and
+needs a different discriminator.
 
 **Scope it to the four AutoMigrate-owned stores.** `bot_access_store.go`
 declares its tables with hand-written DDL where the JSON columns are

--- a/internal/db/bot_access_group_actors_test.go
+++ b/internal/db/bot_access_group_actors_test.go
@@ -1,0 +1,179 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/tingly-dev/tingly-box/remote/access"
+)
+
+// queryCounter is a gorm logger that counts the statements a call issues, so
+// a test can assert the query count rather than trusting that a refactor kept
+// it flat.
+type queryCounter struct {
+	mu         sync.Mutex
+	statements []string
+}
+
+func (c *queryCounter) LogMode(logger.LogLevel) logger.Interface      { return c }
+func (c *queryCounter) Info(context.Context, string, ...interface{})  {}
+func (c *queryCounter) Warn(context.Context, string, ...interface{})  {}
+func (c *queryCounter) Error(context.Context, string, ...interface{}) {}
+
+func (c *queryCounter) Trace(_ context.Context, _ time.Time, fc func() (string, int64), _ error) {
+	sql, _ := fc()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.statements = append(c.statements, sql)
+}
+
+func (c *queryCounter) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.statements = nil
+}
+
+func (c *queryCounter) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.statements)
+}
+
+func (c *queryCounter) dump() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.Join(c.statements, "\n  ")
+}
+
+// setupGroupWithActors builds a group carrying n actors and returns a store
+// whose queries are counted.
+func setupGroupWithActors(t *testing.T, n int) (*BotAccessStore, *queryCounter, string, string) {
+	t.Helper()
+
+	sm, err := NewStoreManager(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sm.Close() })
+
+	bot := createAccessBot(t, sm, "grp")
+	store := sm.BotAccess()
+	ctx := context.Background()
+
+	group, err := store.DiscoverGroup(ctx, bot.UUID, "telegram", "external-group", "Group")
+	require.NoError(t, err)
+
+	for i := 0; i < n; i++ {
+		_, err := store.AddGroupActor(ctx, bot.UUID, group.ID,
+			"actor-"+string(rune('a'+i)), "Actor", "label")
+		require.NoError(t, err)
+	}
+
+	// Re-wrap the shared handle with a counting logger. Same connection, so
+	// the data above is visible; only logging differs.
+	counter := &queryCounter{}
+	counted := &BotAccessStore{
+		db:        sm.db.Session(&gorm.Session{Logger: counter}),
+		transport: store.transport,
+	}
+	return counted, counter, bot.UUID, group.ID
+}
+
+// TestListGroupActorsIsNotNPlusOne pins the query count flat as the group
+// grows. The previous shape issued one actor lookup plus one permission
+// lookup per binding, so a 20-actor group cost 41 queries.
+func TestListGroupActorsIsNotNPlusOne(t *testing.T) {
+	ctx := context.Background()
+
+	counts := map[int]int{}
+	for _, n := range []int{1, 5, 20} {
+		store, counter, botUUID, groupID := setupGroupWithActors(t, n)
+
+		counter.reset()
+		actors, err := store.ListGroupActors(ctx, botUUID, groupID)
+		require.NoError(t, err)
+		require.Len(t, actors, n)
+
+		counts[n] = counter.count()
+		t.Logf("n=%2d -> %d queries", n, counts[n])
+	}
+
+	if counts[20] != counts[1] {
+		t.Errorf("query count grows with group size: n=1 -> %d, n=5 -> %d, n=20 -> %d",
+			counts[1], counts[5], counts[20])
+	}
+	// GetGroup + bindings + actors + permissions. Kept as an explicit bound so
+	// a future change that reintroduces a per-actor query is caught here.
+	if counts[20] > 5 {
+		store, counter, botUUID, groupID := setupGroupWithActors(t, 20)
+		counter.reset()
+		_, _ = store.ListGroupActors(ctx, botUUID, groupID)
+		t.Errorf("ListGroupActors issued %d queries for 20 actors, want a small constant:\n  %s",
+			counts[20], counter.dump())
+	}
+}
+
+// TestListGroupActorsContent verifies the batched form returns the same
+// content the per-binding form did: every actor, its label, and its
+// permissions ordered by capability then action.
+func TestListGroupActorsContent(t *testing.T) {
+	ctx := context.Background()
+	store, _, botUUID, groupID := setupGroupWithActors(t, 3)
+
+	actors, err := store.ListGroupActors(ctx, botUUID, groupID)
+	require.NoError(t, err)
+	require.Len(t, actors, 3)
+
+	seen := map[string]bool{}
+	for _, ga := range actors {
+		require.Equal(t, groupID, ga.GroupID)
+		require.Equal(t, "label", ga.Label)
+		require.NotEmpty(t, ga.Actor.ID)
+		require.False(t, seen[ga.Actor.ID], "actor %s returned twice", ga.Actor.ID)
+		seen[ga.Actor.ID] = true
+
+		// AddGroupActor seeds start+approve allow and privileged deny.
+		require.Len(t, ga.Permissions, 3)
+
+		effects := map[access.ActionName]access.AccessEffect{}
+		for _, p := range ga.Permissions {
+			require.Equal(t, access.CapabilityRemoteControl, p.Capability)
+			effects[p.Action] = p.Effect
+		}
+		require.Equal(t, access.EffectAllow, effects[access.ActionRemoteControlStart])
+		require.Equal(t, access.EffectAllow, effects[access.ActionRemoteControlApprove])
+		require.Equal(t, access.EffectDeny, effects[access.ActionRemoteControlPrivileged])
+
+		// Ordered by capability, then action -- the order the per-binding
+		// query produced.
+		for i := 1; i < len(ga.Permissions); i++ {
+			prev, cur := ga.Permissions[i-1], ga.Permissions[i]
+			prevKey := string(prev.Capability) + "\x00" + string(prev.Action)
+			curKey := string(cur.Capability) + "\x00" + string(cur.Action)
+			require.Less(t, prevKey, curKey, "permissions are not ordered by capability, action")
+		}
+	}
+}
+
+// TestListGroupActorsEmptyAndMissing covers the two edge cases: a group with
+// no actors, and a group that does not belong to the bot.
+func TestListGroupActorsEmptyAndMissing(t *testing.T) {
+	ctx := context.Background()
+	store, _, botUUID, groupID := setupGroupWithActors(t, 0)
+
+	actors, err := store.ListGroupActors(ctx, botUUID, groupID)
+	require.NoError(t, err)
+	require.Empty(t, actors)
+	require.NotNil(t, actors, "an empty group should return an empty slice, not nil")
+
+	_, err = store.ListGroupActors(ctx, botUUID, "no-such-group")
+	require.ErrorIs(t, err, ErrAccessTargetNotFound)
+
+	_, err = store.ListGroupActors(ctx, "no-such-bot", groupID)
+	require.ErrorIs(t, err, ErrAccessTargetNotFound)
+}

--- a/internal/db/bot_access_group_actors_test.go
+++ b/internal/db/bot_access_group_actors_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -70,17 +71,15 @@ func setupGroupWithActors(t *testing.T, n int) (*BotAccessStore, *queryCounter, 
 
 	for i := 0; i < n; i++ {
 		_, err := store.AddGroupActor(ctx, bot.UUID, group.ID,
-			"actor-"+string(rune('a'+i)), "Actor", "label")
+			fmt.Sprintf("actor-%02d", i), "Actor", "label")
 		require.NoError(t, err)
 	}
 
 	// Re-wrap the shared handle with a counting logger. Same connection, so
 	// the data above is visible; only logging differs.
 	counter := &queryCounter{}
-	counted := &BotAccessStore{
-		db:        sm.db.Session(&gorm.Session{Logger: counter}),
-		transport: store.transport,
-	}
+	counted := NewBotAccessStore(sm.db.Session(&gorm.Session{Logger: counter}))
+	counted.SetTransportFactsSource(store.transport)
 	return counted, counter, bot.UUID, group.ID
 }
 
@@ -90,8 +89,11 @@ func setupGroupWithActors(t *testing.T, n int) (*BotAccessStore, *queryCounter, 
 func TestListGroupActorsIsNotNPlusOne(t *testing.T) {
 	ctx := context.Background()
 
-	counts := map[int]int{}
-	for _, n := range []int{1, 5, 20} {
+	sizes := []int{1, 5, 20}
+	queries := make([]int, len(sizes))
+	var largest string
+
+	for i, n := range sizes {
 		store, counter, botUUID, groupID := setupGroupWithActors(t, n)
 
 		counter.reset()
@@ -99,23 +101,15 @@ func TestListGroupActorsIsNotNPlusOne(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, actors, n)
 
-		counts[n] = counter.count()
-		t.Logf("n=%2d -> %d queries", n, counts[n])
+		queries[i] = counter.count()
+		largest = counter.dump()
+		t.Logf("n=%2d -> %d queries", n, queries[i])
 	}
 
-	if counts[20] != counts[1] {
-		t.Errorf("query count grows with group size: n=1 -> %d, n=5 -> %d, n=20 -> %d",
-			counts[1], counts[5], counts[20])
-	}
-	// GetGroup + bindings + actors + permissions. Kept as an explicit bound so
-	// a future change that reintroduces a per-actor query is caught here.
-	if counts[20] > 5 {
-		store, counter, botUUID, groupID := setupGroupWithActors(t, 20)
-		counter.reset()
-		_, _ = store.ListGroupActors(ctx, botUUID, groupID)
-		t.Errorf("ListGroupActors issued %d queries for 20 actors, want a small constant:\n  %s",
-			counts[20], counter.dump())
-	}
+	first, last := queries[0], queries[len(queries)-1]
+	require.Equalf(t, first, last,
+		"query count grows with group size: %v -> %v queries\nstatements at n=%d:\n  %s",
+		sizes, queries, sizes[len(sizes)-1], largest)
 }
 
 // TestListGroupActorsContent verifies the batched form returns the same
@@ -137,26 +131,23 @@ func TestListGroupActorsContent(t *testing.T) {
 		require.False(t, seen[ga.Actor.ID], "actor %s returned twice", ga.Actor.ID)
 		seen[ga.Actor.ID] = true
 
-		// AddGroupActor seeds start+approve allow and privileged deny.
-		require.Len(t, ga.Permissions, 3)
-
-		effects := map[access.ActionName]access.AccessEffect{}
-		for _, p := range ga.Permissions {
-			require.Equal(t, access.CapabilityRemoteControl, p.Capability)
-			effects[p.Action] = p.Effect
+		// The permissions AddGroupActor seeds, in the capability-then-action
+		// order the per-binding query produced. Comparing the whole slice
+		// covers contents and ordering in one assertion.
+		type perm struct {
+			Capability access.CapabilityName
+			Action     access.ActionName
+			Effect     access.AccessEffect
 		}
-		require.Equal(t, access.EffectAllow, effects[access.ActionRemoteControlStart])
-		require.Equal(t, access.EffectAllow, effects[access.ActionRemoteControlApprove])
-		require.Equal(t, access.EffectDeny, effects[access.ActionRemoteControlPrivileged])
-
-		// Ordered by capability, then action -- the order the per-binding
-		// query produced.
-		for i := 1; i < len(ga.Permissions); i++ {
-			prev, cur := ga.Permissions[i-1], ga.Permissions[i]
-			prevKey := string(prev.Capability) + "\x00" + string(prev.Action)
-			curKey := string(cur.Capability) + "\x00" + string(cur.Action)
-			require.Less(t, prevKey, curKey, "permissions are not ordered by capability, action")
+		got := make([]perm, len(ga.Permissions))
+		for i, p := range ga.Permissions {
+			got[i] = perm{p.Capability, p.Action, p.Effect}
 		}
+		require.Equal(t, []perm{
+			{access.CapabilityRemoteControl, access.ActionRemoteControlApprove, access.EffectAllow},
+			{access.CapabilityRemoteControl, access.ActionRemoteControlPrivileged, access.EffectDeny},
+			{access.CapabilityRemoteControl, access.ActionRemoteControlStart, access.EffectAllow},
+		}, got)
 	}
 }
 

--- a/internal/db/bot_access_store.go
+++ b/internal/db/bot_access_store.go
@@ -642,19 +642,63 @@ func (s *BotAccessStore) ListGroupActors(ctx context.Context, botUUID, groupID s
 	if err := s.db.WithContext(ctx).Where("group_id = ?", groupID).Order("created_at").Find(&bindings).Error; err != nil {
 		return nil, err
 	}
+	if len(bindings) == 0 {
+		return []access.GroupActor{}, nil
+	}
+
+	// Two batched reads, not one actor lookup plus one permission lookup per
+	// binding -- that shape cost 2N+1 queries, so listing a 20-actor group
+	// took 41 round trips. Deliberately IN queries rather than gorm
+	// associations: these records are keyed compositely (a permission is
+	// keyed on group_id, actor_id, capability, action, and referenced by a
+	// composite foreign key) over hand-written DDL that gorm does not
+	// generate, which is where its association support is weakest.
+	actorIDs := make([]string, 0, len(bindings))
+	for _, b := range bindings {
+		actorIDs = append(actorIDs, b.ActorID)
+	}
+
+	var actorRows []remoteActorRecord
+	if err := s.db.WithContext(ctx).Where("id IN ?", actorIDs).Find(&actorRows).Error; err != nil {
+		return nil, err
+	}
+	actors := make(map[string]remoteActorRecord, len(actorRows))
+	for _, a := range actorRows {
+		actors[a.ID] = a
+	}
+
+	// One ordered scan grouped in Go. Ordering by capability, action here
+	// preserves the per-actor order the per-binding queries produced, since
+	// grouping keeps relative order within each actor.
+	var permRows []groupActorPermissionRecord
+	if err := s.db.WithContext(ctx).
+		Where("group_id = ? AND actor_id IN ?", groupID, actorIDs).
+		Order("capability, action").Find(&permRows).Error; err != nil {
+		return nil, err
+	}
+	permsByActor := make(map[string][]access.Permission, len(actorRows))
+	for _, p := range permRows {
+		permsByActor[p.ActorID] = append(permsByActor[p.ActorID], access.Permission{
+			Capability: access.CapabilityName(p.Capability),
+			Action:     access.ActionName(p.Action),
+			Effect:     access.AccessEffect(p.Effect),
+			UpdatedAt:  p.UpdatedAt,
+		})
+	}
+
 	out := make([]access.GroupActor, 0, len(bindings))
 	for _, b := range bindings {
-		var ar remoteActorRecord
-		if err := s.db.WithContext(ctx).Where("id = ?", b.ActorID).First(&ar).Error; err != nil {
-			return nil, err
+		ar, ok := actors[b.ActorID]
+		if !ok {
+			// A binding pointing at a missing actor is a broken foreign key,
+			// not an empty result. The per-binding First this replaced failed
+			// the whole call in that case; keep it wrapping the same sentinel
+			// so callers matching on it still match.
+			return nil, fmt.Errorf("group %s binding references missing actor %s: %w", groupID, b.ActorID, gorm.ErrRecordNotFound)
 		}
-		var prs []groupActorPermissionRecord
-		if err := s.db.WithContext(ctx).Where("group_id = ? AND actor_id = ?", groupID, b.ActorID).Order("capability, action").Find(&prs).Error; err != nil {
-			return nil, err
-		}
-		perms := make([]access.Permission, 0, len(prs))
-		for _, p := range prs {
-			perms = append(perms, access.Permission{Capability: access.CapabilityName(p.Capability), Action: access.ActionName(p.Action), Effect: access.AccessEffect(p.Effect), UpdatedAt: p.UpdatedAt})
+		perms := permsByActor[b.ActorID]
+		if perms == nil {
+			perms = make([]access.Permission, 0)
 		}
 		out = append(out, access.GroupActor{GroupID: groupID, Actor: actorFromRecord(ar), Label: b.Label, Permissions: perms, CreatedAt: b.CreatedAt, UpdatedAt: b.UpdatedAt})
 	}

--- a/internal/db/imbot_settings.go
+++ b/internal/db/imbot_settings.go
@@ -6,17 +6,17 @@ import (
 
 // ImBotSettingsRecord is the GORM model for persisting ImBot credentials
 type ImBotSettingsRecord struct {
-	BotUUID       string `gorm:"primaryKey;column:bot_uuid"`
-	Name          string `gorm:"column:name"`
-	Platform      string `gorm:"column:platform;index:idx_platform"`
-	AuthType      string `gorm:"column:auth_type"`
-	AuthConfig    string `gorm:"column:auth_config;type:text"` // JSON string of auth map
-	ProxyURL      string `gorm:"column:proxy_url"`
-	ChatIDLock    string `gorm:"column:chat_id_lock"`
-	BashAllowlist string `gorm:"column:bash_allowlist;type:text"` // JSON array string
-	DefaultCwd    string `gorm:"column:default_cwd"`              // Default working directory
-	DefaultAgent  string `gorm:"column:default_agent"`            // Default Agent UUID
-	Enabled       bool   `gorm:"column:enabled;index:idx_enabled"`
+	BotUUID       string            `gorm:"primaryKey;column:bot_uuid"`
+	Name          string            `gorm:"column:name"`
+	Platform      string            `gorm:"column:platform;index:idx_platform"`
+	AuthType      string            `gorm:"column:auth_type"`
+	AuthConfig    map[string]string `gorm:"column:auth_config;type:text;serializer:json"`
+	ProxyURL      string            `gorm:"column:proxy_url"`
+	ChatIDLock    string            `gorm:"column:chat_id_lock"`
+	BashAllowlist []string          `gorm:"column:bash_allowlist;type:text;serializer:json"`
+	DefaultCwd    string            `gorm:"column:default_cwd"`   // Default working directory
+	DefaultAgent  string            `gorm:"column:default_agent"` // Default Agent UUID
+	Enabled       bool              `gorm:"column:enabled;index:idx_enabled"`
 
 	// Output behavior settings
 	Debug   bool  `gorm:"column:debug;default:false"`  // Show message IDs in output

--- a/internal/db/imbot_settings_store.go
+++ b/internal/db/imbot_settings_store.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -74,11 +73,7 @@ func (s *ImBotSettingsStore) ListSettings() ([]Settings, error) {
 
 	settings := make([]Settings, 0, len(records))
 	for _, record := range records {
-		setting, err := recordToSettings(record)
-		if err != nil {
-			return nil, err
-		}
-		settings = append(settings, setting)
+		settings = append(settings, recordToSettings(record))
 	}
 
 	return settings, nil
@@ -96,11 +91,7 @@ func (s *ImBotSettingsStore) ListEnabledSettings() ([]Settings, error) {
 
 	settings := make([]Settings, 0, len(records))
 	for _, record := range records {
-		setting, err := recordToSettings(record)
-		if err != nil {
-			return nil, err
-		}
-		settings = append(settings, setting)
+		settings = append(settings, recordToSettings(record))
 	}
 
 	return settings, nil
@@ -119,7 +110,7 @@ func (s *ImBotSettingsStore) GetSettingsByUUID(uuid string) (Settings, error) {
 		return Settings{Auth: make(map[string]string)}, fmt.Errorf("failed to get settings by uuid: %w", err)
 	}
 
-	return recordToSettings(record)
+	return recordToSettings(record), nil
 }
 
 // CreateSettings creates a new ImBot configuration.
@@ -135,31 +126,15 @@ func (s *ImBotSettingsStore) CreateSettings(settings Settings) (Settings, error)
 	settings.CreatedAt = now
 	settings.UpdatedAt = now
 
-	// Convert auth map to JSON
-	authConfigJSON := ""
-	if len(settings.Auth) > 0 {
-		if b, err := json.Marshal(settings.Auth); err == nil {
-			authConfigJSON = string(b)
-		}
-	}
-
-	// Convert bash allowlist to JSON
-	allowlistJSON := ""
-	if len(settings.BashAllowlist) > 0 {
-		if b, err := json.Marshal(settings.BashAllowlist); err == nil {
-			allowlistJSON = string(b)
-		}
-	}
-
 	record := ImBotSettingsRecord{
 		BotUUID:            settings.UUID,
 		Name:               settings.Name,
 		Platform:           settings.Platform,
 		AuthType:           settings.AuthType,
-		AuthConfig:         authConfigJSON,
+		AuthConfig:         settings.Auth,
 		ProxyURL:           settings.ProxyURL,
 		ChatIDLock:         settings.ChatIDLock,
-		BashAllowlist:      allowlistJSON,
+		BashAllowlist:      settings.BashAllowlist,
 		DefaultCwd:         settings.DefaultCwd,
 		DefaultAgent:       settings.DefaultAgent,
 		Enabled:            settings.Enabled,
@@ -187,77 +162,67 @@ func (s *ImBotSettingsStore) UpdateSettings(uuid string, settings Settings) erro
 	now := time.Now()
 	settings.UpdatedAt = now
 
-	// Build a map of only the fields to update
-	// This allows partial updates - empty/zero values won't overwrite existing data
-	updates := make(map[string]interface{})
+	// Read-modify-write rather than Updates(map). A map update cannot carry
+	// auth_config or bash_allowlist now that they are serialized columns --
+	// gorm applies a field's serializer only when the value comes off the
+	// model, so a map value would reach the driver raw. Loading the row first
+	// keeps the same partial-update rule (an empty/zero field leaves the
+	// stored value alone) and preserves the columns Settings does not model
+	// at all, such as debug and verbose.
+	var record ImBotSettingsRecord
+	if err := s.db.Where("bot_uuid = ?", uuid).First(&record).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("imbot settings with uuid %s not found", uuid)
+		}
+		return fmt.Errorf("failed to load settings for update: %w", err)
+	}
 
 	if settings.Name != "" {
-		updates["name"] = settings.Name
+		record.Name = settings.Name
 	}
 	if settings.Platform != "" {
-		updates["platform"] = settings.Platform
+		record.Platform = settings.Platform
 	}
 	if settings.AuthType != "" {
-		updates["auth_type"] = settings.AuthType
+		record.AuthType = settings.AuthType
 	}
 	if settings.ProxyURL != "" {
-		updates["proxy_url"] = settings.ProxyURL
+		record.ProxyURL = settings.ProxyURL
 	}
 	if settings.ChatIDLock != "" {
-		updates["chat_id_lock"] = settings.ChatIDLock
+		record.ChatIDLock = settings.ChatIDLock
 	}
-
-	// Handle Auth config - only update if non-empty
 	if len(settings.Auth) > 0 {
-		if b, err := json.Marshal(settings.Auth); err == nil {
-			updates["auth_config"] = string(b)
-		}
+		record.AuthConfig = settings.Auth
 	}
-
-	// Handle BashAllowlist - only update if non-empty
 	if len(settings.BashAllowlist) > 0 {
-		if b, err := json.Marshal(settings.BashAllowlist); err == nil {
-			updates["bash_allowlist"] = string(b)
-		}
+		record.BashAllowlist = settings.BashAllowlist
 	}
-
 	if settings.DefaultCwd != "" {
-		updates["default_cwd"] = settings.DefaultCwd
+		record.DefaultCwd = settings.DefaultCwd
 	}
 	if settings.DefaultAgent != "" {
-		updates["default_agent"] = settings.DefaultAgent
+		record.DefaultAgent = settings.DefaultAgent
 	}
 	if settings.SmartGuideProvider != "" {
-		updates["smartguide_provider"] = settings.SmartGuideProvider
+		record.SmartGuideProvider = settings.SmartGuideProvider
 	}
 	if settings.SmartGuideModel != "" {
-		updates["smartguide_model"] = settings.SmartGuideModel
+		record.SmartGuideModel = settings.SmartGuideModel
 	}
 	if settings.RequirePairing != nil {
-		updates["require_pairing"] = settings.RequirePairing
+		record.RequirePairing = settings.RequirePairing
 	}
 	// Scenarios is intentionally allowed to be cleared (empty string) so
 	// callers can unbind a bot from all scenarios.
-	updates["scenarios"] = settings.Scenarios
+	record.Scenarios = settings.Scenarios
 
-	// Always update enabled and updated_at if explicitly set
-	updates["enabled"] = settings.Enabled
-	updates["updated_at"] = settings.UpdatedAt
+	// enabled and updated_at are always written.
+	record.Enabled = settings.Enabled
+	record.UpdatedAt = settings.UpdatedAt
 
-	if len(updates) == 0 {
-		return nil // Nothing to update
-	}
-
-	result := s.db.Model(&ImBotSettingsRecord{}).
-		Where("bot_uuid = ?", uuid).
-		Updates(updates)
-
-	if result.Error != nil {
-		return fmt.Errorf("failed to update settings: %w", result.Error)
-	}
-
-	if result.RowsAffected == 0 {
-		return fmt.Errorf("imbot settings with uuid %s not found", uuid)
+	if err := s.db.Save(&record).Error; err != nil {
+		return fmt.Errorf("failed to update settings: %w", err)
 	}
 
 	return nil
@@ -322,7 +287,11 @@ func (s *ImBotSettingsStore) SetEnabled(uuid string, enabled bool) error {
 }
 
 // recordToSettings converts an ImBotSettingsRecord to a Settings struct.
-func recordToSettings(record ImBotSettingsRecord) (Settings, error) {
+//
+// This no longer returns an error: auth_config and bash_allowlist are decoded
+// by gorm's json serializer when the row is read, so a malformed column now
+// fails the query itself rather than being re-parsed (and re-reported) here.
+func recordToSettings(record ImBotSettingsRecord) Settings {
 	settings := Settings{
 		UUID:               record.BotUUID,
 		Name:               record.Name,
@@ -339,14 +308,12 @@ func recordToSettings(record ImBotSettingsRecord) (Settings, error) {
 		Scenarios:          record.Scenarios,
 		CreatedAt:          record.CreatedAt,
 		UpdatedAt:          record.UpdatedAt,
-		Auth:               make(map[string]string),
+		BashAllowlist:      record.BashAllowlist,
+		// Auth is always non-nil: callers index and assign into it.
+		Auth: record.AuthConfig,
 	}
-
-	// Parse auth config JSON
-	if record.AuthConfig != "" {
-		if err := json.Unmarshal([]byte(record.AuthConfig), &settings.Auth); err != nil {
-			return Settings{}, fmt.Errorf("failed to unmarshal auth config: %w", err)
-		}
+	if settings.Auth == nil {
+		settings.Auth = make(map[string]string)
 	}
 
 	// Set Token field for backward compatibility (from auth["token"])
@@ -354,14 +321,7 @@ func recordToSettings(record ImBotSettingsRecord) (Settings, error) {
 		settings.Token = token
 	}
 
-	// Parse bash allowlist JSON
-	if record.BashAllowlist != "" {
-		if err := json.Unmarshal([]byte(record.BashAllowlist), &settings.BashAllowlist); err != nil {
-			return Settings{}, fmt.Errorf("failed to unmarshal bash allowlist: %w", err)
-		}
-	}
-
-	return settings, nil
+	return settings
 }
 
 // generateUUID generates a unique ID for settings.

--- a/internal/db/imbot_settings_store_test.go
+++ b/internal/db/imbot_settings_store_test.go
@@ -1,30 +1,18 @@
 package db
 
-import (
-	"testing"
-	"time"
-
-	"github.com/tingly-dev/tingly-box/internal/constant"
-)
+import "testing"
 
 // legacyImBotSettingsRecord is ImBotSettingsRecord as it was before
 // auth_config and bash_allowlist moved to `serializer:json`: both were
 // `string` columns holding hand-marshalled JSON, with "" meaning absent.
 type legacyImBotSettingsRecord struct {
-	BotUUID       string    `gorm:"primaryKey;column:bot_uuid"`
-	Name          string    `gorm:"column:name"`
-	Platform      string    `gorm:"column:platform;index:idx_platform"`
-	AuthType      string    `gorm:"column:auth_type"`
-	AuthConfig    string    `gorm:"column:auth_config;type:text"`
-	ProxyURL      string    `gorm:"column:proxy_url"`
-	BashAllowlist string    `gorm:"column:bash_allowlist;type:text"`
-	DefaultCwd    string    `gorm:"column:default_cwd"`
-	Enabled       bool      `gorm:"column:enabled;index:idx_enabled"`
-	Debug         bool      `gorm:"column:debug;default:false"`
-	Verbose       *bool     `gorm:"column:verbose;default:true"`
-	Scenarios     string    `gorm:"column:scenarios;type:text"`
-	CreatedAt     time.Time `gorm:"column:created_at"`
-	UpdatedAt     time.Time `gorm:"column:updated_at"`
+	BotUUID       string `gorm:"primaryKey;column:bot_uuid"`
+	Name          string `gorm:"column:name"`
+	Platform      string `gorm:"column:platform;index:idx_platform"`
+	AuthType      string `gorm:"column:auth_type"`
+	AuthConfig    string `gorm:"column:auth_config;type:text"`
+	BashAllowlist string `gorm:"column:bash_allowlist;type:text"`
+	Enabled       bool   `gorm:"column:enabled;index:idx_enabled"`
 }
 
 func (legacyImBotSettingsRecord) TableName() string { return "imbot_settings" }
@@ -32,14 +20,7 @@ func (legacyImBotSettingsRecord) TableName() string { return "imbot_settings" }
 func TestImBotSettingsStore_ReadsLegacyJSONStringRows(t *testing.T) {
 	dir := t.TempDir()
 
-	legacyDB, err := OpenSQLite(constant.GetDBFile(dir), 0)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	if err := legacyDB.AutoMigrate(&legacyImBotSettingsRecord{}); err != nil {
-		t.Fatalf("legacy migrate: %v", err)
-	}
-	rows := []legacyImBotSettingsRecord{
+	seedLegacyRows(t, dir, []legacyImBotSettingsRecord{
 		{
 			BotUUID: "full", Name: "full", Platform: "telegram", AuthType: "token",
 			AuthConfig:    `{"token":"legacy-token","secret":"s3cr3t"}`,
@@ -51,19 +32,7 @@ func TestImBotSettingsStore_ReadsLegacyJSONStringRows(t *testing.T) {
 			BotUUID: "bare", Name: "bare", Platform: "weixin",
 			AuthConfig: "", BashAllowlist: "", Enabled: false,
 		},
-	}
-	for i := range rows {
-		if err := legacyDB.Create(&rows[i]).Error; err != nil {
-			t.Fatalf("seed %s: %v", rows[i].BotUUID, err)
-		}
-	}
-	sqlDB, err := legacyDB.DB()
-	if err != nil {
-		t.Fatalf("legacyDB.DB(): %v", err)
-	}
-	if err := sqlDB.Close(); err != nil {
-		t.Fatalf("close: %v", err)
-	}
+	})
 
 	store, err := NewImBotSettingsStore(dir)
 	if err != nil {
@@ -148,28 +117,9 @@ func TestImBotSettingsStore_RoundTrip(t *testing.T) {
 		t.Errorf("BashAllowlist = %v, want [ls]", got.BashAllowlist)
 	}
 
-	t.Run("absent values store as NULL, not an empty json document", func(t *testing.T) {
-		bare, err := store.CreateSettings(Settings{Name: "bare", Platform: "weixin"})
-		if err != nil {
-			t.Fatalf("CreateSettings: %v", err)
-		}
-		type row struct {
-			AuthConfig    *string
-			BashAllowlist *string
-		}
-		var r row
-		if err := store.db.Raw(
-			"SELECT auth_config, bash_allowlist FROM imbot_settings WHERE bot_uuid = ?",
-			bare.UUID).Scan(&r).Error; err != nil {
-			t.Fatalf("raw scan: %v", err)
-		}
-		if r.AuthConfig != nil {
-			t.Errorf("auth_config = %q, want NULL", *r.AuthConfig)
-		}
-		if r.BashAllowlist != nil {
-			t.Errorf("bash_allowlist = %q, want NULL", *r.BashAllowlist)
-		}
-	})
+	if err := store.UpdateSettings("no-such-uuid", Settings{Name: "x"}); err == nil {
+		t.Error("UpdateSettings on a missing row returned nil, want an error")
+	}
 }
 
 // TestImBotSettingsStore_UpdateIsPartial pins the rule UpdateSettings has
@@ -229,7 +179,7 @@ func TestImBotSettingsStore_UpdateIsPartial(t *testing.T) {
 		t.Errorf("platform/authtype not preserved: %q/%q", got.Platform, got.AuthType)
 	}
 
-	t.Run("scenarios can still be cleared explicitly", func(t *testing.T) {
+	t.Run("an unset Scenarios clears the stored value (the documented exception)", func(t *testing.T) {
 		if err := store.UpdateSettings(created.UUID, Settings{Enabled: true}); err != nil {
 			t.Fatalf("UpdateSettings: %v", err)
 		}
@@ -283,12 +233,6 @@ func TestImBotSettingsStore_UpdateIsPartial(t *testing.T) {
 		}
 		if rec.Verbose == nil || *rec.Verbose {
 			t.Errorf("verbose = %v, want preserved false", rec.Verbose)
-		}
-	})
-
-	t.Run("unknown uuid is an error", func(t *testing.T) {
-		if err := store.UpdateSettings("nope", Settings{Name: "x"}); err == nil {
-			t.Error("UpdateSettings on a missing row returned nil, want an error")
 		}
 	})
 }

--- a/internal/db/imbot_settings_store_test.go
+++ b/internal/db/imbot_settings_store_test.go
@@ -1,0 +1,294 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
+)
+
+// legacyImBotSettingsRecord is ImBotSettingsRecord as it was before
+// auth_config and bash_allowlist moved to `serializer:json`: both were
+// `string` columns holding hand-marshalled JSON, with "" meaning absent.
+type legacyImBotSettingsRecord struct {
+	BotUUID       string    `gorm:"primaryKey;column:bot_uuid"`
+	Name          string    `gorm:"column:name"`
+	Platform      string    `gorm:"column:platform;index:idx_platform"`
+	AuthType      string    `gorm:"column:auth_type"`
+	AuthConfig    string    `gorm:"column:auth_config;type:text"`
+	ProxyURL      string    `gorm:"column:proxy_url"`
+	BashAllowlist string    `gorm:"column:bash_allowlist;type:text"`
+	DefaultCwd    string    `gorm:"column:default_cwd"`
+	Enabled       bool      `gorm:"column:enabled;index:idx_enabled"`
+	Debug         bool      `gorm:"column:debug;default:false"`
+	Verbose       *bool     `gorm:"column:verbose;default:true"`
+	Scenarios     string    `gorm:"column:scenarios;type:text"`
+	CreatedAt     time.Time `gorm:"column:created_at"`
+	UpdatedAt     time.Time `gorm:"column:updated_at"`
+}
+
+func (legacyImBotSettingsRecord) TableName() string { return "imbot_settings" }
+
+func TestImBotSettingsStore_ReadsLegacyJSONStringRows(t *testing.T) {
+	dir := t.TempDir()
+
+	legacyDB, err := OpenSQLite(constant.GetDBFile(dir), 0)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := legacyDB.AutoMigrate(&legacyImBotSettingsRecord{}); err != nil {
+		t.Fatalf("legacy migrate: %v", err)
+	}
+	rows := []legacyImBotSettingsRecord{
+		{
+			BotUUID: "full", Name: "full", Platform: "telegram", AuthType: "token",
+			AuthConfig:    `{"token":"legacy-token","secret":"s3cr3t"}`,
+			BashAllowlist: `["ls","cat"]`,
+			Enabled:       true,
+		},
+		{
+			// Both JSON columns in the legacy "absent" encoding.
+			BotUUID: "bare", Name: "bare", Platform: "weixin",
+			AuthConfig: "", BashAllowlist: "", Enabled: false,
+		},
+	}
+	for i := range rows {
+		if err := legacyDB.Create(&rows[i]).Error; err != nil {
+			t.Fatalf("seed %s: %v", rows[i].BotUUID, err)
+		}
+	}
+	sqlDB, err := legacyDB.DB()
+	if err != nil {
+		t.Fatalf("legacyDB.DB(): %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	store, err := NewImBotSettingsStore(dir)
+	if err != nil {
+		t.Fatalf("NewImBotSettingsStore over legacy db: %v", err)
+	}
+	defer store.Close()
+
+	t.Run("decodes legacy auth and allowlist", func(t *testing.T) {
+		got, err := store.GetSettingsByUUID("full")
+		if err != nil {
+			t.Fatalf("GetSettingsByUUID: %v", err)
+		}
+		if got.Auth["token"] != "legacy-token" || got.Auth["secret"] != "s3cr3t" {
+			t.Errorf("Auth = %v, want token/secret", got.Auth)
+		}
+		// Token is mirrored out of Auth for backward compatibility.
+		if got.Token != "legacy-token" {
+			t.Errorf("Token = %q, want legacy-token", got.Token)
+		}
+		if len(got.BashAllowlist) != 2 || got.BashAllowlist[0] != "ls" {
+			t.Errorf("BashAllowlist = %v, want [ls cat]", got.BashAllowlist)
+		}
+	})
+
+	t.Run("empty legacy columns read as absent, Auth stays non-nil", func(t *testing.T) {
+		got, err := store.GetSettingsByUUID("bare")
+		if err != nil {
+			t.Fatalf("GetSettingsByUUID: %v", err)
+		}
+		if got.Auth == nil {
+			t.Fatal("Auth = nil; callers index and assign into it")
+		}
+		if len(got.Auth) != 0 {
+			t.Errorf("Auth = %v, want empty", got.Auth)
+		}
+		if len(got.BashAllowlist) != 0 {
+			t.Errorf("BashAllowlist = %v, want empty", got.BashAllowlist)
+		}
+	})
+
+	t.Run("ListSettings decodes every row", func(t *testing.T) {
+		all, err := store.ListSettings()
+		if err != nil {
+			t.Fatalf("ListSettings: %v", err)
+		}
+		if len(all) != 2 {
+			t.Fatalf("ListSettings returned %d, want 2", len(all))
+		}
+		for _, s := range all {
+			if s.Auth == nil {
+				t.Errorf("%s: Auth = nil", s.UUID)
+			}
+		}
+	})
+}
+
+func TestImBotSettingsStore_RoundTrip(t *testing.T) {
+	store, err := NewImBotSettingsStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewImBotSettingsStore: %v", err)
+	}
+	defer store.Close()
+
+	created, err := store.CreateSettings(Settings{
+		Name: "rt", Platform: "telegram", AuthType: "token",
+		Auth:          map[string]string{"token": "abc"},
+		BashAllowlist: []string{"ls"},
+		Enabled:       true,
+	})
+	if err != nil {
+		t.Fatalf("CreateSettings: %v", err)
+	}
+
+	got, err := store.GetSettingsByUUID(created.UUID)
+	if err != nil {
+		t.Fatalf("GetSettingsByUUID: %v", err)
+	}
+	if got.Auth["token"] != "abc" {
+		t.Errorf("Auth = %v, want token=abc", got.Auth)
+	}
+	if len(got.BashAllowlist) != 1 || got.BashAllowlist[0] != "ls" {
+		t.Errorf("BashAllowlist = %v, want [ls]", got.BashAllowlist)
+	}
+
+	t.Run("absent values store as NULL, not an empty json document", func(t *testing.T) {
+		bare, err := store.CreateSettings(Settings{Name: "bare", Platform: "weixin"})
+		if err != nil {
+			t.Fatalf("CreateSettings: %v", err)
+		}
+		type row struct {
+			AuthConfig    *string
+			BashAllowlist *string
+		}
+		var r row
+		if err := store.db.Raw(
+			"SELECT auth_config, bash_allowlist FROM imbot_settings WHERE bot_uuid = ?",
+			bare.UUID).Scan(&r).Error; err != nil {
+			t.Fatalf("raw scan: %v", err)
+		}
+		if r.AuthConfig != nil {
+			t.Errorf("auth_config = %q, want NULL", *r.AuthConfig)
+		}
+		if r.BashAllowlist != nil {
+			t.Errorf("bash_allowlist = %q, want NULL", *r.BashAllowlist)
+		}
+	})
+}
+
+// TestImBotSettingsStore_UpdateIsPartial pins the rule UpdateSettings has
+// always documented -- an empty/zero field leaves the stored value alone --
+// across the move from Updates(map) to read-modify-write.
+func TestImBotSettingsStore_UpdateIsPartial(t *testing.T) {
+	store, err := NewImBotSettingsStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewImBotSettingsStore: %v", err)
+	}
+	defer store.Close()
+
+	created, err := store.CreateSettings(Settings{
+		Name: "orig", Platform: "telegram", AuthType: "token",
+		Auth:               map[string]string{"token": "orig-token"},
+		BashAllowlist:      []string{"ls", "cat"},
+		ProxyURL:           "http://proxy:8080",
+		DefaultCwd:         "/orig",
+		DefaultAgent:       "agent-1",
+		SmartGuideProvider: "prov-1",
+		SmartGuideModel:    "model-1",
+		Scenarios:          `[{"scenario":"a"}]`,
+		Enabled:            true,
+	})
+	if err != nil {
+		t.Fatalf("CreateSettings: %v", err)
+	}
+
+	// Update only the name; everything else is zero and must survive.
+	if err := store.UpdateSettings(created.UUID, Settings{Name: "renamed", Enabled: true}); err != nil {
+		t.Fatalf("UpdateSettings: %v", err)
+	}
+
+	got, err := store.GetSettingsByUUID(created.UUID)
+	if err != nil {
+		t.Fatalf("GetSettingsByUUID: %v", err)
+	}
+	if got.Name != "renamed" {
+		t.Errorf("Name = %q, want renamed", got.Name)
+	}
+	if got.Auth["token"] != "orig-token" {
+		t.Errorf("Auth = %v, want the original token preserved", got.Auth)
+	}
+	if len(got.BashAllowlist) != 2 {
+		t.Errorf("BashAllowlist = %v, want the original 2 entries preserved", got.BashAllowlist)
+	}
+	if got.ProxyURL != "http://proxy:8080" {
+		t.Errorf("ProxyURL = %q, want preserved", got.ProxyURL)
+	}
+	if got.DefaultCwd != "/orig" || got.DefaultAgent != "agent-1" {
+		t.Errorf("defaults not preserved: cwd=%q agent=%q", got.DefaultCwd, got.DefaultAgent)
+	}
+	if got.SmartGuideProvider != "prov-1" || got.SmartGuideModel != "model-1" {
+		t.Errorf("smartguide not preserved: %q/%q", got.SmartGuideProvider, got.SmartGuideModel)
+	}
+	if got.Platform != "telegram" || got.AuthType != "token" {
+		t.Errorf("platform/authtype not preserved: %q/%q", got.Platform, got.AuthType)
+	}
+
+	t.Run("scenarios can still be cleared explicitly", func(t *testing.T) {
+		if err := store.UpdateSettings(created.UUID, Settings{Enabled: true}); err != nil {
+			t.Fatalf("UpdateSettings: %v", err)
+		}
+		got, err := store.GetSettingsByUUID(created.UUID)
+		if err != nil {
+			t.Fatalf("GetSettingsByUUID: %v", err)
+		}
+		if got.Scenarios != "" {
+			t.Errorf("Scenarios = %q, want cleared", got.Scenarios)
+		}
+	})
+
+	t.Run("replacing auth and allowlist works", func(t *testing.T) {
+		if err := store.UpdateSettings(created.UUID, Settings{
+			Auth:          map[string]string{"token": "new-token"},
+			BashAllowlist: []string{"echo"},
+			Enabled:       true,
+		}); err != nil {
+			t.Fatalf("UpdateSettings: %v", err)
+		}
+		got, err := store.GetSettingsByUUID(created.UUID)
+		if err != nil {
+			t.Fatalf("GetSettingsByUUID: %v", err)
+		}
+		if got.Auth["token"] != "new-token" {
+			t.Errorf("Auth = %v, want new-token", got.Auth)
+		}
+		if len(got.BashAllowlist) != 1 || got.BashAllowlist[0] != "echo" {
+			t.Errorf("BashAllowlist = %v, want [echo]", got.BashAllowlist)
+		}
+	})
+
+	t.Run("columns Settings does not model survive an update", func(t *testing.T) {
+		// debug/verbose exist on the record but not on Settings. The old
+		// Updates(map) path never mentioned them; read-modify-write must not
+		// reset them either.
+		if err := store.db.Exec(
+			"UPDATE imbot_settings SET debug = 1, verbose = 0 WHERE bot_uuid = ?",
+			created.UUID).Error; err != nil {
+			t.Fatalf("seed debug/verbose: %v", err)
+		}
+		if err := store.UpdateSettings(created.UUID, Settings{Name: "again", Enabled: true}); err != nil {
+			t.Fatalf("UpdateSettings: %v", err)
+		}
+		var rec ImBotSettingsRecord
+		if err := store.db.Where("bot_uuid = ?", created.UUID).First(&rec).Error; err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		if !rec.Debug {
+			t.Error("debug was reset by UpdateSettings, want preserved")
+		}
+		if rec.Verbose == nil || *rec.Verbose {
+			t.Errorf("verbose = %v, want preserved false", rec.Verbose)
+		}
+	})
+
+	t.Run("unknown uuid is an error", func(t *testing.T) {
+		if err := store.UpdateSettings("nope", Settings{Name: "x"}); err == nil {
+			t.Error("UpdateSettings on a missing row returned nil, want an error")
+		}
+	})
+}

--- a/internal/db/legacy_rows_test.go
+++ b/internal/db/legacy_rows_test.go
@@ -1,0 +1,37 @@
+package db
+
+import "testing"
+
+// seedLegacyRows creates a table from T -- a narrower, pre-migration shape of
+// one of this package's records -- and writes rows through it, then closes the
+// handle so the caller can reopen the same file through the real store.
+//
+// The store's own AutoMigrate adds whatever columns T omits, which is what
+// makes the reopened rows a faithful stand-in for a database written before
+// the migration under test.
+//
+// Closing here is required, not tidiness: the reopen has to see the schema
+// this handle committed.
+func seedLegacyRows[T any](t *testing.T, dir string, rows []T) {
+	t.Helper()
+
+	db, err := openTinglyDB(dir)
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	if err := db.AutoMigrate(new(T)); err != nil {
+		t.Fatalf("migrate legacy schema: %v", err)
+	}
+	for i := range rows {
+		if err := db.Create(&rows[i]).Error; err != nil {
+			t.Fatalf("seed legacy row %d: %v", i, err)
+		}
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("legacy db handle: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+}

--- a/internal/db/provider_model.go
+++ b/internal/db/provider_model.go
@@ -25,7 +25,7 @@ type ProviderModelRecord struct {
 	ProviderUUID string      `gorm:"primaryKey;column:provider_uuid"`
 	ProviderName string      `gorm:"column:provider_name;index"`
 	APIBase      string      `gorm:"column:api_base"`
-	Models       string      `gorm:"column:models;type:text"`
+	Models       []string    `gorm:"column:models;type:text;serializer:json"`
 	Source       ModelSource `gorm:"column:source"`
 	LastUpdated  time.Time   `gorm:"column:last_updated"`
 
@@ -113,47 +113,46 @@ func (ms *ModelStore) saveModels(provider *typ.Provider, models []string, source
 		whenAt = now
 	}
 
-	var modelsJSON string
-	if models != nil {
-		encoded, err := json.Marshal(models)
-		if err != nil {
-			return fmt.Errorf("failed to marshal models: %w", err)
-		}
-		modelsJSON = string(encoded)
-	}
-
 	var rawResponse *string
 	if len(raw) > 0 {
 		value := string(raw)
 		rawResponse = &value
 	}
 
-	// Failure-only writes omit model fields so the last successful list remains
-	// available as a stale fallback.
-	updates := map[string]any{
-		"provider_name": provider.Name,
-		"api_base":      provider.APIBase,
-		"updated_at":    now,
-	}
+	// applyWrite mutates a record -- freshly built or freshly loaded -- into
+	// the state this write wants. Failure-only writes (models == nil) leave
+	// the model fields alone so the last successful list remains available as
+	// a stale fallback.
+	//
+	// This is deliberately a struct mutation followed by Save, not
+	// Updates(map): a map update bypasses the field's serializer entirely.
+	// Handing Updates a []string makes SQLite fail with "row value misused",
+	// and an empty []string silently writes NULL -- so the map form cannot
+	// express this write at all now that models is a serialized column.
+	applyWrite := func(r *ProviderModelRecord) {
+		r.ProviderName = provider.Name
+		r.APIBase = provider.APIBase
+		r.UpdatedAt = now
 
-	if models != nil {
-		updates["models"] = modelsJSON
-		updates["source"] = source
-		updates["last_updated"] = now
-	}
+		if models != nil {
+			r.Models = models
+			r.Source = source
+			r.LastUpdated = now
+		}
 
-	if rawResponse != nil {
-		updates["raw_response"] = *rawResponse
-	} else if models != nil {
-		updates["raw_response"] = nil
-	}
+		if rawResponse != nil {
+			r.RawResponse = rawResponse
+		} else if models != nil {
+			r.RawResponse = nil
+		}
 
-	if lastErr != nil {
-		updates["last_error"] = *lastErr
-		updates["last_error_at"] = whenAt
-	} else if models != nil {
-		updates["last_error"] = nil
-		updates["last_error_at"] = nil
+		if lastErr != nil {
+			r.LastError = lastErr
+			r.LastErrorAt = &whenAt
+		} else if models != nil {
+			r.LastError = nil
+			r.LastErrorAt = nil
+		}
 	}
 
 	var existing ProviderModelRecord
@@ -161,33 +160,41 @@ func (ms *ModelStore) saveModels(provider *typ.Provider, models []string, source
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		record := ProviderModelRecord{
 			ProviderUUID: provider.UUID,
-			ProviderName: provider.Name,
-			APIBase:      provider.APIBase,
 			CreatedAt:    now,
-			UpdatedAt:    now,
 		}
-		if models != nil {
-			record.Models = modelsJSON
-			record.Source = source
-			record.LastUpdated = now
-		}
-		record.RawResponse = rawResponse
-		if lastErr != nil {
-			record.LastError = lastErr
-			record.LastErrorAt = &whenAt
-		}
+		applyWrite(&record)
 		if err := ms.db.Create(&record).Error; err != nil {
 			return fmt.Errorf("failed to create model record: %w", err)
 		}
 	} else if err != nil {
 		return fmt.Errorf("failed to query existing record: %w", err)
 	} else {
-		if err := ms.db.Model(&existing).Updates(updates).Error; err != nil {
+		applyWrite(&existing)
+		if err := ms.db.Save(&existing).Error; err != nil {
 			return fmt.Errorf("failed to update model record: %w", err)
 		}
 	}
 
 	return nil
+}
+
+// hasStoredModelList is a gorm scope matching rows whose models column holds
+// a stored list. It is shared by GetAllProviders and HasModels so the two
+// cannot drift.
+//
+// The column carries two encodings. Rows written before it moved to a json
+// serializer use the empty string to mean "no list stored"; rows written
+// after use SQL NULL. This one predicate covers both without special-casing:
+// the empty string fails the comparison, and NULL fails it too because
+// comparing NULL to anything yields NULL rather than true. A stored-but-empty
+// list matches under either encoding, which is what this predicate did before
+// the migration.
+//
+// The Go-side equivalent of this check did need rewriting -- see
+// GetProviderInfo, where a decoded empty slice can no longer tell a
+// stored-empty list apart from a never-written column.
+func hasStoredModelList(db *gorm.DB) *gorm.DB {
+	return db.Where("models <> ''")
 }
 
 // GetModels returns models for a provider by UUID.
@@ -208,12 +215,10 @@ func (ms *ModelStore) GetModels(providerUUID string, ttl time.Duration) []string
 		return []string{}
 	}
 
-	var models []string
-	if err := json.Unmarshal([]byte(record.Models), &models); err != nil {
+	if record.Models == nil {
 		return []string{}
 	}
-
-	return models
+	return record.Models
 }
 
 // GetAllProviders returns all provider UUIDs that have models
@@ -222,7 +227,7 @@ func (ms *ModelStore) GetAllProviders() []string {
 	defer ms.mu.RUnlock()
 
 	var records []ProviderModelRecord
-	if err := ms.db.Where("models <> ''").Find(&records).Error; err != nil {
+	if err := ms.db.Scopes(hasStoredModelList).Find(&records).Error; err != nil {
 		return []string{}
 	}
 
@@ -241,7 +246,8 @@ func (ms *ModelStore) HasModels(providerUUID string) bool {
 
 	var count int64
 	if err := ms.db.Model(&ProviderModelRecord{}).
-		Where("provider_uuid = ? AND models <> ''", providerUUID).
+		Where("provider_uuid = ?", providerUUID).
+		Scopes(hasStoredModelList).
 		Count(&count).Error; err != nil {
 		return false
 	}
@@ -268,7 +274,12 @@ func (ms *ModelStore) GetProviderInfo(providerUUID string) (apiBase string, last
 	if errors.Is(err, gorm.ErrRecordNotFound) || err != nil {
 		return "", "", false
 	}
-	if record.Models == "" || record.LastUpdated.IsZero() {
+	// last_updated is the encoding-independent discriminator here: it is
+	// written in the same step as the models list and only then, so a zero
+	// value means no fetch ever succeeded. Post-decode, a stored empty list
+	// and a never-written column are both an empty slice in Go, so the models
+	// field alone can no longer tell those apart.
+	if record.LastUpdated.IsZero() {
 		return "", "", false
 	}
 
@@ -290,12 +301,10 @@ func (ms *ModelStore) GetModelsBySource(providerUUID string, source ModelSource,
 		return []string{}
 	}
 
-	var models []string
-	if err := json.Unmarshal([]byte(record.Models), &models); err != nil {
+	if record.Models == nil {
 		return []string{}
 	}
-
-	return models
+	return record.Models
 }
 
 // GetModelCount returns the number of models for a provider
@@ -308,12 +317,7 @@ func (ms *ModelStore) GetModelCount(providerUUID string) int {
 		return 0
 	}
 
-	var models []string
-	if err := json.Unmarshal([]byte(record.Models), &models); err != nil {
-		return 0
-	}
-
-	return len(models)
+	return len(record.Models)
 }
 
 // GetAllModelRecords returns all provider records (with metadata)

--- a/internal/db/provider_model_serializer_test.go
+++ b/internal/db/provider_model_serializer_test.go
@@ -1,0 +1,284 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// legacyProviderModelRecord is ProviderModelRecord as it was before the
+// models column moved to `serializer:json`: a `string` holding hand-marshalled
+// JSON, with "" meaning "no list ever stored".
+type legacyProviderModelRecord struct {
+	ProviderUUID string    `gorm:"primaryKey;column:provider_uuid"`
+	ProviderName string    `gorm:"column:provider_name;index"`
+	APIBase      string    `gorm:"column:api_base"`
+	Models       string    `gorm:"column:models;type:text"`
+	Source       string    `gorm:"column:source"`
+	LastUpdated  time.Time `gorm:"column:last_updated"`
+	CreatedAt    time.Time `gorm:"column:created_at"`
+	UpdatedAt    time.Time `gorm:"column:updated_at"`
+}
+
+func (legacyProviderModelRecord) TableName() string { return "provider_models" }
+
+func seedLegacyModelRows(t *testing.T, dir string, rows []legacyProviderModelRecord) {
+	t.Helper()
+	db, err := OpenSQLite(constant.GetDBFile(dir), 0)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.AutoMigrate(&legacyProviderModelRecord{}); err != nil {
+		t.Fatalf("legacy migrate: %v", err)
+	}
+	for i := range rows {
+		if err := db.Create(&rows[i]).Error; err != nil {
+			t.Fatalf("seed %s: %v", rows[i].ProviderUUID, err)
+		}
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("db.DB(): %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+// TestModelStore_ReadsLegacyModelRows covers the read paths against rows in
+// the pre-serializer encoding.
+func TestModelStore_ReadsLegacyModelRows(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+
+	seedLegacyModelRows(t, dir, []legacyProviderModelRecord{
+		// A successful fetch with models.
+		{ProviderUUID: "has-models", ProviderName: "a", APIBase: "https://a",
+			Models: `["gpt-4","gpt-4o"]`, Source: "api", LastUpdated: now},
+		// A successful fetch that returned nothing -- stored as "[]".
+		{ProviderUUID: "empty-list", ProviderName: "b", APIBase: "https://b",
+			Models: `[]`, Source: "api", LastUpdated: now},
+		// Never a successful fetch -- the legacy "absent" encoding.
+		{ProviderUUID: "never-fetched", ProviderName: "c", APIBase: "https://c",
+			Models: ``},
+	})
+
+	store, err := NewModelStore(dir)
+	if err != nil {
+		t.Fatalf("NewModelStore over legacy db: %v", err)
+	}
+	defer store.Close()
+
+	t.Run("GetModels decodes a legacy list", func(t *testing.T) {
+		got := store.GetModels("has-models", 0)
+		if len(got) != 2 || got[0] != "gpt-4" || got[1] != "gpt-4o" {
+			t.Errorf("GetModels = %v, want [gpt-4 gpt-4o]", got)
+		}
+	})
+
+	t.Run("GetModels on a never-fetched row is empty", func(t *testing.T) {
+		if got := store.GetModels("never-fetched", 0); len(got) != 0 {
+			t.Errorf("GetModels = %v, want empty", got)
+		}
+	})
+
+	t.Run("GetModelCount", func(t *testing.T) {
+		if got := store.GetModelCount("has-models"); got != 2 {
+			t.Errorf("GetModelCount = %d, want 2", got)
+		}
+		if got := store.GetModelCount("empty-list"); got != 0 {
+			t.Errorf("GetModelCount(empty-list) = %d, want 0", got)
+		}
+	})
+
+	// The predicate has to keep the legacy "" row out while letting the
+	// legacy "[]" and "[...]" rows in -- the behaviour it had pre-migration.
+	t.Run("GetAllProviders excludes never-fetched", func(t *testing.T) {
+		got := store.GetAllProviders()
+		if !contains(got, "has-models") {
+			t.Errorf("GetAllProviders = %v, want it to contain has-models", got)
+		}
+		if !contains(got, "empty-list") {
+			t.Errorf("GetAllProviders = %v, want it to contain empty-list (stored []), matching pre-migration behaviour", got)
+		}
+		if contains(got, "never-fetched") {
+			t.Errorf("GetAllProviders = %v, want it to exclude never-fetched (legacy \"\")", got)
+		}
+	})
+
+	t.Run("HasModels", func(t *testing.T) {
+		if !store.HasModels("has-models") {
+			t.Error("HasModels(has-models) = false, want true")
+		}
+		if store.HasModels("never-fetched") {
+			t.Error("HasModels(never-fetched) = true, want false")
+		}
+	})
+
+	t.Run("GetProviderInfo", func(t *testing.T) {
+		if _, _, ok := store.GetProviderInfo("has-models"); !ok {
+			t.Error("GetProviderInfo(has-models) not found, want found")
+		}
+		if _, _, ok := store.GetProviderInfo("never-fetched"); ok {
+			t.Error("GetProviderInfo(never-fetched) found, want not found")
+		}
+	})
+}
+
+// TestModelStore_NewRowsMatchPredicate is the other half: rows written by the
+// migrated store use NULL for "absent", which the same predicate must handle.
+func TestModelStore_NewRowsMatchPredicate(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewModelStore(dir)
+	if err != nil {
+		t.Fatalf("NewModelStore: %v", err)
+	}
+	defer store.Close()
+
+	withModels := &typ.Provider{UUID: "with", Name: "with", APIBase: "https://w"}
+	emptyList := &typ.Provider{UUID: "empty", Name: "empty", APIBase: "https://e"}
+	failedOnly := &typ.Provider{UUID: "failed", Name: "failed", APIBase: "https://f"}
+
+	if err := store.SaveModels(withModels, []string{"m1", "m2"}, ModelSourceAPI); err != nil {
+		t.Fatalf("SaveModels: %v", err)
+	}
+	if err := store.SaveModels(emptyList, []string{}, ModelSourceAPI); err != nil {
+		t.Fatalf("SaveModels empty: %v", err)
+	}
+	if err := store.SaveFetchFailure(failedOnly, "boom", nil, time.Time{}); err != nil {
+		t.Fatalf("SaveFetchFailure: %v", err)
+	}
+
+	t.Run("raw column encoding", func(t *testing.T) {
+		type row struct {
+			ProviderUUID string
+			Models       *string
+		}
+		var rows []row
+		if err := store.db.Raw("SELECT provider_uuid, models FROM provider_models ORDER BY provider_uuid").
+			Scan(&rows).Error; err != nil {
+			t.Fatalf("raw scan: %v", err)
+		}
+		for _, r := range rows {
+			switch r.ProviderUUID {
+			case "with":
+				if r.Models == nil || *r.Models != `["m1","m2"]` {
+					t.Errorf("with: models = %v, want [\"m1\",\"m2\"]", r.Models)
+				}
+			case "empty":
+				if r.Models == nil || *r.Models != `[]` {
+					t.Errorf("empty: models = %v, want []", r.Models)
+				}
+			case "failed":
+				if r.Models != nil {
+					t.Errorf("failed: models = %q, want NULL", *r.Models)
+				}
+			}
+		}
+	})
+
+	t.Run("GetAllProviders", func(t *testing.T) {
+		got := store.GetAllProviders()
+		if !contains(got, "with") {
+			t.Errorf("GetAllProviders = %v, want it to contain with", got)
+		}
+		if !contains(got, "empty") {
+			t.Errorf("GetAllProviders = %v, want it to contain empty (stored [])", got)
+		}
+		if contains(got, "failed") {
+			t.Errorf("GetAllProviders = %v, want it to exclude failed (NULL models)", got)
+		}
+	})
+
+	t.Run("HasModels", func(t *testing.T) {
+		if !store.HasModels("with") {
+			t.Error("HasModels(with) = false, want true")
+		}
+		if store.HasModels("failed") {
+			t.Error("HasModels(failed) = true, want false")
+		}
+	})
+
+	// A failure-only write must not clobber a previously fetched list.
+	t.Run("failure-only write preserves the stale list", func(t *testing.T) {
+		if err := store.SaveFetchFailure(withModels, "later boom", nil, time.Time{}); err != nil {
+			t.Fatalf("SaveFetchFailure: %v", err)
+		}
+		got := store.GetModels("with", 0)
+		if len(got) != 2 || got[0] != "m1" {
+			t.Errorf("GetModels after failure = %v, want the stale [m1 m2]", got)
+		}
+		if lastErr, ok := store.GetFetchFailure("with"); !ok || lastErr != "later boom" {
+			t.Errorf("GetFetchFailure = %q,%v, want \"later boom\",true", lastErr, ok)
+		}
+	})
+
+	// And a later success must clear the error it left behind.
+	t.Run("success clears the recorded failure", func(t *testing.T) {
+		if err := store.SaveModels(withModels, []string{"m3"}, ModelSourceAPI); err != nil {
+			t.Fatalf("SaveModels: %v", err)
+		}
+		if lastErr, ok := store.GetFetchFailure("with"); ok {
+			t.Errorf("GetFetchFailure = %q, want cleared", lastErr)
+		}
+		if got := store.GetModels("with", 0); len(got) != 1 || got[0] != "m3" {
+			t.Errorf("GetModels = %v, want [m3]", got)
+		}
+	})
+}
+
+// TestHasStoredModelListScope pins the scope against every value the column
+// can hold under either encoding, in one place.
+func TestHasStoredModelListScope(t *testing.T) {
+	db, err := OpenSQLite(constant.GetDBFile(t.TempDir()), 0)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.AutoMigrate(&ProviderModelRecord{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	cases := []struct {
+		uuid  string
+		value any // nil -> SQL NULL
+		want  bool
+	}{
+		{"legacy-absent", "", false},
+		{"legacy-list", `["a"]`, true},
+		{"legacy-empty-list", `[]`, true},
+		{"new-absent", nil, false},
+		{"new-list", `["a"]`, true},
+		{"new-empty-list", `[]`, true},
+	}
+	for _, c := range cases {
+		if err := db.Exec("INSERT INTO provider_models (provider_uuid, models) VALUES (?, ?)",
+			c.uuid, c.value).Error; err != nil {
+			t.Fatalf("insert %s: %v", c.uuid, err)
+		}
+	}
+
+	var matched []ProviderModelRecord
+	if err := db.Scopes(hasStoredModelList).Find(&matched).Error; err != nil {
+		t.Fatalf("scoped find: %v", err)
+	}
+	got := make(map[string]bool, len(matched))
+	for _, r := range matched {
+		got[r.ProviderUUID] = true
+	}
+	for _, c := range cases {
+		if got[c.uuid] != c.want {
+			t.Errorf("hasStoredModelList matched %s = %v, want %v", c.uuid, got[c.uuid], c.want)
+		}
+	}
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/db/provider_model_serializer_test.go
+++ b/internal/db/provider_model_serializer_test.go
@@ -1,10 +1,10 @@
 package db
 
 import (
+	"slices"
 	"testing"
 	"time"
 
-	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -18,34 +18,9 @@ type legacyProviderModelRecord struct {
 	Models       string    `gorm:"column:models;type:text"`
 	Source       string    `gorm:"column:source"`
 	LastUpdated  time.Time `gorm:"column:last_updated"`
-	CreatedAt    time.Time `gorm:"column:created_at"`
-	UpdatedAt    time.Time `gorm:"column:updated_at"`
 }
 
 func (legacyProviderModelRecord) TableName() string { return "provider_models" }
-
-func seedLegacyModelRows(t *testing.T, dir string, rows []legacyProviderModelRecord) {
-	t.Helper()
-	db, err := OpenSQLite(constant.GetDBFile(dir), 0)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	if err := db.AutoMigrate(&legacyProviderModelRecord{}); err != nil {
-		t.Fatalf("legacy migrate: %v", err)
-	}
-	for i := range rows {
-		if err := db.Create(&rows[i]).Error; err != nil {
-			t.Fatalf("seed %s: %v", rows[i].ProviderUUID, err)
-		}
-	}
-	sqlDB, err := db.DB()
-	if err != nil {
-		t.Fatalf("db.DB(): %v", err)
-	}
-	if err := sqlDB.Close(); err != nil {
-		t.Fatalf("close: %v", err)
-	}
-}
 
 // TestModelStore_ReadsLegacyModelRows covers the read paths against rows in
 // the pre-serializer encoding.
@@ -53,7 +28,7 @@ func TestModelStore_ReadsLegacyModelRows(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Now()
 
-	seedLegacyModelRows(t, dir, []legacyProviderModelRecord{
+	seedLegacyRows(t, dir, []legacyProviderModelRecord{
 		// A successful fetch with models.
 		{ProviderUUID: "has-models", ProviderName: "a", APIBase: "https://a",
 			Models: `["gpt-4","gpt-4o"]`, Source: "api", LastUpdated: now},
@@ -97,13 +72,13 @@ func TestModelStore_ReadsLegacyModelRows(t *testing.T) {
 	// legacy "[]" and "[...]" rows in -- the behaviour it had pre-migration.
 	t.Run("GetAllProviders excludes never-fetched", func(t *testing.T) {
 		got := store.GetAllProviders()
-		if !contains(got, "has-models") {
+		if !slices.Contains(got, "has-models") {
 			t.Errorf("GetAllProviders = %v, want it to contain has-models", got)
 		}
-		if !contains(got, "empty-list") {
+		if !slices.Contains(got, "empty-list") {
 			t.Errorf("GetAllProviders = %v, want it to contain empty-list (stored []), matching pre-migration behaviour", got)
 		}
-		if contains(got, "never-fetched") {
+		if slices.Contains(got, "never-fetched") {
 			t.Errorf("GetAllProviders = %v, want it to exclude never-fetched (legacy \"\")", got)
 		}
 	})
@@ -181,13 +156,13 @@ func TestModelStore_NewRowsMatchPredicate(t *testing.T) {
 
 	t.Run("GetAllProviders", func(t *testing.T) {
 		got := store.GetAllProviders()
-		if !contains(got, "with") {
+		if !slices.Contains(got, "with") {
 			t.Errorf("GetAllProviders = %v, want it to contain with", got)
 		}
-		if !contains(got, "empty") {
+		if !slices.Contains(got, "empty") {
 			t.Errorf("GetAllProviders = %v, want it to contain empty (stored [])", got)
 		}
-		if contains(got, "failed") {
+		if slices.Contains(got, "failed") {
 			t.Errorf("GetAllProviders = %v, want it to exclude failed (NULL models)", got)
 		}
 	})
@@ -232,10 +207,15 @@ func TestModelStore_NewRowsMatchPredicate(t *testing.T) {
 // TestHasStoredModelListScope pins the scope against every value the column
 // can hold under either encoding, in one place.
 func TestHasStoredModelListScope(t *testing.T) {
-	db, err := OpenSQLite(constant.GetDBFile(t.TempDir()), 0)
+	db, err := openTinglyDB(t.TempDir())
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
 	if err := db.AutoMigrate(&ProviderModelRecord{}); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
@@ -272,13 +252,4 @@ func TestHasStoredModelListScope(t *testing.T) {
 			t.Errorf("hasStoredModelList matched %s = %v, want %v", c.uuid, got[c.uuid], c.want)
 		}
 	}
-}
-
-func contains(s []string, want string) bool {
-	for _, v := range s {
-		if v == want {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/db/provider_store.go
+++ b/internal/db/provider_store.go
@@ -1,9 +1,10 @@
 package db
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -26,12 +27,12 @@ type ProviderRecord struct {
 	Source   string `gorm:"column:source;default:'user'"` // "user" (default) or "builtin"
 
 	// Configuration fields
-	NoKeyRequired bool   `gorm:"column:no_key_required;default:false"`
-	Enabled       bool   `gorm:"column:enabled;default:true"`
-	ProxyURL      string `gorm:"column:proxy_url"`
-	Timeout       int64  `gorm:"column:timeout"`
-	Tags          string `gorm:"column:tags;type:text"` // JSON array
-	LastUpdated   string `gorm:"column:last_updated"`
+	NoKeyRequired bool     `gorm:"column:no_key_required;default:false"`
+	Enabled       bool     `gorm:"column:enabled;default:true"`
+	ProxyURL      string   `gorm:"column:proxy_url"`
+	Timeout       int64    `gorm:"column:timeout"`
+	Tags          []string `gorm:"column:tags;type:text;serializer:json"`
+	LastUpdated   string   `gorm:"column:last_updated"`
 
 	// Dual-mode optional fields. Independent of APIBase/APIStyle.
 	APIBaseOpenAI    string `gorm:"column:api_base_openai"`
@@ -44,21 +45,22 @@ type ProviderRecord struct {
 	// Credential fields - stored with provider as a unit
 	// For api_key auth: stores the API key
 	// For oauth auth: stores OAuth access token
-	Token             string `gorm:"column:token"`                        // API key or access token
-	OAuthProviderType string `gorm:"column:oauth_provider_type"`          // For oauth: provider type
-	OAuthUserID       string `gorm:"column:oauth_user_id"`                // For oauth: user ID
-	OAuthRefreshToken string `gorm:"column:oauth_refresh_token"`          // For oauth: refresh token
-	OAuthExpiresAt    string `gorm:"column:oauth_expires_at"`             // For oauth: token expiration (RFC3339)
-	OAuthExtraFields  string `gorm:"column:oauth_extra_fields;type:text"` // For oauth: JSON
+	Token             string `gorm:"column:token"`               // API key or access token
+	OAuthProviderType string `gorm:"column:oauth_provider_type"` // For oauth: provider type
+	OAuthUserID       string `gorm:"column:oauth_user_id"`       // For oauth: user ID
+	OAuthRefreshToken string `gorm:"column:oauth_refresh_token"` // For oauth: refresh token
+	OAuthExpiresAt    string `gorm:"column:oauth_expires_at"`    // For oauth: token expiration (RFC3339)
 
-	// VModel-specific fields (only populated when AuthType == "vmodel")
-	VModelDetail string `gorm:"column:vmodel_detail;type:text"` // JSON-encoded typ.VModelDetail
+	OAuthExtraFields map[string]any `gorm:"column:oauth_extra_fields;type:text;serializer:json"`
+
+	// VModelDetail is only populated when AuthType == "vmodel".
+	VModelDetail *typ.VModelDetail `gorm:"column:vmodel_detail;type:text;serializer:json"`
 
 	// Credential holds multi-field credentials for non-bearer auth types
-	// (aws_sigv4, azure_key, gcp_sa). JSON-encoded typ.CredentialBundle.
-	// Empty for api_key/oauth/vmodel. Added additively; AutoMigrate creates
-	// the column on existing databases with no backfill required.
-	Credential string `gorm:"column:credential;type:text"`
+	// (aws_sigv4, azure_key, gcp_sa). Nil for api_key/oauth/vmodel. Added
+	// additively; AutoMigrate creates the column on existing databases with
+	// no backfill required.
+	Credential *typ.CredentialBundle `gorm:"column:credential;type:text;serializer:json"`
 
 	CreatedAt time.Time `gorm:"column:created_at"`
 	UpdatedAt time.Time `gorm:"column:updated_at"`
@@ -67,6 +69,62 @@ type ProviderRecord struct {
 // TableName specifies the table name for GORM
 func (ProviderRecord) TableName() string {
 	return "providers"
+}
+
+// The four JSON-backed columns above used to be `string` fields that every
+// caller marshalled and unmarshalled by hand. `serializer:json` does that
+// now, which surfaces codec errors that were previously discarded -- but it
+// also removes a property the string encoding provided by accident: because
+// unmarshalling allocated fresh values on every read, each caller got a
+// private copy of the tags/map/struct.
+//
+// ProviderStore caches *ProviderRecord and hands out typ.Provider built from
+// it, so without that copy the cache would be sharing mutable state with
+// every caller. That is not hypothetical: the OAuth callback handler does
+// `provider.OAuthDetail.ExtraFields["id_token"] = ...` on a provider it read
+// from the store (internal/server/module/oauth/handler.go), which would
+// otherwise write straight into the cached record -- persisting even if the
+// subsequent UpdateProvider failed.
+//
+// The clone helpers below keep that isolation explicit at both boundaries:
+// toProvider clones on the way out, toRecord/updateRecordFromProvider clone
+// on the way in. Empty is normalized to nil so the column stays NULL rather
+// than "[]"/"{}" -- "absent" must not read back as "present but empty".
+
+func cloneStrings(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	return slices.Clone(s)
+}
+
+func cloneExtraFields(m map[string]any) map[string]any {
+	if len(m) == 0 {
+		return nil
+	}
+	return maps.Clone(m)
+}
+
+func cloneVModelDetail(d *typ.VModelDetail) *typ.VModelDetail {
+	if d == nil {
+		return nil
+	}
+	out := *d
+	out.Models = cloneStrings(d.Models)
+	return &out
+}
+
+func cloneCredential(c *typ.CredentialBundle) *typ.CredentialBundle {
+	if c == nil {
+		return nil
+	}
+	out := *c
+	if len(c.Fields) > 0 {
+		out.Fields = maps.Clone(c.Fields)
+	} else {
+		out.Fields = nil
+	}
+	return &out
 }
 
 // toProvider converts a ProviderRecord to typ.Provider
@@ -88,10 +146,7 @@ func (r *ProviderRecord) toProvider() *typ.Provider {
 		OpenAIEndpointMode: ai.OpenAIEndpointMode(r.OpenAIEndpointMode),
 	}
 
-	// Parse tags JSON
-	if r.Tags != "" {
-		json.Unmarshal([]byte(r.Tags), &provider.Tags)
-	}
+	provider.Tags = cloneStrings(r.Tags)
 
 	// Set credentials based on auth type
 	switch provider.AuthType {
@@ -102,24 +157,12 @@ func (r *ProviderRecord) toProvider() *typ.Provider {
 			UserID:       r.OAuthUserID,
 			RefreshToken: r.OAuthRefreshToken,
 			ExpiresAt:    r.OAuthExpiresAt,
-		}
-		if r.OAuthExtraFields != "" {
-			json.Unmarshal([]byte(r.OAuthExtraFields), &provider.OAuthDetail.ExtraFields)
+			ExtraFields:  cloneExtraFields(r.OAuthExtraFields),
 		}
 	case typ.AuthTypeVirtual:
-		if r.VModelDetail != "" {
-			var detail typ.VModelDetail
-			if err := json.Unmarshal([]byte(r.VModelDetail), &detail); err == nil {
-				provider.VModelDetail = &detail
-			}
-		}
+		provider.VModelDetail = cloneVModelDetail(r.VModelDetail)
 	case typ.AuthTypeAWSSigV4, typ.AuthTypeAzureKey, typ.AuthTypeGCPVertex:
-		if r.Credential != "" {
-			var bundle typ.CredentialBundle
-			if err := json.Unmarshal([]byte(r.Credential), &bundle); err == nil {
-				provider.Credential = &bundle
-			}
-		}
+		provider.Credential = cloneCredential(r.Credential)
 	case typ.AuthTypeAPIKey, "":
 		provider.Token = r.Token
 		provider.AuthType = typ.AuthTypeAPIKey
@@ -158,11 +201,7 @@ func toRecord(p *typ.Provider) *ProviderRecord {
 		record.OAuthExpiresAt = p.OAuthDetail.ExpiresAt
 	}
 
-	// Marshal tags to JSON
-	if len(p.Tags) > 0 {
-		tagsJSON, _ := json.Marshal(p.Tags)
-		record.Tags = string(tagsJSON)
-	}
+	record.Tags = cloneStrings(p.Tags)
 
 	// Set credentials based on auth type
 	switch p.AuthType {
@@ -170,21 +209,12 @@ func toRecord(p *typ.Provider) *ProviderRecord {
 		if p.OAuthDetail != nil {
 			record.Token = p.OAuthDetail.AccessToken
 			record.OAuthRefreshToken = p.OAuthDetail.RefreshToken
-			if p.OAuthDetail.ExtraFields != nil {
-				extraJSON, _ := json.Marshal(p.OAuthDetail.ExtraFields)
-				record.OAuthExtraFields = string(extraJSON)
-			}
+			record.OAuthExtraFields = cloneExtraFields(p.OAuthDetail.ExtraFields)
 		}
 	case typ.AuthTypeVirtual:
-		if p.VModelDetail != nil {
-			vmJSON, _ := json.Marshal(p.VModelDetail)
-			record.VModelDetail = string(vmJSON)
-		}
+		record.VModelDetail = cloneVModelDetail(p.VModelDetail)
 	case typ.AuthTypeAWSSigV4, typ.AuthTypeAzureKey, typ.AuthTypeGCPVertex:
-		if p.Credential != nil {
-			credJSON, _ := json.Marshal(p.Credential)
-			record.Credential = string(credJSON)
-		}
+		record.Credential = cloneCredential(p.Credential)
 	case typ.AuthTypeAPIKey, "":
 		record.Token = p.Token
 	}
@@ -209,13 +239,7 @@ func updateRecordFromProvider(record *ProviderRecord, p *typ.Provider) {
 	record.OpenAIEndpointMode = string(p.OpenAIEndpointMode)
 	record.UpdatedAt = time.Now()
 
-	// Marshal tags to JSON
-	if len(p.Tags) > 0 {
-		tagsJSON, _ := json.Marshal(p.Tags)
-		record.Tags = string(tagsJSON)
-	} else {
-		record.Tags = ""
-	}
+	record.Tags = cloneStrings(p.Tags)
 
 	// Set credentials based on auth type
 	switch p.AuthType {
@@ -226,50 +250,35 @@ func updateRecordFromProvider(record *ProviderRecord, p *typ.Provider) {
 			record.OAuthUserID = p.OAuthDetail.UserID
 			record.OAuthRefreshToken = p.OAuthDetail.RefreshToken
 			record.OAuthExpiresAt = p.OAuthDetail.ExpiresAt
-			if p.OAuthDetail.ExtraFields != nil {
-				extraJSON, _ := json.Marshal(p.OAuthDetail.ExtraFields)
-				record.OAuthExtraFields = string(extraJSON)
-			} else {
-				record.OAuthExtraFields = ""
-			}
+			record.OAuthExtraFields = cloneExtraFields(p.OAuthDetail.ExtraFields)
 		}
 	case typ.AuthTypeVirtual:
-		if p.VModelDetail != nil {
-			vmJSON, _ := json.Marshal(p.VModelDetail)
-			record.VModelDetail = string(vmJSON)
-		} else {
-			record.VModelDetail = ""
-		}
+		record.VModelDetail = cloneVModelDetail(p.VModelDetail)
 		record.Token = ""
 		record.OAuthProviderType = ""
 		record.OAuthUserID = ""
 		record.OAuthRefreshToken = ""
 		record.OAuthExpiresAt = ""
-		record.OAuthExtraFields = ""
-		record.Credential = ""
+		record.OAuthExtraFields = nil
+		record.Credential = nil
 	case typ.AuthTypeAWSSigV4, typ.AuthTypeAzureKey, typ.AuthTypeGCPVertex:
-		if p.Credential != nil {
-			credJSON, _ := json.Marshal(p.Credential)
-			record.Credential = string(credJSON)
-		} else {
-			record.Credential = ""
-		}
+		record.Credential = cloneCredential(p.Credential)
 		record.Token = ""
 		record.OAuthProviderType = ""
 		record.OAuthUserID = ""
 		record.OAuthRefreshToken = ""
 		record.OAuthExpiresAt = ""
-		record.OAuthExtraFields = ""
-		record.VModelDetail = ""
+		record.OAuthExtraFields = nil
+		record.VModelDetail = nil
 	case typ.AuthTypeAPIKey, "":
 		record.Token = p.Token
 		record.OAuthProviderType = ""
 		record.OAuthUserID = ""
 		record.OAuthRefreshToken = ""
 		record.OAuthExpiresAt = ""
-		record.OAuthExtraFields = ""
-		record.VModelDetail = ""
-		record.Credential = ""
+		record.OAuthExtraFields = nil
+		record.VModelDetail = nil
+		record.Credential = nil
 	}
 }
 
@@ -501,8 +510,7 @@ func (ps *ProviderStore) UpdateCredential(uuid string, token string, oauthDetail
 			r.OAuthRefreshToken = oauthDetail.RefreshToken
 			r.OAuthExpiresAt = oauthDetail.ExpiresAt
 			if oauthDetail.ExtraFields != nil {
-				extraJSON, _ := json.Marshal(oauthDetail.ExtraFields)
-				r.OAuthExtraFields = string(extraJSON)
+				r.OAuthExtraFields = cloneExtraFields(oauthDetail.ExtraFields)
 			}
 		} else {
 			r.Token = token
@@ -525,12 +533,7 @@ func (ps *ProviderStore) UpdateCredentialBundle(uuid string, bundle *typ.Credent
 	defer ps.mu.Unlock()
 
 	_, err := ps.writeThroughLocked(uuid, func(r *ProviderRecord) {
-		if bundle != nil {
-			credJSON, _ := json.Marshal(bundle)
-			r.Credential = string(credJSON)
-		} else {
-			r.Credential = ""
-		}
+		r.Credential = cloneCredential(bundle)
 		r.UpdatedAt = time.Now()
 	})
 	if err != nil {

--- a/internal/db/provider_store_bench_test.go
+++ b/internal/db/provider_store_bench_test.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// GetByUUID is resolved once per routed LLM request (ServiceSelector.Select,
+// see .design/db.md) and is served entirely from the write-through cache --
+// so what it costs is whatever toProvider() does to turn the cached record
+// into a typ.Provider. While the JSON columns were `string` fields that meant
+// a json.Unmarshal per request; with `serializer:json` the record already
+// holds the decoded values and toProvider only has to clone them.
+//
+// Run: go test ./internal/db/... -bench 'ProviderStore_GetByUUID' -benchmem -run '^$'
+
+func benchmarkGetByUUID(b *testing.B, p *typ.Provider) {
+	store, err := NewProviderStore(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = store.Close() })
+	if err := store.Save(p); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := store.GetByUUID(p.UUID); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkProviderStore_GetByUUID_Tagged: the common case, a provider
+// carrying a handful of tags.
+func BenchmarkProviderStore_GetByUUID_Tagged(b *testing.B) {
+	benchmarkGetByUUID(b, &typ.Provider{
+		UUID: "bench-uuid", Name: "bench", APIBase: "https://api.example.com",
+		APIStyle: protocol.APIStyleOpenAI, AuthType: typ.AuthTypeAPIKey,
+		Token: "tok", Enabled: true,
+		Tags: []string{"prod", "openai", "us-east", "tier1"},
+	})
+}
+
+// BenchmarkProviderStore_GetByUUID_OAuth: the heaviest shape, tags plus an
+// OAuth ExtraFields map.
+func BenchmarkProviderStore_GetByUUID_OAuth(b *testing.B) {
+	benchmarkGetByUUID(b, &typ.Provider{
+		UUID: "bench-uuid", Name: "bench", APIBase: "https://api.example.com",
+		APIStyle: protocol.APIStyleAnthropic, AuthType: typ.AuthTypeOAuth,
+		Enabled: true, Tags: []string{"prod"},
+		OAuthDetail: &typ.OAuthDetail{
+			AccessToken: "access", RefreshToken: "refresh",
+			ExpiresAt:   "2030-01-01T00:00:00Z",
+			ExtraFields: map[string]any{"id_token": "abc", "organization_id": "org_123"},
+		},
+	})
+}
+
+// BenchmarkProviderStore_GetByUUID_NoJSON is the control: a provider with
+// every JSON column empty. It should be unaffected by how those columns are
+// encoded, and so pins that any delta in the two above is really the JSON
+// work and not measurement drift.
+func BenchmarkProviderStore_GetByUUID_NoJSON(b *testing.B) {
+	benchmarkGetByUUID(b, &typ.Provider{
+		UUID: "bench-uuid", Name: "bench", APIBase: "https://api.example.com",
+		APIStyle: protocol.APIStyleOpenAI, AuthType: typ.AuthTypeAPIKey,
+		Token: "tok", Enabled: true,
+	})
+}

--- a/internal/db/provider_store_serializer_test.go
+++ b/internal/db/provider_store_serializer_test.go
@@ -1,10 +1,8 @@
 package db
 
 import (
-	"path/filepath"
 	"testing"
 
-	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
@@ -36,15 +34,7 @@ func (legacyProviderRecord) TableName() string { return "providers" }
 func TestProviderStore_ReadsLegacyJSONStringRows(t *testing.T) {
 	dir := t.TempDir()
 
-	// Write the legacy rows through a legacy-shaped model.
-	legacyDB, err := OpenSQLite(constant.GetDBFile(dir), 0)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	if err := legacyDB.AutoMigrate(&legacyProviderRecord{}); err != nil {
-		t.Fatalf("legacy migrate: %v", err)
-	}
-	legacyRows := []legacyProviderRecord{
+	seedLegacyRows(t, dir, []legacyProviderRecord{
 		{
 			UUID: "absent", Name: "absent", APIBase: "https://a.example.com",
 			APIStyle: "openai", AuthType: "api_key", Enabled: true, Token: "tok",
@@ -71,19 +61,7 @@ func TestProviderStore_ReadsLegacyJSONStringRows(t *testing.T) {
 			APIStyle: "openai", AuthType: "aws_sigv4", Enabled: true,
 			Credential: `{"fields":{"access_key_id":"AKIA","region":"us-east-1"}}`,
 		},
-	}
-	for i := range legacyRows {
-		if err := legacyDB.Create(&legacyRows[i]).Error; err != nil {
-			t.Fatalf("seed legacy row %s: %v", legacyRows[i].UUID, err)
-		}
-	}
-	sqlDB, err := legacyDB.DB()
-	if err != nil {
-		t.Fatalf("legacyDB.DB(): %v", err)
-	}
-	if err := sqlDB.Close(); err != nil {
-		t.Fatalf("close legacy db: %v", err)
-	}
+	})
 
 	// Now open the same file through the migrated store.
 	store, err := NewProviderStore(dir)
@@ -162,18 +140,6 @@ func TestProviderStore_ReadsLegacyJSONStringRows(t *testing.T) {
 			t.Errorf("region = %q, want us-east-1", got)
 		}
 	})
-
-	// The migration must not have rewritten the column types out from under
-	// the legacy rows -- the file is still the same one AutoMigrate opened.
-	t.Run("db file is the same one", func(t *testing.T) {
-		if _, err := store.GetByUUID("tagged"); err != nil {
-			t.Fatalf("post-migrate read: %v", err)
-		}
-		want := filepath.Join(dir, "db", "tingly.db")
-		if got := constant.GetDBFile(dir); got != want {
-			t.Fatalf("test wired to the wrong path: %s", got)
-		}
-	})
 }
 
 // TestProviderStore_CacheIsolation pins the property the string encoding used
@@ -185,16 +151,25 @@ func TestProviderStore_CacheIsolation(t *testing.T) {
 	store, _ := setupTestProviderStore(t)
 	defer store.Close()
 
-	seed := &typ.Provider{
-		UUID:     "isolation",
-		Name:     "isolation",
-		APIBase:  "https://api.example.com",
-		APIStyle: protocol.APIStyleOpenAI,
-		AuthType: typ.AuthTypeAPIKey,
-		Token:    "tok",
-		Enabled:  true,
-		Tags:     []string{"keep"},
+	// The shared scaffolding is the same for all three; each subtest only
+	// varies the field whose isolation it is checking.
+	newProvider := func(uuid string, authType typ.AuthType, mut func(*typ.Provider)) *typ.Provider {
+		p := &typ.Provider{
+			UUID:     uuid,
+			Name:     uuid,
+			APIBase:  "https://api.example.com",
+			APIStyle: protocol.APIStyleOpenAI,
+			AuthType: authType,
+			Enabled:  true,
+		}
+		mut(p)
+		return p
 	}
+
+	seed := newProvider("isolation", typ.AuthTypeAPIKey, func(p *typ.Provider) {
+		p.Token = "tok"
+		p.Tags = []string{"keep"}
+	})
 	if err := store.Save(seed); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -228,18 +203,12 @@ func TestProviderStore_CacheIsolation(t *testing.T) {
 	})
 
 	t.Run("oauth ExtraFields map is not shared", func(t *testing.T) {
-		oauth := &typ.Provider{
-			UUID:     "isolation-oauth",
-			Name:     "isolation-oauth",
-			APIBase:  "https://api.example.com",
-			APIStyle: protocol.APIStyleOpenAI,
-			AuthType: typ.AuthTypeOAuth,
-			Enabled:  true,
-			OAuthDetail: &typ.OAuthDetail{
+		oauth := newProvider("isolation-oauth", typ.AuthTypeOAuth, func(p *typ.Provider) {
+			p.OAuthDetail = &typ.OAuthDetail{
 				AccessToken: "access",
 				ExtraFields: map[string]any{"id_token": "original"},
-			},
-		}
+			}
+		})
 		if err := store.Save(oauth); err != nil {
 			t.Fatalf("Save oauth: %v", err)
 		}
@@ -261,17 +230,11 @@ func TestProviderStore_CacheIsolation(t *testing.T) {
 	})
 
 	t.Run("credential bundle Fields map is not shared", func(t *testing.T) {
-		bundle := &typ.Provider{
-			UUID:     "isolation-cred",
-			Name:     "isolation-cred",
-			APIBase:  "https://api.example.com",
-			APIStyle: protocol.APIStyleOpenAI,
-			AuthType: typ.AuthTypeAWSSigV4,
-			Enabled:  true,
-			Credential: &typ.CredentialBundle{
+		bundle := newProvider("isolation-cred", typ.AuthTypeAWSSigV4, func(p *typ.Provider) {
+			p.Credential = &typ.CredentialBundle{
 				Fields: map[string]string{"region": "us-east-1"},
-			},
-		}
+			}
+		})
 		if err := store.Save(bundle); err != nil {
 			t.Fatalf("Save bundle: %v", err)
 		}

--- a/internal/db/provider_store_serializer_test.go
+++ b/internal/db/provider_store_serializer_test.go
@@ -1,0 +1,293 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// legacyProviderRecord is the ProviderRecord as it was before the JSON
+// columns moved to `serializer:json`: the four JSON payloads were `string`
+// fields, marshalled by hand, with "" meaning absent. Rows in every existing
+// tingly.db were written through this shape, so the new code has to keep
+// reading them.
+type legacyProviderRecord struct {
+	UUID             string `gorm:"primaryKey;column:uuid"`
+	Name             string `gorm:"column:name;not null;index"`
+	APIBase          string `gorm:"column:api_base;not null"`
+	APIStyle         string `gorm:"column:api_style;not null"`
+	AuthType         string `gorm:"column:auth_type;not null"`
+	Enabled          bool   `gorm:"column:enabled;default:true"`
+	Token            string `gorm:"column:token"`
+	Tags             string `gorm:"column:tags;type:text"`
+	OAuthExtraFields string `gorm:"column:oauth_extra_fields;type:text"`
+	VModelDetail     string `gorm:"column:vmodel_detail;type:text"`
+	Credential       string `gorm:"column:credential;type:text"`
+}
+
+func (legacyProviderRecord) TableName() string { return "providers" }
+
+// TestProviderStore_ReadsLegacyJSONStringRows writes rows exactly as the
+// pre-serializer code did -- including "" for "absent", which is not valid
+// JSON -- and reads them back through the migrated store.
+func TestProviderStore_ReadsLegacyJSONStringRows(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write the legacy rows through a legacy-shaped model.
+	legacyDB, err := OpenSQLite(constant.GetDBFile(dir), 0)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := legacyDB.AutoMigrate(&legacyProviderRecord{}); err != nil {
+		t.Fatalf("legacy migrate: %v", err)
+	}
+	legacyRows := []legacyProviderRecord{
+		{
+			UUID: "absent", Name: "absent", APIBase: "https://a.example.com",
+			APIStyle: "openai", AuthType: "api_key", Enabled: true, Token: "tok",
+			// Every JSON column empty -- the legacy "absent" encoding.
+			Tags: "", OAuthExtraFields: "", VModelDetail: "", Credential: "",
+		},
+		{
+			UUID: "tagged", Name: "tagged", APIBase: "https://b.example.com",
+			APIStyle: "openai", AuthType: "api_key", Enabled: true, Token: "tok",
+			Tags: `["alpha","beta"]`,
+		},
+		{
+			UUID: "oauthy", Name: "oauthy", APIBase: "https://c.example.com",
+			APIStyle: "anthropic", AuthType: "oauth", Enabled: true, Token: "access",
+			OAuthExtraFields: `{"id_token":"legacy-id-token"}`,
+		},
+		{
+			UUID: "virtual", Name: "virtual", APIBase: "https://d.example.com",
+			APIStyle: "openai", AuthType: "vmodel", Enabled: true,
+			VModelDetail: `{"models":["v1","v2"],"latency_profile":"fast"}`,
+		},
+		{
+			UUID: "bundled", Name: "bundled", APIBase: "https://e.example.com",
+			APIStyle: "openai", AuthType: "aws_sigv4", Enabled: true,
+			Credential: `{"fields":{"access_key_id":"AKIA","region":"us-east-1"}}`,
+		},
+	}
+	for i := range legacyRows {
+		if err := legacyDB.Create(&legacyRows[i]).Error; err != nil {
+			t.Fatalf("seed legacy row %s: %v", legacyRows[i].UUID, err)
+		}
+	}
+	sqlDB, err := legacyDB.DB()
+	if err != nil {
+		t.Fatalf("legacyDB.DB(): %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+
+	// Now open the same file through the migrated store.
+	store, err := NewProviderStore(dir)
+	if err != nil {
+		t.Fatalf("NewProviderStore over legacy db: %v", err)
+	}
+	defer store.Close()
+
+	t.Run("empty string columns read as absent", func(t *testing.T) {
+		p, err := store.GetByUUID("absent")
+		if err != nil {
+			t.Fatalf("GetByUUID: %v", err)
+		}
+		if len(p.Tags) != 0 {
+			t.Errorf("Tags = %v, want empty", p.Tags)
+		}
+		if p.VModelDetail != nil {
+			t.Errorf("VModelDetail = %+v, want nil", p.VModelDetail)
+		}
+		if p.Credential != nil {
+			t.Errorf("Credential = %+v, want nil", p.Credential)
+		}
+	})
+
+	t.Run("tags", func(t *testing.T) {
+		p, err := store.GetByUUID("tagged")
+		if err != nil {
+			t.Fatalf("GetByUUID: %v", err)
+		}
+		if len(p.Tags) != 2 || p.Tags[0] != "alpha" || p.Tags[1] != "beta" {
+			t.Errorf("Tags = %v, want [alpha beta]", p.Tags)
+		}
+	})
+
+	t.Run("oauth extra fields", func(t *testing.T) {
+		p, err := store.GetByUUID("oauthy")
+		if err != nil {
+			t.Fatalf("GetByUUID: %v", err)
+		}
+		if p.OAuthDetail == nil {
+			t.Fatal("OAuthDetail = nil")
+		}
+		if got := p.OAuthDetail.ExtraFields["id_token"]; got != "legacy-id-token" {
+			t.Errorf("ExtraFields[id_token] = %v, want legacy-id-token", got)
+		}
+	})
+
+	t.Run("vmodel detail", func(t *testing.T) {
+		p, err := store.GetByUUID("virtual")
+		if err != nil {
+			t.Fatalf("GetByUUID: %v", err)
+		}
+		if p.VModelDetail == nil {
+			t.Fatal("VModelDetail = nil")
+		}
+		if len(p.VModelDetail.Models) != 2 || p.VModelDetail.Models[0] != "v1" {
+			t.Errorf("Models = %v, want [v1 v2]", p.VModelDetail.Models)
+		}
+		if p.VModelDetail.LatencyProfile != "fast" {
+			t.Errorf("LatencyProfile = %q, want fast", p.VModelDetail.LatencyProfile)
+		}
+	})
+
+	t.Run("credential bundle", func(t *testing.T) {
+		p, err := store.GetByUUID("bundled")
+		if err != nil {
+			t.Fatalf("GetByUUID: %v", err)
+		}
+		if p.Credential == nil {
+			t.Fatal("Credential = nil")
+		}
+		if got := p.Credential.Field("access_key_id"); got != "AKIA" {
+			t.Errorf("access_key_id = %q, want AKIA", got)
+		}
+		if got := p.Credential.Field("region"); got != "us-east-1" {
+			t.Errorf("region = %q, want us-east-1", got)
+		}
+	})
+
+	// The migration must not have rewritten the column types out from under
+	// the legacy rows -- the file is still the same one AutoMigrate opened.
+	t.Run("db file is the same one", func(t *testing.T) {
+		if _, err := store.GetByUUID("tagged"); err != nil {
+			t.Fatalf("post-migrate read: %v", err)
+		}
+		want := filepath.Join(dir, "db", "tingly.db")
+		if got := constant.GetDBFile(dir); got != want {
+			t.Fatalf("test wired to the wrong path: %s", got)
+		}
+	})
+}
+
+// TestProviderStore_CacheIsolation pins the property the string encoding used
+// to provide for free: a provider handed out by the store must not share
+// mutable state with the cached record. The OAuth callback handler really
+// does mutate ExtraFields on a provider it read from the store, so a shared
+// map would let an unsaved (or failed) write leak into the cache.
+func TestProviderStore_CacheIsolation(t *testing.T) {
+	store, _ := setupTestProviderStore(t)
+	defer store.Close()
+
+	seed := &typ.Provider{
+		UUID:     "isolation",
+		Name:     "isolation",
+		APIBase:  "https://api.example.com",
+		APIStyle: protocol.APIStyleOpenAI,
+		AuthType: typ.AuthTypeAPIKey,
+		Token:    "tok",
+		Enabled:  true,
+		Tags:     []string{"keep"},
+	}
+	if err := store.Save(seed); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	t.Run("caller mutating a returned provider cannot reach the cache", func(t *testing.T) {
+		got, err := store.GetByUUID("isolation")
+		if err != nil {
+			t.Fatalf("GetByUUID: %v", err)
+		}
+		got.Tags[0] = "tampered"
+
+		again, err := store.GetByUUID("isolation")
+		if err != nil {
+			t.Fatalf("GetByUUID: %v", err)
+		}
+		if again.Tags[0] != "keep" {
+			t.Errorf("cache saw a caller's mutation: Tags[0] = %q, want keep", again.Tags[0])
+		}
+	})
+
+	t.Run("mutating the saved provider cannot reach the cache", func(t *testing.T) {
+		seed.Tags[0] = "tampered-after-save"
+
+		got, err := store.GetByUUID("isolation")
+		if err != nil {
+			t.Fatalf("GetByUUID: %v", err)
+		}
+		if got.Tags[0] != "keep" {
+			t.Errorf("cache aliases the caller's slice: Tags[0] = %q, want keep", got.Tags[0])
+		}
+	})
+
+	t.Run("oauth ExtraFields map is not shared", func(t *testing.T) {
+		oauth := &typ.Provider{
+			UUID:     "isolation-oauth",
+			Name:     "isolation-oauth",
+			APIBase:  "https://api.example.com",
+			APIStyle: protocol.APIStyleOpenAI,
+			AuthType: typ.AuthTypeOAuth,
+			Enabled:  true,
+			OAuthDetail: &typ.OAuthDetail{
+				AccessToken: "access",
+				ExtraFields: map[string]any{"id_token": "original"},
+			},
+		}
+		if err := store.Save(oauth); err != nil {
+			t.Fatalf("Save oauth: %v", err)
+		}
+
+		got, err := store.GetByUUID("isolation-oauth")
+		if err != nil {
+			t.Fatalf("GetByUUID: %v", err)
+		}
+		// Exactly what internal/server/module/oauth/handler.go does.
+		got.OAuthDetail.ExtraFields["id_token"] = "rotated-but-not-saved"
+
+		again, err := store.GetByUUID("isolation-oauth")
+		if err != nil {
+			t.Fatalf("GetByUUID: %v", err)
+		}
+		if v := again.OAuthDetail.ExtraFields["id_token"]; v != "original" {
+			t.Errorf("cache saw an unsaved ExtraFields mutation: id_token = %v, want original", v)
+		}
+	})
+
+	t.Run("credential bundle Fields map is not shared", func(t *testing.T) {
+		bundle := &typ.Provider{
+			UUID:     "isolation-cred",
+			Name:     "isolation-cred",
+			APIBase:  "https://api.example.com",
+			APIStyle: protocol.APIStyleOpenAI,
+			AuthType: typ.AuthTypeAWSSigV4,
+			Enabled:  true,
+			Credential: &typ.CredentialBundle{
+				Fields: map[string]string{"region": "us-east-1"},
+			},
+		}
+		if err := store.Save(bundle); err != nil {
+			t.Fatalf("Save bundle: %v", err)
+		}
+
+		got, err := store.GetByUUID("isolation-cred")
+		if err != nil {
+			t.Fatalf("GetByUUID: %v", err)
+		}
+		got.Credential.Fields["region"] = "eu-west-1"
+
+		again, err := store.GetByUUID("isolation-cred")
+		if err != nil {
+			t.Fatalf("GetByUUID: %v", err)
+		}
+		if v := again.Credential.Field("region"); v != "us-east-1" {
+			t.Errorf("cache saw an unsaved Credential mutation: region = %q, want us-east-1", v)
+		}
+	})
+}

--- a/internal/db/stats_usage_bench_test.go
+++ b/internal/db/stats_usage_bench_test.go
@@ -7,13 +7,16 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 )
 
-// newUsageStoreForBench builds a UsageStore for a fresh temp dir.
-func newUsageStoreForBench(b *testing.B) *UsageStore {
-	b.Helper()
-	store, err := NewUsageStore(b.TempDir())
+// newUsageStoreForTest builds a UsageStore over a fresh temp dir, closed when
+// the test or benchmark finishes. Takes testing.TB so benchmarks and tests
+// share one setup path.
+func newUsageStoreForTest(tb testing.TB) *UsageStore {
+	tb.Helper()
+	store, err := NewUsageStore(tb.TempDir())
 	if err != nil {
-		b.Fatal(err)
+		tb.Fatal(err)
 	}
+	tb.Cleanup(func() { _ = store.Close() })
 	return store
 }
 
@@ -53,7 +56,7 @@ func BenchmarkStatsStore_UpdateFromService(b *testing.B) {
 // recordDetailedUsageWithTokenUsage makes: a single-row INSERT per
 // completed request (the proxy's usage audit log).
 func BenchmarkUsageStore_RecordUsage(b *testing.B) {
-	store := newUsageStoreForBench(b)
+	store := newUsageStoreForTest(b)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -87,7 +90,7 @@ func BenchmarkStatsAndUsage_Combined(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	usageStore := newUsageStoreForBench(b)
+	usageStore := newUsageStoreForTest(b)
 
 	service := &loadbalance.Service{
 		Provider: "bench-provider",

--- a/internal/db/usage_daily.go
+++ b/internal/db/usage_daily.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"time"
@@ -266,16 +267,8 @@ func (us *UsageStore) dailyStatBuckets(q UsageStatsQuery, firstDay, lastDayEx ti
 	}
 
 	db := us.db.Model(&UsageDailyRecord{}).
-		Where("date >= ? AND date < ?", firstDay.Format(dailyDateLayout), lastDayEx.Format(dailyDateLayout))
-	if q.Provider != "" {
-		db = db.Where("provider_uuid = ?", q.Provider)
-	}
-	if q.Model != "" {
-		db = db.Where("model = ?", q.Model)
-	}
-	if q.UserID != "" {
-		db = db.Where("user_id = ?", q.UserID)
-	}
+		Where("date >= ? AND date < ?", firstDay.Format(dailyDateLayout), lastDayEx.Format(dailyDateLayout)).
+		Scopes(withColumnFilters(q.dailyFilterMap()))
 
 	var buckets []aggBucket
 	if err := db.Select(keyExpr + `,
@@ -407,16 +400,58 @@ func (us *UsageStore) timeSeriesFromDaily(interval string, start, end time.Time,
 	return out, true, nil
 }
 
+// dailyFilterColumns is the usage_daily subset of usageFilterColumns. The
+// pre-aggregation table only carries these dimensions -- scenario, rule_uuid
+// and status are not columns here, which is exactly why
+// aggregatedStatsFromDaily and timeSeriesFromDaily refuse a query that sets
+// them and fall back to the raw table.
+var dailyFilterColumns = map[string]struct{}{
+	"provider_uuid": {},
+	"provider_name": {},
+	"model":         {},
+	"user_id":       {},
+}
+
+// validateDailyFilterColumns rejects any filter key usage_daily has no column
+// for. The callers above already gate on the same set, so reaching this is a
+// bug rather than user input -- but an unchecked key would be interpolated
+// into SQL, so it is checked here too.
+func validateDailyFilterColumns(filters map[string]string) error {
+	for key := range filters {
+		if _, ok := dailyFilterColumns[key]; !ok {
+			return fmt.Errorf("usage daily: unsupported filter column %q", key)
+		}
+	}
+	return nil
+}
+
+// dailyFilterMap is UsageStatsQuery.filterMap restricted to the dimensions
+// usage_daily carries.
+func (q UsageStatsQuery) dailyFilterMap() map[string]string {
+	filters := make(map[string]string, 3)
+	for column, value := range map[string]string{
+		"provider_uuid": q.Provider,
+		"model":         q.Model,
+		"user_id":       q.UserID,
+	} {
+		if value != "" {
+			filters[column] = value
+		}
+	}
+	return filters
+}
+
 // dailyTimeSeries returns one bucket per date from usage_daily.
 func (us *UsageStore) dailyTimeSeries(firstDay, lastDayEx time.Time, filters map[string]string) ([]TimeSeriesData, error) {
 	us.mu.RLock()
 	defer us.mu.RUnlock()
 
-	db := us.db.Model(&UsageDailyRecord{}).
-		Where("date >= ? AND date < ?", firstDay.Format(dailyDateLayout), lastDayEx.Format(dailyDateLayout))
-	for k, v := range filters {
-		db = db.Where(k+" = ?", v)
+	if err := validateDailyFilterColumns(filters); err != nil {
+		return nil, err
 	}
+	db := us.db.Model(&UsageDailyRecord{}).
+		Where("date >= ? AND date < ?", firstDay.Format(dailyDateLayout), lastDayEx.Format(dailyDateLayout)).
+		Scopes(withColumnFilters(filters))
 
 	type row struct {
 		Date             string

--- a/internal/db/usage_record.go
+++ b/internal/db/usage_record.go
@@ -3,6 +3,8 @@ package db
 import (
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -247,6 +249,98 @@ type AggregatedStat struct {
 	StreamedRate     float64 `json:"streamed_rate"`
 }
 
+// ---------- query scopes ----------
+//
+// Every read path over usage_records narrows by the same two things: a
+// timestamp range and a set of equality filters. These scopes are that
+// shared shape, so the four call sites (rawAggBuckets, rawTimeSeries,
+// GetRecords, GetPerformanceSummary) cannot drift apart.
+
+// withinTimeRange narrows to [start, end]. A zero bound is left open.
+func withinTimeRange(start, end time.Time) func(*gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		if !start.IsZero() {
+			db = db.Where("timestamp >= ?", start)
+		}
+		if !end.IsZero() {
+			db = db.Where("timestamp <= ?", end)
+		}
+		return db
+	}
+}
+
+// usageFilterColumns is the closed set of columns the map-based filter API
+// may narrow on.
+//
+// The filter map's *key* is a column name that gets interpolated into SQL.
+// Every caller today builds that map with hardcoded keys and takes only the
+// value from the request (see internal/server/module/usage/handler.go), so
+// this is not a live injection, but nothing in the store enforced it and the
+// next caller had no way to know. Validating here makes it structural.
+//
+// An unknown key is an error rather than a silently dropped filter: dropping
+// one widens the result set, and for user_id that would mean handing back
+// another user's records.
+var usageFilterColumns = map[string]struct{}{
+	"provider_uuid": {},
+	"provider_name": {},
+	"model":         {},
+	"request_model": {},
+	"scenario":      {},
+	"rule_uuid":     {},
+	"user_id":       {},
+	"status":        {},
+	"error_code":    {},
+}
+
+// validateFilterColumns rejects any filter key outside usageFilterColumns.
+func validateFilterColumns(filters map[string]string) error {
+	for key := range filters {
+		if _, ok := usageFilterColumns[key]; !ok {
+			return fmt.Errorf("usage: unsupported filter column %q", key)
+		}
+	}
+	return nil
+}
+
+// withColumnFilters applies equality filters keyed by column name. Callers
+// must have run validateFilterColumns first; keys are sorted so the generated
+// SQL is stable (Go randomizes map iteration, which otherwise produces a
+// different statement per call).
+func withColumnFilters(filters map[string]string) func(*gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		for _, key := range slices.Sorted(maps.Keys(filters)) {
+			db = db.Where(key+" = ?", filters[key])
+		}
+		return db
+	}
+}
+
+// withStatsFilters is the UsageStatsQuery equivalent of withColumnFilters:
+// same columns, taken from typed fields instead of a map, so no validation is
+// needed.
+func withStatsFilters(q UsageStatsQuery) func(*gorm.DB) *gorm.DB {
+	return withColumnFilters(q.filterMap())
+}
+
+// filterMap renders the query's set dimension fields as a column filter map.
+func (q UsageStatsQuery) filterMap() map[string]string {
+	filters := make(map[string]string, 6)
+	for column, value := range map[string]string{
+		"provider_uuid": q.Provider,
+		"model":         q.Model,
+		"scenario":      q.Scenario,
+		"rule_uuid":     q.RuleUUID,
+		"user_id":       q.UserID,
+		"status":        q.Status,
+	} {
+		if value != "" {
+			filters[column] = value
+		}
+	}
+	return filters
+}
+
 // GetAggregatedStats returns aggregated statistics. For queries spanning
 // several completed days it combines the usage_daily pre-aggregation table
 // with a raw scan of only the partial edge days (see usage_daily.go), so
@@ -320,36 +414,10 @@ func (us *UsageStore) rawAggBuckets(query UsageStatsQuery, applyLimit bool) ([]a
 	us.mu.RLock()
 	defer us.mu.RUnlock()
 
-	// Build the base query
-	db := us.db.Model(&UsageRecord{})
-
-	// Apply time filter
-	if !query.StartTime.IsZero() {
-		db = db.Where("timestamp >= ?", query.StartTime)
-	}
-	if !query.EndTime.IsZero() {
-		db = db.Where("timestamp <= ?", query.EndTime)
-	}
-
-	// Apply filters
-	if query.Provider != "" {
-		db = db.Where("provider_uuid = ?", query.Provider)
-	}
-	if query.Model != "" {
-		db = db.Where("model = ?", query.Model)
-	}
-	if query.Scenario != "" {
-		db = db.Where("scenario = ?", query.Scenario)
-	}
-	if query.RuleUUID != "" {
-		db = db.Where("rule_uuid = ?", query.RuleUUID)
-	}
-	if query.UserID != "" {
-		db = db.Where("user_id = ?", query.UserID)
-	}
-	if query.Status != "" {
-		db = db.Where("status = ?", query.Status)
-	}
+	db := us.db.Model(&UsageRecord{}).Scopes(
+		withinTimeRange(query.StartTime, query.EndTime),
+		withStatsFilters(query),
+	)
 
 	// Determine grouping and select fields
 	var groupBy string
@@ -452,19 +520,13 @@ func (us *UsageStore) rawTimeSeries(interval string, startTime, endTime time.Tim
 		timeFormat = "%Y-%m-%d %H:00:00" // default to hour
 	}
 
-	// Build query
-	db := us.db.Model(&UsageRecord{})
-
-	if !startTime.IsZero() {
-		db = db.Where("timestamp >= ?", startTime)
+	if err := validateFilterColumns(filters); err != nil {
+		return nil, err
 	}
-	if !endTime.IsZero() {
-		db = db.Where("timestamp <= ?", endTime)
-	}
-
-	for key, value := range filters {
-		db = db.Where(key+" = ?", value)
-	}
+	db := us.db.Model(&UsageRecord{}).Scopes(
+		withinTimeRange(startTime, endTime),
+		withColumnFilters(filters),
+	)
 
 	type result struct {
 		Timestamp        string
@@ -527,18 +589,14 @@ func (us *UsageStore) GetRecords(startTime, endTime time.Time, filters map[strin
 	us.mu.RLock()
 	defer us.mu.RUnlock()
 
+	if err := validateFilterColumns(filters); err != nil {
+		return nil, 0, err
+	}
 	base := func() *gorm.DB {
-		q := us.db.Model(&UsageRecord{})
-		if !startTime.IsZero() {
-			q = q.Where("timestamp >= ?", startTime)
-		}
-		if !endTime.IsZero() {
-			q = q.Where("timestamp <= ?", endTime)
-		}
-		for key, value := range filters {
-			q = q.Where(key+" = ?", value)
-		}
-		return q
+		return us.db.Model(&UsageRecord{}).Scopes(
+			withinTimeRange(startTime, endTime),
+			withColumnFilters(filters),
+		)
 	}
 
 	// Get records with pagination
@@ -582,18 +640,16 @@ func (us *UsageStore) GetPerformanceSummary(startTime, endTime time.Time, filter
 	us.mu.RLock()
 	defer us.mu.RUnlock()
 
+	if err := validateFilterColumns(filters); err != nil {
+		return PerformanceSummary{}, err
+	}
 	query := us.db.Model(&UsageRecord{}).
 		Select("latency_ms", "ttft_ms", "output_tokens", "streamed").
-		Where("status = ?", "success")
-	if !startTime.IsZero() {
-		query = query.Where("timestamp >= ?", startTime)
-	}
-	if !endTime.IsZero() {
-		query = query.Where("timestamp <= ?", endTime)
-	}
-	for key, value := range filters {
-		query = query.Where(key+" = ?", value)
-	}
+		Where("status = ?", "success").
+		Scopes(
+			withinTimeRange(startTime, endTime),
+			withColumnFilters(filters),
+		)
 
 	var records []UsageRecord
 	if err := query.Find(&records).Error; err != nil {

--- a/internal/db/usage_scopes_test.go
+++ b/internal/db/usage_scopes_test.go
@@ -1,0 +1,216 @@
+package db
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func newUsageStoreForScopes(t *testing.T) *UsageStore {
+	t.Helper()
+	store, err := NewUsageStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewUsageStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestUsageFilterColumnValidation covers the whitelist on every entry point
+// that takes a caller-supplied filter map. The map's key is interpolated into
+// SQL, so an unknown key must be refused rather than reaching the driver.
+func TestUsageFilterColumnValidation(t *testing.T) {
+	store := newUsageStoreForScopes(t)
+	seedUsageRecords(t, store, 2)
+
+	start := time.Now().Add(-72 * time.Hour)
+	end := time.Now()
+
+	t.Run("accepts known columns", func(t *testing.T) {
+		ok := map[string]string{"provider_uuid": "prov-a", "model": "model-x", "user_id": "admin"}
+
+		if _, _, err := store.GetRecords(start, end, ok, 10, 0); err != nil {
+			t.Errorf("GetRecords: %v", err)
+		}
+		if _, err := store.GetTimeSeries("hour", start, end, ok); err != nil {
+			t.Errorf("GetTimeSeries: %v", err)
+		}
+		if _, err := store.GetPerformanceSummary(start, end, ok); err != nil {
+			t.Errorf("GetPerformanceSummary: %v", err)
+		}
+	})
+
+	t.Run("rejects an unknown column", func(t *testing.T) {
+		bad := map[string]string{"provider_uuid": "prov-a", "not_a_column": "x"}
+
+		if _, _, err := store.GetRecords(start, end, bad, 10, 0); err == nil {
+			t.Error("GetRecords accepted an unknown filter column")
+		} else if !strings.Contains(err.Error(), "not_a_column") {
+			t.Errorf("GetRecords error = %v, want it to name the column", err)
+		}
+		if _, err := store.GetTimeSeries("hour", start, end, bad); err == nil {
+			t.Error("GetTimeSeries accepted an unknown filter column")
+		}
+		if _, err := store.GetPerformanceSummary(start, end, bad); err == nil {
+			t.Error("GetPerformanceSummary accepted an unknown filter column")
+		}
+	})
+
+	// The whole point of the whitelist: a key carrying SQL must not be
+	// interpolated. It has to be refused before it reaches the driver.
+	t.Run("rejects a key carrying SQL", func(t *testing.T) {
+		injected := map[string]string{"1=1 OR user_id": "admin"}
+		if _, _, err := store.GetRecords(start, end, injected, 10, 0); err == nil {
+			t.Error("GetRecords accepted a filter key carrying SQL")
+		}
+	})
+
+	// An unknown key must not be silently dropped: dropping a user_id filter
+	// would widen the result set to other users' records.
+	t.Run("an unknown key is an error, not a dropped filter", func(t *testing.T) {
+		scoped, _, err := store.GetRecords(start, end, map[string]string{"user_id": "admin"}, 1000, 0)
+		if err != nil {
+			t.Fatalf("GetRecords: %v", err)
+		}
+		unscoped, _, err := store.GetRecords(start, end, nil, 1000, 0)
+		if err != nil {
+			t.Fatalf("GetRecords: %v", err)
+		}
+		if len(scoped) >= len(unscoped) {
+			t.Fatalf("test seed is not discriminating: scoped=%d unscoped=%d", len(scoped), len(unscoped))
+		}
+		if _, _, err := store.GetRecords(start, end, map[string]string{"user_idd": "admin"}, 1000, 0); err == nil {
+			t.Error("a typo'd filter key was accepted, which would widen the result set")
+		}
+	})
+}
+
+// TestUsageFilterScopesPreserveResults pins that routing the four call sites
+// through shared scopes did not change what they return.
+func TestUsageFilterScopesPreserveResults(t *testing.T) {
+	store := newUsageStoreForScopes(t)
+	seedUsageRecords(t, store, 3)
+
+	start := time.Now().Add(-96 * time.Hour)
+	end := time.Now()
+	filters := map[string]string{"provider_uuid": "prov-a", "user_id": "admin"}
+
+	t.Run("GetRecords honours every filter", func(t *testing.T) {
+		records, total, err := store.GetRecords(start, end, filters, 1000, 0)
+		if err != nil {
+			t.Fatalf("GetRecords: %v", err)
+		}
+		if len(records) == 0 {
+			t.Fatal("no records matched; seed does not exercise the filter")
+		}
+		if total < int64(len(records)) {
+			t.Errorf("total %d < returned %d", total, len(records))
+		}
+		for _, r := range records {
+			if r.ProviderUUID != "prov-a" || r.UserID != "admin" {
+				t.Fatalf("filter not applied: got provider=%q user=%q", r.ProviderUUID, r.UserID)
+			}
+		}
+	})
+
+	t.Run("stats filters match the map form", func(t *testing.T) {
+		viaStruct, err := store.GetAggregatedStats(UsageStatsQuery{
+			GroupBy:   "model",
+			StartTime: start,
+			EndTime:   end,
+			Provider:  "prov-a",
+			UserID:    "admin",
+		})
+		if err != nil {
+			t.Fatalf("GetAggregatedStats: %v", err)
+		}
+
+		records, _, err := store.GetRecords(start, end, filters, 100000, 0)
+		if err != nil {
+			t.Fatalf("GetRecords: %v", err)
+		}
+
+		var statsTotal int64
+		for _, s := range viaStruct {
+			statsTotal += s.RequestCount
+		}
+		if statsTotal != int64(len(records)) {
+			t.Errorf("aggregated request count %d != %d records matching the same filter",
+				statsTotal, len(records))
+		}
+	})
+
+	t.Run("repeated calls are stable", func(t *testing.T) {
+		// Map iteration order is randomized in Go; the scope sorts keys so the
+		// generated SQL (and therefore the plan) is the same every call.
+		first, _, err := store.GetRecords(start, end, filters, 1000, 0)
+		if err != nil {
+			t.Fatalf("GetRecords: %v", err)
+		}
+		for i := 0; i < 20; i++ {
+			again, _, err := store.GetRecords(start, end, filters, 1000, 0)
+			if err != nil {
+				t.Fatalf("GetRecords iteration %d: %v", i, err)
+			}
+			if len(again) != len(first) {
+				t.Fatalf("iteration %d returned %d records, first returned %d", i, len(again), len(first))
+			}
+		}
+	})
+}
+
+// TestDailyFilterColumnValidation covers the usage_daily subset, which has
+// fewer dimension columns than usage_records.
+func TestDailyFilterColumnValidation(t *testing.T) {
+	if err := validateDailyFilterColumns(map[string]string{"provider_uuid": "a", "model": "m", "user_id": "u"}); err != nil {
+		t.Errorf("daily columns rejected: %v", err)
+	}
+	// Real usage_records columns that usage_daily does not carry.
+	for _, key := range []string{"scenario", "rule_uuid", "status"} {
+		if err := validateDailyFilterColumns(map[string]string{key: "x"}); err == nil {
+			t.Errorf("validateDailyFilterColumns accepted %q, which usage_daily has no column for", key)
+		}
+		// The same key is fine against the raw table.
+		if err := validateFilterColumns(map[string]string{key: "x"}); err != nil {
+			t.Errorf("validateFilterColumns rejected %q, which usage_records does have: %v", key, err)
+		}
+	}
+}
+
+// TestStatsQueryFilterMap pins the typed-to-map rendering, including that an
+// unset field produces no filter at all.
+func TestStatsQueryFilterMap(t *testing.T) {
+	full := UsageStatsQuery{
+		Provider: "p", Model: "m", Scenario: "s",
+		RuleUUID: "r", UserID: "u", Status: "success",
+	}
+	got := full.filterMap()
+	want := map[string]string{
+		"provider_uuid": "p", "model": "m", "scenario": "s",
+		"rule_uuid": "r", "user_id": "u", "status": "success",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("filterMap = %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("filterMap[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+	// Every key it can emit must be in the whitelist.
+	if err := validateFilterColumns(got); err != nil {
+		t.Errorf("filterMap emitted a non-whitelisted column: %v", err)
+	}
+
+	if got := (UsageStatsQuery{}).filterMap(); len(got) != 0 {
+		t.Errorf("empty query filterMap = %v, want no filters", got)
+	}
+
+	daily := full.dailyFilterMap()
+	if len(daily) != 3 {
+		t.Errorf("dailyFilterMap = %v, want only the 3 usage_daily dimensions", daily)
+	}
+	if err := validateDailyFilterColumns(daily); err != nil {
+		t.Errorf("dailyFilterMap emitted a column usage_daily lacks: %v", err)
+	}
+}

--- a/internal/db/usage_scopes_test.go
+++ b/internal/db/usage_scopes_test.go
@@ -1,26 +1,19 @@
 package db
 
 import (
+	"maps"
 	"strings"
 	"testing"
 	"time"
-)
 
-func newUsageStoreForScopes(t *testing.T) *UsageStore {
-	t.Helper()
-	store, err := NewUsageStore(t.TempDir())
-	if err != nil {
-		t.Fatalf("NewUsageStore: %v", err)
-	}
-	t.Cleanup(func() { _ = store.Close() })
-	return store
-}
+	"gorm.io/gorm"
+)
 
 // TestUsageFilterColumnValidation covers the whitelist on every entry point
 // that takes a caller-supplied filter map. The map's key is interpolated into
 // SQL, so an unknown key must be refused rather than reaching the driver.
 func TestUsageFilterColumnValidation(t *testing.T) {
-	store := newUsageStoreForScopes(t)
+	store := newUsageStoreForTest(t)
 	seedUsageRecords(t, store, 2)
 
 	start := time.Now().Add(-72 * time.Hour)
@@ -65,9 +58,10 @@ func TestUsageFilterColumnValidation(t *testing.T) {
 		}
 	})
 
-	// An unknown key must not be silently dropped: dropping a user_id filter
-	// would widen the result set to other users' records.
-	t.Run("an unknown key is an error, not a dropped filter", func(t *testing.T) {
+	// Rejecting rather than dropping is what keeps a typo from widening the
+	// result set -- for user_id, into another user's records. The narrowing
+	// this protects is real: filtering by user_id returns strictly fewer rows.
+	t.Run("a typo'd key errors instead of widening the result", func(t *testing.T) {
 		scoped, _, err := store.GetRecords(start, end, map[string]string{"user_id": "admin"}, 1000, 0)
 		if err != nil {
 			t.Fatalf("GetRecords: %v", err)
@@ -77,10 +71,10 @@ func TestUsageFilterColumnValidation(t *testing.T) {
 			t.Fatalf("GetRecords: %v", err)
 		}
 		if len(scoped) >= len(unscoped) {
-			t.Fatalf("test seed is not discriminating: scoped=%d unscoped=%d", len(scoped), len(unscoped))
+			t.Fatalf("seed is not discriminating: scoped=%d unscoped=%d", len(scoped), len(unscoped))
 		}
 		if _, _, err := store.GetRecords(start, end, map[string]string{"user_idd": "admin"}, 1000, 0); err == nil {
-			t.Error("a typo'd filter key was accepted, which would widen the result set")
+			t.Errorf("a typo'd user_id key was accepted; it would have returned all %d rows", len(unscoped))
 		}
 	})
 }
@@ -88,7 +82,7 @@ func TestUsageFilterColumnValidation(t *testing.T) {
 // TestUsageFilterScopesPreserveResults pins that routing the four call sites
 // through shared scopes did not change what they return.
 func TestUsageFilterScopesPreserveResults(t *testing.T) {
-	store := newUsageStoreForScopes(t)
+	store := newUsageStoreForTest(t)
 	seedUsageRecords(t, store, 3)
 
 	start := time.Now().Add(-96 * time.Hour)
@@ -140,20 +134,25 @@ func TestUsageFilterScopesPreserveResults(t *testing.T) {
 		}
 	})
 
-	t.Run("repeated calls are stable", func(t *testing.T) {
-		// Map iteration order is randomized in Go; the scope sorts keys so the
-		// generated SQL (and therefore the plan) is the same every call.
-		first, _, err := store.GetRecords(start, end, filters, 1000, 0)
-		if err != nil {
-			t.Fatalf("GetRecords: %v", err)
+	t.Run("filter order does not vary the generated SQL", func(t *testing.T) {
+		// Go randomizes map iteration, so an unsorted scope would emit the
+		// WHERE clauses in a different order per call -- same rows either way,
+		// which is why this has to inspect the statement rather than the
+		// result. Several keys are needed for an ordering to exist at all.
+		many := map[string]string{
+			"provider_uuid": "prov-a", "model": "model-x",
+			"user_id": "admin", "status": "success", "scenario": "default",
 		}
+		render := func() string {
+			return store.db.Session(&gorm.Session{DryRun: true}).
+				Model(&UsageRecord{}).
+				Scopes(withinTimeRange(start, end), withColumnFilters(many)).
+				Find(&[]UsageRecord{}).Statement.SQL.String()
+		}
+		want := render()
 		for i := 0; i < 20; i++ {
-			again, _, err := store.GetRecords(start, end, filters, 1000, 0)
-			if err != nil {
-				t.Fatalf("GetRecords iteration %d: %v", i, err)
-			}
-			if len(again) != len(first) {
-				t.Fatalf("iteration %d returned %d records, first returned %d", i, len(again), len(first))
+			if got := render(); got != want {
+				t.Fatalf("iteration %d rendered different SQL:\n got: %s\nwant: %s", i, got, want)
 			}
 		}
 	})
@@ -165,14 +164,23 @@ func TestDailyFilterColumnValidation(t *testing.T) {
 	if err := validateDailyFilterColumns(map[string]string{"provider_uuid": "a", "model": "m", "user_id": "u"}); err != nil {
 		t.Errorf("daily columns rejected: %v", err)
 	}
-	// Real usage_records columns that usage_daily does not carry.
-	for _, key := range []string{"scenario", "rule_uuid", "status"} {
+	// usage_daily is a pre-aggregation of usage_records, so anything it can be
+	// filtered on must also be filterable on the raw table. Asserting the
+	// relation survives either set legitimately gaining a column.
+	for key := range dailyFilterColumns {
+		if _, ok := usageFilterColumns[key]; !ok {
+			t.Errorf("dailyFilterColumns has %q but usageFilterColumns does not", key)
+		}
+	}
+
+	// Whatever the raw table carries that the daily table does not must be
+	// refused there, which is what makes the callers fall back to a raw scan.
+	for key := range usageFilterColumns {
+		if _, ok := dailyFilterColumns[key]; ok {
+			continue
+		}
 		if err := validateDailyFilterColumns(map[string]string{key: "x"}); err == nil {
 			t.Errorf("validateDailyFilterColumns accepted %q, which usage_daily has no column for", key)
-		}
-		// The same key is fine against the raw table.
-		if err := validateFilterColumns(map[string]string{key: "x"}); err != nil {
-			t.Errorf("validateFilterColumns rejected %q, which usage_records does have: %v", key, err)
 		}
 	}
 }
@@ -189,13 +197,8 @@ func TestStatsQueryFilterMap(t *testing.T) {
 		"provider_uuid": "p", "model": "m", "scenario": "s",
 		"rule_uuid": "r", "user_id": "u", "status": "success",
 	}
-	if len(got) != len(want) {
-		t.Fatalf("filterMap = %v, want %v", got, want)
-	}
-	for k, v := range want {
-		if got[k] != v {
-			t.Errorf("filterMap[%q] = %q, want %q", k, got[k], v)
-		}
+	if !maps.Equal(got, want) {
+		t.Errorf("filterMap = %v, want %v", got, want)
 	}
 	// Every key it can emit must be in the whitelist.
 	if err := validateFilterColumns(got); err != nil {
@@ -207,8 +210,8 @@ func TestStatsQueryFilterMap(t *testing.T) {
 	}
 
 	daily := full.dailyFilterMap()
-	if len(daily) != 3 {
-		t.Errorf("dailyFilterMap = %v, want only the 3 usage_daily dimensions", daily)
+	if !maps.Equal(daily, map[string]string{"provider_uuid": "p", "model": "m", "user_id": "u"}) {
+		t.Errorf("dailyFilterMap = %v, want only the usage_daily dimensions", daily)
 	}
 	if err := validateDailyFilterColumns(daily); err != nil {
 		t.Errorf("dailyFilterMap emitted a column usage_daily lacks: %v", err)


### PR DESCRIPTION
## Summary

After the `internal/db` performance rounds, the stores still hand-rolled several things GORM already does. This audits which are worth converting — three are, four explicitly are not — and applies them, turning up a hot-path win and a silent data-loss path along the way.

## Key Changes

- **JSON column storage**: eight columns across three stores move to `serializer:json`, ending 24 hand-written codec sites that all discarded their error — a provider whose tags failed to marshal was persisted with no tags.
- **Per-request provider lookup**: `GetByUUID` no longer decodes JSON on every routed request — 1637→375 ns/op tagged, 2671→790 ns/op OAuth, with an unaffected no-JSON control proving the delta.
- **Cache isolation**: the string encoding was deep-copying by accident; typed fields would have let the OAuth callback's in-place `ExtraFields` write reach the cache and persist through a failed update. Explicit clones restore it.
- **Usage filter columns**: caller-supplied filter-map keys were interpolated into SQL; they are now validated against a closed column set, and an unknown key errors rather than silently widening the result set.
- **Group actor listing**: `ListGroupActors` batches its per-binding lookups — 2N+2 → 4 queries, measured 42 → 4 at N=20.
- **Legacy data**: rows written in the old encoding read back unchanged; each store has a test seeding rows through its pre-migration shape.

## Notes

- **`Updates(map)` silently bypasses serializers** — an empty `[]string` writes NULL with no error. Two write paths moved to read-modify-write because of it; any future column conversion must check its write path for this.
- `remote_chat_store.project_history` is deliberately **not** converted: the serializer turns a decode failure into a failed query, and `GetChat` gates both the bot message path and every write path, so a bad column would become unrecoverable instead of being overwritten. Rationale in `.design/db.md`.
- Context propagation (only `bot_access_store` threads `ctx` today) is the highest-value item found but changes signatures across the package — left for its own PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_014CQovTHBTwd8WSSbAMKCi7)_