### PR TITLE
feat(storage): migrate rules from config.json to SQLite

### DIFF
--- a/.design/rule-storage.md
+++ b/.design/rule-storage.md
@@ -1,0 +1,214 @@
+# Rule 存储迁移：config.json → SQLite
+
+Rule（路由规则）从 config.json 的 JSON 数组迁入主库 `tingly.db` 的 `rules` 表。
+记录动机、领域模型与持久化模型的分层、列 vs 胖字段的取舍、迁移路径与不变量。
+
+目录：
+
+1. 动机
+2. 分层：领域模型 / 内存工作集 / 持久化
+3. Schema：哪些是列，哪些是胖字段
+4. 写路径收口：Save() 即同步
+5. 一次性迁移与权威性规则
+6. 顺序语义（position 与 DefaultRequestID）
+7. 不变量与边界情况
+8. 未来扩展
+
+---
+
+## 1. 动机
+
+迁移前 rule 是 `Config.Rules []typ.Rule`，整个数组随 config.json 序列化：
+
+- **整文件覆盖写**：任何一条 rule 的小改动都重写整个 config.json，与
+  token、scenario、profile 等无关配置互相放大写冲突面。
+- **无行级身份**：usage 记录、stats 已经在 SQLite 里按 rule UUID 关联，
+  而 rule 本身却在文件里，跨存储 join 只能全量加载后在内存做。
+- **手改文件与运行时互踩**：watcher 热加载会把手改的 rules 数组整个灌回
+  内存，与 API 写入竞争，谁后写谁赢。
+- **provider 已迁完**：providers 走过完全相同的路径（`migrateProvidersToDB`），
+  rule 是 config.json 里最后一大块"实体型"数据。
+
+## 2. 分层：领域模型 / 内存工作集 / 持久化
+
+```
+typ.Rule (领域模型，不变)
+   ↑↓ 内存中直接使用
+Config.Rules []typ.Rule (内存工作集，json:"-")
+   ↑ 启动时 hydrate        ↓ Save() 写穿
+db.RuleRecord / rules 表 (持久化权威)
+```
+
+三个决定：
+
+**`typ.Rule` 不动。** API、swagger、前端、路由匹配全部继续使用领域模型；
+持久化形态（`db.RuleRecord`）是独立的 DTO，转换函数在 store 内部。
+未来改表结构不触碰领域模型，反之亦然。
+
+**内存工作集必须保留，不能改成每次查库。** 两个硬理由：
+
+- 热路径：每个请求都要 `MatchRuleByModelAndScenario`，内存 RLock 扫描远快于
+  SQLite 往返（mattn/go-sqlite3 还有全局锁竞争）。
+- 正确性：`loadbalance.Service.Stats` 是运行时统计对象，由
+  `StatsStore.HydrateRules` 水合到**内存里的 Service 指针**上，负载均衡
+  实时读写。若每次从库里重建 Rule 对象，stats 就丢了。
+
+**数据库是重启后的唯一权威。** config.json 从此不含 rules（写 `"rules": null`），
+手改文件不再能引入 rule（热加载时忽略并告警）。
+
+## 3. Schema：哪些是列，哪些是胖字段
+
+判断标准只有一条：**查询/排序/唯一性真正用到的才是列，其余进 JSON 胖字段。**
+
+```
+rules
+├─ uuid           TEXT PK      -- 身份；与 usage/stats 的 rule_uuid 对齐
+├─ position       INTEGER idx  -- 列表顺序（见 §6）
+├─ scenario       TEXT ┐
+├─ request_model  TEXT ┘ 复合索引 idx_rules_scenario_request_model
+│                              -- 路由键：MatchRuleByModelAndScenario 的两个谓词
+├─ response_model TEXT         -- 展示/改写用，轻查询
+├─ description    TEXT
+├─ active         BOOL         -- 列表过滤
+├─ smart_enabled  BOOL         -- 列表过滤
+├─ services       TEXT(JSON)   -- []*loadbalance.Service（serializer:json）
+├─ flags          TEXT(JSON)   -- typ.RuleFlags（serializer:json）
+├─ lb_tactic      TEXT(JSON)   -- typ.Tactic（serializer:json）
+├─ smart_routing  TEXT(JSON)   -- []smartrouting.SmartRouting（serializer:json）
+├─ created_at / updated_at
+```
+
+四个 JSON 列直接在 `RuleRecord` 上声明为**类型化字段 + `serializer:json`**
+（跟随 internal/db 的 serializer 迁移，见 .design/db.md）：
+编解码由 GORM serializer 完成，store 里没有手写 marshal/unmarshal。与
+ProviderStore 不同，RuleStore 不做记录缓存——每次读取由 serializer 分配全新
+值，天然无共享可变状态，因此也不需要 provider 那套 clone-at-boundary 助手。
+
+胖字段的理由：
+
+- **services / smart_routing**：深嵌套数组，只会随 rule 整体读写，永远不需要
+  "查所有引用 provider X 的 service" 这种谓词——真需要时 SQLite 的
+  `json_each` 也能兜底，不必现在拆表。拆成子表会引入外键、顺序列、
+  两阶段写，换不来任何现有查询的收益。
+- **flags**：字段每隔几周就加一个（cursor_compat、thinking_effort、
+  session_affinity、vision_proxy…）。做成列意味着每个新 flag 都动 schema；
+  JSON 胖字段让 flag 演进完全停留在 `typ.RuleFlags` 一处。
+- **lb_tactic**：带 `Params interface{}` 的和类型，天然 JSON。
+
+序列化格式与 config.json 时代逐字段一致（同一套 json tag），所以迁移是
+无损重编码，零值的归一行为也与旧文件存储相同（如未设置的 tactic 序列化为
+"random"——文档化的默认值）；`Service.Stats` 带 `json:"-"`，运行时统计
+不会渗入持久化。变更检测（SyncAll 的逐行比较）用**往返规范化 JSON**
+（marshal→unmarshal→marshal）：解码会归一的编码差异（`params: null` vs
+`{}`）不会被误判为"变了"。
+
+## 4. 写路径收口：Save() 即同步
+
+rule 的变更入口非常多：AddRule / UpdateRule / DeleteRule / SetRequestConfigs /
+profile 创建删除 / SmartGuide ensure / 十几个日期迁移……但它们有一个共同点：
+**改完 `c.Rules` 之后全部调用 `c.Save()`**。
+
+所以同步点就放在 `Save()` 里：
+
+```go
+func (c *Config) Save() error {
+    // ... 序列化 config.json 内容（不含 rules）...
+    if err := c.syncRulesToStore(); err != nil {  // 先库
+        return err
+    }
+    return os.WriteFile(c.ConfigFile, out, 0644)  // 后文件
+}
+```
+
+**顺序不变量：先写库，后写文件。** 一次性迁移时文件写入会把 rules 数组
+替换为 null；若先清文件、后写库且写库失败，就出现"文件已清空 + 库是空的"
+的丢数据窗口。先库后文件则两种失败都安全：写库失败 → 文件仍带旧 rules，
+下次启动重试导入；写库成功但写文件失败 → 库已权威，下次启动清理陈旧 JSON。
+
+- 不需要逐个改造调用点，也**不可能**出现"改了内存忘了落库"的路径——
+  忘了调 Save() 的代码在旧世界同样丢数据，语义没有变差。
+- `syncRulesToStore` 先做 JSON 快照比对（`lastSyncedRules`），rules 没变的
+  Save()（改 token、scenario 等）完全跳过数据库。
+- `RuleStore.SyncAll` 在单事务里做 upsert + 删除 + position 重排，且逐行
+  与现有 payload 比对，没变的行不写——`updated_at` 只在真实变更时移动。
+
+rule 数量级是几十条，全量 diff-sync 每次毫秒级；换来的是绝对的简单和
+缓存/库不可能漂移。等将来 rule 上万条再谈增量（见 §8）。
+
+## 5. 一次性迁移与权威性规则
+
+完全复刻 provider 迁移的模式（`migrateProvidersToDB`）：
+
+```go
+// Config 结构体
+Rules       []typ.Rule `yaml:"rules" json:"-"`     // 内存工作集
+LegacyRules []typ.Rule `yaml:"-"     json:"rules"` // 只为加载旧文件而存在
+```
+
+启动序列（`NewConfig`）：
+
+```
+StoreManager 初始化（含 rules 表 AutoMigrate）
+load() / CreateDefaultConfig()      -- 旧文件的 rules 进 LegacyRules
+hydrateRulesFromStore():
+    库里有 rule   → Rules = 库；LegacyRules 若非空则视为陈旧备份，清掉
+    库空 + 有遗留 → Rules = LegacyRules；缺 UUID 的补随机 UUID；Save() 落库
+    双空          → 全新安装，内建 rule 稍后由 InsertDefaultRule 走 AddRule 进来
+Migrate(cfg)                        -- 日期迁移在真实规则集上跑，改动经 Save() 落库
+InsertDefaultRule / RefreshStatsFromStore ...
+```
+
+关键点：
+
+- **hydrate 在 Migrate 之前**。日期迁移（内建 rule 身份归一、smart-routing
+  清理等）必须作用于库里的规则集，其结果又经 Save() 写回库。
+- **hydrate 不受 `WithDisableMigration` 控制**——它是存储管道，不是配置迁移，
+  和 `migrateProvidersToDB` 同一待遇。
+- **`rulesHydrated` 门闩**：hydrate 之前的任何 Save()（如 CreateDefaultConfig）
+  不会同步 rules。这保证了"config.json 被删但库还在"的场景不会用空列表
+  把库清空。
+- `LegacyRules` 的 json tag 故意**不带 omitempty**：清空后 Save() 写出
+  `"rules": null`，压过 Save() 的 merge-unknown-keys 逻辑保留的旧值，
+  旧数组从文件里彻底消失。
+- 热加载（watcher → `load()`）时若文件里又出现 rules 数组：告警并忽略。
+  文件不再是 rule 的输入面，UI/API 才是。
+
+## 6. 顺序语义（position 与 DefaultRequestID）
+
+`DefaultRequestID` 是**下标**语义的默认 rule 指针，且仍留在 config.json。
+为了让它跨重启稳定，表里的 `position` 列忠实记录内存切片的顺序：
+SyncAll 时 `position = i`，List 时 `ORDER BY position`。
+
+追加、删除、`SetRequestConfigs` 整体重排都自然正确——顺序永远是"上次
+Save() 时内存里的顺序"，与 config.json 时代逐字节等价。
+
+（`DefaultRequestID` 用 UUID 取代下标是值得做的后续清理，但那是行为语义
+变更，不塞进本次存储迁移。）
+
+## 7. 不变量与边界情况
+
+- **UUID 是主键**：修复策略只有一处——`ensureRuleUUIDs`（补空 UUID、
+  给重复 UUID 重新赋值），`normalizeRuleBasics` 每次启动执行、一次性迁移
+  在首次落库前执行。SyncAll 里的跳过+告警是纯防御，正常情况下永不触发。
+- **腐坏的胖字段不阻断启动**：单字段解码失败记 warning、字段取零值，
+  rule 仍可从 UI 修复。拒绝启动的服务器比缺了 tactic 的 rule 伤害大。
+- **轻量 Config（测试直接构造，无 store）**：`ruleStore == nil` 时
+  hydrate/sync 均为 no-op，退化为纯内存行为，存量测试不受影响。
+- **多进程**：与其它 store 一致依赖 WAL + busy_timeout；rule 写本来就
+  低频（人工操作），无新增风险面。
+- **scenario+request_model 不做库级唯一约束**：应用层校验保留在
+  AddRule/UpdateRule（wildcard、历史脏数据、跨 scenario 复名都有合法场景），
+  硬约束只会让存量数据迁移失败。
+
+## 8. 未来扩展
+
+- **查询下推**：列已备好（scenario、request_model、active），当 rule 数量
+  或调用方（企业版多租户）需要时，可加 `ListByScenario` 等谓词查询而不动
+  schema。
+- **增量写**：若 rule 规模增长到全量 diff-sync 不可接受，把 Save() 收口
+  拆成显式的 store 粒度操作（AddRule → store.Save 单行）；RuleStore 的
+  接口（Save/Delete/GetByUUID 语义）已按这个方向预留。
+- **DefaultRequestID → default rule UUID**：摆脱下标语义，之后
+  `position` 只服务展示排序。
+- **flags 谓词查询**：真出现"找出所有开了 X flag 的 rule"需求时，用
+  SQLite `json_extract` 表达式索引即可，无需拆列。

--- a/.design/rule-storage.md
+++ b/.design/rule-storage.md
@@ -135,14 +135,17 @@ func (c *Config) Save() error {
 rule 数量级是几十条，全量 diff-sync 每次毫秒级；换来的是绝对的简单和
 缓存/库不可能漂移。等将来 rule 上万条再谈增量（见 §8）。
 
-## 5. 一次性迁移与权威性规则
+## 5. 一次性迁移、权威性规则与过渡期双写
 
-完全复刻 provider 迁移的模式（`migrateProvidersToDB`）：
+模式承袭 provider 迁移（`migrateProvidersToDB`），但有一个刻意的差异：
+**迁移后 config.json 里保留 `rules` 数组作为实时镜像（双写），后续某个
+版本再移除**——而不是像 provider 那样立即写 null。
 
 ```go
 // Config 结构体
 Rules       []typ.Rule `yaml:"rules" json:"-"`     // 内存工作集
-LegacyRules []typ.Rule `yaml:"-"     json:"rules"` // 只为加载旧文件而存在
+LegacyRules []typ.Rule `yaml:"-"     json:"rules"` // 只为加载旧文件而存在（读入口）
+// Save() 在序列化后把 next["rules"] 覆盖为实时的 c.Rules（写出口/镜像）
 ```
 
 启动序列（`NewConfig`）：
@@ -151,27 +154,34 @@ LegacyRules []typ.Rule `yaml:"-"     json:"rules"` // 只为加载旧文件而�
 StoreManager 初始化（含 rules 表 AutoMigrate）
 load() / CreateDefaultConfig()      -- 旧文件的 rules 进 LegacyRules
 hydrateRulesFromStore():
-    库里有 rule   → Rules = 库；LegacyRules 若非空则视为陈旧备份，清掉
-    库空 + 有遗留 → Rules = LegacyRules；缺 UUID 的补随机 UUID；Save() 落库
+    库里有 rule   → Rules = 库；文件里的数组只是镜像/手改，忽略
+    库空 + 有遗留 → Rules = LegacyRules；ensureRuleUUIDs 修复；Save() 落库
     双空          → 全新安装，内建 rule 稍后由 InsertDefaultRule 走 AddRule 进来
-Migrate(cfg)                        -- 日期迁移在真实规则集上跑，改动经 Save() 落库
+Migrate(cfg)                        -- 迁移步骤在真实规则集上跑，改动经 Save() 落库
 InsertDefaultRule / RefreshStatsFromStore ...
 ```
 
-关键点：
+**双写语义（过渡期）：**
 
-- **hydrate 在 Migrate 之前**。日期迁移（内建 rule 身份归一、smart-routing
-  清理等）必须作用于库里的规则集，其结果又经 Save() 写回库。
-- **hydrate 不受 `WithDisableMigration` 控制**——它是存储管道，不是配置迁移，
-  和 `migrateProvidersToDB` 同一待遇。
-- **`rulesHydrated` 门闩**：hydrate 之前的任何 Save()（如 CreateDefaultConfig）
-  不会同步 rules。这保证了"config.json 被删但库还在"的场景不会用空列表
-  把库清空。
-- `LegacyRules` 的 json tag 故意**不带 omitempty**：清空后 Save() 写出
-  `"rules": null`，压过 Save() 的 merge-unknown-keys 逻辑保留的旧值，
-  旧数组从文件里彻底消失。
-- 热加载（watcher → `load()`）时若文件里又出现 rules 数组：告警并忽略。
-  文件不再是 rule 的输入面，UI/API 才是。
+- **库是唯一权威，文件镜像只写不读。** 每次 Save() 都把实时 `c.Rules`
+  写进文件的 `rules` 键（先写库、成功后才写文件）；hydration 完成后，
+  load()/热加载读到的文件 rules 一律静默丢弃——文件永远无法把内存/库的
+  状态 fork 掉。
+- **为什么是实时镜像而不是迁移时的冻结快照**：镜像的唯一用途是**降级
+  兜底**——回退到库化之前的旧版本时，旧二进制照常从文件读到最新规则，
+  而不是几周前的旧状态。
+- **手改文件不再生效**（与 provider 迁移后一致）：停机时改的 rules
+  数组会在下次启动的 Save 后被镜像覆盖。规则入口是 UI/API/CLI。
+- **`rulesHydrated` 门闩**：hydrate 之前的任何 Save()（如
+  CreateDefaultConfig）既不同步库、也不覆盖文件镜像（保留 LegacyRules
+  原值），保证"config.json 被删但库还在""迁移前提前 Save"都不丢数据。
+- **hydrate 在 Migrate 之前、且不受 `WithDisableMigration` 控制**——
+  它是存储管道，不是配置迁移，和 `migrateProvidersToDB` 同一待遇。
+
+**移除计划**：某个后续版本停止双写，改为一次性写 `"rules": null`
+（届时 LegacyRules 的非 omitempty tag 保证 null 压过 Save() 的
+merge-unknown-keys 逻辑保留的旧值）。触发条件：确认不再需要回退到
+库化之前的版本。
 
 ## 6. 顺序语义（position 与 DefaultRequestID）
 
@@ -202,6 +212,9 @@ Save() 时内存里的顺序"，与 config.json 时代逐字节等价。
 
 ## 8. 未来扩展
 
+- **移除文件镜像（已排期的第一项）**：停止 Save() 双写 `rules` 键，一次性
+  写 `"rules": null`（见 §5 移除计划）。这是纯删代码：去掉 Save() 里的
+  `next["rules"]` 覆盖即可，读路径本来就不消费镜像。
 - **查询下推**：列已备好（scenario、request_model、active），当 rule 数量
   或调用方（企业版多租户）需要时，可加 `ListByScenario` 等谓词查询而不动
   schema。

--- a/.design/rule-storage.md
+++ b/.design/rule-storage.md
@@ -190,10 +190,14 @@ merge-unknown-keys 逻辑保留的旧值）。触发条件：确认不再需要�
 SyncAll 时 `position = i`，List 时 `ORDER BY position`。
 
 追加、删除、`SetRequestConfigs` 整体重排都自然正确——顺序永远是"上次
-Save() 时内存里的顺序"，与 config.json 时代逐字节等价。
+Save() 时内存里的顺序"。
 
-（`DefaultRequestID` 用 UUID 取代下标是值得做的后续清理，但那是行为语义
-变更，不塞进本次存储迁移。）
+**已知取舍：跨载体写入不原子。** `DefaultRequestID` 在文件、规则列表在
+库，一次 Save 是"先库后文件"两步写。若进程恰好在两步之间崩溃，重启后
+下标可能指向错位/越界的规则——读取侧的边界检查保证不 panic，最坏是默认
+规则暂时选错，UI 一次操作即可修复。config.json 时代两者同文件原子写、
+没有这个窗口；彻底修复是 §8 的「DefaultRequestID → 默认规则 UUID」（届时
+默认规则身份随规则本体一起入库），不塞进本次存储迁移。
 
 ## 7. 不变量与边界情况
 

--- a/internal/db/rule_store.go
+++ b/internal/db/rule_store.go
@@ -1,0 +1,269 @@
+package db
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// RuleRecord is the GORM model for persisting a routing rule.
+//
+// Column vs fat-field split (see .design/rule-storage.md):
+//   - Columns: identity (uuid), the routing key (scenario, request_model),
+//     list/filter state (active, smart_enabled) and ordering (position).
+//     These are what queries actually filter or sort on.
+//   - JSON-backed columns (serializer:json): services, flags, lb_tactic,
+//     smart_routing. They are structurally nested, evolve frequently (flags
+//     gain fields every few weeks), and are only ever read as a whole
+//     together with the rule. Same wire format the legacy config.json used,
+//     so migration is a lossless re-encode.
+//
+// Unlike ProviderStore, RuleStore does not cache records: every read
+// allocates fresh values through the serializer, so no clone-at-boundary
+// helpers are needed (see provider_store.go for the contrast).
+type RuleRecord struct {
+	UUID string `gorm:"primaryKey;column:uuid"`
+
+	// Position preserves the rule-list order that used to be implied by the
+	// JSON array in config.json. DefaultRequestID indexes into that order.
+	Position int `gorm:"column:position;index"`
+
+	Scenario      string `gorm:"column:scenario;not null;index:idx_rules_scenario_request_model"`
+	RequestModel  string `gorm:"column:request_model;not null;index:idx_rules_scenario_request_model"`
+	ResponseModel string `gorm:"column:response_model"`
+	Description   string `gorm:"column:description"`
+	Active        bool   `gorm:"column:active"`
+	SmartEnabled  bool   `gorm:"column:smart_enabled"`
+
+	Services     []*loadbalance.Service      `gorm:"column:services;type:text;serializer:json"`
+	Flags        typ.RuleFlags               `gorm:"column:flags;type:text;serializer:json"`
+	LBTactic     typ.Tactic                  `gorm:"column:lb_tactic;type:text;serializer:json"`
+	SmartRouting []smartrouting.SmartRouting `gorm:"column:smart_routing;type:text;serializer:json"`
+
+	CreatedAt time.Time `gorm:"column:created_at"`
+	UpdatedAt time.Time `gorm:"column:updated_at"`
+}
+
+// TableName specifies the table name for GORM
+func (RuleRecord) TableName() string {
+	return "rules"
+}
+
+// toRule converts a RuleRecord back to the typ.Rule domain model.
+func (r *RuleRecord) toRule() typ.Rule {
+	return typ.Rule{
+		UUID:          r.UUID,
+		Scenario:      typ.RuleScenario(r.Scenario),
+		RequestModel:  r.RequestModel,
+		ResponseModel: r.ResponseModel,
+		Description:   r.Description,
+		Active:        r.Active,
+		SmartEnabled:  r.SmartEnabled,
+		Services:      r.Services,
+		Flags:         r.Flags,
+		LBTactic:      r.LBTactic,
+		SmartRouting:  r.SmartRouting,
+	}
+}
+
+// newRuleRecord converts a typ.Rule to its persistence form at the given
+// list position. Timestamps are left zero; SyncAll fills them in.
+func newRuleRecord(rule *typ.Rule, position int) *RuleRecord {
+	return &RuleRecord{
+		UUID:          rule.UUID,
+		Position:      position,
+		Scenario:      string(rule.Scenario),
+		RequestModel:  rule.RequestModel,
+		ResponseModel: rule.ResponseModel,
+		Description:   rule.Description,
+		Active:        rule.Active,
+		SmartEnabled:  rule.SmartEnabled,
+		Services:      rule.Services,
+		Flags:         rule.Flags,
+		LBTactic:      rule.LBTactic,
+		SmartRouting:  rule.SmartRouting,
+	}
+}
+
+// payloadEqual reports whether two records carry the same persisted rule
+// content (everything except timestamps). Used to skip no-op writes so
+// updated_at only moves when the rule actually changed. The records contain
+// slices and interface-typed tactic params, so the comparison goes through
+// canonical JSON on timestamp-zeroed shallow copies; future columns are
+// included automatically.
+func (r RuleRecord) payloadEqual(other RuleRecord) bool {
+	a, errA := canonicalRecordJSON(r)
+	b, errB := canonicalRecordJSON(other)
+	if errA != nil || errB != nil {
+		return false // undecidable: treat as changed so the write happens
+	}
+	return a == b
+}
+
+// canonicalRecordJSON renders a record as round-trip-stable JSON: one
+// marshal→unmarshal→marshal pass, so encodings that decoding normalizes
+// compare equal. Example: a zero typ.Tactic marshals params as null, but
+// reading a stored row back turns that into RandomParams ("{}") via
+// Tactic.UnmarshalJSON — a record fresh from memory and its own stored form
+// must not be reported as different for it. Timestamps are excluded (zeroed
+// on the value copy).
+func canonicalRecordJSON(r RuleRecord) (string, error) {
+	r.CreatedAt, r.UpdatedAt = time.Time{}, time.Time{}
+	first, err := json.Marshal(r)
+	if err != nil {
+		return "", err
+	}
+	var rt RuleRecord
+	if err := json.Unmarshal(first, &rt); err != nil {
+		return "", err
+	}
+	second, err := json.Marshal(rt)
+	if err != nil {
+		return "", err
+	}
+	return string(second), nil
+}
+
+// RuleStore persists routing rules in SQLite. It is the durability layer
+// behind Config's in-memory rule list: reads at request time stay in memory
+// (rules carry hydrated runtime stats), the store is the source of truth
+// across restarts.
+type RuleStore struct {
+	storeConn
+	mu sync.Mutex
+}
+
+// newRuleStore finishes setting up a RuleStore (schema migration) over an
+// already-open connection — see newProviderStore.
+func newRuleStore(conn storeConn) (*RuleStore, error) {
+	if err := conn.db.AutoMigrate(&RuleRecord{}); err != nil {
+		return nil, fmt.Errorf("failed to migrate rules table: %w", err)
+	}
+	return &RuleStore{storeConn: conn}, nil
+}
+
+// List returns all rules ordered by their list position.
+func (rs *RuleStore) List() ([]typ.Rule, error) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	var records []RuleRecord
+	if err := rs.db.Order("position asc").Find(&records).Error; err != nil {
+		return nil, fmt.Errorf("failed to list rules: %w", err)
+	}
+
+	rules := make([]typ.Rule, 0, len(records))
+	for i := range records {
+		rules = append(rules, records[i].toRule())
+	}
+	return rules, nil
+}
+
+// GetByUUID returns a single rule by UUID.
+func (rs *RuleStore) GetByUUID(uuid string) (*typ.Rule, error) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	var record RuleRecord
+	if err := rs.db.Where("uuid = ?", uuid).First(&record).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("rule with UUID '%s' not found", uuid)
+		}
+		return nil, fmt.Errorf("failed to get rule: %w", err)
+	}
+	rule := record.toRule()
+	return &rule, nil
+}
+
+// Count returns the total number of stored rules.
+func (rs *RuleStore) Count() (int64, error) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	var count int64
+	if err := rs.db.Model(&RuleRecord{}).Count(&count).Error; err != nil {
+		return 0, fmt.Errorf("failed to count rules: %w", err)
+	}
+	return count, nil
+}
+
+// SyncAll makes the table match the given rule list exactly, in one
+// transaction: upserts changed rules, deletes rules no longer present, and
+// records each rule's list position. Unchanged rows are not touched, so
+// created_at/updated_at stay meaningful. Rules with an empty or duplicate
+// UUID are skipped with a warning — they cannot be keyed; the config layer's
+// ensureRuleUUIDs repairs both cases before persisting, so this is pure
+// defense that should never fire.
+func (rs *RuleStore) SyncAll(rules []typ.Rule) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	now := time.Now()
+	return rs.db.Transaction(func(tx *gorm.DB) error {
+		var existing []RuleRecord
+		if err := tx.Find(&existing).Error; err != nil {
+			return fmt.Errorf("failed to load existing rules: %w", err)
+		}
+		existingByUUID := make(map[string]*RuleRecord, len(existing))
+		for i := range existing {
+			existingByUUID[existing[i].UUID] = &existing[i]
+		}
+
+		keep := make(map[string]bool, len(rules))
+		for i := range rules {
+			rule := &rules[i]
+			if rule.UUID == "" {
+				logrus.Warnf("rule store: skipping rule without UUID (request_model=%s scenario=%s)", rule.RequestModel, rule.Scenario)
+				continue
+			}
+			if keep[rule.UUID] {
+				logrus.Warnf("rule store: skipping duplicate rule UUID %s", rule.UUID)
+				continue
+			}
+			keep[rule.UUID] = true
+
+			record := newRuleRecord(rule, i)
+			if old, ok := existingByUUID[rule.UUID]; ok {
+				if record.payloadEqual(*old) {
+					continue
+				}
+				record.CreatedAt = old.CreatedAt
+				record.UpdatedAt = now
+				if err := tx.Save(record).Error; err != nil {
+					return fmt.Errorf("failed to update rule %s: %w", rule.UUID, err)
+				}
+			} else {
+				record.CreatedAt = now
+				record.UpdatedAt = now
+				if err := tx.Create(record).Error; err != nil {
+					return fmt.Errorf("failed to create rule %s: %w", rule.UUID, err)
+				}
+			}
+		}
+
+		for uuid := range existingByUUID {
+			if keep[uuid] {
+				continue
+			}
+			if err := tx.Where("uuid = ?", uuid).Delete(&RuleRecord{}).Error; err != nil {
+				return fmt.Errorf("failed to delete rule %s: %w", uuid, err)
+			}
+		}
+
+		return nil
+	})
+}
+
+// GetDB returns the underlying GORM DB instance (for testing/advanced usage)
+func (rs *RuleStore) GetDB() *gorm.DB {
+	return rs.db
+}

--- a/internal/db/rule_store_test.go
+++ b/internal/db/rule_store_test.go
@@ -1,0 +1,209 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// newTestRuleStore builds the store through NewStoreManager so tests run
+// under the exact production connection settings (DSN pragmas included).
+func newTestRuleStore(t *testing.T) *RuleStore {
+	t.Helper()
+	sm, err := NewStoreManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create store manager: %v", err)
+	}
+	t.Cleanup(func() { sm.Close() })
+	return sm.Rules()
+}
+
+func testRule(uuid, requestModel string) typ.Rule {
+	return typ.Rule{
+		UUID:          uuid,
+		Scenario:      typ.RuleScenario("openai"),
+		RequestModel:  requestModel,
+		ResponseModel: "gpt-x",
+		Description:   "test rule " + uuid,
+		Active:        true,
+		Services: []*loadbalance.Service{
+			{Provider: "prov-1", Model: "m-1", Weight: 2, Active: true, Tier: 1},
+		},
+		Flags: typ.RuleFlags{CleanHeader: true, SessionAffinity: 1800},
+	}
+}
+
+func TestRuleStoreSyncAllAndList(t *testing.T) {
+	store := newTestRuleStore(t)
+
+	rules := []typ.Rule{testRule("r1", "model-a"), testRule("r2", "model-b"), testRule("r3", "model-c")}
+	if err := store.SyncAll(rules); err != nil {
+		t.Fatalf("SyncAll failed: %v", err)
+	}
+
+	got, err := store.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("List returned %d rules, want 3", len(got))
+	}
+	for i, uuid := range []string{"r1", "r2", "r3"} {
+		if got[i].UUID != uuid {
+			t.Errorf("position %d: got UUID %s, want %s (order must follow sync order)", i, got[i].UUID, uuid)
+		}
+	}
+
+	// Fat-field round trip.
+	if len(got[0].Services) != 1 || got[0].Services[0].Provider != "prov-1" || got[0].Services[0].Weight != 2 || got[0].Services[0].Tier != 1 {
+		t.Errorf("services did not round-trip: %+v", got[0].Services)
+	}
+	if !got[0].Flags.CleanHeader || got[0].Flags.SessionAffinity != 1800 {
+		t.Errorf("flags did not round-trip: %+v", got[0].Flags)
+	}
+}
+
+func TestRuleStoreSyncAllUpdatesDeletesReorders(t *testing.T) {
+	store := newTestRuleStore(t)
+
+	rules := []typ.Rule{testRule("r1", "model-a"), testRule("r2", "model-b"), testRule("r3", "model-c")}
+	if err := store.SyncAll(rules); err != nil {
+		t.Fatalf("initial SyncAll failed: %v", err)
+	}
+
+	// Delete r2, reorder r3 before r1, edit r1, add r4.
+	edited := testRule("r1", "model-a-renamed")
+	edited.Active = false
+	next := []typ.Rule{testRule("r3", "model-c"), edited, testRule("r4", "model-d")}
+	if err := store.SyncAll(next); err != nil {
+		t.Fatalf("second SyncAll failed: %v", err)
+	}
+
+	got, err := store.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("List returned %d rules, want 3", len(got))
+	}
+	wantOrder := []string{"r3", "r1", "r4"}
+	for i, uuid := range wantOrder {
+		if got[i].UUID != uuid {
+			t.Errorf("position %d: got %s, want %s", i, got[i].UUID, uuid)
+		}
+	}
+	if got[1].RequestModel != "model-a-renamed" || got[1].Active {
+		t.Errorf("r1 edit not persisted: %+v", got[1])
+	}
+	if _, err := store.GetByUUID("r2"); err == nil {
+		t.Error("r2 should have been deleted")
+	}
+}
+
+func TestRuleStoreSyncAllSkipsUnchangedRows(t *testing.T) {
+	store := newTestRuleStore(t)
+
+	rules := []typ.Rule{testRule("r1", "model-a")}
+	if err := store.SyncAll(rules); err != nil {
+		t.Fatalf("SyncAll failed: %v", err)
+	}
+
+	var before RuleRecord
+	if err := store.GetDB().Where("uuid = ?", "r1").First(&before).Error; err != nil {
+		t.Fatalf("failed to read record: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	if err := store.SyncAll(rules); err != nil {
+		t.Fatalf("second SyncAll failed: %v", err)
+	}
+
+	var after RuleRecord
+	if err := store.GetDB().Where("uuid = ?", "r1").First(&after).Error; err != nil {
+		t.Fatalf("failed to re-read record: %v", err)
+	}
+	if !after.UpdatedAt.Equal(before.UpdatedAt) {
+		t.Errorf("updated_at moved on a no-op sync: %v -> %v", before.UpdatedAt, after.UpdatedAt)
+	}
+}
+
+func TestRuleStoreSkipsEmptyAndDuplicateUUIDs(t *testing.T) {
+	store := newTestRuleStore(t)
+
+	rules := []typ.Rule{
+		testRule("", "no-uuid"),
+		testRule("dup", "first"),
+		testRule("dup", "second"),
+	}
+	if err := store.SyncAll(rules); err != nil {
+		t.Fatalf("SyncAll failed: %v", err)
+	}
+
+	got, err := store.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("List returned %d rules, want 1 (empty + duplicate UUIDs skipped)", len(got))
+	}
+	if got[0].RequestModel != "first" {
+		t.Errorf("first occurrence should win, got %s", got[0].RequestModel)
+	}
+}
+
+func TestRuleStoreSmartRoutingRoundTrip(t *testing.T) {
+	store := newTestRuleStore(t)
+
+	rule := testRule("smart", "model-s")
+	rule.SmartEnabled = true
+	rule.SmartRouting = []smartrouting.SmartRouting{
+		{
+			Description: "long context to big model",
+			Services: []*loadbalance.Service{
+				{Provider: "prov-2", Model: "m-big", Active: true},
+			},
+		},
+	}
+	rule.LBTactic = typ.Tactic{Type: loadbalance.TacticRandom, Params: typ.DefaultRandomParams()}
+
+	if err := store.SyncAll([]typ.Rule{rule}); err != nil {
+		t.Fatalf("SyncAll failed: %v", err)
+	}
+
+	got, err := store.GetByUUID("smart")
+	if err != nil {
+		t.Fatalf("GetByUUID failed: %v", err)
+	}
+	if !got.SmartEnabled || len(got.SmartRouting) != 1 {
+		t.Fatalf("smart routing did not round-trip: %+v", got)
+	}
+	if got.SmartRouting[0].Description != "long context to big model" {
+		t.Errorf("smart routing description lost: %+v", got.SmartRouting[0])
+	}
+	if len(got.SmartRouting[0].Services) != 1 || got.SmartRouting[0].Services[0].Model != "m-big" {
+		t.Errorf("smart routing services lost: %+v", got.SmartRouting[0].Services)
+	}
+	if got.LBTactic.Type != loadbalance.TacticRandom {
+		t.Errorf("lb tactic lost: %+v", got.LBTactic)
+	}
+}
+
+func TestRuleStoreCount(t *testing.T) {
+	store := newTestRuleStore(t)
+
+	count, err := store.Count()
+	if err != nil || count != 0 {
+		t.Fatalf("Count on empty store = %d, %v; want 0, nil", count, err)
+	}
+
+	if err := store.SyncAll([]typ.Rule{testRule("r1", "a"), testRule("r2", "b")}); err != nil {
+		t.Fatalf("SyncAll failed: %v", err)
+	}
+	count, err = store.Count()
+	if err != nil || count != 2 {
+		t.Fatalf("Count = %d, %v; want 2, nil", count, err)
+	}
+}

--- a/internal/db/store_manager.go
+++ b/internal/db/store_manager.go
@@ -31,6 +31,7 @@ type storeSet struct {
 	statsStore         *StatsStore
 	usageStore         *UsageStore
 	providerStore      *ProviderStore
+	ruleStore          *RuleStore
 	imbotSettingsStore *ImBotSettingsStore
 	modelStore         *ModelStore
 	apiTokenStore      *APITokenStore
@@ -47,6 +48,7 @@ func (s *storeSet) initialized() map[string]bool {
 		"stats":          s.statsStore != nil,
 		"usage":          s.usageStore != nil,
 		"provider":       s.providerStore != nil,
+		"rule":           s.ruleStore != nil,
 		"imbotSettings":  s.imbotSettingsStore != nil,
 		"model":          s.modelStore != nil,
 		"apiToken":       s.apiTokenStore != nil,
@@ -144,6 +146,9 @@ func (sm *StoreManager) initStores() error {
 	}
 	if sm.providerStore, err = newProviderStore(conn); err != nil {
 		errs = append(errs, fmt.Errorf("provider store: %w", err))
+	}
+	if sm.ruleStore, err = newRuleStore(conn); err != nil {
+		errs = append(errs, fmt.Errorf("rule store: %w", err))
 	}
 	if sm.imbotSettingsStore, err = newImBotSettingsStore(conn); err != nil {
 		errs = append(errs, fmt.Errorf("imbot settings store: %w", err))
@@ -252,6 +257,14 @@ func (sm *StoreManager) Provider() *ProviderStore {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 	return sm.providerStore
+}
+
+// Rules returns the RuleStore (thread-safe).
+// Returns nil if the store is not initialized or after Close() has been called.
+func (sm *StoreManager) Rules() *RuleStore {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.ruleStore
 }
 
 // ImBotSettings returns the ImBotSettingsStore (thread-safe).

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -25,7 +25,18 @@ import (
 
 // Config represents the global configuration
 type Config struct {
-	Rules              []typ.Rule           `yaml:"rules" json:"rules"`                           // List of request configurations
+	// Rules is the in-memory working set of routing rules. It is hydrated from
+	// SQLite (db.RuleStore) at startup and written back through Save(); it is
+	// deliberately NOT serialized to config.json anymore — the database is the
+	// authority. The in-memory copy stays because the hot request path matches
+	// rules under RLock and services carry hydrated runtime stats.
+	Rules []typ.Rule `yaml:"rules" json:"-"`
+	// LegacyRules is the pre-database JSON storage for rules. It is only
+	// populated on load for one-time migration to the database and is cleared
+	// by hydrateRulesFromStore. The non-omitempty tag ensures that clearing it
+	// results in a JSON null that overrides any stale value in the existing
+	// file (Save() merges unknown keys from the previous file content).
+	LegacyRules        []typ.Rule           `yaml:"-" json:"rules"`
 	DefaultRequestID   int                  `yaml:"default_request_id" json:"default_request_id"` // Index of the default Rule
 	UserToken          string               `yaml:"user_token" json:"user_token"`                 // User token for UI and control API authentication
 	ModelToken         string               `yaml:"model_token" json:"model_token"`               // Model token for OpenAI and Anthropic API authentication
@@ -113,6 +124,18 @@ type Config struct {
 	providerUpdateHooks []ProviderUpdateHook
 	providerDeleteHooks []ProviderDeleteHook
 	hookMu              sync.RWMutex
+
+	// rulesHydrated flips once hydrateRulesFromStore has run; after that,
+	// rules appearing in config.json (e.g. hand edits picked up by the
+	// watcher's hot reload) are ignored — the database is authoritative.
+	rulesHydrated bool
+	// lastSyncedRules caches the JSON snapshot of Rules from the last
+	// successful store sync so Save() calls that didn't touch rules skip the
+	// database write entirely. Guarded by ruleSyncMu, not mu: several Save()
+	// call sites run without holding mu, so the sync bookkeeping needs its
+	// own lock to serialize concurrent Save() calls.
+	lastSyncedRules []byte
+	ruleSyncMu      sync.Mutex
 
 	mu sync.RWMutex
 }
@@ -219,25 +242,27 @@ func NewConfig(opts ...ConfigOption) (*Config, error) {
 			if err != nil {
 				return nil, err
 			}
-
-			// Run migration on fresh install to set up scenario defaults
-			if !options.enableMigration {
-				logrus.Warnf("migration disabled")
-			} else {
-				Migrate(cfg)
-				cfg.Save()
-			}
 		} else {
 			return nil, fmt.Errorf("failed to load global cfg: %w", err)
 		}
+	}
+
+	// Hydrate rules from the database (or migrate legacy JSON rules into it).
+	// Must run before Migrate so migration steps operate on the real rule set.
+	// Like migrateProvidersToDB, this is storage plumbing rather than a config
+	// migration, so it is not gated by enableMigration.
+	if err := cfg.hydrateRulesFromStore(); err != nil {
+		return nil, fmt.Errorf("failed to hydrate rules from store: %w", err)
+	}
+
+	// Run migration only once at startup (not on every load/reload)
+	// Skip migration if disabled (useful when using as a library)
+	if !options.enableMigration {
+		logrus.Warnf("migration disabled")
 	} else {
-		// Run migration only once at startup (not on every load/reload)
-		// Skip migration if disabled (useful when using as a library)
-		if !options.enableMigration {
-			logrus.Warnf("migration disabled")
-		} else {
-			Migrate(cfg)
-			cfg.Save()
+		Migrate(cfg)
+		if err := cfg.Save(); err != nil {
+			logrus.WithError(err).Warn("Failed to persist config after migration; in-memory state may diverge until the next successful save")
 		}
 	}
 
@@ -418,6 +443,14 @@ func (c *Config) load() error {
 	// Restore the config file path after unmarshaling
 	c.ConfigFile = configFile
 
+	// After the one-time hydration, rules live in the database; a "rules"
+	// array re-appearing in config.json (hand edit + hot reload) is ignored
+	// so the file cannot silently fork from the database.
+	if c.rulesHydrated && len(c.LegacyRules) > 0 {
+		logrus.Warnf("Ignoring %d rule(s) found in config.json: rules are stored in the database now; use the API/UI to manage them", len(c.LegacyRules))
+		c.LegacyRules = nil
+	}
+
 	// Note: Migration is now only run at startup in NewConfigWithDir()
 	// Hot-reload (via watcher) does not trigger migration
 
@@ -451,6 +484,20 @@ func (c *Config) Save() error {
 	if err != nil {
 		return err
 	}
+
+	// Rules persist in the database, not in the file. Syncing here — inside
+	// the choke point every rule mutation already goes through — guarantees no
+	// write path can update the in-memory rules without also updating the
+	// store. The store MUST be written before the file: during the one-time
+	// legacy import the file write below replaces the JSON rules array with
+	// null, so a failed store sync must abort while the file still carries the
+	// legacy rules (the next startup then retries the import). The reverse
+	// order would open a window where the file is cleared but the database
+	// never received the rules.
+	if err := c.syncRulesToStore(); err != nil {
+		return err
+	}
+
 	return os.WriteFile(c.ConfigFile, out, 0644)
 }
 

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -446,9 +446,14 @@ func (c *Config) load() error {
 
 	// After the one-time hydration, the database is authoritative for rules.
 	// The "rules" array in config.json is Save()'s own downgrade-compat
-	// mirror (and possibly hand edits) — drop it silently on reload so the
-	// file cannot fork the in-memory/database state.
+	// mirror — a reload of our own write matches the live rules and is
+	// dropped silently. A DIFFERING array means someone hand-edited the file
+	// expecting the pre-database behavior; tell them where rules live now
+	// instead of eating the edit without a trace.
 	if c.rulesHydrated {
+		if !rulesEquivalent(c.LegacyRules, c.Rules) {
+			logrus.Warn("Ignoring rule edits in config.json: rules are stored in the database now; manage them via the UI/API/CLI")
+		}
 		c.LegacyRules = nil
 	}
 
@@ -481,33 +486,31 @@ func (c *Config) Save() error {
 			}
 		}
 	}
-	// Transition-period dual write: the database is the authority for rules,
-	// but the file keeps a live "rules" mirror so downgrading to a pre-database
-	// version loses nothing (the old binary reads the array as before). The
-	// mirror is write-only — load() ignores it once hydrated. Scheduled for
-	// removal in a later release; see .design/rule-storage.md §5.
-	// Pre-hydration Saves leave the marshaled LegacyRules value in place so an
-	// unmigrated file's rules can never be overwritten with an empty list.
-	if c.rulesHydrated {
-		rulesJSON, err := json.Marshal(c.Rules)
-		if err != nil {
-			return err
-		}
-		next["rules"] = json.RawMessage(rulesJSON)
-	}
-
-	out, err := json.MarshalIndent(next, "", "    ")
-	if err != nil {
-		return err
-	}
-
 	// Rules persist authoritatively in the database. Syncing here — inside
 	// the choke point every rule mutation already goes through — guarantees no
 	// write path can update the in-memory rules without also updating the
 	// store. The store MUST be written before the file: if the store sync
 	// fails during the one-time legacy import, aborting here leaves the file's
 	// legacy rules untouched so the next startup retries the import.
-	if err := c.syncRulesToStore(); err != nil {
+	rulesSnapshot, err := c.syncRulesToStore()
+	if err != nil {
+		return err
+	}
+
+	// Transition-period dual write: the file keeps a live "rules" mirror
+	// (the same snapshot the sync produced) so downgrading to a pre-database
+	// version loses nothing — the old binary reads the array as before. The
+	// mirror is write-only; load() ignores it once hydrated. Scheduled for
+	// removal in a later release; see .design/rule-storage.md §5.
+	// Pre-hydration Saves get a nil snapshot and leave the marshaled
+	// LegacyRules value in place, so an unmigrated file's rules can never be
+	// overwritten with an empty list.
+	if rulesSnapshot != nil {
+		next["rules"] = json.RawMessage(rulesSnapshot)
+	}
+
+	out, err := json.MarshalIndent(next, "", "    ")
+	if err != nil {
 		return err
 	}
 

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -31,11 +31,12 @@ type Config struct {
 	// authority. The in-memory copy stays because the hot request path matches
 	// rules under RLock and services carry hydrated runtime stats.
 	Rules []typ.Rule `yaml:"rules" json:"-"`
-	// LegacyRules is the pre-database JSON storage for rules. It is only
-	// populated on load for one-time migration to the database and is cleared
-	// by hydrateRulesFromStore. The non-omitempty tag ensures that clearing it
-	// results in a JSON null that overrides any stale value in the existing
-	// file (Save() merges unknown keys from the previous file content).
+	// LegacyRules receives the file's "rules" array on load. It is consumed
+	// exactly once, by hydrateRulesFromStore (one-time import into the
+	// database on upgraded installs); after hydration the field stays nil and
+	// file rules are ignored on reload. The "rules" key itself keeps being
+	// written by Save() as a live mirror of Rules during the transition
+	// period, purely for downgrade compatibility — see Save().
 	LegacyRules        []typ.Rule           `yaml:"-" json:"rules"`
 	DefaultRequestID   int                  `yaml:"default_request_id" json:"default_request_id"` // Index of the default Rule
 	UserToken          string               `yaml:"user_token" json:"user_token"`                 // User token for UI and control API authentication
@@ -443,11 +444,11 @@ func (c *Config) load() error {
 	// Restore the config file path after unmarshaling
 	c.ConfigFile = configFile
 
-	// After the one-time hydration, rules live in the database; a "rules"
-	// array re-appearing in config.json (hand edit + hot reload) is ignored
-	// so the file cannot silently fork from the database.
-	if c.rulesHydrated && len(c.LegacyRules) > 0 {
-		logrus.Warnf("Ignoring %d rule(s) found in config.json: rules are stored in the database now; use the API/UI to manage them", len(c.LegacyRules))
+	// After the one-time hydration, the database is authoritative for rules.
+	// The "rules" array in config.json is Save()'s own downgrade-compat
+	// mirror (and possibly hand edits) — drop it silently on reload so the
+	// file cannot fork the in-memory/database state.
+	if c.rulesHydrated {
 		c.LegacyRules = nil
 	}
 
@@ -480,20 +481,32 @@ func (c *Config) Save() error {
 			}
 		}
 	}
+	// Transition-period dual write: the database is the authority for rules,
+	// but the file keeps a live "rules" mirror so downgrading to a pre-database
+	// version loses nothing (the old binary reads the array as before). The
+	// mirror is write-only — load() ignores it once hydrated. Scheduled for
+	// removal in a later release; see .design/rule-storage.md §5.
+	// Pre-hydration Saves leave the marshaled LegacyRules value in place so an
+	// unmigrated file's rules can never be overwritten with an empty list.
+	if c.rulesHydrated {
+		rulesJSON, err := json.Marshal(c.Rules)
+		if err != nil {
+			return err
+		}
+		next["rules"] = json.RawMessage(rulesJSON)
+	}
+
 	out, err := json.MarshalIndent(next, "", "    ")
 	if err != nil {
 		return err
 	}
 
-	// Rules persist in the database, not in the file. Syncing here — inside
+	// Rules persist authoritatively in the database. Syncing here — inside
 	// the choke point every rule mutation already goes through — guarantees no
 	// write path can update the in-memory rules without also updating the
-	// store. The store MUST be written before the file: during the one-time
-	// legacy import the file write below replaces the JSON rules array with
-	// null, so a failed store sync must abort while the file still carries the
-	// legacy rules (the next startup then retries the import). The reverse
-	// order would open a window where the file is cleared but the database
-	// never received the rules.
+	// store. The store MUST be written before the file: if the store sync
+	// fails during the one-time legacy import, aborting here leaves the file's
+	// legacy rules untouched so the next startup retries the import.
 	if err := c.syncRulesToStore(); err != nil {
 		return err
 	}

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -392,7 +392,19 @@ func normalizeRuleBasics(c *Config) bool {
 // loader, so both must survive. This is the single place UUID repair policy
 // lives: normalizeRuleBasics applies it every startup and the one-time legacy
 // import (hydrateRulesFromStore) applies it before first persisting to the
-// store. Returns whether anything changed.
+// store; at runtime the rule mutators assign identity at the entry layer
+// (ensureRuleUUID) so no unkeyed rule ever reaches c.Rules. Returns whether
+// anything changed.
+// ensureRuleUUID assigns a fresh UUID to a caller-supplied rule that lacks
+// one — entry-layer identity assignment, matching the provider precedent
+// (AddProviderByName). The rule store keys rows by UUID, so a rule must
+// carry one before it reaches c.Rules or it could never persist.
+func ensureRuleUUID(rule *typ.Rule) {
+	if rule.UUID == "" {
+		rule.UUID = GenerateUUID()
+	}
+}
+
 func ensureRuleUUIDs(rules []typ.Rule) bool {
 	changed := false
 	seen := make(map[string]bool, len(rules))

--- a/internal/server/config/migration.go
+++ b/internal/server/config/migration.go
@@ -3,7 +3,6 @@ package config
 import (
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/ai"
 
@@ -364,13 +363,6 @@ func normalizeRuleBasics(c *Config) bool {
 			}
 		}
 
-		if rule.UUID == "" {
-			uid, err := uuid.NewUUID()
-			if err == nil {
-				rule.UUID = uid.String()
-				needsSave = true
-			}
-		}
 		normalizedTactic := normalizeRuleTactic(rule)
 		if rule.LBTactic.Type != normalizedTactic.Type || !IsTacticValid(&rule.LBTactic) {
 			rule.LBTactic = normalizedTactic
@@ -387,7 +379,36 @@ func normalizeRuleBasics(c *Config) bool {
 		needsSave = true
 	}
 	c.Rules = valid
+	if ensureRuleUUIDs(c.Rules) {
+		needsSave = true
+	}
 	return needsSave
+}
+
+// ensureRuleUUIDs makes every rule carry a unique, non-empty UUID, the
+// invariant the rule store keys on. Empty UUIDs (very old configs) get a
+// fresh one; duplicates (hand-edited copy-pasted rule blocks) keep the first
+// occurrence and reassign the rest — both were routable under the file-based
+// loader, so both must survive. This is the single place UUID repair policy
+// lives: normalizeRuleBasics applies it every startup and the one-time legacy
+// import (hydrateRulesFromStore) applies it before first persisting to the
+// store. Returns whether anything changed.
+func ensureRuleUUIDs(rules []typ.Rule) bool {
+	changed := false
+	seen := make(map[string]bool, len(rules))
+	for i := range rules {
+		rule := &rules[i]
+		if rule.UUID == "" || seen[rule.UUID] {
+			if rule.UUID != "" {
+				logrus.Warnf("Rule %q (scenario %s) duplicates UUID %s; assigning a new one",
+					rule.RequestModel, rule.Scenario, rule.UUID)
+			}
+			rule.UUID = GenerateUUID()
+			changed = true
+		}
+		seen[rule.UUID] = true
+	}
+	return changed
 }
 
 func normalizeRuleTactic(rule typ.Rule) typ.Tactic {

--- a/internal/server/config/rule.go
+++ b/internal/server/config/rule.go
@@ -52,6 +52,7 @@ func (c *Config) AddRule(rule typ.Rule) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	ensureRuleUUID(&rule)
 	applyScenarioCreateDefaults(&rule)
 
 	// A brand-new rule has no grandfathered references — validate everything.
@@ -88,6 +89,11 @@ func (c *Config) AddRule(rule typ.Rule) error {
 func (c *Config) UpdateRule(uid string, rule typ.Rule) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	// A payload without a UUID keeps the identity it is replacing.
+	if rule.UUID == "" {
+		rule.UUID = uid
+	}
 
 	// Incremental validation: references the persisted rule already carries
 	// stay editable even if their provider was disabled/deleted since.
@@ -136,6 +142,8 @@ func (c *Config) UpdateRule(uid string, rule typ.Rule) error {
 func (c *Config) AddRequestConfig(reqConfig typ.Rule) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	ensureRuleUUID(&reqConfig)
 
 	// Check if rule with same UUID already exists
 	for _, rule := range c.Rules {
@@ -314,6 +322,7 @@ func (c *Config) SetRequestConfigs(requestConfigs []typ.Rule) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	ensureRuleUUIDs(requestConfigs)
 	c.Rules = requestConfigs
 
 	return c.Save()
@@ -328,6 +337,12 @@ func (c *Config) UpdateRequestConfigAt(index int, reqConfig typ.Rule) error {
 		return fmt.Errorf("index %d is out of bounds for Rules (length %d)", index, len(c.Rules))
 	}
 
+	// A payload without a UUID keeps the identity it is replacing.
+	if reqConfig.UUID == "" {
+		reqConfig.UUID = c.Rules[index].UUID
+	}
+	ensureRuleUUID(&reqConfig)
+
 	c.Rules[index] = reqConfig
 	return c.Save()
 }
@@ -339,6 +354,11 @@ func (c *Config) UpdateRequestConfigByRequestModel(requestModel string, reqConfi
 
 	for i, rule := range c.Rules {
 		if rule.RequestModel == requestModel {
+			// A payload without a UUID keeps the identity it is replacing.
+			if reqConfig.UUID == "" {
+				reqConfig.UUID = rule.UUID
+			}
+			ensureRuleUUID(&reqConfig)
 			c.Rules[i] = reqConfig
 			return c.Save()
 		}
@@ -354,6 +374,10 @@ func (c *Config) UpdateRequestConfigByUUID(uuid string, reqConfig typ.Rule) erro
 
 	for i, rule := range c.Rules {
 		if rule.UUID == uuid {
+			// A payload without a UUID keeps the identity it is replacing.
+			if reqConfig.UUID == "" {
+				reqConfig.UUID = uuid
+			}
 			c.Rules[i] = reqConfig
 			return c.Save()
 		}
@@ -369,12 +393,18 @@ func (c *Config) AddOrUpdateRequestConfigByRequestModel(reqConfig typ.Rule) erro
 
 	for i, rule := range c.Rules {
 		if rule.RequestModel == reqConfig.RequestModel {
+			// A payload without a UUID keeps the identity it is replacing.
+			if reqConfig.UUID == "" {
+				reqConfig.UUID = rule.UUID
+			}
+			ensureRuleUUID(&reqConfig)
 			c.Rules[i] = reqConfig
 			return c.Save()
 		}
 	}
 
 	// Rule not found, add new one
+	ensureRuleUUID(&reqConfig)
 	c.Rules = append(c.Rules, reqConfig)
 	return c.Save()
 }

--- a/internal/server/config/rule_storage.go
+++ b/internal/server/config/rule_storage.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/db"
+	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
 // Rule storage: rules live in SQLite (db.RuleStore) with Config.Rules as the
@@ -42,12 +43,16 @@ func (c *Config) rulesStore() *db.RuleStore {
 func (c *Config) hydrateRulesFromStore() error {
 	c.rulesHydrated = true
 
+	// Consume the file's rules exactly once, here; the field must never
+	// carry state past hydration (see its doc comment).
+	legacy := c.LegacyRules
+	c.LegacyRules = nil
+
 	store := c.rulesStore()
 	if store == nil {
 		// No store (lightweight test configs): fall back to whatever the JSON
 		// had so behavior degrades to the old in-memory semantics.
-		c.Rules = c.LegacyRules
-		c.LegacyRules = nil
+		c.Rules = legacy
 		return nil
 	}
 
@@ -60,21 +65,26 @@ func (c *Config) hydrateRulesFromStore() error {
 		// Database is authoritative. The file's rules array (Save()'s own
 		// mirror, or a hand edit made while the server was down) is not an
 		// input anymore; the next Save() rewrites it from the live rules.
+		// A divergent mirror means rule changes were made outside this
+		// version's control — most plausibly via an older (pre-database)
+		// binary during a downgrade — and those changes are NOT merged back;
+		// say so loudly instead of discarding them in silence.
+		if len(legacy) > 0 && !rulesEquivalent(legacy, stored) {
+			logrus.Warnf("config.json rules differ from the database (%d in file, %d in database); the database wins and the file copy will be overwritten — rule changes made under an older version or by hand are not merged back", len(legacy), len(stored))
+		}
 		c.Rules = stored
-		c.LegacyRules = nil
 		return nil
 	}
 
-	if len(c.LegacyRules) == 0 {
+	if len(legacy) == 0 {
 		// Fresh install: nothing to migrate.
 		return nil
 	}
 
 	// One-time migration: import legacy JSON rules into the database.
-	logrus.Infof("Migrating %d rule(s) from JSON config to database...", len(c.LegacyRules))
+	logrus.Infof("Migrating %d rule(s) from JSON config to database...", len(legacy))
 
-	c.Rules = c.LegacyRules
-	c.LegacyRules = nil
+	c.Rules = legacy
 
 	// The store keys rules by UUID; repair empty/duplicate UUIDs before the
 	// first sync so no legacy rule is dropped (same policy normalizeRuleBasics
@@ -93,32 +103,53 @@ func (c *Config) hydrateRulesFromStore() error {
 	return nil
 }
 
-// syncRulesToStore writes the in-memory rule list through to the database.
-// Called from Save() so every existing rule-mutation path persists without
-// individual call sites needing to know about the store. No-ops when the
-// rules did not change since the last sync (cheap JSON snapshot compare) or
-// when no store is attached (lightweight test configs, closed stores).
-// ruleSyncMu serializes concurrent Save() calls (not all of them hold c.mu).
-func (c *Config) syncRulesToStore() error {
+// syncRulesToStore writes the in-memory rule list through to the database
+// and returns the JSON snapshot of the rules, which Save() reuses as the
+// file mirror so the rules are marshaled exactly once per Save. Called from
+// Save() so every existing rule-mutation path persists without individual
+// call sites needing to know about the store. The store write is skipped
+// when the rules did not change since the last sync (snapshot compare) or
+// when no store is attached (lightweight test configs, closed stores) — the
+// snapshot is still returned for the mirror. Returns (nil, nil) before
+// hydration. ruleSyncMu serializes concurrent Save() calls (not all of them
+// hold c.mu).
+func (c *Config) syncRulesToStore() ([]byte, error) {
 	c.ruleSyncMu.Lock()
 	defer c.ruleSyncMu.Unlock()
 
-	store := c.rulesStore()
-	if store == nil || !c.rulesHydrated {
-		return nil
+	if !c.rulesHydrated {
+		return nil, nil
 	}
 
 	snapshot, err := json.Marshal(c.Rules)
 	if err != nil {
-		return fmt.Errorf("failed to snapshot rules: %w", err)
+		return nil, fmt.Errorf("failed to snapshot rules: %w", err)
 	}
-	if bytes.Equal(snapshot, c.lastSyncedRules) {
-		return nil
+
+	store := c.rulesStore()
+	if store == nil || bytes.Equal(snapshot, c.lastSyncedRules) {
+		return snapshot, nil
 	}
 
 	if err := store.SyncAll(c.Rules); err != nil {
-		return fmt.Errorf("failed to sync rules to store: %w", err)
+		return nil, fmt.Errorf("failed to sync rules to store: %w", err)
 	}
 	c.lastSyncedRules = snapshot
-	return nil
+	return snapshot, nil
+}
+
+// rulesEquivalent reports whether two rule lists carry the same content,
+// compared through their JSON encoding (both sides are already-decoded
+// domain values, so encoding differences the decoder normalizes cannot
+// produce false negatives here).
+func rulesEquivalent(a, b []typ.Rule) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aj, errA := json.Marshal(a)
+	bj, errB := json.Marshal(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return bytes.Equal(aj, bj)
 }

--- a/internal/server/config/rule_storage.go
+++ b/internal/server/config/rule_storage.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/tingly-dev/tingly-box/internal/db"
+)
+
+// Rule storage: rules live in SQLite (db.RuleStore) with Config.Rules as the
+// in-memory working set. See .design/rule-storage.md for the full rationale.
+//
+// The lifecycle mirrors migrateProvidersToDB:
+//   - database has rules  -> database is authoritative, stale JSON is cleared
+//   - database empty, JSON has rules -> one-time import, then JSON cleared
+//   - both empty -> nothing to do (fresh install; built-ins arrive via AddRule)
+
+// rulesStore resolves the rule store at call time from the StoreManager, so
+// store liveness has a single owner: after StoreManager.Close() the accessor
+// returns nil and rule syncing degrades to a no-op instead of failing on a
+// closed connection. Reads the field directly (not via c.StoreManager()) —
+// callers may already hold c.mu, and the field is only ever set during
+// construction.
+func (c *Config) rulesStore() *db.RuleStore {
+	if c.storeManager == nil {
+		return nil
+	}
+	return c.storeManager.Rules()
+}
+
+// hydrateRulesFromStore populates Config.Rules at startup, migrating legacy
+// config.json rules into the database the first time it runs on an upgraded
+// install. It must run before Migrate() so migration steps see the real rules.
+func (c *Config) hydrateRulesFromStore() error {
+	c.rulesHydrated = true
+
+	store := c.rulesStore()
+	if store == nil {
+		// No store (lightweight test configs): fall back to whatever the JSON
+		// had so behavior degrades to the old in-memory semantics.
+		c.Rules = c.LegacyRules
+		c.LegacyRules = nil
+		return nil
+	}
+
+	stored, err := store.List()
+	if err != nil {
+		return fmt.Errorf("failed to load rules from store: %w", err)
+	}
+
+	if len(stored) > 0 {
+		// Database is authoritative.
+		c.Rules = stored
+		if len(c.LegacyRules) > 0 {
+			// Stale JSON backup left over from an earlier version (or a hand
+			// edit while the server was down). The database wins; clear the
+			// file copy so the two cannot diverge silently.
+			logrus.Infof("Clearing stale rule JSON data (%d rule(s)); database is authoritative", len(c.LegacyRules))
+			c.LegacyRules = nil
+			if err := c.Save(); err != nil {
+				return fmt.Errorf("failed to save config after clearing rule JSON: %w", err)
+			}
+		}
+		return nil
+	}
+
+	if len(c.LegacyRules) == 0 {
+		// Fresh install: nothing to migrate.
+		return nil
+	}
+
+	// One-time migration: import legacy JSON rules into the database.
+	logrus.Infof("Migrating %d rule(s) from JSON config to database...", len(c.LegacyRules))
+
+	c.Rules = c.LegacyRules
+	c.LegacyRules = nil
+
+	// The store keys rules by UUID; repair empty/duplicate UUIDs before the
+	// first sync so no legacy rule is dropped (same policy normalizeRuleBasics
+	// applies on every startup).
+	ensureRuleUUIDs(c.Rules)
+
+	// Save() persists the rules to the store and rewrites config.json with
+	// "rules": null so subsequent startups take the database path.
+	if err := c.Save(); err != nil {
+		return fmt.Errorf("failed to migrate rules to database: %w", err)
+	}
+
+	logrus.Infof("Successfully migrated %d rule(s) to database", len(c.Rules))
+	return nil
+}
+
+// syncRulesToStore writes the in-memory rule list through to the database.
+// Called from Save() so every existing rule-mutation path persists without
+// individual call sites needing to know about the store. No-ops when the
+// rules did not change since the last sync (cheap JSON snapshot compare) or
+// when no store is attached (lightweight test configs, closed stores).
+// ruleSyncMu serializes concurrent Save() calls (not all of them hold c.mu).
+func (c *Config) syncRulesToStore() error {
+	c.ruleSyncMu.Lock()
+	defer c.ruleSyncMu.Unlock()
+
+	store := c.rulesStore()
+	if store == nil || !c.rulesHydrated {
+		return nil
+	}
+
+	snapshot, err := json.Marshal(c.Rules)
+	if err != nil {
+		return fmt.Errorf("failed to snapshot rules: %w", err)
+	}
+	if bytes.Equal(snapshot, c.lastSyncedRules) {
+		return nil
+	}
+
+	if err := store.SyncAll(c.Rules); err != nil {
+		return fmt.Errorf("failed to sync rules to store: %w", err)
+	}
+	c.lastSyncedRules = snapshot
+	return nil
+}

--- a/internal/server/config/rule_storage.go
+++ b/internal/server/config/rule_storage.go
@@ -13,10 +13,15 @@ import (
 // Rule storage: rules live in SQLite (db.RuleStore) with Config.Rules as the
 // in-memory working set. See .design/rule-storage.md for the full rationale.
 //
-// The lifecycle mirrors migrateProvidersToDB:
-//   - database has rules  -> database is authoritative, stale JSON is cleared
-//   - database empty, JSON has rules -> one-time import, then JSON cleared
+// Lifecycle:
+//   - database has rules  -> database is authoritative; file rules ignored
+//   - database empty, JSON has rules -> one-time import into the database
 //   - both empty -> nothing to do (fresh install; built-ins arrive via AddRule)
+//
+// Transition period: unlike migrateProvidersToDB (which nulls the JSON copy),
+// Save() keeps writing a live "rules" mirror into config.json so downgrading
+// to a pre-database version loses nothing. The mirror is write-only; a later
+// release removes it. See .design/rule-storage.md §5.
 
 // rulesStore resolves the rule store at call time from the StoreManager, so
 // store liveness has a single owner: after StoreManager.Close() the accessor
@@ -52,18 +57,11 @@ func (c *Config) hydrateRulesFromStore() error {
 	}
 
 	if len(stored) > 0 {
-		// Database is authoritative.
+		// Database is authoritative. The file's rules array (Save()'s own
+		// mirror, or a hand edit made while the server was down) is not an
+		// input anymore; the next Save() rewrites it from the live rules.
 		c.Rules = stored
-		if len(c.LegacyRules) > 0 {
-			// Stale JSON backup left over from an earlier version (or a hand
-			// edit while the server was down). The database wins; clear the
-			// file copy so the two cannot diverge silently.
-			logrus.Infof("Clearing stale rule JSON data (%d rule(s)); database is authoritative", len(c.LegacyRules))
-			c.LegacyRules = nil
-			if err := c.Save(); err != nil {
-				return fmt.Errorf("failed to save config after clearing rule JSON: %w", err)
-			}
-		}
+		c.LegacyRules = nil
 		return nil
 	}
 
@@ -83,8 +81,10 @@ func (c *Config) hydrateRulesFromStore() error {
 	// applies on every startup).
 	ensureRuleUUIDs(c.Rules)
 
-	// Save() persists the rules to the store and rewrites config.json with
-	// "rules": null so subsequent startups take the database path.
+	// Save() persists the rules to the store; subsequent startups find the
+	// database populated and take the database-authoritative path. The file
+	// keeps its "rules" array (rewritten as a live mirror) for downgrade
+	// compatibility during the transition period.
 	if err := c.Save(); err != nil {
 		return fmt.Errorf("failed to migrate rules to database: %w", err)
 	}

--- a/internal/server/config/rule_storage_test.go
+++ b/internal/server/config/rule_storage_test.go
@@ -1,0 +1,329 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// writeLegacyConfig writes a minimal pre-migration config.json carrying rules
+// in the legacy JSON array, the way installs stored them before the database
+// became authoritative.
+func writeLegacyConfig(t *testing.T, dir string, rules []typ.Rule) {
+	t.Helper()
+	payload := map[string]interface{}{
+		"rules":              rules,
+		"default_request_id": 0,
+		"user_token":         "test-user-token",
+		"model_token":        "test-model-token",
+		"jwt_secret":         "test-secret",
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal legacy config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0600); err != nil {
+		t.Fatalf("failed to write legacy config: %v", err)
+	}
+}
+
+func legacyTestRule(uuid, requestModel string) typ.Rule {
+	return typ.Rule{
+		UUID:          uuid,
+		Scenario:      typ.ScenarioOpenAI,
+		RequestModel:  requestModel,
+		ResponseModel: "resp-model",
+		Description:   "legacy rule",
+		Active:        true,
+		Services: []*loadbalance.Service{
+			{Provider: "prov-legacy", Model: "m-legacy", Active: true},
+		},
+		LBTactic: typ.Tactic{Type: loadbalance.TacticRandom, Params: typ.DefaultRandomParams()},
+	}
+}
+
+// readConfigJSON parses the on-disk config.json into a generic map.
+func readConfigJSON(t *testing.T, dir string) map[string]interface{} {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	if err != nil {
+		t.Fatalf("failed to read config.json: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("failed to parse config.json: %v", err)
+	}
+	return m
+}
+
+func findRule(rules []typ.Rule, uuid string) *typ.Rule {
+	for i := range rules {
+		if rules[i].UUID == uuid {
+			return &rules[i]
+		}
+	}
+	return nil
+}
+
+func findRuleByModel(rules []typ.Rule, requestModel string) *typ.Rule {
+	for i := range rules {
+		if rules[i].RequestModel == requestModel {
+			return &rules[i]
+		}
+	}
+	return nil
+}
+
+// seedLegacyProvider registers the provider that legacyTestRule services
+// reference; AddRule/UpdateRule validate that referenced providers exist and
+// are enabled.
+func seedLegacyProvider(t *testing.T, cfg *Config) {
+	t.Helper()
+	if err := cfg.StoreManager().Provider().Save(&typ.Provider{
+		UUID:    "prov-legacy",
+		Name:    "legacy-provider",
+		APIBase: "https://example.invalid/v1",
+		Enabled: true,
+	}); err != nil {
+		t.Fatalf("failed to seed provider: %v", err)
+	}
+}
+
+func TestRulesMigrateFromLegacyJSONToStore(t *testing.T) {
+	dir := t.TempDir()
+	writeLegacyConfig(t, dir, []typ.Rule{
+		legacyTestRule("legacy-1", "model-one"),
+		legacyTestRule("legacy-2", "model-two"),
+	})
+
+	cfg, err := NewConfigWithDir(dir)
+	if err != nil {
+		t.Fatalf("NewConfigWithDir failed: %v", err)
+	}
+	defer cfg.CloseStores()
+
+	// Legacy rules must survive into the working set.
+	if findRule(cfg.Rules, "legacy-1") == nil || findRule(cfg.Rules, "legacy-2") == nil {
+		t.Fatalf("legacy rules missing after migration; have %d rules", len(cfg.Rules))
+	}
+
+	// The store must now hold every in-memory rule (legacy + built-ins).
+	count, err := cfg.StoreManager().Rules().Count()
+	if err != nil {
+		t.Fatalf("failed to count stored rules: %v", err)
+	}
+	if want := int64(len(cfg.Rules)); count != want {
+		t.Errorf("store has %d rules, want %d", count, want)
+	}
+
+	// Round-trip a fat field through the store.
+	stored, err := cfg.StoreManager().Rules().GetByUUID("legacy-1")
+	if err != nil {
+		t.Fatalf("legacy-1 not in store: %v", err)
+	}
+	if len(stored.Services) != 1 || stored.Services[0].Provider != "prov-legacy" {
+		t.Errorf("services did not survive migration: %+v", stored.Services)
+	}
+
+	// config.json must no longer carry rule data.
+	if rules, ok := readConfigJSON(t, dir)["rules"]; ok && rules != nil {
+		t.Errorf("config.json still carries rules after migration: %v", rules)
+	}
+}
+
+func TestRulesReloadFromStoreOnRestart(t *testing.T) {
+	dir := t.TempDir()
+	writeLegacyConfig(t, dir, []typ.Rule{legacyTestRule("legacy-1", "model-one")})
+
+	cfg, err := NewConfigWithDir(dir)
+	if err != nil {
+		t.Fatalf("first NewConfigWithDir failed: %v", err)
+	}
+
+	seedLegacyProvider(t, cfg)
+
+	// Mutate through the normal API so the change flows through Save().
+	updated := *findRule(cfg.Rules, "legacy-1")
+	if updated.UUID == "" {
+		t.Fatal("legacy-1 missing after first start")
+	}
+	updated.Description = "edited between restarts"
+	if err := cfg.UpdateRule("legacy-1", updated); err != nil {
+		t.Fatalf("UpdateRule failed: %v", err)
+	}
+	firstCount := len(cfg.Rules)
+	if err := cfg.CloseStores(); err != nil {
+		t.Fatalf("CloseStores failed: %v", err)
+	}
+
+	// Restart: rules must come back from the database, not the file.
+	cfg2, err := NewConfigWithDir(dir)
+	if err != nil {
+		t.Fatalf("second NewConfigWithDir failed: %v", err)
+	}
+	defer cfg2.CloseStores()
+
+	if len(cfg2.Rules) != firstCount {
+		t.Errorf("restart changed rule count: %d -> %d", firstCount, len(cfg2.Rules))
+	}
+	got := findRule(cfg2.Rules, "legacy-1")
+	if got == nil {
+		t.Fatal("legacy-1 missing after restart")
+	}
+	if got.Description != "edited between restarts" {
+		t.Errorf("edit lost across restart: %q", got.Description)
+	}
+}
+
+func TestRulesStoreWinsOverStaleJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeLegacyConfig(t, dir, []typ.Rule{legacyTestRule("legacy-1", "model-one")})
+
+	cfg, err := NewConfigWithDir(dir)
+	if err != nil {
+		t.Fatalf("first NewConfigWithDir failed: %v", err)
+	}
+	if err := cfg.CloseStores(); err != nil {
+		t.Fatalf("CloseStores failed: %v", err)
+	}
+
+	// Simulate a hand edit while the server is down: put a different rule set
+	// back into config.json. The database must still win.
+	raw := readConfigJSON(t, dir)
+	raw["rules"] = []typ.Rule{legacyTestRule("hand-edited", "sneaky-model")}
+	data, _ := json.MarshalIndent(raw, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0600); err != nil {
+		t.Fatalf("failed to rewrite config.json: %v", err)
+	}
+
+	cfg2, err := NewConfigWithDir(dir)
+	if err != nil {
+		t.Fatalf("second NewConfigWithDir failed: %v", err)
+	}
+	defer cfg2.CloseStores()
+
+	if findRule(cfg2.Rules, "hand-edited") != nil {
+		t.Error("hand-edited JSON rule leaked into the working set; database should be authoritative")
+	}
+	if findRule(cfg2.Rules, "legacy-1") == nil {
+		t.Error("database rule lost when stale JSON was present")
+	}
+	if rules, ok := readConfigJSON(t, dir)["rules"]; ok && rules != nil {
+		t.Errorf("stale JSON rules were not cleared: %v", rules)
+	}
+}
+
+func TestRuleCRUDWritesThroughToStore(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := NewConfigWithDir(dir)
+	if err != nil {
+		t.Fatalf("NewConfigWithDir failed: %v", err)
+	}
+	defer cfg.CloseStores()
+
+	store := cfg.StoreManager().Rules()
+	seedLegacyProvider(t, cfg)
+
+	rule := legacyTestRule("crud-1", "crud-model")
+	if err := cfg.AddRule(rule); err != nil {
+		t.Fatalf("AddRule failed: %v", err)
+	}
+	if _, err := store.GetByUUID("crud-1"); err != nil {
+		t.Fatalf("AddRule did not reach the store: %v", err)
+	}
+
+	rule.Description = "updated"
+	if err := cfg.UpdateRule("crud-1", rule); err != nil {
+		t.Fatalf("UpdateRule failed: %v", err)
+	}
+	stored, err := store.GetByUUID("crud-1")
+	if err != nil {
+		t.Fatalf("rule missing after update: %v", err)
+	}
+	if stored.Description != "updated" {
+		t.Errorf("update did not reach the store: %q", stored.Description)
+	}
+
+	if err := cfg.DeleteRule("crud-1"); err != nil {
+		t.Fatalf("DeleteRule failed: %v", err)
+	}
+	if _, err := store.GetByUUID("crud-1"); err == nil {
+		t.Error("DeleteRule did not reach the store")
+	}
+}
+
+func TestRulesDuplicateUUIDsSurviveLegacyMigration(t *testing.T) {
+	dir := t.TempDir()
+	first := legacyTestRule("dup-uuid", "model-first")
+	second := legacyTestRule("dup-uuid", "model-second")
+	writeLegacyConfig(t, dir, []typ.Rule{first, second})
+
+	cfg, err := NewConfigWithDir(dir)
+	if err != nil {
+		t.Fatalf("NewConfigWithDir failed: %v", err)
+	}
+	defer cfg.CloseStores()
+
+	gotFirst := findRuleByModel(cfg.Rules, "model-first")
+	gotSecond := findRuleByModel(cfg.Rules, "model-second")
+	if gotFirst == nil || gotSecond == nil {
+		t.Fatalf("a duplicate-UUID rule was dropped during migration (first=%v second=%v)", gotFirst != nil, gotSecond != nil)
+	}
+	if gotFirst.UUID == gotSecond.UUID {
+		t.Fatalf("duplicate UUIDs were not disambiguated: both %q", gotFirst.UUID)
+	}
+
+	store := cfg.StoreManager().Rules()
+	for _, r := range []*typ.Rule{gotFirst, gotSecond} {
+		if _, err := store.GetByUUID(r.UUID); err != nil {
+			t.Errorf("rule %s (%s) missing from store: %v", r.RequestModel, r.UUID, err)
+		}
+	}
+}
+
+func TestSaveAfterCloseStoresStillWritesFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := NewConfigWithDir(dir)
+	if err != nil {
+		t.Fatalf("NewConfigWithDir failed: %v", err)
+	}
+	if err := cfg.CloseStores(); err != nil {
+		t.Fatalf("CloseStores failed: %v", err)
+	}
+
+	// Unrelated config edits must still reach config.json after the stores
+	// are gone; the rule sync silently detaches instead of erroring.
+	if err := cfg.SetVerbose(true); err != nil {
+		t.Fatalf("Save after CloseStores failed: %v", err)
+	}
+	if got, _ := readConfigJSON(t, dir)["verbose"].(bool); !got {
+		t.Error("verbose=true did not reach config.json after CloseStores")
+	}
+}
+
+func TestRulesUUIDAssignedDuringLegacyMigration(t *testing.T) {
+	dir := t.TempDir()
+	noUUID := legacyTestRule("", "uuidless-model")
+	writeLegacyConfig(t, dir, []typ.Rule{noUUID})
+
+	cfg, err := NewConfigWithDir(dir)
+	if err != nil {
+		t.Fatalf("NewConfigWithDir failed: %v", err)
+	}
+	defer cfg.CloseStores()
+
+	migrated := findRuleByModel(cfg.Rules, "uuidless-model")
+	if migrated == nil {
+		t.Fatal("uuidless rule lost during migration")
+	}
+	if migrated.UUID == "" {
+		t.Fatal("rule was not assigned a UUID during migration")
+	}
+	if _, err := cfg.StoreManager().Rules().GetByUUID(migrated.UUID); err != nil {
+		t.Errorf("uuidless rule not persisted to store: %v", err)
+	}
+}

--- a/internal/server/config/rule_storage_test.go
+++ b/internal/server/config/rule_storage_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -129,9 +130,15 @@ func TestRulesMigrateFromLegacyJSONToStore(t *testing.T) {
 		t.Errorf("services did not survive migration: %+v", stored.Services)
 	}
 
-	// config.json must no longer carry rule data.
-	if rules, ok := readConfigJSON(t, dir)["rules"]; ok && rules != nil {
-		t.Errorf("config.json still carries rules after migration: %v", rules)
+	// Transition period: config.json keeps a live "rules" mirror for
+	// downgrade compatibility. It must reflect the full working set
+	// (legacy + built-ins), not the pre-migration snapshot.
+	mirror, ok := readConfigJSON(t, dir)["rules"].([]interface{})
+	if !ok {
+		t.Fatalf("config.json rules mirror missing after migration")
+	}
+	if len(mirror) != len(cfg.Rules) {
+		t.Errorf("rules mirror has %d entries, want %d (live mirror of working set)", len(mirror), len(cfg.Rules))
 	}
 }
 
@@ -212,8 +219,15 @@ func TestRulesStoreWinsOverStaleJSON(t *testing.T) {
 	if findRule(cfg2.Rules, "legacy-1") == nil {
 		t.Error("database rule lost when stale JSON was present")
 	}
-	if rules, ok := readConfigJSON(t, dir)["rules"]; ok && rules != nil {
-		t.Errorf("stale JSON rules were not cleared: %v", rules)
+
+	// The startup Save rewrites the file mirror from the database-backed
+	// working set, so the hand edit disappears from the file too.
+	raw2, _ := json.Marshal(readConfigJSON(t, dir)["rules"])
+	if bytes.Contains(raw2, []byte("hand-edited")) {
+		t.Error("hand-edited rule still present in the file mirror after restart")
+	}
+	if !bytes.Contains(raw2, []byte("legacy-1")) {
+		t.Error("file mirror does not reflect the database rules after restart")
 	}
 }
 
@@ -302,6 +316,45 @@ func TestSaveAfterCloseStoresStillWritesFile(t *testing.T) {
 	}
 	if got, _ := readConfigJSON(t, dir)["verbose"].(bool); !got {
 		t.Error("verbose=true did not reach config.json after CloseStores")
+	}
+}
+
+func TestRuleMutationsKeepFileMirrorFresh(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := NewConfigWithDir(dir)
+	if err != nil {
+		t.Fatalf("NewConfigWithDir failed: %v", err)
+	}
+	defer cfg.CloseStores()
+	seedLegacyProvider(t, cfg)
+
+	rule := legacyTestRule("mirror-1", "mirror-model")
+	if err := cfg.AddRule(rule); err != nil {
+		t.Fatalf("AddRule failed: %v", err)
+	}
+
+	// The downgrade-compat mirror must parse as the pre-database format:
+	// a typ.Rule array under "rules", containing the new rule.
+	var onDisk struct {
+		Rules []typ.Rule `json:"rules"`
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	if err != nil {
+		t.Fatalf("failed to read config.json: %v", err)
+	}
+	if err := json.Unmarshal(raw, &onDisk); err != nil {
+		t.Fatalf("file mirror is not old-format parseable: %v", err)
+	}
+	if findRule(onDisk.Rules, "mirror-1") == nil {
+		t.Error("AddRule did not refresh the file mirror")
+	}
+
+	if err := cfg.DeleteRule("mirror-1"); err != nil {
+		t.Fatalf("DeleteRule failed: %v", err)
+	}
+	raw, _ = os.ReadFile(filepath.Join(dir, "config.json"))
+	if bytes.Contains(raw, []byte("mirror-1")) {
+		t.Error("DeleteRule did not remove the rule from the file mirror")
 	}
 }
 

--- a/internal/server/config/rule_storage_test.go
+++ b/internal/server/config/rule_storage_test.go
@@ -358,6 +358,40 @@ func TestRuleMutationsKeepFileMirrorFresh(t *testing.T) {
 	}
 }
 
+func TestUUIDlessRuleFromLegacyMutatorSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := NewConfigWithDir(dir)
+	if err != nil {
+		t.Fatalf("NewConfigWithDir failed: %v", err)
+	}
+
+	// AddRequestConfig is a legacy mutator that does not assign UUIDs
+	// (used by replay/test tooling). The sync layer must repair the UUID so
+	// the rule reaches the database instead of silently evaporating.
+	rule := legacyTestRule("", "uuidless-live-model")
+	rule.Services = nil // avoid provider validation; not the point here
+	if err := cfg.AddRequestConfig(rule); err != nil {
+		t.Fatalf("AddRequestConfig failed: %v", err)
+	}
+	if err := cfg.CloseStores(); err != nil {
+		t.Fatalf("CloseStores failed: %v", err)
+	}
+
+	cfg2, err := NewConfigWithDir(dir)
+	if err != nil {
+		t.Fatalf("second NewConfigWithDir failed: %v", err)
+	}
+	defer cfg2.CloseStores()
+
+	survived := findRuleByModel(cfg2.Rules, "uuidless-live-model")
+	if survived == nil {
+		t.Fatal("UUID-less rule vanished across restart")
+	}
+	if survived.UUID == "" {
+		t.Error("rule persisted without a UUID")
+	}
+}
+
 func TestRulesUUIDAssignedDuringLegacyMigration(t *testing.T) {
 	dir := t.TempDir()
 	noUUID := legacyTestRule("", "uuidless-model")


### PR DESCRIPTION
## Summary

Rules were the last entity-shaped data in config.json — every edit rewrote the whole file, and hand edits raced the API via hot reload. They now live in SQLite as the sole authority, following the same pattern providers already use.

## Key Changes

- **Rules table on the new db layer**: `internal/db.RuleStore` — routing keys (`scenario`+`request_model`, `active`, `position`) as indexed columns, nested/fast-evolving fields (`services`, `flags`, `lb_tactic`, `smart_routing`) as typed `serializer:json` columns.
- **Save() is the write-through choke point**: every rule mutation already funnels through it; store is written before the file so a failed sync can never lose data.
- **One-time import**: legacy JSON rules migrate into the database on first startup, repairing missing/duplicate UUIDs so hand-copied rule blocks survive.
- **Downgrade safety**: config.json keeps a write-only, always-fresh `rules` mirror during a transition period, so rolling back to a pre-database build still reads current rules (removal planned, see design doc).
- **Divergence is loud, never silent**: startup and hot reload warn when file rules differ from the database instead of discarding them quietly.
- **Entry-layer rule identity**: rule mutators assign/inherit UUIDs the way providers do, so no unkeyed rule can silently fail to persist.
- **Order preserved**: a `position` column mirrors the old JSON array order, keeping index-based `DefaultRequestID` behavior unchanged.

## Notes

- `DefaultRequestID` (file) and rules (DB) are no longer one atomic write; a crash between them can leave a stale default-rule index (bounds-checked, UI-recoverable). Documented trade-off — real fix is a planned default-rule-by-UUID migration.
- Hand-editing `rules` in config.json no longer has effect; manage rules via UI/API/CLI.

## Testing

Store + config lifecycle tests (import, restart, DB-wins-over-stale-file, mirror freshness, UUID repair) run with `-race`; `internal/server`, `internal/command`, `internal/servertest` regressions green; end-to-end smoke against a real legacy config.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoVcDSjyC8Cz5B6kx1qgLn