### PR TITLE
feat(agent, config): Add auto config for DeepSeek Harness (dsh)

### DIFF
--- a/ai/agent/apply_support.go
+++ b/ai/agent/apply_support.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	tomlpkg "github.com/pelletier/go-toml/v2"
+	yamlpkg "gopkg.in/yaml.v3"
 )
 
 // defaultBackupRetention is the default number of backup files to keep per
@@ -1240,6 +1241,310 @@ func ApplyCodexAuth(mode CodexAuthMode, apiKey string, tokens *CodexChatGPTToken
 	}
 
 	if err := os.WriteFile(targetPath, output, 0600); err != nil {
+		result.Message = fmt.Sprintf("Failed to write file: %v", err)
+		return result, nil
+	}
+
+	result.Success = true
+	if result.Created {
+		result.Message = fmt.Sprintf("Created %s", targetPath)
+	} else if result.BackupPath != "" {
+		result.Message = fmt.Sprintf("Updated %s (backup: %s)", targetPath, result.BackupPath)
+	} else {
+		result.Message = fmt.Sprintf("Updated %s", targetPath)
+	}
+	return result, nil
+}
+
+// ---------------------------------------------------------------------------
+// DeepSeek Harness (dsh) settings/credentials application
+//
+// dsh splits its config the same way Codex does: a settings file that
+// references credentials indirectly (apiKeyEnv names an env var rather than
+// embedding the secret) and a separate write-only credentials file. See
+// https://deepseek-harness.github.io/deepseek-harness/en/guide/providers.
+// ---------------------------------------------------------------------------
+
+// dshGatewayProviderName is the tingly-box provider key written into
+// settings.yaml's `llm-pi-ai.providers` map by mergeDshSettings.
+const dshGatewayProviderName = "tingly-box"
+
+// dshAPIKeyEnvName is the env var name settings.yaml's apiKeyEnv points at,
+// and the key written into .credentials.yaml. Fixed rather than
+// user-configurable: it's an implementation detail of dsh's credential
+// indirection, not a user-tunable knob.
+const dshAPIKeyEnvName = "TINGLY_BOX_API_KEY"
+
+// dshHomeDir resolves $DSH_HOME, falling back to ~/.dsh when unset (dsh's
+// docs do not state a default; ~/.dsh follows the common single-dotdir
+// convention used by similar CLIs).
+func dshHomeDir() (string, error) {
+	if v := strings.TrimSpace(os.Getenv("DSH_HOME")); v != "" {
+		return v, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	if home == "" {
+		return "", fmt.Errorf("home directory resolved to empty path")
+	}
+	return filepath.Join(home, ".dsh"), nil
+}
+
+// DshPrefs is the typed, user-tunable surface of settings.yaml's tingly-box
+// provider entry. DefaultInput mirrors the provider-level `defaultInput` key
+// ("text" or "text_image" -> [text] / [text, image]); empty omits the key so
+// dsh treats the provider as text-only — the conservative default for models
+// tingly-box cannot verify support vision (same stance as Codex's third-party
+// defaults, see .design/codex-config.md).
+type DshPrefs struct {
+	DefaultInput string `json:"default_input,omitempty"`
+}
+
+// DefaultDshPrefs returns the defaults for the CLI path and no-prefs
+// fallback: DefaultInput unset (text-only).
+func DefaultDshPrefs() *DshPrefs {
+	return &DshPrefs{}
+}
+
+// dshDefaultInputList converts the enum value into the YAML modality list,
+// or nil for an unset/invalid value (dropped, forward-compatible).
+func dshDefaultInputList(val string) []string {
+	switch val {
+	case "text":
+		return []string{"text"}
+	case "text_image":
+		return []string{"text", "image"}
+	default:
+		return nil
+	}
+}
+
+// toConfig converts prefs into the provider-stanza fields it controls.
+func (p *DshPrefs) toConfig() map[string]interface{} {
+	out := map[string]interface{}{}
+	if p == nil {
+		return out
+	}
+	if list := dshDefaultInputList(strings.TrimSpace(p.DefaultInput)); list != nil {
+		out["defaultInput"] = list
+	}
+	return out
+}
+
+// DshPrefsFromConfig is the inverse of toConfig: it extracts DefaultInput
+// from a parsed tingly-box provider stanza.
+func DshPrefsFromConfig(providerStanza map[string]interface{}) *DshPrefs {
+	prefs := &DshPrefs{}
+	list, ok := providerStanza["defaultInput"].([]interface{})
+	if !ok || len(list) == 0 {
+		return prefs
+	}
+	hasImage := false
+	for _, v := range list {
+		if s, ok := v.(string); ok && s == "image" {
+			hasImage = true
+		}
+	}
+	if hasImage {
+		prefs.DefaultInput = "text_image"
+	} else {
+		prefs.DefaultInput = "text"
+	}
+	return prefs
+}
+
+// dshProviderStanza drills into cfg["llm-pi-ai"]["providers"]["tingly-box"]
+// and returns it if present.
+func dshProviderStanza(cfg map[string]interface{}) (map[string]interface{}, bool) {
+	root, ok := cfg["llm-pi-ai"].(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	providers, ok := root["providers"].(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	stanza, ok := providers[dshGatewayProviderName].(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	return stanza, true
+}
+
+// ReadDshSettings reads $DSH_HOME/settings.yaml and returns the typed prefs
+// and whether a tingly-managed provider stanza exists. A missing or
+// unparseable file yields empty prefs, exists=false, so the form falls back
+// to defaults rather than erroring on first-time setup.
+func ReadDshSettings() (prefs *DshPrefs, exists bool, err error) {
+	dshHome, err := dshHomeDir()
+	if err != nil {
+		return nil, false, err
+	}
+	targetPath := filepath.Join(dshHome, "settings.yaml")
+
+	data, readErr := os.ReadFile(targetPath)
+	if readErr != nil {
+		return DefaultDshPrefs(), false, nil
+	}
+
+	cfg := map[string]interface{}{}
+	if err := yamlpkg.Unmarshal(data, &cfg); err != nil {
+		return DefaultDshPrefs(), false, nil
+	}
+
+	stanza, ok := dshProviderStanza(cfg)
+	if !ok {
+		return DefaultDshPrefs(), false, nil
+	}
+	return DshPrefsFromConfig(stanza), true, nil
+}
+
+// ApplyDshSettings merges tingly-box's provider entry into
+// $DSH_HOME/settings.yaml.
+//
+// MERGE semantics: only the `llm-pi-ai.providers.tingly-box` stanza is
+// overwritten; everything else the user has in settings.yaml — other
+// providers, unrelated top-level keys — is left alone. The previous file (if
+// any) is backed up before rewrite.
+func ApplyDshSettings(baseURL string, models []string, prefs *DshPrefs) (*ApplyResult, error) {
+	dshHome, err := dshHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	targetPath := filepath.Join(dshHome, "settings.yaml")
+	result := &ApplyResult{}
+
+	if err := os.MkdirAll(dshHome, 0755); err != nil {
+		result.Message = fmt.Sprintf("Failed to create directory: %v", err)
+		return result, nil
+	}
+
+	existing := map[string]interface{}{}
+	if data, err := os.ReadFile(targetPath); err == nil {
+		if err := yamlpkg.Unmarshal(data, &existing); err != nil {
+			result.Message = fmt.Sprintf("Failed to parse existing settings.yaml: %v", err)
+			return result, nil
+		}
+		backupPath, err := backupFile(targetPath)
+		if err != nil {
+			result.Message = fmt.Sprintf("Failed to create backup: %v", err)
+			return result, nil
+		}
+		result.BackupPath = backupPath
+		result.Updated = true
+	} else {
+		result.Created = true
+	}
+
+	mergeDshSettings(existing, baseURL, models, prefs)
+
+	out, err := yamlpkg.Marshal(existing)
+	if err != nil {
+		result.Message = fmt.Sprintf("Failed to marshal settings.yaml: %v", err)
+		return result, nil
+	}
+	if err := os.WriteFile(targetPath, out, 0644); err != nil {
+		result.Message = fmt.Sprintf("Failed to write file: %v", err)
+		return result, nil
+	}
+
+	result.Success = true
+	if result.Created {
+		result.Message = fmt.Sprintf("Created %s", targetPath)
+	} else if result.BackupPath != "" {
+		result.Message = fmt.Sprintf("Updated %s (backup: %s)", targetPath, result.BackupPath)
+	} else {
+		result.Message = fmt.Sprintf("Updated %s", targetPath)
+	}
+	return result, nil
+}
+
+// RenderDshSettingsYAML returns the YAML that would be written to a fresh
+// settings.yaml — i.e. the merge applied to an empty starting point. Used by
+// the preview endpoint so the UI can show exactly what's pending.
+func RenderDshSettingsYAML(baseURL string, models []string, prefs *DshPrefs) ([]byte, error) {
+	cfg := map[string]interface{}{}
+	mergeDshSettings(cfg, baseURL, models, prefs)
+	return yamlpkg.Marshal(cfg)
+}
+
+// mergeDshSettings mutates cfg in place, applying the tingly-box provider
+// stanza while preserving everything else. See ApplyDshSettings for the
+// contract.
+func mergeDshSettings(cfg map[string]interface{}, baseURL string, models []string, prefs *DshPrefs) {
+	root, _ := cfg["llm-pi-ai"].(map[string]interface{})
+	if root == nil {
+		root = map[string]interface{}{}
+	}
+	providers, _ := root["providers"].(map[string]interface{})
+	if providers == nil {
+		providers = map[string]interface{}{}
+	}
+
+	modelEntries := make([]map[string]interface{}, 0, len(models))
+	for _, model := range models {
+		modelEntries = append(modelEntries, map[string]interface{}{"id": model})
+	}
+
+	stanza := map[string]interface{}{
+		"apiKeyEnv": dshAPIKeyEnvName,
+		"api":       "openai-completions",
+		"baseURL":   baseURL,
+		"models":    modelEntries,
+	}
+	for k, v := range prefs.toConfig() {
+		stanza[k] = v
+	}
+
+	providers[dshGatewayProviderName] = stanza
+	root["providers"] = providers
+	cfg["llm-pi-ai"] = root
+}
+
+// ApplyDshCredentials writes $DSH_HOME/.credentials.yaml, setting only the
+// tingly-box managed env var key; other keys already in the file (other
+// providers' credentials) are preserved. The previous file (if any) is
+// backed up before modification.
+func ApplyDshCredentials(apiKey string) (*ApplyResult, error) {
+	dshHome, err := dshHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	targetPath := filepath.Join(dshHome, ".credentials.yaml")
+	result := &ApplyResult{}
+
+	if err := os.MkdirAll(dshHome, 0755); err != nil {
+		result.Message = fmt.Sprintf("Failed to create directory: %v", err)
+		return result, nil
+	}
+
+	existing := map[string]interface{}{}
+	if data, err := os.ReadFile(targetPath); err == nil {
+		if err := yamlpkg.Unmarshal(data, &existing); err != nil {
+			result.Message = fmt.Sprintf("Failed to parse existing .credentials.yaml: %v", err)
+			return result, nil
+		}
+		backupPath, err := backupFile(targetPath)
+		if err != nil {
+			result.Message = fmt.Sprintf("Failed to create backup: %v", err)
+			return result, nil
+		}
+		result.BackupPath = backupPath
+		result.Updated = true
+	} else {
+		result.Created = true
+	}
+
+	existing[dshAPIKeyEnvName] = apiKey
+
+	out, err := yamlpkg.Marshal(existing)
+	if err != nil {
+		result.Message = fmt.Sprintf("Failed to marshal .credentials.yaml: %v", err)
+		return result, nil
+	}
+	if err := os.WriteFile(targetPath, out, 0600); err != nil {
 		result.Message = fmt.Sprintf("Failed to write file: %v", err)
 		return result, nil
 	}

--- a/ai/agent/dsh.go
+++ b/ai/agent/dsh.go
@@ -1,0 +1,76 @@
+package agent
+
+import "fmt"
+
+// DshConfig implements AgentConfig for DeepSeek Harness (dsh)
+type DshConfig struct{}
+
+// DshParams contains parameters for applying DeepSeek Harness configuration
+type DshParams struct {
+	// DshBaseURL is the base URL dsh should route the tingly-box provider to.
+	DshBaseURL string
+
+	// APIKey is written into $DSH_HOME/.credentials.yaml under the env var
+	// name settings.yaml references via apiKeyEnv.
+	APIKey string
+
+	// Models is the list of model ids for the tingly-box provider entry.
+	// Caller is responsible for collecting and deduplicating these.
+	Models []string
+
+	// Prefs holds the typed, whitelisted, user-tunable settings.yaml keys
+	// (see DshPrefs). nil means "use built-in defaults".
+	Prefs *DshPrefs
+}
+
+// Apply applies DeepSeek Harness configuration
+func (d *DshConfig) Apply(paramsInterface interface{}) (*ApplyAgentResult, error) {
+	params, ok := paramsInterface.(*DshParams)
+	if !ok {
+		return nil, fmt.Errorf("invalid params type, expected *DshParams")
+	}
+
+	result := &ApplyAgentResult{
+		AgentType: AgentTypeDsh,
+		Success:   true,
+	}
+
+	settingsResult, err := ApplyDshSettings(params.DshBaseURL, params.Models, params.Prefs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply DeepSeek Harness settings: %w", err)
+	}
+	result.Success = result.Success && settingsResult.Success
+	if settingsResult.Success {
+		suffix := " (updated)"
+		if settingsResult.Created {
+			suffix = " (created)"
+		}
+		result.ConfigFiles = append(result.ConfigFiles, "$DSH_HOME/settings.yaml"+suffix)
+	}
+	if settingsResult.BackupPath != "" {
+		result.BackupPaths = append(result.BackupPaths, settingsResult.BackupPath)
+	}
+
+	credsResult, err := ApplyDshCredentials(params.APIKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply DeepSeek Harness credentials: %w", err)
+	}
+	result.Success = result.Success && credsResult.Success
+	if credsResult.Success {
+		suffix := " (updated)"
+		if credsResult.Created {
+			suffix = " (created)"
+		}
+		result.ConfigFiles = append(result.ConfigFiles, "$DSH_HOME/.credentials.yaml"+suffix)
+	}
+	if credsResult.BackupPath != "" {
+		result.BackupPaths = append(result.BackupPaths, credsResult.BackupPath)
+	}
+
+	return result, nil
+}
+
+// Restore restores DeepSeek Harness configuration from backup
+func (d *DshConfig) Restore() (*RestoreAgentResult, error) {
+	return RestoreAgent(AgentTypeDsh)
+}

--- a/ai/agent/dsh_test.go
+++ b/ai/agent/dsh_test.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDshConfig_Apply(t *testing.T) {
+	dshHome := t.TempDir()
+	t.Setenv("DSH_HOME", dshHome)
+
+	cfg := &DshConfig{}
+	result, err := cfg.Apply(&DshParams{
+		DshBaseURL: "https://tingly.local/tingly/dsh",
+		APIKey:     "sk-test",
+		Models:     []string{"tingly-dsh"},
+		Prefs:      DefaultDshPrefs(),
+	})
+	if err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got %+v", result)
+	}
+	if len(result.ConfigFiles) != 2 {
+		t.Errorf("expected settings.yaml + .credentials.yaml to both be written, got %v", result.ConfigFiles)
+	}
+
+	settingsData, err := os.ReadFile(filepath.Join(dshHome, "settings.yaml"))
+	if err != nil {
+		t.Fatalf("expected settings.yaml to be written: %v", err)
+	}
+	settings := string(settingsData)
+	if !strings.Contains(settings, "tingly.local") {
+		t.Errorf("expected settings.yaml to reference the base URL, got %s", settings)
+	}
+	if !strings.Contains(settings, "tingly-dsh") {
+		t.Errorf("expected settings.yaml to reference the model, got %s", settings)
+	}
+	if !strings.Contains(settings, dshAPIKeyEnvName) {
+		t.Errorf("expected settings.yaml to reference apiKeyEnv, got %s", settings)
+	}
+	if strings.Contains(settings, "sk-test") {
+		t.Errorf("expected settings.yaml NOT to contain the literal API key, got %s", settings)
+	}
+
+	credsData, err := os.ReadFile(filepath.Join(dshHome, ".credentials.yaml"))
+	if err != nil {
+		t.Fatalf("expected .credentials.yaml to be written: %v", err)
+	}
+	if !strings.Contains(string(credsData), "sk-test") {
+		t.Errorf("expected .credentials.yaml to contain the API key, got %s", credsData)
+	}
+}
+
+func TestDshConfig_Apply_PreservesUnrelatedSettings(t *testing.T) {
+	dshHome := t.TempDir()
+	t.Setenv("DSH_HOME", dshHome)
+
+	if err := os.WriteFile(filepath.Join(dshHome, "settings.yaml"), []byte(
+		"llm-pi-ai:\n  providers:\n    other-gateway:\n      apiKeyEnv: OTHER_KEY\n      api: openai-completions\n      baseURL: https://other.example/v1\n      models:\n        - id: other-model\n"),
+		0644); err != nil {
+		t.Fatalf("failed to seed settings.yaml: %v", err)
+	}
+
+	cfg := &DshConfig{}
+	result, err := cfg.Apply(&DshParams{
+		DshBaseURL: "https://tingly.local/tingly/dsh",
+		APIKey:     "sk-test",
+		Models:     []string{"tingly-dsh"},
+		Prefs:      DefaultDshPrefs(),
+	})
+	if err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got %+v", result)
+	}
+
+	settingsData, err := os.ReadFile(filepath.Join(dshHome, "settings.yaml"))
+	if err != nil {
+		t.Fatalf("expected settings.yaml to be written: %v", err)
+	}
+	settings := string(settingsData)
+	if !strings.Contains(settings, "other-gateway") {
+		t.Errorf("expected existing other-gateway provider to be preserved, got %s", settings)
+	}
+	if !strings.Contains(settings, dshGatewayProviderName) {
+		t.Errorf("expected tingly-box provider to be written, got %s", settings)
+	}
+}
+
+func TestDshConfig_Apply_InvalidParams(t *testing.T) {
+	cfg := &DshConfig{}
+	if _, err := cfg.Apply("not-the-right-type"); err == nil {
+		t.Fatal("expected error for invalid params type")
+	}
+}
+
+func TestDshConfig_Restore_NoBackupFails(t *testing.T) {
+	dshHome := t.TempDir()
+	t.Setenv("DSH_HOME", dshHome)
+
+	cfg := &DshConfig{}
+	result, err := cfg.Restore()
+	if err != nil {
+		t.Fatalf("Restore returned error: %v", err)
+	}
+	if result.Success {
+		t.Fatalf("expected restore to fail with no backups, got %+v", result)
+	}
+}

--- a/ai/agent/info.go
+++ b/ai/agent/info.go
@@ -50,6 +50,16 @@ func ListAgentInfo() []AgentInfo {
 			},
 			Scenario: "codex",
 		},
+		{
+			Type:        AgentTypeDsh,
+			Name:        "DeepSeek Harness",
+			Description: "DeepSeek Harness CLI (dsh)",
+			ConfigFiles: []string{
+				"$DSH_HOME/settings.yaml",
+				"$DSH_HOME/.credentials.yaml",
+			},
+			Scenario: "dsh",
+		},
 	}
 }
 

--- a/ai/agent/interface.go
+++ b/ai/agent/interface.go
@@ -56,4 +56,5 @@ func init() {
 	DefaultRegistry.Register(AgentTypeClaudeCode, &ClaudeCodeConfig{})
 	DefaultRegistry.Register(AgentTypeOpenCode, &OpenCodeConfig{})
 	DefaultRegistry.Register(AgentTypeCodex, &CodexConfig{})
+	DefaultRegistry.Register(AgentTypeDsh, &DshConfig{})
 }

--- a/ai/agent/parse.go
+++ b/ai/agent/parse.go
@@ -11,6 +11,7 @@ import (
 //   - "cc", "claude", "claude-code" -> AgentTypeClaudeCode
 //   - "oc", "opencode" -> AgentTypeOpenCode
 //   - "cx", "codex" -> AgentTypeCodex
+//   - "dsh" -> AgentTypeDsh
 func ParseAgentType(input string) (AgentType, error) {
 	if input == "" {
 		return "", fmt.Errorf("agent type cannot be empty")
@@ -25,7 +26,9 @@ func ParseAgentType(input string) (AgentType, error) {
 		return AgentTypeOpenCode, nil
 	case "cx", "codex":
 		return AgentTypeCodex, nil
+	case "dsh":
+		return AgentTypeDsh, nil
 	default:
-		return "", fmt.Errorf("unknown agent type: %s (supported: cc/claude-code, oc/opencode, cx/codex)", input)
+		return "", fmt.Errorf("unknown agent type: %s (supported: cc/claude-code, oc/opencode, cx/codex, dsh)", input)
 	}
 }

--- a/ai/agent/types.go
+++ b/ai/agent/types.go
@@ -12,6 +12,9 @@ const (
 
 	// AgentTypeCodex represents the OpenAI Codex CLI
 	AgentTypeCodex AgentType = "codex"
+
+	// AgentTypeDsh represents the DeepSeek Harness CLI
+	AgentTypeDsh AgentType = "dsh"
 )
 
 // String returns the string representation of AgentType
@@ -22,7 +25,7 @@ func (at AgentType) String() string {
 // IsValid checks if the AgentType is valid
 func (at AgentType) IsValid() bool {
 	switch at {
-	case AgentTypeClaudeCode, AgentTypeOpenCode, AgentTypeCodex:
+	case AgentTypeClaudeCode, AgentTypeOpenCode, AgentTypeCodex, AgentTypeDsh:
 		return true
 	default:
 		return false

--- a/ai/agent/types_test.go
+++ b/ai/agent/types_test.go
@@ -79,8 +79,8 @@ func TestAgentTypeIsValid(t *testing.T) {
 func TestListAgentInfo(t *testing.T) {
 	infos := ListAgentInfo()
 
-	if len(infos) != 3 {
-		t.Errorf("ListAgentInfo() returned %d items, want 3", len(infos))
+	if len(infos) != 4 {
+		t.Errorf("ListAgentInfo() returned %d items, want 4", len(infos))
 	}
 
 	// Verify Claude Code

--- a/ai/agent/utils.go
+++ b/ai/agent/utils.go
@@ -6,9 +6,20 @@ import (
 	"path/filepath"
 )
 
-// expandUser resolves a leading "~" or "~/" in p against the current user's
-// home directory. Other paths are returned unchanged.
+// expandUser resolves a leading "~" or "~/" (against the user's home
+// directory) or "$DSH_HOME" (against dshHomeDir) in p. Other paths are
+// returned unchanged.
 func expandUser(p string) (string, error) {
+	if p == "$DSH_HOME" || hasPrefix(p, "$DSH_HOME/") {
+		home, err := dshHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if p == "$DSH_HOME" {
+			return home, nil
+		}
+		return filepath.Join(home, p[len("$DSH_HOME"):]), nil
+	}
 	if p == "~" || hasPrefix(p, "~/") {
 		home, err := os.UserHomeDir()
 		if err != nil {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -929,6 +929,16 @@ export default {
       "keepExisting": "Keep existing auth.json (don\u2019t modify)"
     }
   },
+  "dshConfig": {
+    "title": "Configure DeepSeek Harness",
+    "subtitle": "Configure dsh to use Tingly Box through `$DSH_HOME/settings.yaml` and `$DSH_HOME/.credentials.yaml`",
+    "resetTooltip": "Reset model capabilities to defaults",
+    "tabQuick": "Quick Config",
+    "tabManual": "Manual",
+    "applySuccess": "DeepSeek Harness configuration applied to $DSH_HOME",
+    "applyFailed": "Failed to apply configuration",
+    "modelsPreviewNote": "Model ids written to settings.yaml: {{models}}"
+  },
   "claudeCode": {
     "configModes": {
       "unified": {
@@ -1617,7 +1627,8 @@ export default {
       "applyStepDescription": "Point dsh's model provider plugin base URL and API key at the values above — see the dsh docs for the exact plugin config.",
       "openGuide": "View Config",
       "configTitle": "Configure DSH",
-      "modalDescription": "Point dsh's model provider plugin at the base URL and API key shown on this page, then check the repo below for dsh's plugin configuration options."
+      "modalDescription": "Point dsh's model provider plugin at the base URL and API key shown on this page, then check the repo below for dsh's plugin configuration options.",
+      "applyFailed": "Failed to apply configuration"
     }
   },
   "scenarioOverview": {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -931,6 +931,16 @@ export default {
       "keepExisting": "保留现有 auth.json（不修改）"
     }
   },
+  "dshConfig": {
+    "title": "配置 DeepSeek Harness",
+    "subtitle": "通过 `$DSH_HOME/settings.yaml` 和 `$DSH_HOME/.credentials.yaml` 配置 dsh 使用 Tingly Box",
+    "resetTooltip": "将模型能力设置重置为默认值",
+    "tabQuick": "快速配置",
+    "tabManual": "手动配置",
+    "applySuccess": "DeepSeek Harness 配置已应用到 $DSH_HOME",
+    "applyFailed": "应用配置失败",
+    "modelsPreviewNote": "写入 settings.yaml 的模型 id：{{models}}"
+  },
   "claudeCode": {
     "configModes": {
       "unified": {
@@ -1618,6 +1628,7 @@ export default {
       "openGuide": "查看配置",
       "configTitle": "配置 DSH",
       "modalDescription": "把 dsh 的模型 provider 插件指向本页面上方显示的 base URL 和 API Key，具体插件配置请参考下方仓库中的说明。",
+      "applyFailed": "应用配置失败"
     },
   },
   "scenarioOverview": {

--- a/frontend/src/pages/scenario/UseDshPage.tsx
+++ b/frontend/src/pages/scenario/UseDshPage.tsx
@@ -1,9 +1,11 @@
 import CardGrid from "@/components/CardGrid.tsx";
 import UnifiedCard from "@/components/UnifiedCard.tsx";
 import ProviderConfigCard from "@/components/ProviderConfigCard.tsx";
-import AgentSetupCard, { hasModelOnAnyRule, scrollToModelsCard } from './components/AgentSetupCard';
+import AgentSetupCard, { type AgentApplyResult, hasModelOnAnyRule, scrollToModelsCard } from './components/AgentSetupCard';
 import ConnectAIDialogs from '@/components/ConnectAIDialogs';
 import {useProviderDialog} from '@/hooks/useProviderDialog';
+import { defaultDshPrefs } from './components/DshQuickConfig';
+import { api } from '@/services/api';
 import { Box, Button, Tooltip, IconButton } from '@mui/material';
 import { Info as InfoIcon } from '@/components/icons';
 import { useState } from 'react';
@@ -30,12 +32,34 @@ const UseDshPageContent: React.FC = () => {
         rules,
     } = useScenarioPageInternal(scenario);
     const [configModalOpen, setConfigModalOpen] = useState(false);
+    const [isApplyLoading, setIsApplyLoading] = useState(false);
     // Unified Connect AI add flow (picker + form/OAuth/paste/import dialogs).
     const connectAI = useProviderDialog(showNotification, {
         onProviderAdded: () => window.location.reload(),
     });
     const handleOpenConfigModal = () => {
         setConfigModalOpen(true);
+    };
+    const handleApply = async (): Promise<AgentApplyResult> => {
+        try {
+            setIsApplyLoading(true);
+            const result = await api.applyDshConfig(defaultDshPrefs() as Record<string, string>);
+            if (result.success) {
+                const files: string[] = [];
+                if (result.settingsResult?.created || result.settingsResult?.updated) {
+                    files.push('$DSH_HOME/settings.yaml');
+                }
+                if (result.credentialsResult?.created || result.credentialsResult?.updated) {
+                    files.push('$DSH_HOME/.credentials.yaml');
+                }
+                return { success: true, files };
+            }
+            return { success: false, error: result.message || t('scenarioPage.unknownError') };
+        } catch (err: any) {
+            return { success: false, error: err?.message || t('dshConfig.applyFailed') };
+        } finally {
+            setIsApplyLoading(false);
+        }
     };
     return (
         <PageLayout loading={isLoading} loadingContent={<ScenarioPageSkeleton />} notification={notification}>
@@ -71,7 +95,7 @@ const UseDshPageContent: React.FC = () => {
                                 variant="outlined"
                                 size="small"
                             >
-                                {t('scenarioPage.config')}
+                                {t('scenarioPage.autoConfig')}
                             </Button>
                         </Box>
                     }
@@ -95,6 +119,8 @@ const UseDshPageContent: React.FC = () => {
                         { label: t('scenarioPage.dsh.openWebUi'), href: DSH_WEB_UI_URL, variant: 'contained', external: true },
                         { label: t('scenarioPage.dsh.viewRepo'), href: DSH_REPO_URL, variant: 'outlined', external: true },
                     ]}
+                    onApply={handleApply}
+                    isApplyLoading={isApplyLoading}
                     onViewConfig={handleOpenConfigModal}
                     applyStepLabel={t('scenarioPage.dsh.applyStepLabel')}
                     applyStepDescription={t('scenarioPage.dsh.applyStepDescription')}
@@ -111,6 +137,8 @@ const UseDshPageContent: React.FC = () => {
                 <DshConfigModal
                     open={configModalOpen}
                     onClose={() => setConfigModalOpen(false)}
+                    copyToClipboard={copyToClipboard}
+                    showNotification={showNotification}
                 />
                 <ConnectAIDialogs flow={connectAI}/>
             </CardGrid>

--- a/frontend/src/pages/scenario/components/AgentSetupCard.tsx
+++ b/frontend/src/pages/scenario/components/AgentSetupCard.tsx
@@ -240,8 +240,12 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     };
 
     const handleApplyWithStatusLine = async () => {
-        if (!onApplyWithStatusLine) return;
-        const result = await onApplyWithStatusLine();
+        // onApplyWithStatusLine is only provided by callers with an extra
+        // install-time toggle (e.g. Claude Code's status line); everyone else
+        // wires the plain onApply and expects the button to invoke it.
+        const apply = onApplyWithStatusLine ?? onApply;
+        if (!apply) return;
+        const result = await apply();
         setApplyResult(result);
         if (result.success) {
             localStorage.setItem(APPLY_DONE_KEY(agentKey), 'true');

--- a/frontend/src/pages/scenario/components/DshConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/DshConfigModal.tsx
@@ -1,62 +1,339 @@
-import { Dialog, DialogActions, DialogContent, DialogTitle, Button, Typography, Stack, Link } from '@mui/material';
+import { Box, Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, Tab, Tabs, Tooltip, Typography } from '@mui/material';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { RestartAlt } from '@/components/icons';
+import CodeBlock from '@/components/CodeBlock';
+import DshQuickConfig, { type DshPrefs, defaultDshPrefs, mergeSavedDshPrefs } from './DshQuickConfig';
+import { shouldIgnoreDialogClose } from '@/components/dialogClose';
+import { api } from '@/services/api';
+import { useScenarioPageModal } from '@/pages/scenario/context/ScenarioPageContext';
 
 interface DshConfigModalProps {
     open: boolean;
     onClose: () => void;
+    copyToClipboard: (text: string, label: string) => Promise<void>;
+    // Shared page-level toast, used for apply success/error so feedback is
+    // consistent with the rest of the scenario pages.
+    showNotification?: (message: string, severity: 'success' | 'error' | 'info' | 'warning') => void;
 }
 
-const DSH_REPO_URL = 'https://github.com/deepseek-ai/deepseek-harness';
+type MainTab = 'quick' | 'manual';
+type ScriptTab = 'yaml' | 'windows' | 'unix';
+
+const DSH_API_KEY_ENV = 'TINGLY_BOX_API_KEY';
 
 const DshConfigModal: React.FC<DshConfigModalProps> = ({
     open,
     onClose,
+    copyToClipboard,
+    showNotification,
 }) => {
     const { t } = useTranslation();
+    // Fallback for the credentials.yaml preview while the preview request is
+    // in flight.
+    const { token } = useScenarioPageModal();
+    const [mainTab, setMainTab] = React.useState<MainTab>('quick');
+    const [prefs, setPrefs] = React.useState<DshPrefs>(() => defaultDshPrefs());
+    const [settingsTab, setSettingsTab] = React.useState<ScriptTab>('yaml');
+    const [credsTab, setCredsTab] = React.useState<ScriptTab>('yaml');
+    const [settingsYaml, setSettingsYaml] = React.useState<string>('# Loading...');
+    const [credentialsYaml, setCredentialsYaml] = React.useState<string>(`${DSH_API_KEY_ENV}: "${token}"\n`);
+    const [previewModels, setPreviewModels] = React.useState<string[]>([]);
+
+    // True while the applied-config readback is in flight, so the Quick tab
+    // can show a spinner instead of flashing the defaults before the saved
+    // values land.
+    const [isConfigLoading, setIsConfigLoading] = React.useState(false);
+    const [isApplying, setIsApplying] = React.useState(false);
+
+    // On open, restore the prefs previously applied to
+    // $DSH_HOME/settings.yaml; first-time users fall back to defaults.
+    React.useEffect(() => {
+        if (!open) {
+            setPrefs(defaultDshPrefs());
+            setIsConfigLoading(false);
+            return;
+        }
+        let active = true;
+        setIsConfigLoading(true);
+        void api.getAppliedDshConfig().then(result => {
+            if (!active) return;
+            if (result?.success && result.exists) {
+                setPrefs(mergeSavedDshPrefs(result.preferences || {}));
+            } else {
+                setPrefs(defaultDshPrefs());
+            }
+        }).finally(() => {
+            if (active) setIsConfigLoading(false);
+        });
+        return () => {
+            active = false;
+        };
+    }, [open]);
+
+    // Re-render the server-authoritative YAML whenever prefs change while the
+    // modal is open. Debounced so dragging through the Select doesn't spam
+    // the backend.
+    React.useEffect(() => {
+        if (!open) return;
+        let cancelled = false;
+        const handle = setTimeout(async () => {
+            try {
+                const resp = await api.getDshConfigPreview(prefs as Record<string, string>);
+                if (cancelled) return;
+                if (resp?.success) {
+                    setSettingsYaml(resp.settingsYaml || '');
+                    setCredentialsYaml(resp.credentialsYaml || `${DSH_API_KEY_ENV}: "${token}"\n`);
+                    setPreviewModels(resp.models || []);
+                }
+            } catch {
+                // Leave existing placeholders in place.
+            }
+        }, 250);
+        return () => { cancelled = true; clearTimeout(handle); };
+    }, [open, prefs, token]);
+
+    const windowsSettingsScript = `$dshHome = if ($env:DSH_HOME) { $env:DSH_HOME } else { Join-Path $HOME ".dsh" }
+$settingsPath = Join-Path $dshHome "settings.yaml"
+
+New-Item -ItemType Directory -Force -Path $dshHome | Out-Null
+
+@'
+${settingsYaml}
+'@ | Set-Content -Path $settingsPath`;
+
+    const unixSettingsScript = `DSH_HOME="\${DSH_HOME:-$HOME/.dsh}"
+mkdir -p "$DSH_HOME"
+
+cat > "$DSH_HOME/settings.yaml" <<'EOF'
+${settingsYaml}
+EOF`;
+
+    const windowsCredsScript = `$dshHome = if ($env:DSH_HOME) { $env:DSH_HOME } else { Join-Path $HOME ".dsh" }
+$credsPath = Join-Path $dshHome ".credentials.yaml"
+
+New-Item -ItemType Directory -Force -Path $dshHome | Out-Null
+
+@'
+${credentialsYaml}
+'@ | Set-Content -Path $credsPath`;
+
+    const unixCredsScript = `DSH_HOME="\${DSH_HOME:-$HOME/.dsh}"
+mkdir -p "$DSH_HOME"
+
+cat > "$DSH_HOME/.credentials.yaml" <<'EOF'
+${credentialsYaml}
+EOF`;
+
+    const handleApplyConfiguration = async () => {
+        setIsApplying(true);
+        try {
+            const response = await api.applyDshConfig(prefs as Record<string, string>);
+            if (response?.success) {
+                showNotification?.(t('dshConfig.applySuccess'), 'success');
+            } else {
+                showNotification?.(response?.message || t('dshConfig.applyFailed'), 'error');
+            }
+        } catch (err: any) {
+            showNotification?.(err?.message || t('dshConfig.applyFailed'), 'error');
+        } finally {
+            setIsApplying(false);
+        }
+    };
+
     return (
         <Dialog
             open={open}
-            onClose={onClose}
-            maxWidth="sm"
+            onClose={(event, reason) => {
+                if (shouldIgnoreDialogClose(reason)) {
+                    return;
+                }
+                onClose();
+            }}
+            maxWidth="lg"
             fullWidth
             slotProps={{
                 paper: {
                     sx: {
                         borderRadius: 3,
-                    }
+                        maxHeight: '90vh',
+                    },
                 }
             }}
         >
-            <DialogTitle sx={{ pb: 1 }}>
-                <Typography variant="h6" sx={{
-                    fontWeight: 600
-                }}>
-                    {t('scenarioPage.dsh.configTitle')}
+            <DialogTitle sx={{ pb: 1, borderBottom: 1, borderColor: 'divider', position: 'relative' }}>
+                <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                    {t('dshConfig.title')}
                 </Typography>
+                <Typography variant="body2" sx={{ color: 'text.secondary', mt: 0.5 }}>
+                    {t('dshConfig.subtitle')}
+                </Typography>
+                {mainTab === 'quick' && (
+                    <Tooltip title={t('dshConfig.resetTooltip')} arrow>
+                        <IconButton
+                            size="small"
+                            onClick={() => setPrefs(defaultDshPrefs())}
+                            sx={{ position: 'absolute', top: 12, right: 12 }}
+                        >
+                            <RestartAlt fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
+                )}
+                <Tabs
+                    value={mainTab}
+                    onChange={(_, value) => setMainTab(value)}
+                    sx={{ mt: 1, minHeight: 40, '& .MuiTabs-indicator': { height: 3 } }}
+                >
+                    <Tab label={t('dshConfig.tabQuick')} value="quick" sx={{ minHeight: 40, textTransform: 'none' }} />
+                    <Tab label={t('dshConfig.tabManual')} value="manual" sx={{ minHeight: 40, textTransform: 'none' }} />
+                </Tabs>
             </DialogTitle>
-            <DialogContent sx={{ pt: 1 }}>
-                <Stack spacing={2}>
-                    <Typography variant="body2" sx={{
-                        color: "text.secondary"
-                    }}>
-                        {t('scenarioPage.dsh.modalDescription')}
-                    </Typography>
-                    <Button
-                        component={Link}
-                        href={DSH_REPO_URL}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        variant="outlined"
-                    >
-                        {t('scenarioPage.dsh.viewRepo')}
-                    </Button>
-                </Stack>
+            <DialogContent sx={{ p: 3 }}>
+                {mainTab === 'quick' && isConfigLoading && (
+                    <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+                        <CircularProgress size={28} />
+                    </Box>
+                )}
+
+                {mainTab === 'quick' && !isConfigLoading && (
+                    <DshQuickConfig prefs={prefs} setPrefs={setPrefs} />
+                )}
+
+                {mainTab === 'manual' && (
+                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                            <Box sx={{ mb: 1, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                                <Typography variant="subtitle2" sx={{ color: 'text.secondary' }}>
+                                    Step 1 · Create or update `$DSH_HOME/settings.yaml`
+                                </Typography>
+                                <Tabs
+                                    value={settingsTab}
+                                    onChange={(_, value) => setSettingsTab(value)}
+                                    variant="standard"
+                                    sx={{ minHeight: 32, '& .MuiTabs-indicator': { height: 3 } }}
+                                >
+                                    <Tab label="YAML" value="yaml" sx={{ minHeight: 32, py: 0.5, fontSize: '0.875rem' }} />
+                                    <Tab label="Windows" value="windows" sx={{ minHeight: 32, py: 0.5, fontSize: '0.875rem' }} />
+                                    <Tab label="Linux/macOS" value="unix" sx={{ minHeight: 32, py: 0.5, fontSize: '0.875rem' }} />
+                                </Tabs>
+                            </Box>
+                            <Box>
+                                {settingsTab === 'yaml' && (
+                                    <CodeBlock
+                                        code={settingsYaml}
+                                        language="yaml"
+                                        filename="Create or update $DSH_HOME/settings.yaml"
+                                        wrap={true}
+                                        onCopy={(code) => copyToClipboard(code, 'settings.yaml')}
+                                        maxHeight={220}
+                                        minHeight={180}
+                                    />
+                                )}
+                                {settingsTab === 'windows' && (
+                                    <CodeBlock
+                                        code={windowsSettingsScript}
+                                        language="js"
+                                        filename="PowerShell script to setup settings.yaml"
+                                        wrap={true}
+                                        onCopy={(code) => copyToClipboard(code, 'Windows settings script')}
+                                        maxHeight={260}
+                                        minHeight={220}
+                                    />
+                                )}
+                                {settingsTab === 'unix' && (
+                                    <CodeBlock
+                                        code={unixSettingsScript}
+                                        language="js"
+                                        filename="Bash script to setup settings.yaml"
+                                        wrap={true}
+                                        onCopy={(code) => copyToClipboard(code, 'Unix settings script')}
+                                        maxHeight={260}
+                                        minHeight={220}
+                                    />
+                                )}
+                            </Box>
+                        </Box>
+
+                        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                            <Box sx={{ mb: 1, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                                <Typography variant="subtitle2" sx={{ color: 'text.secondary' }}>
+                                    Step 2 · Create or update `$DSH_HOME/.credentials.yaml`
+                                </Typography>
+                                <Tabs
+                                    value={credsTab}
+                                    onChange={(_, value) => setCredsTab(value)}
+                                    variant="standard"
+                                    sx={{ minHeight: 32, '& .MuiTabs-indicator': { height: 3 } }}
+                                >
+                                    <Tab label="YAML" value="yaml" sx={{ minHeight: 32, py: 0.5, fontSize: '0.875rem' }} />
+                                    <Tab label="Windows" value="windows" sx={{ minHeight: 32, py: 0.5, fontSize: '0.875rem' }} />
+                                    <Tab label="Linux/macOS" value="unix" sx={{ minHeight: 32, py: 0.5, fontSize: '0.875rem' }} />
+                                </Tabs>
+                            </Box>
+                            <Box sx={{ mb: 1.5 }}>
+                                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                                    Set `{DSH_API_KEY_ENV}` in `$DSH_HOME/.credentials.yaml` to the API key generated by Tingly Box. If the file already exists, update the existing value.
+                                </Typography>
+                            </Box>
+                            <Box>
+                                {credsTab === 'yaml' && (
+                                    <CodeBlock
+                                        code={credentialsYaml}
+                                        language="yaml"
+                                        filename="Create or update $DSH_HOME/.credentials.yaml"
+                                        wrap={true}
+                                        onCopy={(code) => copyToClipboard(code, '.credentials.yaml')}
+                                        maxHeight={140}
+                                        minHeight={100}
+                                    />
+                                )}
+                                {credsTab === 'windows' && (
+                                    <CodeBlock
+                                        code={windowsCredsScript}
+                                        language="js"
+                                        filename="PowerShell script to setup .credentials.yaml"
+                                        wrap={true}
+                                        onCopy={(code) => copyToClipboard(code, 'Windows credentials script')}
+                                        maxHeight={220}
+                                        minHeight={180}
+                                    />
+                                )}
+                                {credsTab === 'unix' && (
+                                    <CodeBlock
+                                        code={unixCredsScript}
+                                        language="js"
+                                        filename="Bash script to setup .credentials.yaml"
+                                        wrap={true}
+                                        onCopy={(code) => copyToClipboard(code, 'Unix credentials script')}
+                                        maxHeight={220}
+                                        minHeight={180}
+                                    />
+                                )}
+                            </Box>
+                        </Box>
+
+                        {previewModels.length > 0 && (
+                            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                                {t('dshConfig.modelsPreviewNote', { models: previewModels.join(', ') })}
+                            </Typography>
+                        )}
+                    </Box>
+                )}
             </DialogContent>
-            <DialogActions sx={{ px: 3, pb: 2, pt: 1 }}>
-                <Button onClick={onClose} variant="contained">
-                    {t('common.done')}
-                </Button>
+            <DialogActions sx={{ px: 3, pb: 2 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, width: '100%' }}>
+                    <Button onClick={onClose} variant="outlined">
+                        {t('common.close')}
+                    </Button>
+                    <Button
+                        onClick={handleApplyConfiguration}
+                        variant="contained"
+                        disabled={isApplying}
+                        startIcon={isApplying ? <CircularProgress size={16} color="inherit" /> : null}
+                    >
+                        {isApplying ? t('common.applying') : t('scenarioPage.autoConfig')}
+                    </Button>
+                </Box>
             </DialogActions>
         </Dialog>
     );

--- a/frontend/src/pages/scenario/components/DshQuickConfig.tsx
+++ b/frontend/src/pages/scenario/components/DshQuickConfig.tsx
@@ -1,0 +1,176 @@
+import {
+    Box,
+    Divider,
+    MenuItem,
+    Select,
+    Stack,
+    Tooltip,
+    Typography,
+} from '@mui/material';
+import { InfoOutlined as InfoOutlinedIcon } from '@/components/icons';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+// DshPrefs mirrors the Go struct in internal/server/config (DshPrefs). Keys
+// are the literal settings.yaml provider-stanza keys so the object
+// round-trips through the backend without an intermediate mapping layer.
+// All values are strings; "" means "omit this key, dsh treats the provider
+// as text-only".
+export interface DshPrefs {
+    default_input?: string; // "text" | "text_image" | ""
+}
+
+export function defaultDshPrefs(): DshPrefs {
+    // Conservative default: no defaultInput key, so dsh treats the provider
+    // as text-only until the user opts a model into vision — keep this in
+    // sync with Go's DefaultDshPrefs.
+    return {};
+}
+
+// DSH_PREF_KEYS is the single source of truth for the durable dsh pref keys
+// on the frontend (mirrors CODEX_PREF_KEYS in CodexQuickConfig.tsx and the
+// backend DshPrefs struct).
+const DSH_PREF_KEYS = ['default_input'] as const satisfies readonly (keyof DshPrefs)[];
+
+// Merge a previously-applied prefs object over the current defaults so
+// reopening the dsh config modal restores durable user choices rather than
+// resetting to defaults every time.
+export function mergeSavedDshPrefs(applied: DshPrefs = {}): DshPrefs {
+    const merged: DshPrefs = { ...defaultDshPrefs() };
+    for (const key of DSH_PREF_KEYS) {
+        const v = applied[key];
+        if (v !== undefined && v !== '') {
+            merged[key] = v;
+        }
+    }
+    return merged;
+}
+
+type Lang = 'zh' | 'en';
+
+const UNSET = '';
+const DEFAULT_INPUT_VALUES = ['text', 'text_image'];
+
+interface FieldText {
+    label: string;
+    purpose: string;
+    tooltip: string;
+}
+
+const FIELD_TEXT: Record<Lang, FieldText> = {
+    zh: {
+        label: '支持的输入模态',
+        purpose: '控制该 provider 下的模型默认能否接收图片',
+        tooltip: 'text 仅文本；text_image 允许图片输入。留空表示不写入 defaultInput，dsh 按文本模型处理。',
+    },
+    en: {
+        label: 'Supported input modality',
+        purpose: 'Whether models under this provider accept image input by default',
+        tooltip: 'text is text-only; text_image also accepts images. Empty = omit defaultInput, dsh treats models as text-only.',
+    },
+};
+
+const VALUE_LABEL: Record<Lang, Record<string, string>> = {
+    zh: { text: 'text（仅文本）', text_image: 'text_image（文本 + 图片）' },
+    en: { text: 'text (text-only)', text_image: 'text_image (text + image)' },
+};
+
+const UI_TEXT: Record<Lang, { panelHeader: string; sectionTitle: string; sectionHint: string; unsetLabel: string }> = {
+    zh: {
+        panelHeader: '这些项写入 $DSH_HOME/settings.yaml 的 tingly-box provider 条目',
+        sectionTitle: '模型能力',
+        sectionHint: '留空表示用 dsh 默认（仅文本）',
+        unsetLabel: '（默认，仅文本）',
+    },
+    en: {
+        panelHeader: 'Written into the tingly-box provider entry in $DSH_HOME/settings.yaml',
+        sectionTitle: 'Model capabilities',
+        sectionHint: 'Empty = dsh default (text-only)',
+        unsetLabel: '(default, text-only)',
+    },
+};
+
+function useLang(): Lang {
+    const { i18n } = useTranslation();
+    return i18n.language === 'zh' ? 'zh' : 'en';
+}
+
+interface DshQuickConfigProps {
+    prefs: DshPrefs;
+    setPrefs: (p: DshPrefs) => void;
+}
+
+const DshQuickConfig: React.FC<DshQuickConfigProps> = ({ prefs, setPrefs }) => {
+    const lang = useLang();
+    const uiText = UI_TEXT[lang];
+    const text = FIELD_TEXT[lang];
+    const valueLabel = VALUE_LABEL[lang];
+
+    const value = prefs.default_input ?? '';
+    const setValue = (next: string) => setPrefs({ ...prefs, default_input: next });
+
+    const richTooltip = (
+        <Box sx={{ maxWidth: 280 }}>
+            <Typography variant="caption" sx={{ display: 'block', mb: 0.5 }}>{text.purpose}</Typography>
+            <Typography variant="caption" sx={{ display: 'block', opacity: 0.85 }}>{text.tooltip}</Typography>
+        </Box>
+    );
+
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>{uiText.panelHeader}</Typography>
+            <Box>
+                <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5, mb: 0.5 }}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{uiText.sectionTitle}</Typography>
+                    <Typography variant="caption" sx={{ color: 'text.secondary' }}>{uiText.sectionHint}</Typography>
+                </Box>
+                <Divider />
+                <Stack>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 1, minHeight: 44 }}>
+                        <Box sx={{ flex: '0 0 180px', display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                            <Typography variant="body2" noWrap sx={{ fontWeight: 500 }}>{text.label}</Typography>
+                            <Tooltip placement="top" arrow title={richTooltip}>
+                                <InfoOutlinedIcon sx={{ fontSize: 14, color: 'text.disabled', cursor: 'help' }} />
+                            </Tooltip>
+                        </Box>
+                        <Box sx={{ flex: '0 0 320px', minWidth: 0 }}>
+                            <Box
+                                component="span"
+                                sx={{
+                                    px: 0.75,
+                                    py: 0.25,
+                                    borderRadius: 0.75,
+                                    bgcolor: 'action.hover',
+                                    fontFamily: 'monospace',
+                                    fontSize: '0.72rem',
+                                    color: 'text.secondary',
+                                    whiteSpace: 'nowrap',
+                                }}
+                            >
+                                defaultInput
+                            </Box>
+                        </Box>
+                        <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}>
+                            <Select
+                                size="small"
+                                value={value}
+                                displayEmpty
+                                onChange={(e) => setValue(e.target.value)}
+                                sx={{ minWidth: 220, fontSize: '0.85rem' }}
+                            >
+                                <MenuItem value={UNSET}>
+                                    <Typography variant="body2" sx={{ color: 'text.disabled' }}>{uiText.unsetLabel}</Typography>
+                                </MenuItem>
+                                {DEFAULT_INPUT_VALUES.map((v) => (
+                                    <MenuItem key={v} value={v} sx={{ fontSize: '0.85rem' }}>{valueLabel[v]}</MenuItem>
+                                ))}
+                            </Select>
+                        </Box>
+                    </Box>
+                </Stack>
+            </Box>
+        </Box>
+    );
+};
+
+export default DshQuickConfig;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -536,6 +536,13 @@ export const api = {
         return controlApi((client, headers) => (client as any).GET('/api/v1/config/codex', {headers}));
     },
 
+    // Placeholder for the DeepSeek Harness (dsh) applied-config endpoint. Uses
+    // the generated client's runtime transport; remove the casts after the
+    // next OpenAPI client regeneration includes this route.
+    getAppliedDshConfig: async (): Promise<any> => {
+        return controlApi((client, headers) => (client as any).GET('/api/v1/config/dsh', {headers}));
+    },
+
     getProfiles: async (scenario: string): Promise<any> => {
         return controlApi((client, headers) => client.GET('/api/v1/scenario/{scenario}/profiles', {
             headers,
@@ -1161,6 +1168,50 @@ export const api = {
             return unwrap(response);
         } catch (error: any) {
             return { success: false, message: error?.message || 'Failed to preview Codex configuration' };
+        }
+    },
+
+    applyDshConfig: async (
+        preferences?: Record<string, string>,
+    ): Promise<any> => {
+        try {
+            const client = await getClient();
+            const headers = await getAuthHeaders();
+            const response = await (client as any).POST('/api/v1/config/apply/dsh', {
+                headers,
+                body: {
+                    preferences: preferences ?? {},
+                },
+            });
+            // Callers read `message` (not `error`) on this endpoint — keep the
+            // shape but carry the backend's real message instead of a generic.
+            if (response.error) {
+                return { success: false, message: errorMessage(response.error) };
+            }
+            return unwrap(response);
+        } catch (error: any) {
+            return { success: false, message: error?.message || 'Failed to apply DeepSeek Harness configuration' };
+        }
+    },
+
+    getDshConfigPreview: async (
+        preferences?: Record<string, string>,
+    ): Promise<any> => {
+        try {
+            const client = await getClient();
+            const headers = await getAuthHeaders();
+            const response = await (client as any).POST('/api/v1/config/preview/dsh', {
+                headers,
+                body: {
+                    preferences: preferences ?? {},
+                },
+            });
+            if (response.error) {
+                return { success: false, message: errorMessage(response.error) };
+            }
+            return unwrap(response);
+        } catch (error: any) {
+            return { success: false, message: error?.message || 'Failed to preview DeepSeek Harness configuration' };
         }
     },
 

--- a/internal/agent/rule.go
+++ b/internal/agent/rule.go
@@ -31,6 +31,13 @@ var CodexRequestModels = []string{
 	"tingly-codex",
 }
 
+// DshRequestModels defines the default request models for the dsh scenario.
+// Users typically add additional rules with their own request_model names;
+// this list only seeds the default rule when none exists yet.
+var DshRequestModels = []string{
+	"tingly-dsh",
+}
+
 // createOrUpdateClaudeCodeRules creates or updates all Claude Code rules.
 // For convenience, all tingly/cc-* rules are updated with the same provider + model.
 func (aa *AgentApply) createOrUpdateClaudeCodeRules(providerUUID, model string) (int, int, error) {
@@ -47,6 +54,13 @@ func (aa *AgentApply) createOrUpdateOpenCodeRules(providerUUID, model string) (i
 // needs *some* active rule to seed the generated config.toml.
 func (aa *AgentApply) createOrUpdateCodexRules(providerUUID, model string) (int, int, error) {
 	return aa.createOrUpdateRulesForScenario(typ.ScenarioCodex, "Codex", CodexRequestModels, providerUUID, model)
+}
+
+// createOrUpdateDshRules creates or updates the default dsh rule (tingly-dsh).
+// Other dsh rules the user has added by hand are left alone — dsh apply just
+// needs *some* active rule to seed the generated settings.yaml.
+func (aa *AgentApply) createOrUpdateDshRules(providerUUID, model string) (int, int, error) {
+	return aa.createOrUpdateRulesForScenario(typ.ScenarioDsh, "DeepSeek Harness", DshRequestModels, providerUUID, model)
 }
 
 // createOrUpdateRulesForScenario applies a single provider+model to every request

--- a/internal/agent/rule_bridge.go
+++ b/internal/agent/rule_bridge.go
@@ -42,6 +42,9 @@ const (
 
 	// AgentTypeCodex represents the OpenAI Codex CLI
 	AgentTypeCodex = aiagent.AgentTypeCodex
+
+	// AgentTypeDsh represents the DeepSeek Harness CLI
+	AgentTypeDsh = aiagent.AgentTypeDsh
 )
 
 // Re-export functions for backward compatibility
@@ -135,6 +138,21 @@ func (aa *AgentApply) ApplyAgent(req *ApplyAgentRequest) (*ApplyAgentResult, err
 			Prefs:        aiagent.DefaultCodexPrefs(),
 			WriteCatalog: true,
 		})
+	case AgentTypeDsh:
+		config, ok := aiagent.DefaultRegistry.Get(req.AgentType)
+		if !ok {
+			return nil, fmt.Errorf("dsh config not registered")
+		}
+		dshBaseURL := baseURL + "/tingly/dsh"
+		// Collect models with business logic
+		rawModels := aa.collectDshRuleModels()
+		models := CollectCodexModels(rawModels)
+		fileResult, err = config.Apply(&aiagent.DshParams{
+			DshBaseURL: dshBaseURL,
+			APIKey:     apiKey,
+			Models:     models,
+			Prefs:      aiagent.DefaultDshPrefs(),
+		})
 	}
 
 	if err != nil {
@@ -176,6 +194,8 @@ func (aa *AgentApply) createOrUpdateRules(agentType AgentType, providerUUID, mod
 		return aa.createOrUpdateOpenCodeRules(providerUUID, model)
 	case AgentTypeCodex:
 		return aa.createOrUpdateCodexRules(providerUUID, model)
+	case AgentTypeDsh:
+		return aa.createOrUpdateDshRules(providerUUID, model)
 	default:
 		return 0, 0, fmt.Errorf("agent type %s not implemented", agentType)
 	}
@@ -196,6 +216,19 @@ func (aa *AgentApply) collectCodexRuleModels() []string {
 	var models []string
 	for _, rule := range aa.config.GetRequestConfigs() {
 		if rule.GetScenario() != typ.ScenarioCodex || !rule.Active {
+			continue
+		}
+		models = append(models, rule.RequestModel)
+	}
+	return CollectCodexModels(models)
+}
+
+// collectDshRuleModels returns the request_models of every active rule under
+// the dsh scenario, deduplicated and in declaration order.
+func (aa *AgentApply) collectDshRuleModels() []string {
+	var models []string
+	for _, rule := range aa.config.GetRequestConfigs() {
+		if rule.GetScenario() != typ.ScenarioDsh || !rule.Active {
 			continue
 		}
 		models = append(models, rule.RequestModel)

--- a/internal/agent/types_test.go
+++ b/internal/agent/types_test.go
@@ -90,8 +90,8 @@ func TestAgentTypeIsValid(t *testing.T) {
 func TestListAgentInfo(t *testing.T) {
 	info := ListAgentInfo()
 
-	if len(info) != 3 {
-		t.Errorf("ListAgentInfo() returned %d items, want 3", len(info))
+	if len(info) != 4 {
+		t.Errorf("ListAgentInfo() returned %d items, want 4", len(info))
 	}
 
 	// Check Claude Code info

--- a/internal/server/config/apply_config_dsh.go
+++ b/internal/server/config/apply_config_dsh.go
@@ -1,0 +1,321 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	yamlpkg "gopkg.in/yaml.v3"
+)
+
+// DeepSeek Harness (dsh) config/credentials application: render and merge the
+// tingly-managed provider stanza of $DSH_HOME/settings.yaml, and the
+// tingly-managed key in $DSH_HOME/.credentials.yaml.
+//
+// dsh splits its config the same way Codex does: a settings file that
+// references credentials indirectly (apiKeyEnv names an env var rather than
+// embedding the secret) and a separate write-only credentials file. See
+// https://deepseek-harness.github.io/deepseek-harness/en/guide/providers.
+
+// dshGatewayProviderName is the tingly-box provider key written into
+// settings.yaml's `llm-pi-ai.providers` map by mergeDshSettings.
+const dshGatewayProviderName = "tingly-box"
+
+// dshAPIKeyEnvName is the env var name settings.yaml's apiKeyEnv points at,
+// and the key written into .credentials.yaml. Fixed rather than
+// user-configurable: it's an implementation detail of dsh's credential
+// indirection, not a user-tunable knob.
+const dshAPIKeyEnvName = "TINGLY_BOX_API_KEY"
+
+// dshHomeDir resolves $DSH_HOME, falling back to ~/.dsh when unset (dsh's
+// docs do not state a default; ~/.dsh follows the common single-dotdir
+// convention used by similar CLIs).
+func dshHomeDir() (string, error) {
+	if v := strings.TrimSpace(os.Getenv("DSH_HOME")); v != "" {
+		return v, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	if home == "" {
+		return "", fmt.Errorf("home directory resolved to empty path")
+	}
+	return filepath.Join(home, ".dsh"), nil
+}
+
+// DshPrefs is the typed, user-tunable surface of settings.yaml's tingly-box
+// provider entry. DefaultInput mirrors the provider-level `defaultInput` key
+// ("text" or "text_image" -> [text] / [text, image]); empty omits the key so
+// dsh treats the provider as text-only — the conservative default for models
+// tingly-box cannot verify support vision (same stance as Codex's third-party
+// defaults, see .design/codex-config.md).
+type DshPrefs struct {
+	DefaultInput string `json:"default_input,omitempty"`
+}
+
+// DefaultDshPrefs returns the defaults for the CLI path and no-prefs
+// fallback: DefaultInput unset (text-only).
+func DefaultDshPrefs() *DshPrefs {
+	return &DshPrefs{}
+}
+
+// dshDefaultInputList converts the enum value into the YAML modality list,
+// or nil for an unset/invalid value (dropped, forward-compatible).
+func dshDefaultInputList(val string) []string {
+	switch val {
+	case "text":
+		return []string{"text"}
+	case "text_image":
+		return []string{"text", "image"}
+	default:
+		return nil
+	}
+}
+
+// toConfig converts prefs into the provider-stanza fields it controls.
+func (p *DshPrefs) toConfig() map[string]interface{} {
+	out := map[string]interface{}{}
+	if p == nil {
+		return out
+	}
+	if list := dshDefaultInputList(strings.TrimSpace(p.DefaultInput)); list != nil {
+		out["defaultInput"] = list
+	}
+	return out
+}
+
+// DshPrefsFromConfig is the inverse of toConfig: it extracts DefaultInput
+// from a parsed tingly-box provider stanza.
+func DshPrefsFromConfig(providerStanza map[string]interface{}) *DshPrefs {
+	prefs := &DshPrefs{}
+	list, ok := providerStanza["defaultInput"].([]interface{})
+	if !ok || len(list) == 0 {
+		return prefs
+	}
+	hasImage := false
+	for _, v := range list {
+		if s, ok := v.(string); ok && s == "image" {
+			hasImage = true
+		}
+	}
+	if hasImage {
+		prefs.DefaultInput = "text_image"
+	} else {
+		prefs.DefaultInput = "text"
+	}
+	return prefs
+}
+
+// dshProviderStanza drills into cfg["llm-pi-ai"]["providers"]["tingly-box"]
+// and returns it if present.
+func dshProviderStanza(cfg map[string]interface{}) (map[string]interface{}, bool) {
+	root, ok := cfg["llm-pi-ai"].(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	providers, ok := root["providers"].(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	stanza, ok := providers[dshGatewayProviderName].(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	return stanza, true
+}
+
+// ReadDshSettings reads $DSH_HOME/settings.yaml and returns the typed prefs
+// and whether a tingly-managed provider stanza exists. A missing or
+// unparseable file yields empty prefs, exists=false, so the form falls back
+// to defaults rather than erroring on first-time setup.
+func ReadDshSettings() (prefs *DshPrefs, exists bool, err error) {
+	dshHome, err := dshHomeDir()
+	if err != nil {
+		return nil, false, err
+	}
+	targetPath := filepath.Join(dshHome, "settings.yaml")
+
+	data, readErr := os.ReadFile(targetPath)
+	if readErr != nil {
+		return DefaultDshPrefs(), false, nil
+	}
+
+	cfg := map[string]interface{}{}
+	if err := yamlpkg.Unmarshal(data, &cfg); err != nil {
+		return DefaultDshPrefs(), false, nil
+	}
+
+	stanza, ok := dshProviderStanza(cfg)
+	if !ok {
+		return DefaultDshPrefs(), false, nil
+	}
+	return DshPrefsFromConfig(stanza), true, nil
+}
+
+// ApplyDshSettings merges tingly-box's provider entry into
+// $DSH_HOME/settings.yaml.
+//
+// MERGE semantics: only the `llm-pi-ai.providers.tingly-box` stanza is
+// overwritten; everything else the user has in settings.yaml — other
+// providers, unrelated top-level keys — is left alone. The previous file (if
+// any) is backed up before rewrite.
+func ApplyDshSettings(baseURL string, models []string, prefs *DshPrefs) (*ApplyResult, error) {
+	dshHome, err := dshHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	targetPath := filepath.Join(dshHome, "settings.yaml")
+	result := &ApplyResult{}
+
+	if err := os.MkdirAll(dshHome, 0755); err != nil {
+		result.Message = fmt.Sprintf("Failed to create directory: %v", err)
+		return result, nil
+	}
+
+	existing := map[string]interface{}{}
+	if data, err := os.ReadFile(targetPath); err == nil {
+		if err := yamlpkg.Unmarshal(data, &existing); err != nil {
+			result.Message = fmt.Sprintf("Failed to parse existing settings.yaml: %v", err)
+			return result, nil
+		}
+		backupPath, err := backupFile(targetPath)
+		if err != nil {
+			result.Message = fmt.Sprintf("Failed to create backup: %v", err)
+			return result, nil
+		}
+		result.BackupPath = backupPath
+		result.Updated = true
+	} else {
+		result.Created = true
+	}
+
+	mergeDshSettings(existing, baseURL, models, prefs)
+
+	out, err := yamlpkg.Marshal(existing)
+	if err != nil {
+		result.Message = fmt.Sprintf("Failed to marshal settings.yaml: %v", err)
+		return result, nil
+	}
+	if err := os.WriteFile(targetPath, out, 0644); err != nil {
+		result.Message = fmt.Sprintf("Failed to write file: %v", err)
+		return result, nil
+	}
+
+	result.Success = true
+	if result.Created {
+		result.Message = fmt.Sprintf("Created %s", targetPath)
+	} else if result.BackupPath != "" {
+		result.Message = fmt.Sprintf("Updated %s (backup: %s)", targetPath, result.BackupPath)
+	} else {
+		result.Message = fmt.Sprintf("Updated %s", targetPath)
+	}
+	return result, nil
+}
+
+// RenderDshSettingsYAML returns the YAML that would be written to a fresh
+// settings.yaml — i.e. the merge applied to an empty starting point. Used by
+// the preview endpoint so the UI can show exactly what's pending.
+func RenderDshSettingsYAML(baseURL string, models []string, prefs *DshPrefs) ([]byte, error) {
+	cfg := map[string]interface{}{}
+	mergeDshSettings(cfg, baseURL, models, prefs)
+	return yamlpkg.Marshal(cfg)
+}
+
+// mergeDshSettings mutates cfg in place, applying the tingly-box provider
+// stanza while preserving everything else. See ApplyDshSettings for the
+// contract.
+func mergeDshSettings(cfg map[string]interface{}, baseURL string, models []string, prefs *DshPrefs) {
+	root, _ := cfg["llm-pi-ai"].(map[string]interface{})
+	if root == nil {
+		root = map[string]interface{}{}
+	}
+	providers, _ := root["providers"].(map[string]interface{})
+	if providers == nil {
+		providers = map[string]interface{}{}
+	}
+
+	modelEntries := make([]map[string]interface{}, 0, len(models))
+	for _, model := range models {
+		modelEntries = append(modelEntries, map[string]interface{}{"id": model})
+	}
+
+	stanza := map[string]interface{}{
+		"apiKeyEnv": dshAPIKeyEnvName,
+		"api":       "openai-completions",
+		"baseURL":   baseURL,
+		"models":    modelEntries,
+	}
+	for k, v := range prefs.toConfig() {
+		stanza[k] = v
+	}
+
+	providers[dshGatewayProviderName] = stanza
+	root["providers"] = providers
+	cfg["llm-pi-ai"] = root
+}
+
+// RenderDshCredentialsYAML returns the YAML that would be written to a fresh
+// .credentials.yaml — i.e. just the tingly-managed key. Used by the preview
+// endpoint; the real ApplyDshCredentials merges into any existing file.
+func RenderDshCredentialsYAML(apiKey string) ([]byte, error) {
+	return yamlpkg.Marshal(map[string]string{dshAPIKeyEnvName: apiKey})
+}
+
+// ApplyDshCredentials writes $DSH_HOME/.credentials.yaml, setting only the
+// tingly-box managed env var key; other keys already in the file (other
+// providers' credentials) are preserved. The previous file (if any) is
+// backed up before modification.
+func ApplyDshCredentials(apiKey string) (*ApplyResult, error) {
+	dshHome, err := dshHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	targetPath := filepath.Join(dshHome, ".credentials.yaml")
+	result := &ApplyResult{}
+
+	if err := os.MkdirAll(dshHome, 0755); err != nil {
+		result.Message = fmt.Sprintf("Failed to create directory: %v", err)
+		return result, nil
+	}
+
+	existing := map[string]interface{}{}
+	if data, err := os.ReadFile(targetPath); err == nil {
+		if err := yamlpkg.Unmarshal(data, &existing); err != nil {
+			result.Message = fmt.Sprintf("Failed to parse existing .credentials.yaml: %v", err)
+			return result, nil
+		}
+		backupPath, err := backupFile(targetPath)
+		if err != nil {
+			result.Message = fmt.Sprintf("Failed to create backup: %v", err)
+			return result, nil
+		}
+		result.BackupPath = backupPath
+		result.Updated = true
+	} else {
+		result.Created = true
+	}
+
+	existing[dshAPIKeyEnvName] = apiKey
+
+	out, err := yamlpkg.Marshal(existing)
+	if err != nil {
+		result.Message = fmt.Sprintf("Failed to marshal .credentials.yaml: %v", err)
+		return result, nil
+	}
+	if err := os.WriteFile(targetPath, out, 0600); err != nil {
+		result.Message = fmt.Sprintf("Failed to write file: %v", err)
+		return result, nil
+	}
+
+	result.Success = true
+	if result.Created {
+		result.Message = fmt.Sprintf("Created %s", targetPath)
+	} else if result.BackupPath != "" {
+		result.Message = fmt.Sprintf("Updated %s (backup: %s)", targetPath, result.BackupPath)
+	} else {
+		result.Message = fmt.Sprintf("Updated %s", targetPath)
+	}
+	return result, nil
+}

--- a/internal/server/config/apply_config_dsh_test.go
+++ b/internal/server/config/apply_config_dsh_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yamlpkg "gopkg.in/yaml.v3"
+)
+
+// ============================================================================
+// ApplyDshSettings / ApplyDshCredentials tests
+//
+// Contract: writing $DSH_HOME/settings.yaml and .credentials.yaml must MERGE —
+// only the tingly-box provider stanza / managed key is overwritten. Unrelated
+// providers, top-level keys, and credential entries must survive.
+// ============================================================================
+
+func loadDshYAMLForTest(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	cfg := map[string]interface{}{}
+	require.NoError(t, yamlpkg.Unmarshal(data, &cfg))
+	return cfg
+}
+
+func TestApplyDshSettings_CreatesFreshFile(t *testing.T) {
+	dshHome := t.TempDir()
+	t.Setenv("DSH_HOME", dshHome)
+
+	result, err := ApplyDshSettings("https://tingly.local/tingly/dsh", []string{"tingly-dsh"}, DefaultDshPrefs())
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.True(t, result.Created)
+	assert.Empty(t, result.BackupPath)
+
+	cfg := loadDshYAMLForTest(t, filepath.Join(dshHome, "settings.yaml"))
+	stanza, ok := dshProviderStanza(cfg)
+	require.True(t, ok, "expected llm-pi-ai.providers.tingly-box stanza")
+	assert.Equal(t, "https://tingly.local/tingly/dsh", stanza["baseURL"])
+	assert.Equal(t, dshAPIKeyEnvName, stanza["apiKeyEnv"])
+	assert.Equal(t, "openai-completions", stanza["api"])
+	assert.NotContains(t, stanza, "defaultInput", "unset prefs must not write defaultInput")
+}
+
+func TestApplyDshSettings_PreservesUnrelatedProvidersAndKeys(t *testing.T) {
+	dshHome := t.TempDir()
+	t.Setenv("DSH_HOME", dshHome)
+
+	seed := "otherTopLevelKey: keepme\n" +
+		"llm-pi-ai:\n" +
+		"  providers:\n" +
+		"    other-gateway:\n" +
+		"      apiKeyEnv: OTHER_KEY\n" +
+		"      api: openai-completions\n" +
+		"      baseURL: https://other.example/v1\n" +
+		"      models:\n" +
+		"        - id: other-model\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dshHome, "settings.yaml"), []byte(seed), 0644))
+
+	result, err := ApplyDshSettings("https://tingly.local/tingly/dsh", []string{"tingly-dsh"}, DefaultDshPrefs())
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.True(t, result.Updated)
+	assert.NotEmpty(t, result.BackupPath)
+
+	cfg := loadDshYAMLForTest(t, filepath.Join(dshHome, "settings.yaml"))
+	assert.Equal(t, "keepme", cfg["otherTopLevelKey"])
+
+	root := cfg["llm-pi-ai"].(map[string]interface{})
+	providers := root["providers"].(map[string]interface{})
+	other, ok := providers["other-gateway"].(map[string]interface{})
+	require.True(t, ok, "expected other-gateway provider to survive the merge")
+	assert.Equal(t, "https://other.example/v1", other["baseURL"])
+
+	_, ok = providers[dshGatewayProviderName]
+	assert.True(t, ok, "expected tingly-box provider stanza to be written")
+}
+
+func TestApplyDshSettings_DefaultInputEnum(t *testing.T) {
+	dshHome := t.TempDir()
+	t.Setenv("DSH_HOME", dshHome)
+
+	result, err := ApplyDshSettings("https://tingly.local/tingly/dsh", []string{"vision-model"}, &DshPrefs{DefaultInput: "text_image"})
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+
+	cfg := loadDshYAMLForTest(t, filepath.Join(dshHome, "settings.yaml"))
+	stanza, ok := dshProviderStanza(cfg)
+	require.True(t, ok)
+	assert.Equal(t, []interface{}{"text", "image"}, stanza["defaultInput"])
+}
+
+func TestReadDshSettings_RoundTrip(t *testing.T) {
+	dshHome := t.TempDir()
+	t.Setenv("DSH_HOME", dshHome)
+
+	// No file yet — not tingly-managed, defaults returned.
+	prefs, exists, err := ReadDshSettings()
+	require.NoError(t, err)
+	assert.False(t, exists)
+	assert.Equal(t, DefaultDshPrefs(), prefs)
+
+	_, err = ApplyDshSettings("https://tingly.local/tingly/dsh", []string{"m1"}, &DshPrefs{DefaultInput: "text_image"})
+	require.NoError(t, err)
+
+	prefs, exists, err = ReadDshSettings()
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "text_image", prefs.DefaultInput)
+}
+
+func TestApplyDshCredentials_PreservesOtherKeys(t *testing.T) {
+	dshHome := t.TempDir()
+	t.Setenv("DSH_HOME", dshHome)
+
+	seed := "OTHER_KEY: other-secret\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dshHome, ".credentials.yaml"), []byte(seed), 0600))
+
+	result, err := ApplyDshCredentials("sk-test")
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.True(t, result.Updated)
+	assert.NotEmpty(t, result.BackupPath)
+
+	cfg := loadDshYAMLForTest(t, filepath.Join(dshHome, ".credentials.yaml"))
+	assert.Equal(t, "other-secret", cfg["OTHER_KEY"])
+	assert.Equal(t, "sk-test", cfg[dshAPIKeyEnvName])
+
+	info, err := os.Stat(filepath.Join(dshHome, ".credentials.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestRenderDshSettingsYAML_MatchesApply(t *testing.T) {
+	dshHome := t.TempDir()
+	t.Setenv("DSH_HOME", dshHome)
+
+	rendered, err := RenderDshSettingsYAML("https://tingly.local/tingly/dsh", []string{"tingly-dsh"}, DefaultDshPrefs())
+	require.NoError(t, err)
+
+	_, err = ApplyDshSettings("https://tingly.local/tingly/dsh", []string{"tingly-dsh"}, DefaultDshPrefs())
+	require.NoError(t, err)
+	written, err := os.ReadFile(filepath.Join(dshHome, "settings.yaml"))
+	require.NoError(t, err)
+
+	assert.YAMLEq(t, string(rendered), string(written))
+}

--- a/internal/server/module/configapply/handler_dsh.go
+++ b/internal/server/module/configapply/handler_dsh.go
@@ -1,0 +1,164 @@
+package configapply
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tingly-dev/tingly-box/internal/agent"
+	"github.com/tingly-dev/tingly-box/internal/middleware"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// collectDshRuleModels returns the request_models of every active rule in
+// the dsh scenario, deduplicated and in declaration order.
+func collectDshRuleModels(cfg *config.Config) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, rule := range cfg.GetRequestConfigs() {
+		if rule.GetScenario() != typ.ScenarioDsh || !rule.Active {
+			continue
+		}
+		model := strings.TrimSpace(rule.RequestModel)
+		if model == "" {
+			continue
+		}
+		if _, dup := seen[model]; dup {
+			continue
+		}
+		seen[model] = struct{}{}
+		out = append(out, model)
+	}
+	return out
+}
+
+// GetDshConfig reads the values previously applied to the user's
+// $DSH_HOME/settings.yaml so reopening the editor restores durable state.
+// Routing/auth fields are not returned (see DshConfigResponse).
+func (h *Handler) GetDshConfig(c *gin.Context) {
+	prefs, exists, err := config.ReadDshSettings()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+	if prefs == nil {
+		prefs = config.DefaultDshPrefs()
+	}
+	c.JSON(http.StatusOK, DshConfigResponse{
+		Success:     true,
+		Exists:      exists,
+		Preferences: *prefs,
+	})
+}
+
+// ApplyDshConfigFromState applies the DeepSeek Harness (dsh) configuration
+// derived from the active dsh scenario rules. Mirrors the Codex endpoint: it
+// does NOT touch routing rules — those are managed via the rules UI.
+func (h *Handler) ApplyDshConfigFromState(c *gin.Context) {
+	cfg := h.config
+	if cfg == nil {
+		c.JSON(http.StatusInternalServerError, ApplyDshConfigResponse{
+			Success: false,
+			Message: "Global config not available",
+		})
+		return
+	}
+
+	// preferences is optional; an absent/empty body falls back to defaults.
+	var req ApplyDshConfigRequest
+	_ = c.ShouldBindJSON(&req)
+	prefs := req.Preferences
+	if prefs == nil {
+		prefs = config.DefaultDshPrefs()
+	}
+
+	models := collectDshRuleModels(cfg)
+
+	port := h.resolvedPort()
+	dshBaseURL := middleware.BaseURLFromRequest(c, port) + "/tingly/dsh"
+	apiKey := h.config.GetModelToken()
+
+	settingsResult, err := config.ApplyDshSettings(dshBaseURL, models, prefs)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ApplyDshConfigResponse{
+			Success: false,
+			Message: "Internal error: " + err.Error(),
+		})
+		return
+	}
+	credsResult, err := config.ApplyDshCredentials(apiKey)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ApplyDshConfigResponse{
+			Success: false,
+			Message: "Internal error: " + err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, ApplyDshConfigResponse{
+		Success:           settingsResult.Success && credsResult.Success,
+		SettingsResult:    *settingsResult,
+		CredentialsResult: *credsResult,
+		Models:            models,
+	})
+}
+
+// GetDshConfigPreview returns the YAML that ApplyDshConfigFromState would
+// write to fresh files. The real apply still merges into any existing
+// $DSH_HOME/settings.yaml / .credentials.yaml; this preview just shows the
+// managed slice.
+func (h *Handler) GetDshConfigPreview(c *gin.Context) {
+	cfg := h.config
+	if cfg == nil {
+		c.JSON(http.StatusInternalServerError, DshConfigPreviewResponse{
+			Success: false,
+			Message: "Global config not available",
+		})
+		return
+	}
+
+	var req ApplyDshConfigRequest
+	_ = c.ShouldBindJSON(&req)
+	prefs := req.Preferences
+	if prefs == nil {
+		prefs = config.DefaultDshPrefs()
+	}
+
+	models := collectDshRuleModels(cfg)
+
+	port := h.resolvedPort()
+	dshBaseURL := middleware.BaseURLFromRequest(c, port) + "/tingly/dsh"
+	apiKey := h.config.GetModelToken()
+
+	settingsYaml, err := config.RenderDshSettingsYAML(dshBaseURL, models, prefs)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, DshConfigPreviewResponse{
+			Success: false,
+			Message: "Failed to render settings: " + err.Error(),
+		})
+		return
+	}
+
+	credentialsYamlBytes, err := config.RenderDshCredentialsYAML(apiKey)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, DshConfigPreviewResponse{
+			Success: false,
+			Message: "Failed to render credentials: " + err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, DshConfigPreviewResponse{
+		Success:         true,
+		SettingsYaml:    string(settingsYaml),
+		CredentialsYaml: string(credentialsYamlBytes),
+		Models:          models,
+	})
+}
+
+// RestoreDshConfig rolls back dsh config files to their most recent backup.
+func (h *Handler) RestoreDshConfig(c *gin.Context) {
+	h.restoreAgent(c, agent.AgentTypeDsh)
+}

--- a/internal/server/module/configapply/routes.go
+++ b/internal/server/module/configapply/routes.go
@@ -29,6 +29,12 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 		swagger.WithResponseModel(CodexConfigResponse{}),
 	)
 
+	router.GET("/config/dsh", handler.GetDshConfig,
+		swagger.WithDescription("Get the currently applied DeepSeek Harness (dsh) preferences"),
+		swagger.WithTags("config"),
+		swagger.WithResponseModel(DshConfigResponse{}),
+	)
+
 	// Config apply endpoints - requires authentication (applied by caller)
 	router.POST("/config/apply/claude", handler.ApplyClaudeConfig,
 		swagger.WithDescription("Generate and apply Claude Code configuration from system state"),
@@ -50,6 +56,13 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 		swagger.WithResponseModel(ApplyCodexConfigResponse{}),
 	)
 
+	router.POST("/config/apply/dsh", handler.ApplyDshConfigFromState,
+		swagger.WithDescription("Generate and apply DeepSeek Harness (dsh) configuration from system state"),
+		swagger.WithTags("config"),
+		swagger.WithRequestModel(ApplyDshConfigRequest{}),
+		swagger.WithResponseModel(ApplyDshConfigResponse{}),
+	)
+
 	// Config preview endpoint - returns config for display without applying
 	router.GET("/config/preview/opencode", handler.GetOpenCodeConfigPreview,
 		swagger.WithDescription("Generate OpenCode configuration preview from system state"),
@@ -62,6 +75,13 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 		swagger.WithTags("config"),
 		swagger.WithRequestModel(ApplyCodexConfigRequest{}),
 		swagger.WithResponseModel(CodexConfigPreviewResponse{}),
+	)
+
+	router.POST("/config/preview/dsh", handler.GetDshConfigPreview,
+		swagger.WithDescription("Generate DeepSeek Harness (dsh) configuration preview from system state"),
+		swagger.WithTags("config"),
+		swagger.WithRequestModel(ApplyDshConfigRequest{}),
+		swagger.WithResponseModel(DshConfigPreviewResponse{}),
 	)
 
 	// Config restore endpoints - roll back to the most recent on-disk backup.
@@ -79,6 +99,12 @@ func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
 
 	router.POST("/config/restore/codex", handler.RestoreCodexConfig,
 		swagger.WithDescription("Restore Codex configuration from the most recent backup"),
+		swagger.WithTags("config"),
+		swagger.WithResponseModel(RestoreConfigResponse{}),
+	)
+
+	router.POST("/config/restore/dsh", handler.RestoreDshConfig,
+		swagger.WithDescription("Restore DeepSeek Harness (dsh) configuration from the most recent backup"),
 		swagger.WithTags("config"),
 		swagger.WithResponseModel(RestoreConfigResponse{}),
 	)

--- a/internal/server/module/configapply/types.go
+++ b/internal/server/module/configapply/types.go
@@ -111,6 +111,42 @@ type CodexConfigPreviewResponse struct {
 	Message     string   `json:"message,omitempty"`
 }
 
+// ApplyDshConfigRequest is the request body for the DeepSeek Harness (dsh)
+// apply and preview endpoints. `preferences` is the typed, whitelisted set of
+// settings.yaml provider-stanza keys (see config.DshPrefs). nil means "use
+// built-in defaults".
+type ApplyDshConfigRequest struct {
+	Preferences *config.DshPrefs `json:"preferences"`
+}
+
+// ApplyDshConfigResponse is the response for ApplyDshConfigFromState.
+type ApplyDshConfigResponse struct {
+	Success           bool               `json:"success"`
+	SettingsResult    config.ApplyResult `json:"settingsResult"`
+	CredentialsResult config.ApplyResult `json:"credentialsResult"`
+	Models            []string           `json:"models"`
+	Message           string             `json:"message,omitempty"`
+}
+
+// DshConfigResponse returns the typed values currently persisted in the
+// user's $DSH_HOME/settings.yaml so the frontend can restore Apply state on
+// reopen. Routing/auth-owned fields (models, baseURL, the gateway token) are
+// NOT returned — same safety stance as CodexConfigResponse.
+type DshConfigResponse struct {
+	Success     bool            `json:"success"`
+	Exists      bool            `json:"exists"`
+	Preferences config.DshPrefs `json:"preferences"`
+}
+
+// DshConfigPreviewResponse is the response for GetDshConfigPreview.
+type DshConfigPreviewResponse struct {
+	Success         bool     `json:"success"`
+	SettingsYaml    string   `json:"settingsYaml"`
+	CredentialsYaml string   `json:"credentialsYaml"`
+	Models          []string `json:"models"`
+	Message         string   `json:"message,omitempty"`
+}
+
 // RestoreConfigResponse is the response for the restore endpoints. It mirrors
 // the agent.RestoreAgentResult so callers can drive UI from the same data
 // the CLI prints.

--- a/internal/usecase/agent.go
+++ b/internal/usecase/agent.go
@@ -61,6 +61,8 @@ func (uc *AgentUseCase) RoutingKey(agentType agent.AgentType) (requestModel stri
 		return "tingly-opencode", typ.ScenarioOpenCode, nil
 	case agent.AgentTypeCodex:
 		return "tingly-codex", typ.ScenarioCodex, nil
+	case agent.AgentTypeDsh:
+		return "tingly-dsh", typ.ScenarioDsh, nil
 	default:
 		return "", "", ErrUnsupportedAgentType{AgentType: agentType}
 	}

--- a/openapi.json
+++ b/openapi.json
@@ -1699,6 +1699,39 @@
         }
       }
     },
+    "/api/v1/config/apply/dsh": {
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Generate and apply DeepSeek Harness (dsh) configuration from system state",
+        "description": "Generate and apply DeepSeek Harness (dsh) configuration from system state",
+        "operationId": "apiV1ConfigApplyDshPost",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplyDshConfigRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplyDshConfigResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/config/apply/opencode": {
       "post": {
         "tags": [
@@ -1765,6 +1798,28 @@
         }
       }
     },
+    "/api/v1/config/dsh": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Get the currently applied DeepSeek Harness (dsh) preferences",
+        "description": "Get the currently applied DeepSeek Harness (dsh) preferences",
+        "operationId": "apiV1ConfigDshGet",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DshConfigResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/config/preview/codex": {
       "post": {
         "tags": [
@@ -1791,6 +1846,39 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CodexConfigPreviewResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config/preview/dsh": {
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Generate DeepSeek Harness (dsh) configuration preview from system state",
+        "description": "Generate DeepSeek Harness (dsh) configuration preview from system state",
+        "operationId": "apiV1ConfigPreviewDshPost",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplyDshConfigRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DshConfigPreviewResponse"
                 }
               }
             }
@@ -1850,6 +1938,28 @@
         "summary": "Restore Codex configuration from the most recent backup",
         "description": "Restore Codex configuration from the most recent backup",
         "operationId": "apiV1ConfigRestoreCodexPost",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreConfigResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config/restore/dsh": {
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Restore DeepSeek Harness (dsh) configuration from the most recent backup",
+        "description": "Restore DeepSeek Harness (dsh) configuration from the most recent backup",
+        "operationId": "apiV1ConfigRestoreDshPost",
         "responses": {
           "200": {
             "description": "Successful response",
@@ -6515,6 +6625,15 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "name": "force_upstream",
+            "in": "query",
+            "description": "Attempt the upstream models endpoint even when normally skipped",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -7584,6 +7703,49 @@
           "createdFiles",
           "updatedFiles",
           "backupPaths"
+        ]
+      },
+      "ApplyDshConfigRequest": {
+        "type": "object",
+        "properties": {
+          "preferences": {
+            "$ref": "#/components/schemas/DshPrefs"
+          }
+        },
+        "required": [
+          "preferences"
+        ]
+      },
+      "ApplyDshConfigResponse": {
+        "type": "object",
+        "properties": {
+          "credentialsResult": {
+            "$ref": "#/components/schemas/ApplyResult"
+          },
+          "message": {
+            "type": "string",
+            "description": "Field message"
+          },
+          "models": {
+            "type": "array",
+            "description": "Field models",
+            "items": {
+              "type": "string"
+            }
+          },
+          "settingsResult": {
+            "$ref": "#/components/schemas/ApplyResult"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "settingsResult",
+          "credentialsResult",
+          "models"
         ]
       },
       "ApplyOpenCodeConfigResponse": {
@@ -8927,6 +9089,70 @@
           "locations"
         ]
       },
+      "DshConfigPreviewResponse": {
+        "type": "object",
+        "properties": {
+          "credentialsYaml": {
+            "type": "string",
+            "description": "Field credentialsYaml"
+          },
+          "message": {
+            "type": "string",
+            "description": "Field message"
+          },
+          "models": {
+            "type": "array",
+            "description": "Field models",
+            "items": {
+              "type": "string"
+            }
+          },
+          "settingsYaml": {
+            "type": "string",
+            "description": "Field settingsYaml"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "settingsYaml",
+          "credentialsYaml",
+          "models"
+        ]
+      },
+      "DshConfigResponse": {
+        "type": "object",
+        "properties": {
+          "exists": {
+            "type": "boolean",
+            "description": "Field exists"
+          },
+          "preferences": {
+            "$ref": "#/components/schemas/DshPrefs"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          }
+        },
+        "required": [
+          "success",
+          "exists",
+          "preferences"
+        ]
+      },
+      "DshPrefs": {
+        "type": "object",
+        "properties": {
+          "default_input": {
+            "type": "string",
+            "description": "Field default_input"
+          }
+        }
+      },
       "E2ERequest": {
         "type": "object",
         "properties": {
@@ -8980,6 +9206,11 @@
             "type": "string",
             "description": "Field test_mode"
           },
+          "thinking": {
+            "type": "string",
+            "description": "Field thinking",
+            "example": "medium"
+          },
           "token": {
             "type": "string",
             "description": "Field token"
@@ -8994,7 +9225,7 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/ProbeResult"
+            "$ref": "#/components/schemas/Result"
           },
           "error": {
             "$ref": "#/components/schemas/errorDetail"
@@ -11892,135 +12123,6 @@
           "verdict"
         ]
       },
-      "ProbeResult": {
-        "type": "object",
-        "properties": {
-          "applied_flags": {
-            "type": "string",
-            "description": "Field applied_flags"
-          },
-          "completion_tokens": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field completion_tokens"
-          },
-          "content": {
-            "type": "string",
-            "description": "Field content"
-          },
-          "error_message": {
-            "type": "string",
-            "description": "Field error_message"
-          },
-          "latency_ms": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field latency_ms"
-          },
-          "matched_rule": {
-            "type": "string",
-            "description": "Field matched_rule"
-          },
-          "matched_rule_desc": {
-            "type": "string",
-            "description": "Field matched_rule_desc"
-          },
-          "matched_smart_rule": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field matched_smart_rule"
-          },
-          "message": {
-            "type": "string",
-            "description": "Field message"
-          },
-          "models_count": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field models_count"
-          },
-          "prompt_tokens": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field prompt_tokens"
-          },
-          "request_url": {
-            "type": "string",
-            "description": "Field request_url"
-          },
-          "routing_source": {
-            "type": "string",
-            "description": "Field routing_source"
-          },
-          "selected_model": {
-            "type": "string",
-            "description": "Field selected_model"
-          },
-          "selected_provider": {
-            "type": "string",
-            "description": "Field selected_provider"
-          },
-          "selected_provider_uuid": {
-            "type": "string",
-            "description": "Field selected_provider_uuid"
-          },
-          "stream": {
-            "type": "boolean",
-            "description": "Field stream"
-          },
-          "success": {
-            "type": "boolean",
-            "description": "Field success"
-          },
-          "tool_calls": {
-            "type": "array",
-            "description": "Field tool_calls",
-            "items": {
-              "$ref": "#/components/schemas/ProbeToolCall"
-            }
-          },
-          "total_tokens": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field total_tokens"
-          },
-          "upstream_api": {
-            "type": "string",
-            "description": "Field upstream_api"
-          },
-          "upstream_url": {
-            "type": "string",
-            "description": "Field upstream_url"
-          }
-        },
-        "required": [
-          "success",
-          "latency_ms"
-        ]
-      },
-      "ProbeToolCall": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Field id"
-          },
-          "input": {
-            "type": "object",
-            "description": "Field input",
-            "additionalProperties": {}
-          },
-          "name": {
-            "type": "string",
-            "description": "Field name"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "input"
-        ]
-      },
       "ProfileClaudeConfigData": {
         "type": "object",
         "properties": {
@@ -12754,6 +12856,95 @@
           "restoredFiles",
           "preRestoreBackups",
           "message"
+        ]
+      },
+      "Result": {
+        "type": "object",
+        "properties": {
+          "applied_flags": {
+            "type": "string",
+            "description": "Field applied_flags"
+          },
+          "content": {
+            "type": "string",
+            "description": "Field content"
+          },
+          "error_message": {
+            "type": "string",
+            "description": "Field error_message"
+          },
+          "latency_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field latency_ms"
+          },
+          "matched_rule": {
+            "type": "string",
+            "description": "Field matched_rule"
+          },
+          "matched_rule_desc": {
+            "type": "string",
+            "description": "Field matched_rule_desc"
+          },
+          "matched_smart_rule": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field matched_smart_rule"
+          },
+          "message": {
+            "type": "string",
+            "description": "Field message"
+          },
+          "request_url": {
+            "type": "string",
+            "description": "Field request_url"
+          },
+          "routing_source": {
+            "type": "string",
+            "description": "Field routing_source"
+          },
+          "selected_model": {
+            "type": "string",
+            "description": "Field selected_model"
+          },
+          "selected_provider": {
+            "type": "string",
+            "description": "Field selected_provider"
+          },
+          "selected_provider_uuid": {
+            "type": "string",
+            "description": "Field selected_provider_uuid"
+          },
+          "stream": {
+            "type": "boolean",
+            "description": "Field stream"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          },
+          "tool_calls": {
+            "type": "array",
+            "description": "Field tool_calls",
+            "items": {
+              "$ref": "#/components/schemas/ToolCall"
+            }
+          },
+          "upstream_api": {
+            "type": "string",
+            "description": "Field upstream_api"
+          },
+          "upstream_url": {
+            "type": "string",
+            "description": "Field upstream_url"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/TokenUsage"
+          }
+        },
+        "required": [
+          "success",
+          "latency_ms"
         ]
       },
       "Route": {
@@ -14327,6 +14518,68 @@
         "required": [
           "token",
           "type"
+        ]
+      },
+      "TokenUsage": {
+        "type": "object",
+        "properties": {
+          "cache_read_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field cache_read_tokens"
+          },
+          "cache_write_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field cache_write_tokens"
+          },
+          "input_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field input_tokens"
+          },
+          "output_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field output_tokens"
+          },
+          "reasoning_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field reasoning_tokens"
+          },
+          "system_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field system_tokens"
+          }
+        },
+        "required": [
+          "input_tokens",
+          "output_tokens"
+        ]
+      },
+      "ToolCall": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Field id"
+          },
+          "input": {
+            "type": "object",
+            "description": "Field input",
+            "additionalProperties": {}
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "input"
         ]
       },
       "UpdateClientRequest": {


### PR DESCRIPTION
## Summary
DeepSeek Harness (dsh) had nav/icon/i18n scaffolding but only a "manual instructions" setup page. This adds real one-click auto config, mirroring the Codex/Claude Code pattern.

## Key Changes

- **Config apply/restore**: new `DshConfig` agent (`ai/agent/dsh.go`) writes a merge-safe `tingly-box` provider stanza into `$DSH_HOME/settings.yaml` (apiKeyEnv indirection, matching dsh's credential model) and the key into `$DSH_HOME/.credentials.yaml`, both backed up before rewrite and restorable via `agent restore dsh`.
- **API surface**: `GET /config/dsh`, `POST /config/apply/dsh`, `POST /config/preview/dsh`, `POST /config/restore/dsh`, wired through the CLI (`ParseAgentType`, routing-rule sync) the same way Codex is.
- **Frontend**: `UseDshPage` now wires `onApply`, and `DshConfigModal`/`DshQuickConfig` replace the old static-instructions modal with Quick/Manual tabs and live YAML preview.

## Minor
- Fixed `AgentSetupCard`'s Apply button silently no-oping for every `onApply`-only caller (Codex, OpenCode, and this new dsh page) — it only ever invoked `onApplyWithStatusLine`.
- Added `internal/server/config/apply_config_dsh_test.go`, matching existing Codex test coverage for the HTTP-facing merge/render logic.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eu8oB1Hidk6oA4mcdjxRGW)_