### PR TITLE
feat(usage,protocol,frontend): surface reasoning tokens across the usage stack

### DIFF
--- a/.design/stream-usage-tracking.md
+++ b/.design/stream-usage-tracking.md
@@ -480,7 +480,7 @@ level=debug msg="OpenAI->Anthropic stream usage: model=... in=42 out=17 cache=11
 
 **唯一保留的真实限制**：这个字段是 SDK/API 层面新加的，历史请求／未升级到能上报它的模型或客户端仍拿不到；这是版本问题，不是"Anthropic 架构上做不到"。
 
-**未覆盖**：`vmodel/` 测试 mock（§9.1）没有跟着更新——`MockUsage.ReasoningTokens` 仍只在 OpenAI 侧渲染，Anthropic mock fixture 测不出 `thinking_tokens` 的覆盖率；需要时再补 §9 的 mock 渲染逻辑。
+**未覆盖**：~~`vmodel/` 测试 mock（§9.1）没有跟着更新——`MockUsage.ReasoningTokens` 仍只在 OpenAI 侧渲染，Anthropic mock fixture 测不出 `thinking_tokens` 的覆盖率~~。已补：`vmodel/virtualserver` 的 `AnthropicUsage` 加了 `OutputTokensDetails`，`handleAnthropicStreaming` 的 `message_delta` 现在把 `explicitUsage.ReasoningTokens` 渲成 `output_tokens_details.thinking_tokens`（此前误渲成扁平的 `reasoning_tokens`，与真实 Anthropic wire 格式不符）；`TestStreamTestMocks_AnthropicMessageDelta` 同步更新断言。Anthropic 非流式路径（`handleAnthropicNonStreaming`）仍未接 `MockUsage`（OpenAI 非流式同样如此，是更早就有的通用限制，不只是 reasoning 的坑），需要时再补。
 
 单测：`internal/protocol/usage/usage_test.go`（`TestFromAnthropicMessage`/`TestAnthropicAccumulator_ExtendedThinking`/`TestToAnthropicUsageMap_ReasoningTokens`）、`internal/protocol/assembler/anthropic_assembler_test.go`（`TestAnthropicStreamAssembler_SetUsageFromTokenUsage_CarriesReasoning`/`TestAnthropicStreamAssembler_RecordV1Event_CarriesReasoning`）、`internal/protocol/nonstream/openai_usage_test.go`（`TestBuildAnthropicPayloadFromChat_ReasoningTokens`）。
 
@@ -498,7 +498,7 @@ type MockUsage struct {
     CompletionTokens  int64
     CachedInputTokens int64 // OpenAI cached_tokens / Anthropic cache_read
     CacheWriteTokens  int64 // Anthropic cache_creation / OpenAI cache_write_tokens
-    ReasoningTokens   int64 // OpenAI only — mock renderer not extended for Anthropic thinking_tokens, see §8.5
+    ReasoningTokens   int64 // OpenAI reasoning_tokens / Anthropic thinking_tokens — see §9.2 rendering
 }
 ```
 

--- a/.design/stream-usage-tracking.md
+++ b/.design/stream-usage-tracking.md
@@ -150,7 +150,7 @@ ReasoningTokens  = reasoning_tokens                 // 仅作展示，是 Output
 | `cache_creation_input_tokens` | 本次**写入**缓存的 token（按写入价计费） | 与 input **并列**，独立不重叠 |
 | `cache_read_input_tokens` | 本次**命中读取**缓存的 token（便宜） | 与 input **并列**，独立不重叠 |
 | `output_tokens` | 本次**全部** output | 父字段，**已含** thinking |
-| `output_tokens_details.thinking_tokens`（`Usage`/`BetaUsage` 均有，非 beta 字段，随 claude-opus-4-8 引入） | extended thinking 消耗（含 thinking-block 分隔符 token） | ⊂ `output_tokens` 的**子集**，与 OpenAI `reasoning_tokens` 同构 |
+| `output_tokens_details.thinking_tokens`（`Usage`/`BetaUsage` 均有，非 beta 字段） | extended thinking 消耗（含 thinking-block 分隔符 token） | ⊂ `output_tokens` 的**子集**，与 OpenAI `reasoning_tokens` 同构 |
 
 归一化计算（`FromAnthropicMessage` / `FromAnthropicBetaMessage`）：
 
@@ -201,7 +201,7 @@ usage.FromAnthropicBetaMessage(resp.Usage) // anthropic.BetaUsage
 ```
 
 OpenAI 侧：`InputTokens = prompt − cached`，cache read / cache write / reasoning 直接读 details。
-Anthropic 侧：`InputTokens = input + cache_creation`，`CacheReadTokens = cache_read`，`CacheWriteTokens = cache_creation`，`ReasoningTokens = output_tokens_details.thinking_tokens`（随 claude-opus-4-8 引入）。
+Anthropic 侧：`InputTokens = input + cache_creation`，`CacheReadTokens = cache_read`，`CacheWriteTokens = cache_creation`，`ReasoningTokens = output_tokens_details.thinking_tokens`。
 
 反向（`*TokenUsage` → wire）：
 
@@ -323,7 +323,7 @@ OpenAI→Anthropic converter 的终态收口在 `emitTerminalEvents()`：从 cou
   - `OutputTokens → anthropic.Usage.OutputTokens`
   - `CacheReadTokens → anthropic.Usage.CacheReadInputTokens`
   - `CacheWriteTokens → anthropic.Usage.CacheCreationInputTokens`
-  - `ReasoningTokens > 0 → anthropic.Usage.OutputTokensDetails.ThinkingTokens`（Anthropic 自己的字段，随 claude-opus-4-8 引入，不是"无对应字段"）
+  - `ReasoningTokens > 0 → anthropic.Usage.OutputTokensDetails.ThinkingTokens`（Anthropic 自己的字段，不是"无对应字段"）
 - `Finish(model, in, out) → *anthropic.Message`：有 `SetUsage*` 数据就用它，否则回退入参
 
 ### 4.2 `streamRecorder`（`internal/server/recording_hooks.go`）

--- a/.design/stream-usage-tracking.md
+++ b/.design/stream-usage-tracking.md
@@ -65,7 +65,7 @@ type TokenUsage struct {
     OutputTokens     int `json:"output_tokens"`                // 输出/completion
     CacheReadTokens  int `json:"cache_read_tokens,omitempty"`  // cache read 命中（折扣的那半）
     CacheWriteTokens int `json:"cache_write_tokens,omitempty"` // cache write，⊂ InputTokens（溢价的那半）
-    ReasoningTokens  int `json:"reasoning_tokens,omitempty"`   // o1/o3 reasoning，是 OutputTokens 的子集
+    ReasoningTokens  int `json:"reasoning_tokens,omitempty"`   // OpenAI o1/o3/reasoning 或 Anthropic extended thinking，是 OutputTokens 的子集
     SystemTokens     int `json:"system_tokens,omitempty"`      // 模板/系统指令/框架开销
 }
 ```
@@ -149,7 +149,8 @@ ReasoningTokens  = reasoning_tokens                 // 仅作展示，是 Output
 | `input_tokens` | **仅未命中缓存**的 input | 不含任何 cache |
 | `cache_creation_input_tokens` | 本次**写入**缓存的 token（按写入价计费） | 与 input **并列**，独立不重叠 |
 | `cache_read_input_tokens` | 本次**命中读取**缓存的 token（便宜） | 与 input **并列**，独立不重叠 |
-| `output_tokens` | 本次**全部** output | **已含** thinking，无独立 reasoning 字段 |
+| `output_tokens` | 本次**全部** output | 父字段，**已含** thinking |
+| `output_tokens_details.thinking_tokens`（`Usage`/`BetaUsage` 均有，非 beta 字段，随 claude-opus-4-8 引入） | extended thinking 消耗（含 thinking-block 分隔符 token） | ⊂ `output_tokens` 的**子集**，与 OpenAI `reasoning_tokens` 同构 |
 
 归一化计算（`FromAnthropicMessage` / `FromAnthropicBetaMessage`）：
 
@@ -157,11 +158,11 @@ ReasoningTokens  = reasoning_tokens                 // 仅作展示，是 Output
 InputTokens      = input_tokens + cache_creation_input_tokens  // 写入成本并进 input（进分母）
 CacheReadTokens = cache_read_input_tokens                      // 命中缓存（读）
 CacheWriteTokens = cache_creation_input_tokens                  // 写入明细，⊂ InputTokens
-OutputTokens     = output_tokens                                // thinking 已含在内
-ReasoningTokens  = 0                                            // Anthropic 不单列 reasoning
+OutputTokens     = output_tokens                                // thinking 已含在内，不减
+ReasoningTokens  = output_tokens_details.thinking_tokens        // 仅作展示，是 Output 的子集，不重复计入
 ```
 
-> 单测佐证：`input=100, creation=900, read=800, output=50` → `Input=1000, Cache=800, Output=50`。
+> 单测佐证：`input=100, creation=900, read=800, output=50` → `Input=1000, Cache=800, Output=50`；`input=100, output=80, reasoning=30` → `Reasoning=30`（不从 output 减掉）。见 `usage_test.go` 的 `TestFromAnthropicMessage`/`TestAnthropicAccumulator_ExtendedThinking`/`TestToAnthropicUsageMap_ReasoningTokens`。这条字段从「无对应字段」到「有但没接」到「已接上」的完整经过记在 §8.5。
 
 #### 归一化后的不变量（两侧统一）
 
@@ -200,7 +201,7 @@ usage.FromAnthropicBetaMessage(resp.Usage) // anthropic.BetaUsage
 ```
 
 OpenAI 侧：`InputTokens = prompt − cached`，cache read / cache write / reasoning 直接读 details。
-Anthropic 侧：`InputTokens = input + cache_creation`，`CacheReadTokens = cache_read`，`CacheWriteTokens = cache_creation`，无 reasoning。
+Anthropic 侧：`InputTokens = input + cache_creation`，`CacheReadTokens = cache_read`，`CacheWriteTokens = cache_creation`，`ReasoningTokens = output_tokens_details.thinking_tokens`（随 claude-opus-4-8 引入）。
 
 反向（`*TokenUsage` → wire）：
 
@@ -214,7 +215,7 @@ usage.ChatUsage(u) // → openai.CompletionUsage：PromptTokens = Input + Cache�
 Anthropic 把 usage 拆在两个事件里：
 
 - `message_start` → `input_tokens` / `cache_creation_input_tokens` / `cache_read_input_tokens`
-- `message_delta` → `output_tokens`（个别非标准 provider 也在这里塞 `input_tokens`）
+- `message_delta` → `output_tokens` / `output_tokens_details.thinking_tokens`（个别非标准 provider 也在这里塞 `input_tokens`）
 - **协议转换特例**：OpenAI → Anthropic 这类转换在流开始时拿不到权威 input usage，只能在上游终态事件拿到完整 usage；因此终态 `message_delta.usage` 可以携带完整 normalized usage（`input_tokens` / `output_tokens` / `cache_read_input_tokens`），这是为了保持对外 SSE、录制与计费同源一致。
 
 ```go
@@ -275,7 +276,7 @@ tiktoken：默认 `O200kBase`；流前用 `EstimateInputTokensSimple(req)`（`le
 | `HandleAnthropicV1NonStream` | `usage.FromAnthropicMessage` |
 | `HandleAnthropicV1BetaNonStream` | `usage.FromAnthropicBetaMessage` |
 | `nonstream/anthropic_to_openai.go` | inline（返回 wire `map[string]interface{}`，不是 `*TokenUsage`） |
-| `nonstream/openai_to_anthropic.go` | inline（同上）；reasoning 在 Anthropic 无对等字段 |
+| `nonstream/openai_to_anthropic.go` | inline（同上）；`anthropicUsageWire` 把 `ReasoningTokens` 写回 `output_tokens_details.thinking_tokens` |
 
 ### 3.2 `internal/protocol/stream/`
 
@@ -315,14 +316,14 @@ OpenAI→Anthropic converter 的终态收口在 `emitTerminalEvents()`：从 cou
 
 把流式事件攒成一个完整的 `anthropic.Message`。
 
-- `RecordV1Event` / `RecordV1BetaEvent`：处理 `message_start`（msgID/role）、`content_block_*`（攒 text/thinking/tool input）、`message_delta`（stop_reason + 若带 usage 则存 `usageData`，**含 `CacheReadInputTokens`**）
+- `RecordV1Event` / `RecordV1BetaEvent`：处理 `message_start`（msgID/role）、`content_block_*`（攒 text/thinking/tool input）、`message_delta`（stop_reason + 若带 usage 则存 `usageData`，**含 `CacheReadInputTokens` / `OutputTokensDetails.ThinkingTokens`**）
 - `SetUsage(in, out)`：原始计数（简单入口，优先用下面那个）
 - `SetUsageFromTokenUsage(u *ai.TokenUsage)`：canonical 入口
   - `UncachedInputTokens() → anthropic.Usage.InputTokens`（**注意不是 `InputTokens` 直传**：canonical 把写入成本折进了 `InputTokens`，而 Anthropic wire 的 `input_tokens` 不含它，直传会和下一行一起把写入计两次）
   - `OutputTokens → anthropic.Usage.OutputTokens`
   - `CacheReadTokens → anthropic.Usage.CacheReadInputTokens`
   - `CacheWriteTokens → anthropic.Usage.CacheCreationInputTokens`
-  - `ReasoningTokens` 丢弃（Anthropic 无对应字段，已计入 output）
+  - `ReasoningTokens > 0 → anthropic.Usage.OutputTokensDetails.ThinkingTokens`（Anthropic 自己的字段，随 claude-opus-4-8 引入，不是"无对应字段"）
 - `Finish(model, in, out) → *anthropic.Message`：有 `SetUsage*` 数据就用它，否则回退入参
 
 ### 4.2 `streamRecorder`（`internal/server/recording_hooks.go`）
@@ -466,6 +467,23 @@ dev-stage 破坏式清理，按存在性条件执行：
 level=debug msg="OpenAI->Anthropic stream usage: model=... in=42 out=17 cache=11 reasoning=9 stop=stop"
 ```
 
+### 8.5 2026-08-15：Anthropic `thinking_tokens` 补齐
+
+`anthropic-sdk-go`（vendor 进来的 SDK）随 claude-opus-4-8 加了 `usage.output_tokens_details.thinking_tokens`——`Usage`/`BetaUsage` 都有，是**非 beta**字段，和 OpenAI 的 `reasoning_tokens` 同构（⊂ `output_tokens`，不重复计入）。但 `extract.go` 从未读过它：`FromAnthropicMessage`/`FromAnthropicBetaMessage` 一直硬编码 `ReasoningTokens=0`，本文档也曾据此把"Anthropic 不单列 reasoning"写成架构结论——那是基于旧版 SDK 的过时判断，不是 API 做不到，只是没人接。
+
+打通了两个方向：
+
+- **读入**（Anthropic → canonical）：`FromAnthropicMessage`/`FromAnthropicBetaMessage`（§2.1）；流式的 `AnthropicAccumulator` 读 `message_delta.usage.output_tokens_details.thinking_tokens`（§2.3）
+- **写出**（canonical → Anthropic wire）：`AnthropicStreamAssembler.SetUsageFromTokenUsage` / `RecordV1Event`（§4.1）；`ai.TokenUsage.ToAnthropicUsageMap`；`wire.AnthropicUsageWire` 新增 `AnthropicOutputTokensDetailsWire`，供 `nonstream/openai_to_anthropic.go` 的 `anthropicUsageWire` 使用（§3.1）——所以 OpenAI 上游的 `reasoning_tokens` 转成 Anthropic 形状响应时也能带出来，不只是原生 Anthropic 请求
+
+同时把这条数据接到了 dashboard：`usage_records`/`usage_daily` 加 `reasoning_tokens` 列，`AggregatedStat`/`TimeSeriesData`/`UsageRecordResponse` 三个 API 模型暴露它，前端在 output 列后面新增一列，值为 0/缺失时显示 `—`（不区分"Anthropic 恒测不到"和"真实测量为零"）。
+
+**唯一保留的真实限制**：这个字段是 SDK/API 层面新加的，历史请求／未升级到能上报它的模型或客户端仍拿不到；这是版本问题，不是"Anthropic 架构上做不到"。
+
+**未覆盖**：`vmodel/` 测试 mock（§9.1）没有跟着更新——`MockUsage.ReasoningTokens` 仍只在 OpenAI 侧渲染，Anthropic mock fixture 测不出 `thinking_tokens` 的覆盖率；需要时再补 §9 的 mock 渲染逻辑。
+
+单测：`internal/protocol/usage/usage_test.go`（`TestFromAnthropicMessage`/`TestAnthropicAccumulator_ExtendedThinking`/`TestToAnthropicUsageMap_ReasoningTokens`）、`internal/protocol/assembler/anthropic_assembler_test.go`（`TestAnthropicStreamAssembler_SetUsageFromTokenUsage_CarriesReasoning`/`TestAnthropicStreamAssembler_RecordV1Event_CarriesReasoning`）、`internal/protocol/nonstream/openai_usage_test.go`（`TestBuildAnthropicPayloadFromChat_ReasoningTokens`）。
+
 ---
 
 ## 9. vmodel 测试基建
@@ -480,7 +498,7 @@ type MockUsage struct {
     CompletionTokens  int64
     CachedInputTokens int64 // OpenAI cached_tokens / Anthropic cache_read
     CacheWriteTokens  int64 // Anthropic cache_creation / OpenAI cache_write_tokens
-    ReasoningTokens   int64 // OpenAI only
+    ReasoningTokens   int64 // OpenAI only — mock renderer not extended for Anthropic thinking_tokens, see §8.5
 }
 ```
 
@@ -556,8 +574,8 @@ anthropicvm.RegisterStreamTestMocks(svc.GetAnthropicRegistry())
 | `stream/anthropic_beta_to_openai_responses*.go` | ✅ | 同上，落在 `input_tokens_details` |
 | `stream/openai_chat_to_responses*.go` | ✅ | usage 持续抽取，无早退；cache_write 透传 |
 | `stream/openai_responses_to_chat*.go` | ✅ | 完整抽 input/output/cache read+write/reasoning |
-| `nonstream/openai_to_anthropic.go` | ✅ | cache_write → `cache_creation_input_tokens`；reasoning 在 Anthropic 无对等 |
-| `nonstream/anthropic_to_openai.go` | ✅ | cache_read/cache_creation 双向已映射；Anthropic 不发 reasoning |
+| `nonstream/openai_to_anthropic.go` | ✅ | cache_write → `cache_creation_input_tokens`；reasoning → `output_tokens_details.thinking_tokens` |
+| `nonstream/anthropic_to_openai.go` | ✅ | cache_read/cache_creation 双向已映射；Anthropic 自身的 `output_tokens_details.thinking_tokens` 经 `FromAnthropicMessage`/`FromAnthropicBetaMessage` 读入 |
 | `nonstream/openai_responses_to_chat.go` | ✅ | 完整 |
 | `stream/google_to_any.go` + `nonstream/google_to.go` | skip | Google SDK 无结构化 cache 子字段 |
 

--- a/ai/protocol.go
+++ b/ai/protocol.go
@@ -127,8 +127,7 @@ func (u *TokenUsage) ToAnthropicUsageMap() map[string]interface{} {
 	}
 	if u.ReasoningTokens > 0 {
 		// Mirrors Anthropic's own usage.output_tokens_details.thinking_tokens
-		// (added alongside claude-opus-4-8) -- a subset of output_tokens, not
-		// something Anthropic lacks.
+		// -- a subset of output_tokens.
 		usage["output_tokens_details"] = map[string]interface{}{
 			"thinking_tokens": u.ReasoningTokens,
 		}

--- a/ai/protocol.go
+++ b/ai/protocol.go
@@ -125,6 +125,14 @@ func (u *TokenUsage) ToAnthropicUsageMap() map[string]interface{} {
 	if u.CacheWriteTokens > 0 {
 		usage["cache_creation_input_tokens"] = u.CacheWriteTokens
 	}
+	if u.ReasoningTokens > 0 {
+		// Mirrors Anthropic's own usage.output_tokens_details.thinking_tokens
+		// (added alongside claude-opus-4-8) -- a subset of output_tokens, not
+		// something Anthropic lacks.
+		usage["output_tokens_details"] = map[string]interface{}{
+			"thinking_tokens": u.ReasoningTokens,
+		}
+	}
 	return usage
 }
 

--- a/frontend/src/components/dashboard/RequestsView.tsx
+++ b/frontend/src/components/dashboard/RequestsView.tsx
@@ -40,6 +40,7 @@ export interface UsageRecord {
     total_tokens: number;
     cache_read_tokens: number;
     cache_write_tokens?: number;
+    reasoning_tokens?: number;
     status: string;
     error_code?: string;
     latency_ms: number;
@@ -141,6 +142,7 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                             {showCacheWrite && <TableCell align="right">{t('dashboard.requestsView.colCacheWrite', { defaultValue: 'Cache Write' })}</TableCell>}
                             <TableCell align="right">{t('dashboard.requestsView.colInput', { defaultValue: 'Input' })}</TableCell>
                             <TableCell align="right">{t('dashboard.requestsView.colOutput', { defaultValue: 'Output' })}</TableCell>
+                            <TableCell align="right">{t('dashboard.requestsView.colReasoning', { defaultValue: 'Reasoning' })}</TableCell>
                             <TableCell align="right">{t('dashboard.requestsView.colLatency', { defaultValue: 'Latency' })}</TableCell>
                             <TableCell align="right">{t('dashboard.requestsView.colTTFT', { defaultValue: 'TTFT' })}</TableCell>
                             <TableCell align="right">{t('dashboard.requestsView.colTPS', { defaultValue: 'TPS' })}</TableCell>
@@ -151,7 +153,7 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                     <TableBody>
                         {records.length === 0 && !loading ? (
                             <TableRow>
-                                <TableCell colSpan={11 + (showCacheWrite ? 1 : 0)} align="center" sx={{ py: 5 }}>
+                                <TableCell colSpan={12 + (showCacheWrite ? 1 : 0)} align="center" sx={{ py: 5 }}>
                                     <Typography variant="body2" sx={{
                                         color: "text.secondary"
                                     }}>{t('dashboard.requestsView.empty', { defaultValue: 'No requests found' })}</Typography>
@@ -227,6 +229,14 @@ function RequestTable({ records, total, page, rowsPerPage, statusFilter, loading
                                 <TableCell align="right">
                                     <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: TOKEN_COLORS.output.main }}>
                                         {fmtTokens(r.output_tokens)}
+                                    </Typography>
+                                </TableCell>
+
+                                {/* Reasoning (thinking) tokens — a subset of output, absent/zero shown as
+                                    "-" rather than 0 (Anthropic doesn't always report it separately). */}
+                                <TableCell align="right">
+                                    <Typography sx={{ fontFamily: 'monospace', fontSize: '0.75rem', color: (r.reasoning_tokens || 0) > 0 ? 'text.primary' : 'text.disabled' }}>
+                                        {(r.reasoning_tokens || 0) > 0 ? fmtTokens(r.reasoning_tokens || 0) : '-'}
                                     </Typography>
                                 </TableCell>
 

--- a/frontend/src/components/dashboard/ServiceStatsTable.tsx
+++ b/frontend/src/components/dashboard/ServiceStatsTable.tsx
@@ -34,6 +34,7 @@ export interface AggregatedStat {
     total_output_tokens: number;
     cache_read_tokens?: number;
     cache_write_tokens?: number;
+    reasoning_tokens?: number;
     avg_latency_ms?: number;
     error_count?: number;
     error_rate?: number;

--- a/frontend/src/components/dashboard/TokenHistoryChart/types.ts
+++ b/frontend/src/components/dashboard/TokenHistoryChart/types.ts
@@ -8,6 +8,10 @@ export interface TimeSeriesData {
     output_tokens: number;
     cache_read_tokens?: number;
     cache_write_tokens?: number;
+    // Reasoning is a SUBSET of output_tokens (thinking/reasoning tokens,
+    // OpenAI reasoning models only -- always 0/absent for Anthropic). Not
+    // yet plotted as its own chart series; present for API parity.
+    reasoning_tokens?: number;
     error_count?: number;
     avg_latency_ms?: number;
 }

--- a/frontend/src/components/dashboard/UsageMetricCells.tsx
+++ b/frontend/src/components/dashboard/UsageMetricCells.tsx
@@ -24,6 +24,7 @@ export function UsageMetricHeaderCells({
         cacheHit: t('dashboard.metricLabels.cacheHit', { defaultValue: 'Cache Hit' }),
         input: t('dashboard.metricLabels.input', { defaultValue: 'Input Tokens' }),
         output: t('dashboard.metricLabels.output', { defaultValue: 'Output Tokens' }),
+        reasoning: t('dashboard.metricLabels.reasoning', { defaultValue: 'Reasoning Tokens' }),
         errorRate: t('dashboard.metricLabels.errorRate', { defaultValue: 'Error Rate' }),
     };
     return getUsageMetricColumns({ showTotal, showCacheWrite }, resolvedLabels).map((column) => (
@@ -65,6 +66,9 @@ export function UsageMetricValueCells({
             <TableCell align="right">{getCacheHitRate(cacheRead, input).toFixed(cacheHitDigits)}%</TableCell>
             <TableCell align="right">{formatNumber(input)}</TableCell>
             <TableCell align="right">{formatNumber(usage.total_output_tokens || 0)}</TableCell>
+            <TableCell align="right">
+                {usage.reasoning_tokens ? formatNumber(usage.reasoning_tokens) : '—'}
+            </TableCell>
             <TableCell align="right">
                 <Typography
                     variant="body2"

--- a/frontend/src/components/dashboard/usageMetricColumns.ts
+++ b/frontend/src/components/dashboard/usageMetricColumns.ts
@@ -6,6 +6,7 @@ export type UsageMetricKey =
     | 'cacheHit'
     | 'input'
     | 'output'
+    | 'reasoning'
     | 'errorRate';
 
 export interface UsageMetricLabels {
@@ -16,6 +17,7 @@ export interface UsageMetricLabels {
     cacheHit: string;
     input: string;
     output: string;
+    reasoning: string;
     errorRate: string;
 }
 
@@ -25,6 +27,7 @@ export interface UsageMetricSource {
     total_output_tokens?: number;
     cache_read_tokens?: number;
     cache_write_tokens?: number;
+    reasoning_tokens?: number;
     error_rate?: number;
 }
 
@@ -46,6 +49,7 @@ export const defaultUsageMetricLabels: UsageMetricLabels = {
     cacheHit: 'Cache Hit',
     input: 'Input Tokens',
     output: 'Output Tokens',
+    reasoning: 'Reasoning Tokens',
     errorRate: 'Error Rate',
 };
 
@@ -60,5 +64,6 @@ export const getUsageMetricColumns = (
     { key: 'cacheHit', label: labels.cacheHit },
     { key: 'input', label: labels.input },
     { key: 'output', label: labels.output },
+    { key: 'reasoning', label: labels.reasoning },
     { key: 'errorRate', label: labels.errorRate },
 ];

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1231,6 +1231,7 @@ export default {
       "joined": "Added {{value}}",
       "input": "Input",
       "output": "Output",
+      "reasoning": "Reasoning",
       "cacheRead": "Cache Read",
       "allModels": "All models",
       "modelMix": "Where their tokens went",
@@ -1354,6 +1355,7 @@ export default {
       "cacheHit": "Cache Hit",
       "input": "Input Tokens",
       "output": "Output Tokens",
+      "reasoning": "Reasoning Tokens",
       "errorRate": "Error Rate"
     },
     "chart": {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1305,6 +1305,7 @@ export default {
       "colCacheWrite": "Cache Write",
       "colInput": "Input",
       "colOutput": "Output",
+      "colReasoning": "Reasoning",
       "colLatency": "Latency",
       "colTTFT": "TTFT",
       "colTPS": "TPS",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1305,6 +1305,7 @@ export default {
       "colCacheWrite": "缓存写入",
       "colInput": "输入",
       "colOutput": "输出",
+      "colReasoning": "推理",
       "colLatency": "延迟",
       "colTTFT": "TTFT",
       "colTPS": "TPS",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1231,6 +1231,7 @@ export default {
       "joined": "添加于 {{value}}",
       "input": "输入",
       "output": "输出",
+      "reasoning": "推理",
       "cacheRead": "缓存读取",
       "allModels": "全部模型",
       "modelMix": "Token 用在了哪里",
@@ -1354,6 +1355,7 @@ export default {
       "cacheHit": "缓存命中",
       "input": "输入 Token",
       "output": "输出 Token",
+      "reasoning": "推理 Token",
       "errorRate": "错误率"
     },
     "chart": {

--- a/frontend/src/pages/UserUsagePage.tsx
+++ b/frontend/src/pages/UserUsagePage.tsx
@@ -432,6 +432,7 @@ export default function UserUsagePage() {
         cacheHit: t('dashboard.userUsage.cacheHit', { defaultValue: 'Cache Hit' }),
         input: t('dashboard.userUsage.input', { defaultValue: 'Input' }),
         output: t('dashboard.userUsage.output', { defaultValue: 'Output' }),
+        reasoning: t('dashboard.userUsage.reasoning', { defaultValue: 'Reasoning' }),
         errorRate: t('dashboard.userUsage.errorRate', { defaultValue: 'Error rate' }),
     };
     const userColumns: Array<{

--- a/internal/db/usage_daily.go
+++ b/internal/db/usage_daily.go
@@ -128,7 +128,7 @@ func (us *UsageStore) aggregateDay(key string, dayStart time.Time) (int64, error
 		res := tx.Exec(`
 			INSERT INTO usage_daily (date, provider_uuid, provider_name, model, user_id,
 				request_count, total_tokens, input_tokens, output_tokens,
-				cache_input_tokens, cache_write_tokens, system_tokens, error_count, streamed_count, latency_sum_ms)
+				cache_input_tokens, cache_write_tokens, reasoning_tokens, system_tokens, error_count, streamed_count, latency_sum_ms)
 			SELECT ?, COALESCE(provider_uuid, ''), COALESCE(provider_name, ''), COALESCE(model, ''), COALESCE(user_id, ''),
 				COUNT(*),
 				COALESCE(SUM(total_tokens), 0),
@@ -136,6 +136,7 @@ func (us *UsageStore) aggregateDay(key string, dayStart time.Time) (int64, error
 				COALESCE(SUM(output_tokens), 0),
 				COALESCE(SUM(cache_input_tokens), 0),
 				COALESCE(SUM(cache_write_tokens), 0),
+				COALESCE(SUM(reasoning_tokens), 0),
 				COALESCE(SUM(system_tokens), 0),
 				COALESCE(SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END), 0),
 				COALESCE(SUM(CASE WHEN streamed = true THEN 1 ELSE 0 END), 0),
@@ -190,6 +191,7 @@ func (us *UsageStore) aggregatedStatsFromDaily(q UsageStatsQuery) ([]AggregatedS
 				cur.OutputTokens += b.OutputTokens
 				cur.CacheReadTokens += b.CacheReadTokens
 				cur.CacheWriteTokens += b.CacheWriteTokens
+				cur.ReasoningTokens += b.ReasoningTokens
 				cur.SystemTokens += b.SystemTokens
 				cur.ErrorCount += b.ErrorCount
 				cur.StreamedCount += b.StreamedCount
@@ -278,6 +280,7 @@ func (us *UsageStore) dailyStatBuckets(q UsageStatsQuery, firstDay, lastDayEx ti
 		COALESCE(SUM(output_tokens), 0) as output_tokens,
 		COALESCE(SUM(cache_input_tokens), 0) as cache_read_tokens,
 		COALESCE(SUM(cache_write_tokens), 0) as cache_write_tokens,
+		COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens,
 		COALESCE(SUM(system_tokens), 0) as system_tokens,
 		COALESCE(SUM(error_count), 0) as error_count,
 		COALESCE(SUM(streamed_count), 0) as streamed_count,
@@ -461,6 +464,7 @@ func (us *UsageStore) dailyTimeSeries(firstDay, lastDayEx time.Time, filters map
 		OutputTokens     int64
 		CacheReadTokens  int64
 		CacheWriteTokens int64
+		ReasoningTokens  int64
 		SystemTokens     int64
 		ErrorCount       int64
 		LatencySum       int64
@@ -473,6 +477,7 @@ func (us *UsageStore) dailyTimeSeries(firstDay, lastDayEx time.Time, filters map
 		COALESCE(SUM(output_tokens), 0) as output_tokens,
 		COALESCE(SUM(cache_input_tokens), 0) as cache_read_tokens,
 		COALESCE(SUM(cache_write_tokens), 0) as cache_write_tokens,
+		COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens,
 		COALESCE(SUM(system_tokens), 0) as system_tokens,
 		COALESCE(SUM(error_count), 0) as error_count,
 		COALESCE(SUM(latency_sum_ms), 0) as latency_sum`).
@@ -498,6 +503,7 @@ func (us *UsageStore) dailyTimeSeries(firstDay, lastDayEx time.Time, filters map
 			OutputTokens:     r.OutputTokens,
 			CacheReadTokens:  r.CacheReadTokens,
 			CacheWriteTokens: r.CacheWriteTokens,
+			ReasoningTokens:  r.ReasoningTokens,
 			SystemTokens:     r.SystemTokens,
 			ErrorCount:       r.ErrorCount,
 			AvgLatencyMs:     avgFloat(float64(r.LatencySum), r.RequestCount),

--- a/internal/db/usage_daily_test.go
+++ b/internal/db/usage_daily_test.go
@@ -40,6 +40,7 @@ func seedUsageRecords(t *testing.T, store *UsageStore, days int) int {
 					OutputTokens:     50 + h,
 					CacheReadTokens:  20 * i,
 					CacheWriteTokens: 7 * (d % 3),
+					ReasoningTokens:  3 * (h % 4),
 					SystemTokens:     5,
 					Status:           status,
 					LatencyMs:        200 + h*3,
@@ -115,6 +116,7 @@ func TestAggregatedStatsDailyMatchesRaw(t *testing.T) {
 				m.OutputTokens != r.OutputTokens ||
 				m.CacheReadTokens != r.CacheReadTokens ||
 				m.CacheWriteTokens != r.CacheWriteTokens ||
+				m.ReasoningTokens != r.ReasoningTokens ||
 				m.SystemTokens != r.SystemTokens ||
 				m.ErrorCount != r.ErrorCount ||
 				m.StreamedCount != r.StreamedCount {
@@ -216,6 +218,7 @@ func TestTimeSeriesDailyMatchesRaw(t *testing.T) {
 			m.OutputTokens != r.OutputTokens ||
 			m.CacheReadTokens != r.CacheReadTokens ||
 			m.CacheWriteTokens != r.CacheWriteTokens ||
+			m.ReasoningTokens != r.ReasoningTokens ||
 			m.ErrorCount != r.ErrorCount {
 			t.Fatalf("bucket %d mismatch:\nmerged=%+v\nraw=%+v", i, m, r)
 		}

--- a/internal/db/usage_record.go
+++ b/internal/db/usage_record.go
@@ -37,11 +37,9 @@ type UsageRecord struct {
 	// alias it (`SUM(cache_input_tokens) as cache_read_tokens`) so Scan binds.
 	CacheReadTokens  int `gorm:"column:cache_input_tokens;default:0"`
 	CacheWriteTokens int `gorm:"column:cache_write_tokens;default:0"`
-	// ReasoningTokens counts thinking/reasoning tokens (OpenAI o1/o3/gpt-5.x
-	// reasoning models). It is a SUBSET of OutputTokens, not an addition to
-	// it -- OutputTokens already includes them upstream. Anthropic does not
-	// expose a separate thinking-token count at all, so this is always 0 for
-	// Anthropic-routed requests even when extended thinking was used.
+	// ReasoningTokens counts thinking/reasoning tokens (OpenAI reasoning
+	// models, Anthropic extended thinking). A SUBSET of OutputTokens, not
+	// an addition to it.
 	ReasoningTokens int `gorm:"column:reasoning_tokens;default:0"`
 	// System tokens (framework overhead, templates, etc.)
 	SystemTokens int    `gorm:"column:system_tokens;default:0"`

--- a/internal/db/usage_record.go
+++ b/internal/db/usage_record.go
@@ -37,6 +37,12 @@ type UsageRecord struct {
 	// alias it (`SUM(cache_input_tokens) as cache_read_tokens`) so Scan binds.
 	CacheReadTokens  int `gorm:"column:cache_input_tokens;default:0"`
 	CacheWriteTokens int `gorm:"column:cache_write_tokens;default:0"`
+	// ReasoningTokens counts thinking/reasoning tokens (OpenAI o1/o3/gpt-5.x
+	// reasoning models). It is a SUBSET of OutputTokens, not an addition to
+	// it -- OutputTokens already includes them upstream. Anthropic does not
+	// expose a separate thinking-token count at all, so this is always 0 for
+	// Anthropic-routed requests even when extended thinking was used.
+	ReasoningTokens int `gorm:"column:reasoning_tokens;default:0"`
 	// System tokens (framework overhead, templates, etc.)
 	SystemTokens int    `gorm:"column:system_tokens;default:0"`
 	Status       string `gorm:"column:status;index;not null"` // success, error, partial
@@ -75,6 +81,8 @@ type UsageDailyRecord struct {
 	// Cache tokens: reads, then writes (a subset of InputTokens)
 	CacheReadTokens  int64 `gorm:"column:cache_input_tokens;default:0"`
 	CacheWriteTokens int64 `gorm:"column:cache_write_tokens;default:0"`
+	// ReasoningTokens: a subset of OutputTokens (see UsageRecord doc)
+	ReasoningTokens int64 `gorm:"column:reasoning_tokens;default:0"`
 	// System tokens
 	SystemTokens  int64 `gorm:"column:system_tokens;default:0"`
 	ErrorCount    int64 `gorm:"column:error_count;default:0"`
@@ -239,6 +247,7 @@ type AggregatedStat struct {
 	OutputTokens     int64   `json:"total_output_tokens"`
 	CacheReadTokens  int64   `json:"cache_read_tokens"`
 	CacheWriteTokens int64   `json:"cache_write_tokens"`
+	ReasoningTokens  int64   `json:"reasoning_tokens"`
 	SystemTokens     int64   `json:"system_tokens"`
 	AvgInputTokens   float64 `json:"avg_input_tokens"`
 	AvgOutputTokens  float64 `json:"avg_output_tokens"`
@@ -376,6 +385,7 @@ type aggBucket struct {
 	OutputTokens     int64
 	CacheReadTokens  int64
 	CacheWriteTokens int64
+	ReasoningTokens  int64
 	SystemTokens     int64
 	ErrorCount       int64
 	StreamedCount    int64
@@ -396,6 +406,7 @@ func (b aggBucket) toAggregatedStat() AggregatedStat {
 		OutputTokens:     b.OutputTokens,
 		CacheReadTokens:  b.CacheReadTokens,
 		CacheWriteTokens: b.CacheWriteTokens,
+		ReasoningTokens:  b.ReasoningTokens,
 		SystemTokens:     b.SystemTokens,
 		AvgInputTokens:   avgFloat(float64(b.InputTokens), b.RequestCount),
 		AvgOutputTokens:  avgFloat(float64(b.OutputTokens), b.RequestCount),
@@ -460,6 +471,7 @@ func (us *UsageStore) rawAggBuckets(query UsageStatsQuery, applyLimit bool) ([]a
 		COALESCE(SUM(output_tokens), 0) as output_tokens,
 		COALESCE(SUM(cache_input_tokens), 0) as cache_read_tokens,
 		COALESCE(SUM(cache_write_tokens), 0) as cache_write_tokens,
+		COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens,
 		COALESCE(SUM(system_tokens), 0) as system_tokens,
 		COALESCE(SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END), 0) as error_count,
 		COALESCE(SUM(CASE WHEN streamed = true THEN 1 ELSE 0 END), 0) as streamed_count,
@@ -486,6 +498,7 @@ type TimeSeriesData struct {
 	OutputTokens     int64   `json:"output_tokens"`
 	CacheReadTokens  int64   `json:"cache_read_tokens"`
 	CacheWriteTokens int64   `json:"cache_write_tokens"`
+	ReasoningTokens  int64   `json:"reasoning_tokens"`
 	SystemTokens     int64   `json:"system_tokens"`
 	ErrorCount       int64   `json:"error_count"`
 	AvgLatencyMs     float64 `json:"avg_latency_ms"`
@@ -536,6 +549,7 @@ func (us *UsageStore) rawTimeSeries(interval string, startTime, endTime time.Tim
 		OutputTokens     int64
 		CacheReadTokens  int64
 		CacheWriteTokens int64
+		ReasoningTokens  int64
 		SystemTokens     int64
 		ErrorCount       int64
 		AvgLatency       float64
@@ -551,6 +565,7 @@ func (us *UsageStore) rawTimeSeries(interval string, startTime, endTime time.Tim
 		COALESCE(SUM(output_tokens), 0) as output_tokens,
 		COALESCE(SUM(cache_input_tokens), 0) as cache_read_tokens,
 		COALESCE(SUM(cache_write_tokens), 0) as cache_write_tokens,
+		COALESCE(SUM(reasoning_tokens), 0) as reasoning_tokens,
 		COALESCE(SUM(system_tokens), 0) as system_tokens,
 		COALESCE(SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END), 0) as error_count,
 		COALESCE(AVG(latency_ms), 0) as avg_latency
@@ -575,6 +590,7 @@ func (us *UsageStore) rawTimeSeries(interval string, startTime, endTime time.Tim
 			OutputTokens:     r.OutputTokens,
 			CacheReadTokens:  r.CacheReadTokens,
 			CacheWriteTokens: r.CacheWriteTokens,
+			ReasoningTokens:  r.ReasoningTokens,
 			SystemTokens:     r.SystemTokens,
 			ErrorCount:       r.ErrorCount,
 			AvgLatencyMs:     r.AvgLatency,

--- a/internal/protocol/assembler/anthropic_assembler.go
+++ b/internal/protocol/assembler/anthropic_assembler.go
@@ -218,10 +218,8 @@ func (a *AnthropicStreamAssembler) SetUsage(inputTokens, outputTokens int) {
 // ai.TokenUsage type. Cache-read input tokens are mapped to
 // anthropic.Usage.CacheReadInputTokens and cache writes to
 // CacheCreationInputTokens. ReasoningTokens maps to
-// Usage.OutputTokensDetails.ThinkingTokens -- Anthropic's own
-// usage.output_tokens_details.thinking_tokens field (added alongside
-// claude-opus-4-8), a genuine subset of OutputTokens like OpenAI's
-// reasoning_tokens, not something Anthropic lacks.
+// Usage.OutputTokensDetails.ThinkingTokens, a genuine subset of OutputTokens
+// like OpenAI's reasoning_tokens.
 //
 // InputTokens goes through UncachedInputTokens() because canonical usage folds
 // the cache-write cost into InputTokens while Anthropic's wire field excludes it.

--- a/internal/protocol/assembler/anthropic_assembler.go
+++ b/internal/protocol/assembler/anthropic_assembler.go
@@ -64,6 +64,9 @@ func (a *AnthropicStreamAssembler) RecordV1Event(event *anthropic.MessageStreamE
 				InputTokens:          event.Usage.InputTokens,
 				OutputTokens:         event.Usage.OutputTokens,
 				CacheReadInputTokens: event.Usage.CacheReadInputTokens,
+				OutputTokensDetails: anthropic.OutputTokensDetails{
+					ThinkingTokens: event.Usage.OutputTokensDetails.ThinkingTokens,
+				},
 			}
 		}
 	}
@@ -92,6 +95,9 @@ func (a *AnthropicStreamAssembler) RecordV1BetaEvent(event *anthropic.BetaRawMes
 				InputTokens:          event.Usage.InputTokens,
 				OutputTokens:         event.Usage.OutputTokens,
 				CacheReadInputTokens: event.Usage.CacheReadInputTokens,
+				OutputTokensDetails: anthropic.OutputTokensDetails{
+					ThinkingTokens: event.Usage.OutputTokensDetails.ThinkingTokens,
+				},
 			}
 		}
 	}
@@ -211,8 +217,11 @@ func (a *AnthropicStreamAssembler) SetUsage(inputTokens, outputTokens int) {
 // SetUsageFromTokenUsage sets the assembled response usage from the canonical
 // ai.TokenUsage type. Cache-read input tokens are mapped to
 // anthropic.Usage.CacheReadInputTokens and cache writes to
-// CacheCreationInputTokens; reasoning_tokens has no Anthropic analogue
-// (extended-thinking tokens are billed inside output_tokens).
+// CacheCreationInputTokens. ReasoningTokens maps to
+// Usage.OutputTokensDetails.ThinkingTokens -- Anthropic's own
+// usage.output_tokens_details.thinking_tokens field (added alongside
+// claude-opus-4-8), a genuine subset of OutputTokens like OpenAI's
+// reasoning_tokens, not something Anthropic lacks.
 //
 // InputTokens goes through UncachedInputTokens() because canonical usage folds
 // the cache-write cost into InputTokens while Anthropic's wire field excludes it.
@@ -225,6 +234,11 @@ func (a *AnthropicStreamAssembler) SetUsageFromTokenUsage(u *ai.TokenUsage) {
 		OutputTokens:             int64(u.OutputTokens),
 		CacheReadInputTokens:     int64(u.CacheReadTokens),
 		CacheCreationInputTokens: int64(u.CacheWriteTokens),
+	}
+	if u.ReasoningTokens > 0 {
+		a.usageData.OutputTokensDetails = anthropic.OutputTokensDetails{
+			ThinkingTokens: int64(u.ReasoningTokens),
+		}
 	}
 }
 

--- a/internal/protocol/assembler/anthropic_assembler_test.go
+++ b/internal/protocol/assembler/anthropic_assembler_test.go
@@ -268,8 +268,7 @@ func TestAnthropicStreamAssembler_SetUsageFromTokenUsage_CarriesCacheWrite(t *te
 // TestAnthropicStreamAssembler_SetUsageFromTokenUsage_CarriesReasoning checks
 // that ReasoningTokens (from OpenAI upstream, or Anthropic's own extended
 // thinking) survives into the assembled Anthropic response as
-// output_tokens_details.thinking_tokens -- a real Anthropic wire field
-// (added alongside claude-opus-4-8), not something Anthropic lacks.
+// output_tokens_details.thinking_tokens.
 func TestAnthropicStreamAssembler_SetUsageFromTokenUsage_CarriesReasoning(t *testing.T) {
 	assembler := NewAnthropicStreamAssembler()
 	assembler.SetUsageFromTokenUsage(&ai.TokenUsage{

--- a/internal/protocol/assembler/anthropic_assembler_test.go
+++ b/internal/protocol/assembler/anthropic_assembler_test.go
@@ -264,3 +264,47 @@ func TestAnthropicStreamAssembler_SetUsageFromTokenUsage_CarriesCacheWrite(t *te
 	assert.Equal(t, int64(11), result.Usage.CacheReadInputTokens)
 	assert.Equal(t, int64(17), result.Usage.OutputTokens)
 }
+
+// TestAnthropicStreamAssembler_SetUsageFromTokenUsage_CarriesReasoning checks
+// that ReasoningTokens (from OpenAI upstream, or Anthropic's own extended
+// thinking) survives into the assembled Anthropic response as
+// output_tokens_details.thinking_tokens -- a real Anthropic wire field
+// (added alongside claude-opus-4-8), not something Anthropic lacks.
+func TestAnthropicStreamAssembler_SetUsageFromTokenUsage_CarriesReasoning(t *testing.T) {
+	assembler := NewAnthropicStreamAssembler()
+	assembler.SetUsageFromTokenUsage(&ai.TokenUsage{
+		InputTokens:     42,
+		OutputTokens:    80,
+		ReasoningTokens: 30,
+	})
+	assembler.msgID = "msg_reasoning"
+	assembler.blocks[0] = anthropic.ContentBlockUnion{Type: "text", Text: "ok"}
+
+	result := assembler.Finish("model", 0, 0)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(30), result.Usage.OutputTokensDetails.ThinkingTokens)
+}
+
+// TestAnthropicStreamAssembler_RecordV1Event_CarriesReasoning verifies a
+// native Anthropic message_delta with output_tokens_details.thinking_tokens
+// survives RecordV1Event into the assembled response.
+func TestAnthropicStreamAssembler_RecordV1Event_CarriesReasoning(t *testing.T) {
+	assembler := NewAnthropicStreamAssembler()
+
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_t","type":"message","role":"assistant"}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":100,"output_tokens":80,"output_tokens_details":{"thinking_tokens":30}}}`,
+	}
+	for _, raw := range events {
+		var evt anthropic.MessageStreamEventUnion
+		require.NoError(t, json.Unmarshal([]byte(raw), &evt))
+		assembler.RecordV1Event(&evt)
+	}
+
+	result := assembler.Finish("model", 0, 0)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(80), result.Usage.OutputTokens)
+	assert.Equal(t, int64(30), result.Usage.OutputTokensDetails.ThinkingTokens)
+}

--- a/internal/protocol/nonstream/openai_to_anthropic.go
+++ b/internal/protocol/nonstream/openai_to_anthropic.go
@@ -19,12 +19,18 @@ import (
 // InputTokens, so emitting it unchanged alongside cache_creation_input_tokens
 // would bill the write portion twice.
 func anthropicUsageWire(u *protocol.TokenUsage) wire.AnthropicUsageWire {
-	return wire.AnthropicUsageWire{
+	w := wire.AnthropicUsageWire{
 		InputTokens:              int64(u.UncachedInputTokens()),
 		OutputTokens:             int64(u.OutputTokens),
 		CacheReadInputTokens:     int64(u.CacheReadTokens),
 		CacheCreationInputTokens: int64(u.CacheWriteTokens),
 	}
+	if u.ReasoningTokens > 0 {
+		w.OutputTokensDetails = &wire.AnthropicOutputTokensDetailsWire{
+			ThinkingTokens: int64(u.ReasoningTokens),
+		}
+	}
+	return w
 }
 
 func HandleOpenAIChatToAnthropic(chat *openai.ChatCompletion, model string) *anthropic.BetaMessage {

--- a/internal/protocol/nonstream/openai_usage_test.go
+++ b/internal/protocol/nonstream/openai_usage_test.go
@@ -237,8 +237,7 @@ func TestBuildAnthropicPayloadFromChat_CacheWriteTokens(t *testing.T) {
 
 // TestBuildAnthropicPayloadFromChat_ReasoningTokens verifies OpenAI
 // reasoning_tokens survives conversion into an Anthropic-shaped response as
-// usage.output_tokens_details.thinking_tokens -- a real Anthropic wire field
-// (added alongside claude-opus-4-8), not something the protocol lacks.
+// usage.output_tokens_details.thinking_tokens.
 func TestBuildAnthropicPayloadFromChat_ReasoningTokens(t *testing.T) {
 	resp := &openai.ChatCompletion{
 		ID: "chatcmpl-4",

--- a/internal/protocol/nonstream/openai_usage_test.go
+++ b/internal/protocol/nonstream/openai_usage_test.go
@@ -234,3 +234,29 @@ func TestBuildAnthropicPayloadFromChat_CacheWriteTokens(t *testing.T) {
 		out.Usage.InputTokens+out.Usage.CacheReadInputTokens+out.Usage.CacheCreationInputTokens,
 		"the three fields must reconstruct the original prompt total")
 }
+
+// TestBuildAnthropicPayloadFromChat_ReasoningTokens verifies OpenAI
+// reasoning_tokens survives conversion into an Anthropic-shaped response as
+// usage.output_tokens_details.thinking_tokens -- a real Anthropic wire field
+// (added alongside claude-opus-4-8), not something the protocol lacks.
+func TestBuildAnthropicPayloadFromChat_ReasoningTokens(t *testing.T) {
+	resp := &openai.ChatCompletion{
+		ID: "chatcmpl-4",
+		Choices: []openai.ChatCompletionChoice{
+			{Message: openai.ChatCompletionMessage{Role: "assistant", Content: "hi"}, FinishReason: "stop"},
+		},
+		Usage: openai.CompletionUsage{
+			PromptTokens:     200,
+			CompletionTokens: 80,
+			TotalTokens:      280,
+			CompletionTokensDetails: openai.CompletionUsageCompletionTokensDetails{
+				ReasoningTokens: 30,
+			},
+		},
+	}
+
+	out := HandleOpenAIChatToAnthropic(resp, "claude-x")
+	require.NotNil(t, out)
+	assert.EqualValues(t, 80, out.Usage.OutputTokens)
+	assert.EqualValues(t, 30, out.Usage.OutputTokensDetails.ThinkingTokens)
+}

--- a/internal/protocol/usage/accumulator.go
+++ b/internal/protocol/usage/accumulator.go
@@ -56,6 +56,8 @@ func (a *AnthropicAccumulator) Consume(evt *anthropic.MessageStreamEventUnion) {
 		parsed.Get("usage.cache_read_input_tokens").Int(),
 		evt.Message.Usage.CacheCreationInputTokens,
 		evt.Usage.CacheCreationInputTokens,
+		evt.Usage.OutputTokensDetails.ThinkingTokens,
+		parsed.Get("usage.output_tokens_details.thinking_tokens").Int(),
 	)
 }
 
@@ -76,6 +78,8 @@ func (a *AnthropicAccumulator) ConsumeBeta(evt *anthropic.BetaRawMessageStreamEv
 		0,
 		evt.Message.Usage.CacheCreationInputTokens,
 		evt.Usage.CacheCreationInputTokens,
+		evt.Usage.OutputTokensDetails.ThinkingTokens,
+		0,
 	)
 }
 
@@ -86,6 +90,7 @@ func (a *AnthropicAccumulator) ConsumeBeta(evt *anthropic.BetaRawMessageStreamEv
 //   - Output: delta path only
 //   - Cache read: prefer message_start, fall back to delta
 //   - Cache creation: added to inputTokens (normalization)
+//   - Reasoning (extended thinking): delta path only, subset of output
 func (a *AnthropicAccumulator) consumeRaw(
 	msgStartInput, msgStartInputRaw int64,
 	deltaInput, deltaInputRaw int64,
@@ -93,6 +98,7 @@ func (a *AnthropicAccumulator) consumeRaw(
 	msgStartCacheRead, deltaCacheRead int64,
 	msgStartCacheReadRaw, deltaCacheReadRaw int64,
 	msgStartCacheCreation, deltaCacheCreation int64,
+	deltaReasoning, deltaReasoningRaw int64,
 ) {
 	if a.usage == nil {
 		a.usage = protocol.ZeroTokenUsage()
@@ -149,6 +155,17 @@ func (a *AnthropicAccumulator) consumeRaw(
 	case deltaCacheCreation > 0:
 		a.usage.CacheWriteTokens = int(deltaCacheCreation)
 		a.usage.InputTokens += int(deltaCacheCreation)
+	}
+
+	// Reasoning (extended thinking) tokens — a subset of OutputTokens, not
+	// added on top of it. Delta path only, same as output tokens.
+	switch {
+	case deltaReasoning > 0:
+		a.usage.ReasoningTokens = int(deltaReasoning)
+		a.hasUsage = true
+	case deltaReasoningRaw > 0:
+		a.usage.ReasoningTokens = int(deltaReasoningRaw)
+		a.hasUsage = true
 	}
 }
 

--- a/internal/protocol/usage/extract.go
+++ b/internal/protocol/usage/extract.go
@@ -62,23 +62,27 @@ func FromOpenAIResponses(u responses.ResponseUsage) *protocol.TokenUsage {
 // FromAnthropicMessage extracts normalized TokenUsage from an Anthropic v1
 // (non-beta) Message usage block. CacheCreationInputTokens is added to
 // InputTokens so the denominator covers all non-cache-read prompt cost.
+// ThinkingTokens (extended thinking) is a subset of OutputTokens, same
+// relationship as OpenAI's reasoning_tokens -- not subtracted.
 func FromAnthropicMessage(u anthropic.Usage) *protocol.TokenUsage {
-	return protocol.NewTokenUsageWithCacheDetails(
+	return protocol.NewTokenUsageFull(
 		int(u.InputTokens)+int(u.CacheCreationInputTokens),
 		int(u.OutputTokens),
 		int(u.CacheReadInputTokens),
 		int(u.CacheCreationInputTokens),
+		int(u.OutputTokensDetails.ThinkingTokens),
 	)
 }
 
 // FromAnthropicBetaMessage extracts normalized TokenUsage from an Anthropic
 // beta BetaMessage usage block. Same normalization as the non-beta path.
 func FromAnthropicBetaMessage(u anthropic.BetaUsage) *protocol.TokenUsage {
-	return protocol.NewTokenUsageWithCacheDetails(
+	return protocol.NewTokenUsageFull(
 		int(u.InputTokens)+int(u.CacheCreationInputTokens),
 		int(u.OutputTokens),
 		int(u.CacheReadInputTokens),
 		int(u.CacheCreationInputTokens),
+		int(u.OutputTokensDetails.ThinkingTokens),
 	)
 }
 

--- a/internal/protocol/usage/usage_test.go
+++ b/internal/protocol/usage/usage_test.go
@@ -128,8 +128,10 @@ func TestFromAnthropicMessage(t *testing.T) {
 		name                  string
 		input, creation, read int64
 		output                int64
+		reasoning             int64
 		wantInput, wantOutput int
 		wantCache             int
+		wantReasoning         int
 	}{
 		{
 			name:  "cache read only",
@@ -146,6 +148,13 @@ func TestFromAnthropicMessage(t *testing.T) {
 			input: 300, creation: 0, read: 0, output: 80,
 			wantInput: 300, wantOutput: 80, wantCache: 0,
 		},
+		{
+			// output_tokens_details.thinking_tokens (added alongside
+			// claude-opus-4-8): a subset of output_tokens, not subtracted.
+			name:  "extended thinking",
+			input: 100, creation: 0, read: 0, output: 80, reasoning: 30,
+			wantInput: 100, wantOutput: 80, wantCache: 0, wantReasoning: 30,
+		},
 	}
 
 	for _, tc := range tests {
@@ -155,11 +164,15 @@ func TestFromAnthropicMessage(t *testing.T) {
 				OutputTokens:             tc.output,
 				CacheCreationInputTokens: tc.creation,
 				CacheReadInputTokens:     tc.read,
+				OutputTokensDetails: anthropic.OutputTokensDetails{
+					ThinkingTokens: tc.reasoning,
+				},
 			}
 			got := usage.FromAnthropicMessage(u)
 			assert.Equal(t, tc.wantInput, got.InputTokens)
 			assert.Equal(t, tc.wantOutput, got.OutputTokens)
 			assert.Equal(t, tc.wantCache, got.CacheReadTokens)
+			assert.Equal(t, tc.wantReasoning, got.ReasoningTokens)
 		})
 	}
 }
@@ -170,11 +183,15 @@ func TestFromAnthropicBetaMessage(t *testing.T) {
 		OutputTokens:             50,
 		CacheCreationInputTokens: 200,
 		CacheReadInputTokens:     400,
+		OutputTokensDetails: anthropic.BetaOutputTokensDetails{
+			ThinkingTokens: 15,
+		},
 	}
 	got := usage.FromAnthropicBetaMessage(u)
 	assert.Equal(t, 300, got.InputTokens) // 100 + 200
 	assert.Equal(t, 50, got.OutputTokens)
 	assert.Equal(t, 400, got.CacheReadTokens)
+	assert.Equal(t, 15, got.ReasoningTokens)
 }
 
 // ---------------------------------------------------------------------------
@@ -255,6 +272,26 @@ func messageDeltaFullJSON(t *testing.T, inputTokens, outputTokens, cacheRead int
 			"input_tokens":            inputTokens,
 			"output_tokens":           outputTokens,
 			"cache_read_input_tokens": cacheRead,
+		},
+	}
+	b, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// thinkingDeltaJSON is outputOnlyDeltaJSON plus a
+// usage.output_tokens_details.thinking_tokens breakdown (extended thinking,
+// added alongside claude-opus-4-8).
+func thinkingDeltaJSON(t *testing.T, outputTokens, thinkingTokens int64) string {
+	t.Helper()
+	ev := map[string]interface{}{
+		"type":  "message_delta",
+		"delta": map[string]interface{}{"stop_reason": "end_turn"},
+		"usage": map[string]interface{}{
+			"output_tokens":         outputTokens,
+			"output_tokens_details": map[string]interface{}{"thinking_tokens": thinkingTokens},
 		},
 	}
 	b, err := json.Marshal(ev)
@@ -350,6 +387,30 @@ func TestAnthropicAccumulator_Beta(t *testing.T) {
 	assert.Equal(t, 45, got.InputTokens) // 40 + 5
 	assert.Equal(t, 22, got.OutputTokens)
 	assert.Equal(t, 8, got.CacheReadTokens)
+}
+
+// TestAnthropicAccumulator_ExtendedThinking verifies
+// output_tokens_details.thinking_tokens accumulates into ReasoningTokens
+// (a subset of OutputTokens, not added on top of it).
+func TestAnthropicAccumulator_ExtendedThinking(t *testing.T) {
+	events := []string{
+		messageStartJSON(t, 100, 0, 0),
+		thinkingDeltaJSON(t, 80, 30),
+	}
+	dec := newFakeDecoder(events)
+	stream := anthropicstream.NewStream[anthropic.MessageStreamEventUnion](dec, nil)
+
+	acc := usage.NewAnthropicAccumulator()
+	for stream.Next() {
+		evt := stream.Current()
+		acc.Consume(&evt)
+	}
+
+	got := acc.Result()
+	assert.Equal(t, 100, got.InputTokens)
+	assert.Equal(t, 80, got.OutputTokens)
+	assert.Equal(t, 30, got.ReasoningTokens)
+	assert.True(t, acc.HasUsage())
 }
 
 // TestAnthropicAccumulator_NoUsage verifies HasUsage is false when no usage seen.
@@ -494,8 +555,23 @@ func TestToAnthropicUsageMap_UnfoldsCacheWrite(t *testing.T) {
 	assert.Equal(t, 200, m["input_tokens"], "input_tokens excludes the write portion")
 	assert.Equal(t, 50, m["cache_creation_input_tokens"])
 	assert.Equal(t, 800, m["cache_read_input_tokens"])
+	assert.Nil(t, m["output_tokens_details"], "absent when there is no reasoning to report")
 
 	// input + creation + read must reconstruct the original prompt total.
 	assert.Equal(t, u.InputTokens+u.CacheReadTokens,
 		m["input_tokens"].(int)+m["cache_creation_input_tokens"].(int)+m["cache_read_input_tokens"].(int))
+}
+
+// TestToAnthropicUsageMap_ReasoningTokens verifies ReasoningTokens (whether
+// sourced from OpenAI or Anthropic itself) round-trips onto the Anthropic
+// wire shape as output_tokens_details.thinking_tokens.
+func TestToAnthropicUsageMap_ReasoningTokens(t *testing.T) {
+	u := protocol.NewTokenUsageFull(100, 80, 0, 0, 30)
+
+	m := u.ToAnthropicUsageMap()
+	details, ok := m["output_tokens_details"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected output_tokens_details map, got %T", m["output_tokens_details"])
+	}
+	assert.Equal(t, 30, details["thinking_tokens"])
 }

--- a/internal/protocol/usage/usage_test.go
+++ b/internal/protocol/usage/usage_test.go
@@ -149,8 +149,8 @@ func TestFromAnthropicMessage(t *testing.T) {
 			wantInput: 300, wantOutput: 80, wantCache: 0,
 		},
 		{
-			// output_tokens_details.thinking_tokens (added alongside
-			// claude-opus-4-8): a subset of output_tokens, not subtracted.
+			// output_tokens_details.thinking_tokens: a subset of
+			// output_tokens, not subtracted.
 			name:  "extended thinking",
 			input: 100, creation: 0, read: 0, output: 80, reasoning: 30,
 			wantInput: 100, wantOutput: 80, wantCache: 0, wantReasoning: 30,
@@ -282,8 +282,7 @@ func messageDeltaFullJSON(t *testing.T, inputTokens, outputTokens, cacheRead int
 }
 
 // thinkingDeltaJSON is outputOnlyDeltaJSON plus a
-// usage.output_tokens_details.thinking_tokens breakdown (extended thinking,
-// added alongside claude-opus-4-8).
+// usage.output_tokens_details.thinking_tokens breakdown (extended thinking).
 func thinkingDeltaJSON(t *testing.T, outputTokens, thinkingTokens int64) string {
 	t.Helper()
 	ev := map[string]interface{}{

--- a/internal/protocol/wire/anthropic.go
+++ b/internal/protocol/wire/anthropic.go
@@ -18,8 +18,17 @@ type AnthropicMsgWire struct {
 // AnthropicUsageWire represents the Anthropic usage wire format.
 // input_tokens = uncached only; cache_read and cache_creation are separate.
 type AnthropicUsageWire struct {
-	InputTokens              int64 `json:"input_tokens"`
-	OutputTokens             int64 `json:"output_tokens"`
-	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
-	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens,omitempty"`
+	InputTokens              int64                             `json:"input_tokens"`
+	OutputTokens             int64                             `json:"output_tokens"`
+	CacheReadInputTokens     int64                             `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64                             `json:"cache_creation_input_tokens,omitempty"`
+	OutputTokensDetails      *AnthropicOutputTokensDetailsWire `json:"output_tokens_details,omitempty"`
+}
+
+// AnthropicOutputTokensDetailsWire mirrors Anthropic's own
+// usage.output_tokens_details (added alongside claude-opus-4-8):
+// thinking_tokens is a subset of output_tokens, same relationship as
+// OpenAI's completion_tokens_details.reasoning_tokens.
+type AnthropicOutputTokensDetailsWire struct {
+	ThinkingTokens int64 `json:"thinking_tokens"`
 }

--- a/internal/protocol/wire/anthropic.go
+++ b/internal/protocol/wire/anthropic.go
@@ -26,9 +26,8 @@ type AnthropicUsageWire struct {
 }
 
 // AnthropicOutputTokensDetailsWire mirrors Anthropic's own
-// usage.output_tokens_details (added alongside claude-opus-4-8):
-// thinking_tokens is a subset of output_tokens, same relationship as
-// OpenAI's completion_tokens_details.reasoning_tokens.
+// usage.output_tokens_details: thinking_tokens is a subset of output_tokens,
+// same relationship as OpenAI's completion_tokens_details.reasoning_tokens.
 type AnthropicOutputTokensDetailsWire struct {
 	ThinkingTokens int64 `json:"thinking_tokens"`
 }

--- a/internal/protocolserver/usage_tracking.go
+++ b/internal/protocolserver/usage_tracking.go
@@ -389,6 +389,7 @@ func (ph *ProtocolHandler) recordDetailedUsageWithTokenUsage(c *gin.Context, rul
 		OutputTokens:     usage.OutputTokens,
 		CacheReadTokens:  usage.CacheReadTokens,
 		CacheWriteTokens: usage.CacheWriteTokens,
+		ReasoningTokens:  usage.ReasoningTokens,
 		SystemTokens:     usage.SystemTokens,
 		TotalTokens:      usage.TotalTokens(),
 		Status:           status,

--- a/internal/server/module/usage/handler.go
+++ b/internal/server/module/usage/handler.go
@@ -79,6 +79,7 @@ func (h *Handler) GetStats(c *gin.Context) {
 			StreamedRate:     s.StreamedRate,
 			CacheReadTokens:  s.CacheReadTokens,
 			CacheWriteTokens: s.CacheWriteTokens,
+			ReasoningTokens:  s.ReasoningTokens,
 		}
 	}
 
@@ -141,6 +142,7 @@ func (h *Handler) GetTimeSeries(c *gin.Context) {
 			OutputTokens:     d.OutputTokens,
 			CacheReadTokens:  d.CacheReadTokens,
 			CacheWriteTokens: d.CacheWriteTokens,
+			ReasoningTokens:  d.ReasoningTokens,
 			ErrorCount:       d.ErrorCount,
 			AvgLatencyMs:     d.AvgLatencyMs,
 		}
@@ -223,6 +225,7 @@ func (h *Handler) GetRecords(c *gin.Context) {
 			TotalTokens:      r.TotalTokens,
 			CacheReadTokens:  r.CacheReadTokens,
 			CacheWriteTokens: r.CacheWriteTokens,
+			ReasoningTokens:  r.ReasoningTokens,
 			Status:           r.Status,
 			ErrorCode:        r.ErrorCode,
 			LatencyMs:        r.LatencyMs,

--- a/internal/server/module/usage/handler_test.go
+++ b/internal/server/module/usage/handler_test.go
@@ -375,3 +375,71 @@ func TestParseIntQuery_Helper(t *testing.T) {
 		})
 	}
 }
+
+// TestReasoningTokensSurviveHandlerConversion exercises the real Handler
+// (backed by a real db.UsageStore, not the mock) end to end, verifying
+// ReasoningTokens survives the db.X -> usage.X conversion in all three
+// handlers instead of being dropped like it used to be before persistence.
+func TestReasoningTokensSurviveHandlerConversion(t *testing.T) {
+	sm, err := db.NewStoreManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStoreManager failed: %v", err)
+	}
+	defer sm.Close()
+	store := sm.Usage()
+
+	if err := store.RecordUsage(&db.UsageRecord{
+		ProviderUUID:    "prov-1",
+		ProviderName:    "openai",
+		Model:           "gpt-5.1-reasoning",
+		Scenario:        "default",
+		UserID:          "admin",
+		Timestamp:       time.Now(),
+		InputTokens:     100,
+		OutputTokens:    80,
+		ReasoningTokens: 30,
+		Status:          "success",
+	}); err != nil {
+		t.Fatalf("RecordUsage failed: %v", err)
+	}
+
+	handler := NewHandler(store)
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/usage/stats", handler.GetStats)
+	router.GET("/usage/timeseries", handler.GetTimeSeries)
+	router.GET("/usage/records", handler.GetRecords)
+
+	start := time.Now().Add(-time.Hour).Format(time.RFC3339)
+	end := time.Now().Add(time.Hour).Format(time.RFC3339)
+
+	t.Run("stats", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/usage/stats?start_time="+start+"&end_time="+end, nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		assert.Contains(t, w.Body.String(), `"reasoning_tokens":30`)
+	})
+
+	t.Run("timeseries", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/usage/timeseries?interval=hour&start_time="+start+"&end_time="+end, nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		assert.Contains(t, w.Body.String(), `"reasoning_tokens":30`)
+	})
+
+	t.Run("records", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/usage/records?start_time="+start+"&end_time="+end, nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		assert.Contains(t, w.Body.String(), `"reasoning_tokens":30`)
+	})
+}

--- a/internal/server/module/usage/types.go
+++ b/internal/server/module/usage/types.go
@@ -41,6 +41,11 @@ type AggregatedStat struct {
 	StreamedRate     float64 `json:"streamed_rate" example:"0.885"`
 	CacheReadTokens  int64   `json:"cache_read_tokens" example:"500000"`
 	CacheWriteTokens int64   `json:"cache_write_tokens" example:"75000"`
+	// ReasoningTokens is a subset of OutputTokens (thinking/reasoning
+	// tokens). Always 0 for Anthropic-routed requests -- Anthropic does not
+	// expose a separate thinking-token count, even when extended thinking
+	// was used.
+	ReasoningTokens int64 `json:"reasoning_tokens" example:"12000"`
 }
 
 // UsageStatsResponse represents the response for usage statistics
@@ -77,6 +82,7 @@ type TimeSeriesData struct {
 	OutputTokens     int64   `json:"output_tokens" example:"20000"`
 	CacheReadTokens  int64   `json:"cache_read_tokens" example:"10000"`
 	CacheWriteTokens int64   `json:"cache_write_tokens" example:"1500"`
+	ReasoningTokens  int64   `json:"reasoning_tokens" example:"800"`
 	ErrorCount       int64   `json:"error_count" example:"0"`
 	AvgLatencyMs     float64 `json:"avg_latency_ms" example:"1100"`
 }
@@ -123,6 +129,7 @@ type UsageRecordResponse struct {
 	TotalTokens      int     `json:"total_tokens" example:"1500"`
 	CacheReadTokens  int     `json:"cache_read_tokens" example:"2000"`
 	CacheWriteTokens int     `json:"cache_write_tokens" example:"300"`
+	ReasoningTokens  int     `json:"reasoning_tokens" example:"50"`
 	Status           string  `json:"status" example:"success"`
 	ErrorCode        string  `json:"error_code,omitempty"`
 	LatencyMs        int     `json:"latency_ms" example:"1200"`

--- a/internal/server/module/usage/types.go
+++ b/internal/server/module/usage/types.go
@@ -42,9 +42,7 @@ type AggregatedStat struct {
 	CacheReadTokens  int64   `json:"cache_read_tokens" example:"500000"`
 	CacheWriteTokens int64   `json:"cache_write_tokens" example:"75000"`
 	// ReasoningTokens is a subset of OutputTokens (thinking/reasoning
-	// tokens). Always 0 for Anthropic-routed requests -- Anthropic does not
-	// expose a separate thinking-token count, even when extended thinking
-	// was used.
+	// tokens); populated for both OpenAI and Anthropic.
 	ReasoningTokens int64 `json:"reasoning_tokens" example:"12000"`
 }
 

--- a/openapi.json
+++ b/openapi.json
@@ -6515,6 +6515,15 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "name": "force_upstream",
+            "in": "query",
+            "description": "Attempt the upstream models endpoint even when normally skipped",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -7398,6 +7407,12 @@
             "description": "Field provider_uuid",
             "example": "uuid-123"
           },
+          "reasoning_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field reasoning_tokens",
+            "example": 12000
+          },
           "request_count": {
             "type": "integer",
             "format": "int64",
@@ -7459,7 +7474,8 @@
           "streamed_count",
           "streamed_rate",
           "cache_read_tokens",
-          "cache_write_tokens"
+          "cache_write_tokens",
+          "reasoning_tokens"
         ]
       },
       "ApplyClaudeConfigRequest": {
@@ -8980,6 +8996,11 @@
             "type": "string",
             "description": "Field test_mode"
           },
+          "thinking": {
+            "type": "string",
+            "description": "Field thinking",
+            "example": "medium"
+          },
           "token": {
             "type": "string",
             "description": "Field token"
@@ -8994,7 +9015,7 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/ProbeResult"
+            "$ref": "#/components/schemas/Result"
           },
           "error": {
             "$ref": "#/components/schemas/errorDetail"
@@ -11892,135 +11913,6 @@
           "verdict"
         ]
       },
-      "ProbeResult": {
-        "type": "object",
-        "properties": {
-          "applied_flags": {
-            "type": "string",
-            "description": "Field applied_flags"
-          },
-          "completion_tokens": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field completion_tokens"
-          },
-          "content": {
-            "type": "string",
-            "description": "Field content"
-          },
-          "error_message": {
-            "type": "string",
-            "description": "Field error_message"
-          },
-          "latency_ms": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field latency_ms"
-          },
-          "matched_rule": {
-            "type": "string",
-            "description": "Field matched_rule"
-          },
-          "matched_rule_desc": {
-            "type": "string",
-            "description": "Field matched_rule_desc"
-          },
-          "matched_smart_rule": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field matched_smart_rule"
-          },
-          "message": {
-            "type": "string",
-            "description": "Field message"
-          },
-          "models_count": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field models_count"
-          },
-          "prompt_tokens": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field prompt_tokens"
-          },
-          "request_url": {
-            "type": "string",
-            "description": "Field request_url"
-          },
-          "routing_source": {
-            "type": "string",
-            "description": "Field routing_source"
-          },
-          "selected_model": {
-            "type": "string",
-            "description": "Field selected_model"
-          },
-          "selected_provider": {
-            "type": "string",
-            "description": "Field selected_provider"
-          },
-          "selected_provider_uuid": {
-            "type": "string",
-            "description": "Field selected_provider_uuid"
-          },
-          "stream": {
-            "type": "boolean",
-            "description": "Field stream"
-          },
-          "success": {
-            "type": "boolean",
-            "description": "Field success"
-          },
-          "tool_calls": {
-            "type": "array",
-            "description": "Field tool_calls",
-            "items": {
-              "$ref": "#/components/schemas/ProbeToolCall"
-            }
-          },
-          "total_tokens": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Field total_tokens"
-          },
-          "upstream_api": {
-            "type": "string",
-            "description": "Field upstream_api"
-          },
-          "upstream_url": {
-            "type": "string",
-            "description": "Field upstream_url"
-          }
-        },
-        "required": [
-          "success",
-          "latency_ms"
-        ]
-      },
-      "ProbeToolCall": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Field id"
-          },
-          "input": {
-            "type": "object",
-            "description": "Field input",
-            "additionalProperties": {}
-          },
-          "name": {
-            "type": "string",
-            "description": "Field name"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "input"
-        ]
-      },
       "ProfileClaudeConfigData": {
         "type": "object",
         "properties": {
@@ -12754,6 +12646,95 @@
           "restoredFiles",
           "preRestoreBackups",
           "message"
+        ]
+      },
+      "Result": {
+        "type": "object",
+        "properties": {
+          "applied_flags": {
+            "type": "string",
+            "description": "Field applied_flags"
+          },
+          "content": {
+            "type": "string",
+            "description": "Field content"
+          },
+          "error_message": {
+            "type": "string",
+            "description": "Field error_message"
+          },
+          "latency_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field latency_ms"
+          },
+          "matched_rule": {
+            "type": "string",
+            "description": "Field matched_rule"
+          },
+          "matched_rule_desc": {
+            "type": "string",
+            "description": "Field matched_rule_desc"
+          },
+          "matched_smart_rule": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field matched_smart_rule"
+          },
+          "message": {
+            "type": "string",
+            "description": "Field message"
+          },
+          "request_url": {
+            "type": "string",
+            "description": "Field request_url"
+          },
+          "routing_source": {
+            "type": "string",
+            "description": "Field routing_source"
+          },
+          "selected_model": {
+            "type": "string",
+            "description": "Field selected_model"
+          },
+          "selected_provider": {
+            "type": "string",
+            "description": "Field selected_provider"
+          },
+          "selected_provider_uuid": {
+            "type": "string",
+            "description": "Field selected_provider_uuid"
+          },
+          "stream": {
+            "type": "boolean",
+            "description": "Field stream"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Field success"
+          },
+          "tool_calls": {
+            "type": "array",
+            "description": "Field tool_calls",
+            "items": {
+              "$ref": "#/components/schemas/ToolCall"
+            }
+          },
+          "upstream_api": {
+            "type": "string",
+            "description": "Field upstream_api"
+          },
+          "upstream_url": {
+            "type": "string",
+            "description": "Field upstream_url"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/TokenUsage"
+          }
+        },
+        "required": [
+          "success",
+          "latency_ms"
         ]
       },
       "Route": {
@@ -14050,6 +14031,12 @@
             "description": "Field output_tokens",
             "example": 20000
           },
+          "reasoning_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field reasoning_tokens",
+            "example": 800
+          },
           "request_count": {
             "type": "integer",
             "format": "int64",
@@ -14076,6 +14063,7 @@
           "output_tokens",
           "cache_read_tokens",
           "cache_write_tokens",
+          "reasoning_tokens",
           "error_count",
           "avg_latency_ms"
         ]
@@ -14327,6 +14315,68 @@
         "required": [
           "token",
           "type"
+        ]
+      },
+      "TokenUsage": {
+        "type": "object",
+        "properties": {
+          "cache_read_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field cache_read_tokens"
+          },
+          "cache_write_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field cache_write_tokens"
+          },
+          "input_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field input_tokens"
+          },
+          "output_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field output_tokens"
+          },
+          "reasoning_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field reasoning_tokens"
+          },
+          "system_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field system_tokens"
+          }
+        },
+        "required": [
+          "input_tokens",
+          "output_tokens"
+        ]
+      },
+      "ToolCall": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Field id"
+          },
+          "input": {
+            "type": "object",
+            "description": "Field input",
+            "additionalProperties": {}
+          },
+          "name": {
+            "type": "string",
+            "description": "Field name"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "input"
         ]
       },
       "UpdateClientRequest": {
@@ -14855,6 +14905,12 @@
             "description": "Field provider_uuid",
             "example": "uuid-123"
           },
+          "reasoning_tokens": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field reasoning_tokens",
+            "example": 50
+          },
           "request_model": {
             "type": "string",
             "description": "Field request_model",
@@ -14921,6 +14977,7 @@
           "total_tokens",
           "cache_read_tokens",
           "cache_write_tokens",
+          "reasoning_tokens",
           "status",
           "latency_ms",
           "ttft_ms",

--- a/vmodel/virtualserver/handler.go
+++ b/vmodel/virtualserver/handler.go
@@ -365,7 +365,10 @@ func (h *Handler) handleAnthropicStreaming(c *gin.Context, req *AnthropicMessage
 						usageMap["cache_creation_input_tokens"] = explicitUsage.CacheWriteTokens
 					}
 					if explicitUsage.ReasoningTokens > 0 {
-						usageMap["reasoning_tokens"] = explicitUsage.ReasoningTokens
+						// Anthropic nests this under output_tokens_details, not a flat key.
+						usageMap["output_tokens_details"] = map[string]interface{}{
+							"thinking_tokens": explicitUsage.ReasoningTokens,
+						}
 					}
 				} else {
 					// Estimate fallback, mirroring the non-streaming handler:

--- a/vmodel/virtualserver/stream_test_mocks_test.go
+++ b/vmodel/virtualserver/stream_test_mocks_test.go
@@ -116,7 +116,8 @@ func TestStreamTestMocks_AnthropicMessageDelta(t *testing.T) {
 			assert.EqualValues(t, 17, jsonNum(usage, "output_tokens"))
 			assert.EqualValues(t, 11, jsonNum(usage, "cache_read_input_tokens"))
 			assert.EqualValues(t, 5, jsonNum(usage, "cache_creation_input_tokens"))
-			assert.EqualValues(t, 9, jsonNum(usage, "reasoning_tokens"))
+			outputDetails := usage["output_tokens_details"].(map[string]interface{})
+			assert.EqualValues(t, 9, jsonNum(outputDetails, "thinking_tokens"))
 		})
 	}
 }

--- a/vmodel/virtualserver/types.go
+++ b/vmodel/virtualserver/types.go
@@ -71,8 +71,15 @@ type AnthropicContent struct {
 
 // AnthropicUsage holds token usage in Anthropic format.
 type AnthropicUsage struct {
-	InputTokens  int64 `json:"input_tokens"`
-	OutputTokens int64 `json:"output_tokens"`
+	InputTokens         int64                         `json:"input_tokens"`
+	OutputTokens        int64                         `json:"output_tokens"`
+	OutputTokensDetails *AnthropicOutputTokensDetails `json:"output_tokens_details,omitempty"`
+}
+
+// AnthropicOutputTokensDetails mirrors Anthropic's usage.output_tokens_details;
+// ThinkingTokens is a subset of OutputTokens (like OpenAI's reasoning_tokens).
+type AnthropicOutputTokensDetails struct {
+	ThinkingTokens int64 `json:"thinking_tokens"`
 }
 
 // AnthropicStreamEvent is a streaming event in Anthropic format.


### PR DESCRIPTION
## Summary
Reasoning/thinking tokens were extracted but never persisted, and Anthropic's own extended-thinking tokens weren't read at all — the dashboard could never show them.

## Key Changes

- **Persistence**: `reasoning_tokens` now flows through DB, API, and dashboard.
- **Anthropic extraction**: reads `output_tokens_details.thinking_tokens` instead of hard-coding 0.
- **Conversion round-trip**: OpenAI `reasoning_tokens` survives OpenAI→Anthropic conversion.
- **vmodel mock fix**: Anthropic mock now renders reasoning in the correct nested wire shape.
