### PR TITLE
fix(quota): require explicit Kind tag before treating a window as self-healing

### DIFF
--- a/.design/quota-semantics.md
+++ b/.design/quota-semantics.md
@@ -134,7 +134,7 @@ Codex code review、Z.ai MCP、MiniMax 的视频/语音/图片/音乐额度都�
 `UsageWindow` 增三个字段、删一个：
 
 ```go
-Kind      WindowKind `json:"kind,omitempty"`      // "limit"（会重置）| "resource"（要充钱）
+Kind      WindowKind `json:"kind,omitempty"`      // "unknown"(空串，缺省) | "limit"（会重置） | "resource"（要充钱）
 Unknown   bool       `json:"unknown,omitempty"`   // 上游没说；不等于 0%
 Unlimited bool       `json:"unlimited,omitempty"` // 真·无限制
 // Tier 已删除：全仓库只写不读，排序改用周期后没有任何消费方
@@ -143,20 +143,16 @@ Unlimited bool       `json:"unlimited,omitempty"` // 真·无限制
 `Unknown` / `Unlimited` 合起来消掉 `Limit == 0` 的三义。`Windows` 走 JSON 持久化，
 新字段自动 round-trip，**不需要 DB 迁移**；旧行缺字段按 false 解码，行为不变。
 
-`Kind` **没有默认值**：未显式打标签的窗口既不算 `limit` 也不算 `resource`，
-在所有"这个会不会自己恢复"的判定里都按保守方向处理（不承诺恢复时间、排序上不领先于
-明确标了 `limit` 的窗口、不计入 `PctLimit`）——宁可漏判，也不要把一个语义不明的窗口
-当成安全的标准配额。这条原则最初是给 §8.1 的路由判定收紧的，但既然默认值本身是
-`ai/quota` 的共享逻辑，索性把 `RecoversAt` / 排序也一起收紧，不留一个"未标注 = 当
-limit"的口子在别处继续存在。
+`Kind` 三态：`WindowKindUnknown`（缺省值，空串）/ `WindowKindLimit` / `WindowKindResource`。
+`Unknown` 在 `RecoversAt`、排序、`Pct(WindowKindLimit)` 里一律按"不会自己恢复"处理。
 
-判定 API（`ai/quota/semantic.go`）：
+判定 API（`ai/quota/semantic.go`）：`kinds` 留空回答展示问题（不分 `Kind`，含资源型）；
+传 `WindowKindLimit` 回答自动化判定问题（§8.1 的 `service_quota`，只认显式标了 `limit` 的窗口）。
 
 ```go
-func (p *ProviderUsage) Pct() (float64, bool)      // 最紧窗口的百分比；false = 整个 provider 不可知
-func (p *ProviderUsage) PctLimit() (float64, bool) // 同上，但只看显式 Kind==limit 的窗口，不兜底
-func (p *ProviderUsage) Tightest() *UsageWindow    // 卡住你的那个窗口（能说"卡在哪"）
-func (p *ProviderUsage) RecoversAt() *time.Time    // Kind==limit → ResetsAt；其余（含未标）→ nil
+func (p *ProviderUsage) Pct(kinds ...WindowKind) (float64, bool)   // 最紧窗口的百分比；kinds 留空 = 不分 Kind，传 WindowKindLimit = 只看显式打了这个标签的窗口
+func (p *ProviderUsage) Tightest(kinds ...WindowKind) *UsageWindow // Pct 的来源窗口（能说"卡在哪"），kinds 语义同上
+func (p *ProviderUsage) RecoversAt() *time.Time                    // Tightest() 本身 Kind==limit → ResetsAt；否则 → nil
 
 func (w *UsageWindow) Percent() float64            // 窗口自己的百分比
 func (w *UsageWindow) Countable() bool             // 是否带可比用量

--- a/.design/quota-semantics.md
+++ b/.design/quota-semantics.md
@@ -143,16 +143,23 @@ Unlimited bool       `json:"unlimited,omitempty"` // 真·无限制
 `Unknown` / `Unlimited` 合起来消掉 `Limit == 0` 的三义。`Windows` 走 JSON 持久化，
 新字段自动 round-trip，**不需要 DB 迁移**；旧行缺字段按 false 解码，行为不变。
 
+`Kind` **没有默认值**：未显式打标签的窗口既不算 `limit` 也不算 `resource`，
+在所有"这个会不会自己恢复"的判定里都按保守方向处理（不承诺恢复时间、排序上不领先于
+明确标了 `limit` 的窗口、不计入 `PctLimit`）——宁可漏判，也不要把一个语义不明的窗口
+当成安全的标准配额。这条原则最初是给 §8.1 的路由判定收紧的，但既然默认值本身是
+`ai/quota` 的共享逻辑，索性把 `RecoversAt` / 排序也一起收紧，不留一个"未标注 = 当
+limit"的口子在别处继续存在。
+
 判定 API（`ai/quota/semantic.go`）：
 
 ```go
-func (p *ProviderUsage) Pct() (float64, bool)     // 最紧窗口的百分比；false = 整个 provider 不可知
-func (p *ProviderUsage) Tightest() *UsageWindow   // 卡住你的那个窗口（能说"卡在哪"）
-func (p *ProviderUsage) RecoversAt() *time.Time   // 额度 → ResetsAt；资源/不可知 → nil
+func (p *ProviderUsage) Pct() (float64, bool)      // 最紧窗口的百分比；false = 整个 provider 不可知
+func (p *ProviderUsage) PctLimit() (float64, bool) // 同上，但只看显式 Kind==limit 的窗口，不兜底
+func (p *ProviderUsage) Tightest() *UsageWindow    // 卡住你的那个窗口（能说"卡在哪"）
+func (p *ProviderUsage) RecoversAt() *time.Time    // Kind==limit → ResetsAt；其余（含未标）→ nil
 
-func (w *UsageWindow) Percent() float64           // 窗口自己的百分比
-func (w *UsageWindow) Countable() bool            // 是否带可比用量
-func (w *UsageWindow) EffectiveKind() WindowKind  // Kind 缺省为额度（兼容旧数据）
+func (w *UsageWindow) Percent() float64            // 窗口自己的百分比
+func (w *UsageWindow) Countable() bool             // 是否带可比用量
 ```
 
 `Countable` 是整个模型的门闩：

--- a/ai/quota/fetcher/anthropic.go
+++ b/ai/quota/fetcher/anthropic.go
@@ -130,7 +130,7 @@ func (f *AnthropicFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*q
 	// Used/Limit normalized to 0-100 scale for unified frontend rendering
 	fiveHour := usage.AddWindow("five_hour", &quota.UsageWindow{
 		Type:          quota.WindowTypeSession,
-		Kind:          quota.WindowKindLimit, // recovers on its own; see PctLimit
+		Kind:          quota.WindowKindLimit, // recovers on its own; see Pct(WindowKindLimit)
 		Used:          apiResp.FiveHour.Utilization,
 		Limit:         100,
 		UsedPercent:   apiResp.FiveHour.Utilization,
@@ -174,10 +174,10 @@ func (f *AnthropicFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*q
 		// upstream conveyed.
 		//
 		// Kind deliberately left unset: this is pay-as-you-go overage, closer
-		// to a spend-more resource than a self-healing allowance, and PctLimit
-		// (smart-routing's service_quota) only counts windows explicitly
-		// tagged Kind: WindowKindLimit — leaving this untagged keeps it out
-		// rather than defaulting it in.
+		// to a spend-more resource than a self-healing allowance, and
+		// Pct(WindowKindLimit) (smart-routing's service_quota) only counts
+		// windows explicitly tagged Kind: WindowKindLimit — leaving this
+		// untagged keeps it out rather than defaulting it in.
 		extra := &quota.UsageWindow{
 			Type:          quota.WindowTypeMonthly,
 			Unit:          quota.UsageUnitPercent,

--- a/ai/quota/fetcher/anthropic.go
+++ b/ai/quota/fetcher/anthropic.go
@@ -130,6 +130,7 @@ func (f *AnthropicFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*q
 	// Used/Limit normalized to 0-100 scale for unified frontend rendering
 	fiveHour := usage.AddWindow("five_hour", &quota.UsageWindow{
 		Type:          quota.WindowTypeSession,
+		Kind:          quota.WindowKindLimit, // recovers on its own; see PctLimit
 		Used:          apiResp.FiveHour.Utilization,
 		Limit:         100,
 		UsedPercent:   apiResp.FiveHour.Utilization,
@@ -143,6 +144,7 @@ func (f *AnthropicFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*q
 	// Used/Limit normalized to 0-100 scale for unified frontend rendering
 	sevenDay := usage.AddWindow("seven_day", &quota.UsageWindow{
 		Type:          quota.WindowTypeWeekly,
+		Kind:          quota.WindowKindLimit,
 		Used:          apiResp.SevenDay.Utilization,
 		Limit:         100,
 		UsedPercent:   apiResp.SevenDay.Utilization,
@@ -170,6 +172,12 @@ func (f *AnthropicFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*q
 		// A null utilization means the API did not say. Reporting it as 0%
 		// would tell the user the add-on is untouched — the opposite of what
 		// upstream conveyed.
+		//
+		// Kind deliberately left unset: this is pay-as-you-go overage, closer
+		// to a spend-more resource than a self-healing allowance, and PctLimit
+		// (smart-routing's service_quota) only counts windows explicitly
+		// tagged Kind: WindowKindLimit — leaving this untagged keeps it out
+		// rather than defaulting it in.
 		extra := &quota.UsageWindow{
 			Type:          quota.WindowTypeMonthly,
 			Unit:          quota.UsageUnitPercent,

--- a/ai/quota/fetcher/codex.go
+++ b/ai/quota/fetcher/codex.go
@@ -132,7 +132,7 @@ func codexWindow(w *codexRateLimitWindow, typ quota.WindowType, label, descripti
 	resetsAt := time.Unix(w.ResetAt, 0)
 	return &quota.UsageWindow{
 		Type:          typ,
-		Kind:          quota.WindowKindLimit,  // recovers on its own; see PctLimit
+		Kind:          quota.WindowKindLimit,  // recovers on its own; see Pct(WindowKindLimit)
 		Used:          float64(w.UsedPercent), // Normalize to 0-100 scale
 		Limit:         100,                    // Normalize to 0-100 scale
 		UsedPercent:   float64(w.UsedPercent),

--- a/ai/quota/fetcher/codex.go
+++ b/ai/quota/fetcher/codex.go
@@ -132,6 +132,7 @@ func codexWindow(w *codexRateLimitWindow, typ quota.WindowType, label, descripti
 	resetsAt := time.Unix(w.ResetAt, 0)
 	return &quota.UsageWindow{
 		Type:          typ,
+		Kind:          quota.WindowKindLimit,  // recovers on its own; see PctLimit
 		Used:          float64(w.UsedPercent), // Normalize to 0-100 scale
 		Limit:         100,                    // Normalize to 0-100 scale
 		UsedPercent:   float64(w.UsedPercent),

--- a/ai/quota/fetcher/codex_test.go
+++ b/ai/quota/fetcher/codex_test.go
@@ -173,8 +173,8 @@ func TestCodexFetcher_Fetch(t *testing.T) {
 
 	// Verify credits balance: a resource with no percentage to report.
 	credits := findWindow(t, usage, "credits")
-	if credits.EffectiveKind() != quota.WindowKindResource {
-		t.Errorf("credits Kind = %q, want resource", credits.EffectiveKind())
+	if credits.Kind != quota.WindowKindResource {
+		t.Errorf("credits Kind = %q, want resource", credits.Kind)
 	}
 	if !credits.Unknown {
 		t.Error("credits balance has no percentage; it must be marked unknown")
@@ -585,8 +585,8 @@ func TestCodexFetcher_ResetCreditCarriesNoRecoveryTime(t *testing.T) {
 	checkInvariants(t, usage)
 
 	credit := findBreakdown(t, usage, "rc_1").Windows[0]
-	if credit.EffectiveKind() != quota.WindowKindResource {
-		t.Errorf("reset credit Kind = %q, want resource", credit.EffectiveKind())
+	if credit.Kind != quota.WindowKindResource {
+		t.Errorf("reset credit Kind = %q, want resource", credit.Kind)
 	}
 	if credit.ResetsAt != nil {
 		t.Error("a voucher does not refill on its own; ResetsAt must be nil")

--- a/ai/quota/fetcher/gemini.go
+++ b/ai/quota/fetcher/gemini.go
@@ -102,8 +102,9 @@ func (f *GeminiFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quot
 
 		window := &quota.UsageWindow{
 			Type:          quota.WindowTypeDaily,
-			Used:          usedPercent, // Normalize to 0-100 scale
-			Limit:         100,         // Normalize to 0-100 scale
+			Kind:          quota.WindowKindLimit, // recovers on its own; see PctLimit
+			Used:          usedPercent,           // Normalize to 0-100 scale
+			Limit:         100,                   // Normalize to 0-100 scale
 			UsedPercent:   usedPercent,
 			Unit:          quota.UsageUnitPercent,
 			WindowMinutes: 24 * 60,

--- a/ai/quota/fetcher/gemini.go
+++ b/ai/quota/fetcher/gemini.go
@@ -102,7 +102,7 @@ func (f *GeminiFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quot
 
 		window := &quota.UsageWindow{
 			Type:          quota.WindowTypeDaily,
-			Kind:          quota.WindowKindLimit, // recovers on its own; see PctLimit
+			Kind:          quota.WindowKindLimit, // recovers on its own; see Pct(WindowKindLimit)
 			Used:          usedPercent,           // Normalize to 0-100 scale
 			Limit:         100,                   // Normalize to 0-100 scale
 			UsedPercent:   usedPercent,

--- a/ai/quota/fetcher/invariants_test.go
+++ b/ai/quota/fetcher/invariants_test.go
@@ -62,14 +62,14 @@ func checkWindow(t *testing.T, where string, w *quota.UsageWindow) {
 
 	// A resource is brought back by topping up, not by waiting, so a reset
 	// time on it would be read as a recovery that never happens.
-	if w.EffectiveKind() == quota.WindowKindResource && w.ResetsAt != nil {
+	if w.Kind == quota.WindowKindResource && w.ResetsAt != nil {
 		t.Errorf("%s: resource has ResetsAt set; a balance does not refill on its own", where)
 	}
 
 	// The direction that catches an omission: a balance left as an allowance
 	// would claim it refills, and RecoversAt would promise a recovery that
 	// never arrives.
-	if w.Type == quota.WindowTypeBalance && w.EffectiveKind() != quota.WindowKindResource {
+	if w.Type == quota.WindowTypeBalance && w.Kind != quota.WindowKindResource {
 		t.Errorf("%s: balance is not marked as a resource", where)
 	}
 

--- a/ai/quota/fetcher/kimi_code.go
+++ b/ai/quota/fetcher/kimi_code.go
@@ -262,6 +262,7 @@ func (f *KimiCodeFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*qu
 	if used, limit, ok := apiResp.Usage.values(); ok {
 		usage.AddWindow("weekly", &quota.UsageWindow{
 			Type:          quota.WindowTypeWeekly,
+			Kind:          quota.WindowKindLimit, // recovers on its own; see PctLimit
 			Used:          used,
 			Limit:         limit,
 			Unit:          quota.UsageUnitCredits,
@@ -290,6 +291,7 @@ func (f *KimiCodeFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*qu
 		}
 		usage.AddWindow(fmt.Sprintf("limit_%d", index+1), &quota.UsageWindow{
 			Type:          windowType,
+			Kind:          quota.WindowKindLimit, // recovers on its own; see PctLimit
 			Used:          used,
 			Limit:         limit,
 			Unit:          quota.UsageUnitCredits,

--- a/ai/quota/fetcher/kimi_code.go
+++ b/ai/quota/fetcher/kimi_code.go
@@ -262,7 +262,7 @@ func (f *KimiCodeFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*qu
 	if used, limit, ok := apiResp.Usage.values(); ok {
 		usage.AddWindow("weekly", &quota.UsageWindow{
 			Type:          quota.WindowTypeWeekly,
-			Kind:          quota.WindowKindLimit, // recovers on its own; see PctLimit
+			Kind:          quota.WindowKindLimit, // recovers on its own; see Pct(WindowKindLimit)
 			Used:          used,
 			Limit:         limit,
 			Unit:          quota.UsageUnitCredits,
@@ -291,7 +291,7 @@ func (f *KimiCodeFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*qu
 		}
 		usage.AddWindow(fmt.Sprintf("limit_%d", index+1), &quota.UsageWindow{
 			Type:          windowType,
-			Kind:          quota.WindowKindLimit, // recovers on its own; see PctLimit
+			Kind:          quota.WindowKindLimit, // recovers on its own; see Pct(WindowKindLimit)
 			Used:          used,
 			Limit:         limit,
 			Unit:          quota.UsageUnitCredits,

--- a/ai/quota/fetcher/kimi_code_test.go
+++ b/ai/quota/fetcher/kimi_code_test.go
@@ -354,8 +354,8 @@ func TestKimiCodeSemantics(t *testing.T) {
 
 	// A wallet balance does not come back by waiting.
 	booster := findWindow(t, usage, "booster")
-	if booster.EffectiveKind() != quota.WindowKindResource {
-		t.Errorf("booster Kind = %q, want resource", booster.EffectiveKind())
+	if booster.Kind != quota.WindowKindResource {
+		t.Errorf("booster Kind = %q, want resource", booster.Kind)
 	}
 
 	// The weekly limit is the binding one here (40% vs the balance's 50% is

--- a/ai/quota/fetcher/kimik2_test.go
+++ b/ai/quota/fetcher/kimik2_test.go
@@ -84,8 +84,8 @@ func TestKimiK2CreditsAreAResource(t *testing.T) {
 	checkInvariants(t, usage)
 
 	credits := findWindow(t, usage, "credits")
-	if credits.EffectiveKind() != quota.WindowKindResource {
-		t.Errorf("credits Kind = %q, want resource", credits.EffectiveKind())
+	if credits.Kind != quota.WindowKindResource {
+		t.Errorf("credits Kind = %q, want resource", credits.Kind)
 	}
 	if pct, ok := usage.Pct(); !ok || pct != 30 {
 		t.Fatalf("Pct() = %v, %v; want 30, true", pct, ok)

--- a/ai/quota/fetcher/minimax_shared.go
+++ b/ai/quota/fetcher/minimax_shared.go
@@ -236,7 +236,7 @@ func addMiniMaxAccountWindows(usage *quota.ProviderUsage, models []minimaxModelW
 			continue
 		}
 		account := *best
-		account.Kind = quota.WindowKindLimit // recovers on its own; see PctLimit
+		account.Kind = quota.WindowKindLimit // recovers on its own; see Pct(WindowKindLimit)
 		account.Label = label + " Quota"
 		account.Description = fmt.Sprintf("%s · %s", best.Description, bestModel)
 		usage.AddWindow(strings.ToLower(label), &account)

--- a/ai/quota/fetcher/minimax_shared.go
+++ b/ai/quota/fetcher/minimax_shared.go
@@ -236,6 +236,7 @@ func addMiniMaxAccountWindows(usage *quota.ProviderUsage, models []minimaxModelW
 			continue
 		}
 		account := *best
+		account.Kind = quota.WindowKindLimit // recovers on its own; see PctLimit
 		account.Label = label + " Quota"
 		account.Description = fmt.Sprintf("%s · %s", best.Description, bestModel)
 		usage.AddWindow(strings.ToLower(label), &account)

--- a/ai/quota/fetcher/openrouter_test.go
+++ b/ai/quota/fetcher/openrouter_test.go
@@ -210,8 +210,8 @@ func TestOpenRouterKeyLimitIsAResource(t *testing.T) {
 	checkInvariants(t, usage)
 
 	keyLimit := findWindow(t, usage, "key_limit")
-	if keyLimit.EffectiveKind() != quota.WindowKindResource {
-		t.Errorf("key_limit Kind = %q, want resource", keyLimit.EffectiveKind())
+	if keyLimit.Kind != quota.WindowKindResource {
+		t.Errorf("key_limit Kind = %q, want resource", keyLimit.Kind)
 	}
 	if pct, ok := usage.Pct(); !ok || pct < 40.4 || pct > 40.6 {
 		t.Fatalf("Pct() = %v, %v; want ~40.5, true", pct, ok)

--- a/ai/quota/fetcher/zai_shared.go
+++ b/ai/quota/fetcher/zai_shared.go
@@ -159,6 +159,7 @@ func buildZaiProviderUsage(provider *ai.Provider, providerType quota.ProviderTyp
 
 		window := &quota.UsageWindow{
 			Type:          class.windowType,
+			Kind:          quota.WindowKindLimit, // recovers on its own; see PctLimit
 			Used:          used,
 			Limit:         total,
 			UsedPercent:   usedPercent,

--- a/ai/quota/fetcher/zai_shared.go
+++ b/ai/quota/fetcher/zai_shared.go
@@ -159,7 +159,7 @@ func buildZaiProviderUsage(provider *ai.Provider, providerType quota.ProviderTyp
 
 		window := &quota.UsageWindow{
 			Type:          class.windowType,
-			Kind:          quota.WindowKindLimit, // recovers on its own; see PctLimit
+			Kind:          quota.WindowKindLimit, // recovers on its own; see Pct(WindowKindLimit)
 			Used:          used,
 			Limit:         total,
 			UsedPercent:   usedPercent,

--- a/ai/quota/semantic.go
+++ b/ai/quota/semantic.go
@@ -12,15 +12,6 @@ import (
 // can act on: how much is used, and when it comes back.
 // See .design/quota-semantics.md.
 
-// EffectiveKind reports the window kind, defaulting to WindowKindLimit for
-// windows written before the field existed.
-func (w *UsageWindow) EffectiveKind() WindowKind {
-	if w == nil || w.Kind == "" {
-		return WindowKindLimit
-	}
-	return w.Kind
-}
-
 // Percent returns the window's used percentage, falling back to used/limit for
 // windows that have not had UsedPercent filled in yet.
 func (w *UsageWindow) Percent() float64 {
@@ -80,12 +71,55 @@ func (p *ProviderUsage) Tightest() *UsageWindow {
 	return best
 }
 
+// PctLimit is Pct restricted to periodic-allowance windows (Kind ==
+// WindowKindLimit) — used by callers that must react only to quota that
+// recovers on its own, not to a standing balance/credit that requires a
+// manual top-up (smart-routing's service_quota op is the first of these;
+// see .design/quota-semantics.md §8.1).
+//
+// A window with Kind left unset is excluded here, same as everywhere else
+// in this file that makes a "will this heal on its own" claim (RecoversAt,
+// windowRank) — Kind has no default. A fetcher must explicitly tag
+// Kind: WindowKindLimit for a window to count as standard quota; silently
+// letting an ambiguous or new window (an overage add-on, a balance type
+// someone forgot to flag) count as standard is the dangerous direction to
+// fail in, since it would drive an automatic avoidance decision — or a
+// promised recovery time — off something that may not even self-heal.
+func (p *ProviderUsage) PctLimit() (float64, bool) {
+	w := p.tightestOfKind(WindowKindLimit)
+	if w == nil {
+		return 0, false
+	}
+	return w.Percent(), true
+}
+
+// tightestOfKind is Tightest restricted to windows whose Kind is exactly
+// kind — a strict equality check, so an unset Kind never matches.
+func (p *ProviderUsage) tightestOfKind(kind WindowKind) *UsageWindow {
+	if p == nil {
+		return nil
+	}
+	var best *UsageWindow
+	for _, w := range p.Windows {
+		if !w.Countable() || w.Kind != kind {
+			continue
+		}
+		if best == nil || tighter(w, best) {
+			best = w
+		}
+	}
+	return best
+}
+
 // RecoversAt returns when the binding window refills. It is nil when usage is
-// unknown, when the binding window is a resource (a top-up, not a reset, is
-// what brings it back), or when upstream did not report a reset time.
+// unknown, when the binding window is not explicitly tagged as a
+// self-healing allowance (Kind == WindowKindLimit — a resource needs a
+// top-up, not a reset, to come back, and an untagged window's ability to
+// self-heal is simply not established), or when upstream did not report a
+// reset time.
 func (p *ProviderUsage) RecoversAt() *time.Time {
 	w := p.Tightest()
-	if w == nil || w.EffectiveKind() == WindowKindResource {
+	if w == nil || w.Kind != WindowKindLimit {
 		return nil
 	}
 	return w.ResetsAt
@@ -147,14 +181,17 @@ func periodRank(w *UsageWindow) int {
 }
 
 // windowRank groups windows for display; within a group they order by period.
+// Rank 0 (self-healing allowances) requires an explicit Kind ==
+// WindowKindLimit tag — an untagged window is not assumed to belong there,
+// so it sorts alongside resources (rank 1) instead of jumping the queue.
 func windowRank(w *UsageWindow) int {
 	switch {
 	case !w.Countable():
 		return 2
-	case w.EffectiveKind() == WindowKindResource:
-		return 1
-	default:
+	case w.Kind == WindowKindLimit:
 		return 0
+	default:
+		return 1
 	}
 }
 

--- a/ai/quota/semantic.go
+++ b/ai/quota/semantic.go
@@ -43,8 +43,18 @@ func (w *UsageWindow) Countable() bool {
 //
 // Only Windows are considered. Breakdowns are scoped to one model or feature
 // and do not describe the provider as a whole.
-func (p *ProviderUsage) Pct() (float64, bool) {
-	w := p.Tightest()
+//
+// With no kinds given, every countable window is eligible regardless of Kind
+// — the display question, "how much pressure is on this account, from
+// whatever source": a resource (OpenRouter's key balance, KimiK2's only
+// window) is meant to win here just as readily as a periodic allowance.
+// Pass WindowKindLimit to instead answer the automated-decision question,
+// "what will recover on its own" (smart-routing's service_quota is the
+// first caller that needs this; see .design/quota-semantics.md §8.1) — a
+// window whose Kind isn't exactly one of the given values never matches, so
+// an unset Kind is excluded rather than assumed safe.
+func (p *ProviderUsage) Pct(kinds ...WindowKind) (float64, bool) {
+	w := p.Tightest(kinds...)
 	if w == nil {
 		return 0, false
 	}
@@ -52,16 +62,16 @@ func (p *ProviderUsage) Pct() (float64, bool) {
 }
 
 // Tightest returns the window Pct came from, so callers can say which window
-// is binding rather than just quoting a number. Ties go to the shorter window,
-// which is the more actionable one to show.
-func (p *ProviderUsage) Tightest() *UsageWindow {
+// is binding rather than just quoting a number. Ties go to the shorter
+// window, which is the more actionable one to show. See Pct for what kinds
+// filters.
+func (p *ProviderUsage) Tightest(kinds ...WindowKind) *UsageWindow {
 	if p == nil {
 		return nil
 	}
-
 	var best *UsageWindow
 	for _, w := range p.Windows {
-		if !w.Countable() {
+		if !w.Countable() || !matchesKind(w, kinds) {
 			continue
 		}
 		if best == nil || tighter(w, best) {
@@ -71,44 +81,20 @@ func (p *ProviderUsage) Tightest() *UsageWindow {
 	return best
 }
 
-// PctLimit is Pct restricted to periodic-allowance windows (Kind ==
-// WindowKindLimit) — used by callers that must react only to quota that
-// recovers on its own, not to a standing balance/credit that requires a
-// manual top-up (smart-routing's service_quota op is the first of these;
-// see .design/quota-semantics.md §8.1).
-//
-// A window with Kind left unset is excluded here, same as everywhere else
-// in this file that makes a "will this heal on its own" claim (RecoversAt,
-// windowRank) — Kind has no default. A fetcher must explicitly tag
-// Kind: WindowKindLimit for a window to count as standard quota; silently
-// letting an ambiguous or new window (an overage add-on, a balance type
-// someone forgot to flag) count as standard is the dangerous direction to
-// fail in, since it would drive an automatic avoidance decision — or a
-// promised recovery time — off something that may not even self-heal.
-func (p *ProviderUsage) PctLimit() (float64, bool) {
-	w := p.tightestOfKind(WindowKindLimit)
-	if w == nil {
-		return 0, false
+// matchesKind reports whether w should be considered given a Pct/Tightest
+// kinds filter: no filter matches anything, otherwise w.Kind must equal one
+// of the given values exactly (no default — see the Kind field's doc in
+// types.go).
+func matchesKind(w *UsageWindow, kinds []WindowKind) bool {
+	if len(kinds) == 0 {
+		return true
 	}
-	return w.Percent(), true
-}
-
-// tightestOfKind is Tightest restricted to windows whose Kind is exactly
-// kind — a strict equality check, so an unset Kind never matches.
-func (p *ProviderUsage) tightestOfKind(kind WindowKind) *UsageWindow {
-	if p == nil {
-		return nil
-	}
-	var best *UsageWindow
-	for _, w := range p.Windows {
-		if !w.Countable() || w.Kind != kind {
-			continue
-		}
-		if best == nil || tighter(w, best) {
-			best = w
+	for _, k := range kinds {
+		if w.Kind == k {
+			return true
 		}
 	}
-	return best
+	return false
 }
 
 // RecoversAt returns when the binding window refills. It is nil when usage is

--- a/ai/quota/semantic_test.go
+++ b/ai/quota/semantic_test.go
@@ -5,8 +5,13 @@ import (
 	"time"
 )
 
+// window builds a fixture defaulting to Kind: WindowKindLimit — most tests
+// in this file model an ordinary periodic allowance. Production code has no
+// such default (Kind must be tagged explicitly by the fetcher); tests that
+// need a resource or an untagged window override via opts (see
+// unclassified()) or build a literal UsageWindow directly.
 func window(pct float64, minutes int, opts ...func(*UsageWindow)) *UsageWindow {
-	w := &UsageWindow{UsedPercent: pct, WindowMinutes: minutes, Limit: 100, Used: pct}
+	w := &UsageWindow{Kind: WindowKindLimit, UsedPercent: pct, WindowMinutes: minutes, Limit: 100, Used: pct}
 	for _, opt := range opts {
 		opt(w)
 	}
@@ -15,6 +20,13 @@ func window(pct float64, minutes int, opts ...func(*UsageWindow)) *UsageWindow {
 
 func labelled(label string) func(*UsageWindow) {
 	return func(w *UsageWindow) { w.Label = label }
+}
+
+// unclassified clears Kind, simulating a fetcher that never tagged the
+// window — the case PctLimit/RecoversAt/windowRank must treat as "not
+// proven self-healing", not default to limit.
+func unclassified() func(*UsageWindow) {
+	return func(w *UsageWindow) { w.Kind = "" }
 }
 
 func TestPctTakesTheTightestWindow(t *testing.T) {
@@ -174,12 +186,36 @@ func TestBreakdownsDoNotAnswerForTheProvider(t *testing.T) {
 	}
 }
 
-func TestKindDefaultsToLimit(t *testing.T) {
-	if got := (&UsageWindow{}).EffectiveKind(); got != WindowKindLimit {
-		t.Fatalf("EffectiveKind() = %q; want %q", got, WindowKindLimit)
+func TestUnclassifiedKindDoesNotRecoverOnItsOwn(t *testing.T) {
+	// No default: a window nobody explicitly tagged Kind: WindowKindLimit
+	// must not promise a recovery time, same treatment as a resource.
+	expires := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
+	usage := &ProviderUsage{Windows: []*UsageWindow{
+		window(90, 300, unclassified(), func(w *UsageWindow) { w.ResetsAt = &expires }),
+	}}
+
+	if got := usage.RecoversAt(); got != nil {
+		t.Fatalf("RecoversAt() = %v; want nil for an untagged window", got)
 	}
-	if got := (&UsageWindow{Kind: WindowKindResource}).EffectiveKind(); got != WindowKindResource {
-		t.Fatalf("EffectiveKind() = %q; want %q", got, WindowKindResource)
+	// Pct() still counts it — only the "will it come back" claim is withheld.
+	if pct, ok := usage.Pct(); !ok || pct != 90 {
+		t.Fatalf("Pct() = %v, %v; want 90, true", pct, ok)
+	}
+}
+
+func TestUnclassifiedKindDoesNotJumpTheDisplayQueue(t *testing.T) {
+	// An untagged window must not outrank an explicitly-tagged limit window
+	// on the strength of a shorter period — the Kind tag gates the group,
+	// period only breaks ties within it.
+	usage := &ProviderUsage{Windows: []*UsageWindow{
+		window(50, 100, unclassified(), labelled("untagged-short")),
+		window(50, 500, labelled("tagged-limit")),
+	}}
+
+	usage.NormalizeWindows()
+
+	if got := usage.Windows[0].Label; got != "tagged-limit" {
+		t.Fatalf("first window = %q; want tagged-limit — an untagged window must not outrank a tagged one", got)
 	}
 }
 
@@ -230,8 +266,8 @@ func TestBalanceDefaultsToResource(t *testing.T) {
 		Type: WindowTypeBalance, Used: 30, Limit: 100, ResetsAt: &reset,
 	})
 
-	if w.EffectiveKind() != WindowKindResource {
-		t.Errorf("EffectiveKind() = %q; want resource", w.EffectiveKind())
+	if w.Kind != WindowKindResource {
+		t.Errorf("Kind = %q; want resource", w.Kind)
 	}
 	if usage.RecoversAt() != nil {
 		t.Error("a balance must not report a recovery time")
@@ -265,6 +301,50 @@ func TestOrderingAndTieBreakAgreeOnUnsizedWindows(t *testing.T) {
 	usage.NormalizeWindows()
 	if got := usage.Windows[0].Key; got != "weekly" {
 		t.Errorf("first window = %q; want weekly — display must match the tie-break", got)
+	}
+}
+
+func TestPctLimitExcludesResourceWindows(t *testing.T) {
+	// A near-exhausted balance must not read as standard quota running out —
+	// callers like smart-routing's service_quota need to react only to
+	// self-healing allowances, not to something that needs a manual top-up.
+	usage := &ProviderUsage{Windows: []*UsageWindow{
+		window(95, 0, func(w *UsageWindow) { w.Kind = WindowKindResource }),
+	}}
+
+	if pct, ok := usage.PctLimit(); ok {
+		t.Fatalf("PctLimit() = %v, %v; want unknown when only a resource window exists", pct, ok)
+	}
+}
+
+func TestPctLimitDoesNotDefaultUnsetKindToLimit(t *testing.T) {
+	// PctLimit requires an explicit tag — a fetcher that forgot to (or
+	// deliberately did not, e.g. Anthropic's pay-as-you-go overage add-on)
+	// mark a window Kind: WindowKindLimit must not silently count.
+	usage := &ProviderUsage{Windows: []*UsageWindow{
+		window(95, 300, unclassified(), labelled("untagged")),
+	}}
+
+	if pct, ok := usage.PctLimit(); ok {
+		t.Fatalf("PctLimit() = %v, %v; want unknown for an untagged (Kind=\"\") window", pct, ok)
+	}
+	// Sanity check: Pct() (the general-purpose accessor) does count it —
+	// only PctLimit is strict.
+	if pct, ok := usage.Pct(); !ok || pct != 95 {
+		t.Fatalf("Pct() = %v, %v; want 95, true", pct, ok)
+	}
+}
+
+func TestPctLimitTakesTheTightestLimitWindow(t *testing.T) {
+	usage := &ProviderUsage{Windows: []*UsageWindow{
+		window(12, 300, func(w *UsageWindow) { w.Kind = WindowKindLimit; w.Label = "5h" }),
+		window(96, 10080, func(w *UsageWindow) { w.Kind = WindowKindLimit; w.Label = "7d" }),
+		window(99, 0, func(w *UsageWindow) { w.Kind = WindowKindResource }), // higher %, must be ignored
+	}}
+
+	pct, ok := usage.PctLimit()
+	if !ok || pct != 96 {
+		t.Fatalf("PctLimit() = %v, %v; want 96, true (resource window must not win)", pct, ok)
 	}
 }
 

--- a/ai/quota/semantic_test.go
+++ b/ai/quota/semantic_test.go
@@ -22,11 +22,10 @@ func labelled(label string) func(*UsageWindow) {
 	return func(w *UsageWindow) { w.Label = label }
 }
 
-// unclassified clears Kind, simulating a fetcher that never tagged the
-// window — the case PctLimit/RecoversAt/windowRank must treat as "not
-// proven self-healing", not default to limit.
+// unclassified sets Kind to WindowKindUnknown, simulating a fetcher that
+// never tagged the window.
 func unclassified() func(*UsageWindow) {
-	return func(w *UsageWindow) { w.Kind = "" }
+	return func(w *UsageWindow) { w.Kind = WindowKindUnknown }
 }
 
 func TestPctTakesTheTightestWindow(t *testing.T) {
@@ -304,7 +303,7 @@ func TestOrderingAndTieBreakAgreeOnUnsizedWindows(t *testing.T) {
 	}
 }
 
-func TestPctLimitExcludesResourceWindows(t *testing.T) {
+func TestPctFilteredByKindExcludesResourceWindows(t *testing.T) {
 	// A near-exhausted balance must not read as standard quota running out —
 	// callers like smart-routing's service_quota need to react only to
 	// self-healing allowances, not to something that needs a manual top-up.
@@ -312,39 +311,71 @@ func TestPctLimitExcludesResourceWindows(t *testing.T) {
 		window(95, 0, func(w *UsageWindow) { w.Kind = WindowKindResource }),
 	}}
 
-	if pct, ok := usage.PctLimit(); ok {
-		t.Fatalf("PctLimit() = %v, %v; want unknown when only a resource window exists", pct, ok)
+	if pct, ok := usage.Pct(WindowKindLimit); ok {
+		t.Fatalf("Pct(WindowKindLimit) = %v, %v; want unknown when only a resource window exists", pct, ok)
 	}
 }
 
-func TestPctLimitDoesNotDefaultUnsetKindToLimit(t *testing.T) {
-	// PctLimit requires an explicit tag — a fetcher that forgot to (or
-	// deliberately did not, e.g. Anthropic's pay-as-you-go overage add-on)
-	// mark a window Kind: WindowKindLimit must not silently count.
+func TestPctFilteredByKindDoesNotDefaultUnsetKindToLimit(t *testing.T) {
+	// Filtering by WindowKindLimit requires an explicit tag — a fetcher that
+	// forgot to (or deliberately did not, e.g. Anthropic's pay-as-you-go
+	// overage add-on) mark a window Kind: WindowKindLimit must not silently
+	// count.
 	usage := &ProviderUsage{Windows: []*UsageWindow{
 		window(95, 300, unclassified(), labelled("untagged")),
 	}}
 
-	if pct, ok := usage.PctLimit(); ok {
-		t.Fatalf("PctLimit() = %v, %v; want unknown for an untagged (Kind=\"\") window", pct, ok)
+	if pct, ok := usage.Pct(WindowKindLimit); ok {
+		t.Fatalf("Pct(WindowKindLimit) = %v, %v; want unknown for an untagged (Kind=\"\") window", pct, ok)
 	}
-	// Sanity check: Pct() (the general-purpose accessor) does count it —
-	// only PctLimit is strict.
+	// Sanity check: the unfiltered Pct() does count it — only the filtered
+	// call is strict.
 	if pct, ok := usage.Pct(); !ok || pct != 95 {
 		t.Fatalf("Pct() = %v, %v; want 95, true", pct, ok)
 	}
 }
 
-func TestPctLimitTakesTheTightestLimitWindow(t *testing.T) {
+func TestPctFilteredByKindTakesTheTightestMatchingWindow(t *testing.T) {
 	usage := &ProviderUsage{Windows: []*UsageWindow{
 		window(12, 300, func(w *UsageWindow) { w.Kind = WindowKindLimit; w.Label = "5h" }),
 		window(96, 10080, func(w *UsageWindow) { w.Kind = WindowKindLimit; w.Label = "7d" }),
 		window(99, 0, func(w *UsageWindow) { w.Kind = WindowKindResource }), // higher %, must be ignored
 	}}
 
-	pct, ok := usage.PctLimit()
+	pct, ok := usage.Pct(WindowKindLimit)
 	if !ok || pct != 96 {
-		t.Fatalf("PctLimit() = %v, %v; want 96, true (resource window must not win)", pct, ok)
+		t.Fatalf("Pct(WindowKindLimit) = %v, %v; want 96, true (resource window must not win)", pct, ok)
+	}
+}
+
+func TestTightestFilteredByKindLetsACallerSayWhichWindow(t *testing.T) {
+	// Pct(kind) quotes a bare number; Tightest(kind) is how a caller (e.g. a
+	// routing trace) says *which* window.
+	usage := &ProviderUsage{Windows: []*UsageWindow{
+		window(12, 300, func(w *UsageWindow) { w.Kind = WindowKindLimit; w.Label = "5h" }),
+		window(96, 10080, func(w *UsageWindow) { w.Kind = WindowKindLimit; w.Label = "7d" }),
+		window(99, 0, func(w *UsageWindow) { w.Kind = WindowKindResource; w.Label = "balance" }),
+	}}
+
+	got := usage.Tightest(WindowKindLimit)
+	if got == nil || got.Label != "7d" {
+		t.Fatalf("Tightest(WindowKindLimit) = %v; want the 7d window (99%% balance must be ignored)", got)
+	}
+}
+
+func TestTightestFilteredByKindNilWhenNothingIsTagged(t *testing.T) {
+	usage := &ProviderUsage{Windows: []*UsageWindow{
+		window(50, 300, unclassified()),
+		window(90, 0, func(w *UsageWindow) { w.Kind = WindowKindResource }),
+	}}
+
+	if got := usage.Tightest(WindowKindLimit); got != nil {
+		t.Fatalf("Tightest(WindowKindLimit) = %v; want nil when nothing is tagged Kind=limit", got)
+	}
+	// Unfiltered Tightest() still finds the resource window (90% > 50%) — a
+	// display caller should still see it, Kind doesn't gate this path.
+	if got := usage.Tightest(); got == nil || got.Kind != WindowKindResource {
+		t.Fatalf("Tightest() = %v; want the resource window", got)
 	}
 }
 

--- a/ai/quota/types.go
+++ b/ai/quota/types.go
@@ -48,6 +48,7 @@ const (
 type WindowKind string
 
 const (
+	WindowKindUnknown  WindowKind = ""         // not tagged by the fetcher; treated as not self-healing
 	WindowKindLimit    WindowKind = "limit"    // periodic allowance (Anthropic 5h/7d, MiniMax daily)
 	WindowKindResource WindowKind = "resource" // standing balance (OpenRouter credit, Kimi booster)
 )
@@ -134,7 +135,7 @@ type UsageWindow struct {
 	// Unlimited say why UsedPercent should not be read as a usage figure.
 	// Between them they replace the three-way ambiguity of Limit == 0
 	// (unlimited / unknown / no entitlement).
-	Kind      WindowKind `json:"kind,omitempty"`      // no default; unset is treated as "not proven self-healing" everywhere (RecoversAt, display sort, PctLimit) — a fetcher must tag WindowKindLimit explicitly
+	Kind      WindowKind `json:"kind,omitempty"`      // WindowKindUnknown unless the fetcher tags it; RecoversAt/sort/Pct(WindowKindLimit) all treat Unknown as not self-healing
 	Unknown   bool       `json:"unknown,omitempty"`   // upstream did not report usage; not the same as 0%
 	Unlimited bool       `json:"unlimited,omitempty"` // no cap at all
 
@@ -181,7 +182,7 @@ func applyWindowSemantics(window *UsageWindow) {
 	// A balance is a resource by definition. Leaving each fetcher to say so
 	// means one that forgets produces a balance claiming it refills, and
 	// RecoversAt() then promises a recovery that never arrives.
-	if window.Kind == "" && window.Type == WindowTypeBalance {
+	if window.Kind == WindowKindUnknown && window.Type == WindowTypeBalance {
 		window.Kind = WindowKindResource
 	}
 	// A window with no usage figure must not carry one — a reader that skips

--- a/ai/quota/types.go
+++ b/ai/quota/types.go
@@ -134,7 +134,7 @@ type UsageWindow struct {
 	// Unlimited say why UsedPercent should not be read as a usage figure.
 	// Between them they replace the three-way ambiguity of Limit == 0
 	// (unlimited / unknown / no entitlement).
-	Kind      WindowKind `json:"kind,omitempty"`      // defaults to WindowKindLimit, see EffectiveKind()
+	Kind      WindowKind `json:"kind,omitempty"`      // no default; unset is treated as "not proven self-healing" everywhere (RecoversAt, display sort, PctLimit) — a fetcher must tag WindowKindLimit explicitly
 	Unknown   bool       `json:"unknown,omitempty"`   // upstream did not report usage; not the same as 0%
 	Unlimited bool       `json:"unlimited,omitempty"` // no cap at all
 


### PR DESCRIPTION
## Summary
`ai/quota`'s `Kind` field silently defaulted an untagged window to `WindowKindLimit`, letting an unclassified window promise a recovery time, win the display sort, and (for any future strict consumer) count as standard quota it may not be. This removes the default and requires an explicit tag everywhere that claim matters.

## Key Changes
- **No default Kind**: `EffectiveKind()` deleted; `RecoversAt()` and `windowRank()` (mirrored in the frontend's `windowSortKey`) now require literal `Kind == WindowKindLimit` — an untagged window neither promises a recovery time nor jumps the display queue.
- **`Pct`/`Tightest` take an optional `kinds ...WindowKind` filter** instead of a parallel `PctLimit`/`TightestLimit` API: no args = today's Kind-blind behavior (unchanged, used by display — statusline, Summary, CLI, frontend); pass `WindowKindLimit` for the strict, automated-decision variant that excludes a standing balance/credit. No external code depends on this shape, so one parameterized pair beats a second naming series.
- **Fetchers tagged explicitly**: Anthropic 5h/7d, Codex current/weekly, Gemini per-model tightest, Z.ai/GLM limits, MiniMax account windows, and Kimi Code weekly/limit windows now carry `Kind: WindowKindLimit` so the stricter default doesn't regress real data. Anthropic's pay-as-you-go `extra_usage` overage window is deliberately left untagged.

## Notes
- `Pct(WindowKindLimit)` has no caller yet in this PR — a follow-up PR (smart-routing's `service_quota` op) is the first consumer.
- DB rows persisted before this change may briefly show up in the "resource" display group / without a recovery time until their next scheduled refresh (self-heals within one refresh cycle).
