### PR TITLE
feat(smart_routing): add service_quota op to gate routing on cached quota usage

### DIFF
--- a/.design/quota-semantics.md
+++ b/.design/quota-semantics.md
@@ -265,7 +265,34 @@ MiniMax 打满的视频额度让全账号显得耗尽；OpenRouter 的月度花�
 
 ---
 
-## 8. 范围外决定：quota 怎么参与路由（只记结论，未实现）
+## 8. quota 怎么参与路由
+
+quota 参与路由分两条线，管的是两件不重叠的事：smart op 管**"不想用"**（主动避让），
+`stage_health` 管**"不能用"**（事后摘除）。前者已实现（本节 §8.1），后者仍是范围外决定，
+只记结论未实现（§8.2）。
+
+### 8.1 smart op：`service_quota`（已实现）
+
+新增 `SmartOp` position `service_quota`，操作符 `pct_le` / `pct_ge` / `pct_lt` / `pct_gt`，
+值是 0-100 的百分比阈值。代码见 `internal/smart_routing`（`op.go` / `routing.go`
+/ `context.go`）与 `internal/routing/stage_smart_routing.go`；用法示例见
+`internal/smart_routing/README.md` "Switch to a cheaper pool once quota runs hot"。
+
+- **数据来源**：`ai/quota` 本地缓存（`Manager.GetQuotaNoCache`），按 `Service.Provider`
+  （provider UUID）查 `ProviderUsage.Pct(quota.WindowKindLimit)`（§4）。纯读库，路由
+  热路径不发起线上配额请求；刷新节奏由 `Manager` 后台 refresher 决定（§9.1 未处理）。
+- **只算 `Kind=limit`，不算 `Kind=resource`**：余额耗尽要充钱，不会自己恢复，不该驱动
+  这种本该是临时避让的判定。
+- **聚合方式：跨 service 取最紧（max），不取平均**——一个池子里任何一个 service 吃紧
+  就判定整个池吃紧。分级降级用 `Service.Tier` + `TacticTier` 或多条规则，不用这个 op
+  在多个 service 间取平均；UI 建议每条规则只配一个 service。
+- **未知不计入判定**：查不到配额的 service 从 `ServiceQuota` 里剔除，不当 0%；一条规则
+  所有 service 都没有配额数据时直接放行（`Matched=true`），不阻塞路由。
+- **和 §8.2 的边界**：smart op 是主动的、阈值可配的"不想用"，在真吃到 429 之前就切走；
+  `stage_health` 是被动的、reactive 的"不能用"，两者数据源相同（`ai/quota`）但不是
+  同一个机制，互不替代。
+
+### 8.2 `stage_health` 摘除（范围外决定，未实现）
 
 **quota 只做减法，不做排序**——摘掉事实上不能用的候选，选择交给现有 tactic。
 
@@ -279,9 +306,6 @@ quota 不该发明第三种。
 `health_monitor.go` 的 `RateLimitedUntil = now + 固定超时` 是猜的，`RecoversAt()` 是上游真值——
 quota 是 health 的**前瞻版**：不用先吃 429，恢复时间从猜变准，出口/降级/日志全复用。
 保守方向写死：`Unknown` 或数据过期 → 不摘。
-
-**smart op 不做**：它管"不想用"（超 85% 就切便宜池子），与摘除管的"不能用"不重叠；
-需要的数据 §4 已备齐，等真有人要再加。
 
 ---
 

--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -18,7 +18,7 @@ export interface ConfigProvider {
 
 export interface SmartOp {
     uuid: string;
-    position: 'model' | 'thinking' | 'context_system' | 'context_user' | 'latest_user' | 'token' | 'service_ttft' | 'service_capacity' | 'agent.claude_code' | 'time';
+    position: 'model' | 'thinking' | 'context_system' | 'context_user' | 'latest_user' | 'token' | 'service_ttft' | 'service_capacity' | 'service_quota' | 'agent.claude_code' | 'time';
     operation: string;
     value: string;
     meta?: {

--- a/frontend/src/components/rule-card/SmartRuleCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/SmartRuleCatalogDialog.tsx
@@ -57,6 +57,7 @@ const POSITION_OPTIONS: PositionMeta[] = [
     { value: 'token', label: 'Token Count', description: 'Token count', category: 'request' },
     { value: 'service_ttft', label: 'Service TTFT', description: 'Time to first token across services (ms)', category: 'service' },
     { value: 'service_capacity', label: 'Service Capacity', description: 'Seat utilization across services (%)', category: 'service' },
+    { value: 'service_quota', label: 'Service Quota', description: 'Tightest cached upstream quota usage across services (%)', category: 'service' },
 ];
 
 const VALUE_OPTIONS: Record<string, Array<{ value: string; label: string }> | undefined> = {
@@ -103,6 +104,12 @@ const OPERATION_OPTIONS: Record<string, Array<{ value: string; label: string; de
         { value: 'util_ge', label: 'Util ≥', description: 'Avg seat utilization across services >= value (%)', valueType: 'int' },
         { value: 'util_lt', label: 'Util <', description: 'Avg seat utilization across services < value (%)', valueType: 'int' },
         { value: 'util_gt', label: 'Util >', description: 'Avg seat utilization across services > value (%)', valueType: 'int' },
+    ],
+    service_quota: [
+        { value: 'pct_le', label: 'Quota ≤', description: 'Tightest cached quota usage across services <= value (%)', valueType: 'int' },
+        { value: 'pct_ge', label: 'Quota ≥', description: 'Tightest cached quota usage across services >= value (%)', valueType: 'int' },
+        { value: 'pct_lt', label: 'Quota <', description: 'Tightest cached quota usage across services < value (%)', valueType: 'int' },
+        { value: 'pct_gt', label: 'Quota >', description: 'Tightest cached quota usage across services > value (%)', valueType: 'int' },
     ],
     'agent.claude_code': [
         { value: 'equals', label: 'Equals', description: 'Claude Code request kind equals the value', valueType: 'string' },
@@ -598,7 +605,7 @@ export const SmartRuleCatalogDialog: React.FC<SmartRuleCatalogDialogProps> = ({
                                                                                 handleValueChange(op.uuid, e.target.value)
                                                                             }
                                                                             placeholder={
-                                                                                pos.value === 'service_capacity'
+                                                                                pos.value === 'service_capacity' || pos.value === 'service_quota'
                                                                                     ? '0–100'
                                                                                     : pos.value === 'service_ttft'
                                                                                     ? 'ms'

--- a/frontend/src/types/quota.ts
+++ b/frontend/src/types/quota.ts
@@ -31,9 +31,17 @@ export function isCountable(window: CountableFields): boolean {
     return !window.unknown && !window.unlimited && window.limit > 0;
 }
 
-/** Rank, then period length — the same order the backend establishes. */
+/**
+ * Rank, then period length — the same order the backend establishes.
+ *
+ * Rank 0 (self-healing allowances) requires an explicit `kind === 'limit'` —
+ * an untagged window (`kind` undefined) is not assumed to belong there, so
+ * it sorts alongside resources (rank 1) instead of jumping the queue. No
+ * default toward "limit" here, mirroring ai/quota's windowRank in
+ * semantic.go: only a positively-classified window gets the front seat.
+ */
 function windowSortKey(window: QuotaWindow): [number, number] {
-    const rank = !isCountable(window) ? 2 : window.kind === 'resource' ? 1 : 0;
+    const rank = !isCountable(window) ? 2 : window.kind === 'limit' ? 0 : 1;
     const minutes = window.window_minutes && window.window_minutes > 0
         ? window.window_minutes
         : Number.MAX_SAFE_INTEGER;

--- a/internal/routing/selector.go
+++ b/internal/routing/selector.go
@@ -173,6 +173,18 @@ func NewServiceSelectorWithLogger(
 	return s
 }
 
+// SetQuotaProvider wires cached quota lookups into the pipeline's smart
+// routing stage so service_quota ops can compare against provider usage.
+// Optional — call it after construction once a quota manager is available;
+// unset leaves service_quota ops passing through (see QuotaProvider).
+func (s *ServiceSelector) SetQuotaProvider(qp QuotaProvider) {
+	for _, stage := range s.pipeline {
+		if sm, ok := stage.(*SmartRoutingStage); ok {
+			sm.SetQuotaProvider(qp)
+		}
+	}
+}
+
 // Select is the main entry point for service selection.
 // It picks a pre-built pipeline based on rule configuration and executes it.
 func (s *ServiceSelector) Select(ctx *SelectionContext) (*SelectionResult, error) {

--- a/internal/routing/stage_smart_routing.go
+++ b/internal/routing/stage_smart_routing.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/tingly-dev/tingly-box/ai/quota"
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
@@ -13,10 +14,21 @@ import (
 	pkgobs "github.com/tingly-dev/tingly-box/pkg/obs"
 )
 
+// QuotaProvider gives the smart-routing stage read access to cached quota
+// usage (ai/quota) so the service_quota position can compare against
+// provider usage without a live upstream fetch. *quota.Manager satisfies
+// this. GetQuotaNoCache reads the last-refreshed value straight from the
+// store (no expiry-triggered live fetch), keeping the op a local DB read
+// rather than a per-request network call.
+type QuotaProvider interface {
+	GetQuotaNoCache(ctx context.Context, providerUUID string) (*quota.ProviderUsage, error)
+}
+
 // SmartRoutingStage evaluates smart routing rules and returns matched services.
 // If multiple services match, applies load balancing within the matched set.
 type SmartRoutingStage struct {
 	affinityStore AffinityStore
+	quotaProvider QuotaProvider       // optional; wires service_quota ops to cached quota usage
 	multiLogger   *pkgobs.MultiLogger // optional; used to emit structured smart-routing logs
 }
 
@@ -29,6 +41,13 @@ func NewSmartRoutingStage(affinity AffinityStore) *SmartRoutingStage {
 // smart-routing evaluation logs viewable from the frontend system log page.
 func (s *SmartRoutingStage) SetMultiLogger(ml *pkgobs.MultiLogger) {
 	s.multiLogger = ml
+}
+
+// SetQuotaProvider wires cached quota lookups into the stage. Optional —
+// when unset, service_quota ops see no data and pass through (see
+// evaluateServiceQuotaOp in internal/smart_routing/routing.go).
+func (s *SmartRoutingStage) SetQuotaProvider(qp QuotaProvider) {
+	s.quotaProvider = qp
 }
 
 // Name returns the stage identifier
@@ -182,6 +201,10 @@ func (s *SmartRoutingStage) Evaluate(ctx *SelectionContext, candidates []*loadba
 	// evaluateRule will filter this down to per-rule services when evaluating.
 	reqCtx.ServiceCapacity = s.collectAllCapacityInfo(rule.SmartRouting)
 
+	// Pre-collect cached quota usage the same way. A no-op (nil slice) when
+	// no QuotaProvider is wired, so service_quota ops simply pass through.
+	reqCtx.ServiceQuota = s.collectAllQuotaInfo(selectionLogContext(ctx), rule.SmartRouting)
+
 	// Create router and evaluate
 	router, err := smartrouting.NewRouter(rule.SmartRouting)
 	if err != nil {
@@ -330,6 +353,55 @@ func (s *SmartRoutingStage) collectAllCapacityInfo(rules []smartrouting.SmartRou
 				ServiceID:   id,
 				Capacity:    cap,
 				ActiveCount: active,
+			})
+		}
+	}
+	return result
+}
+
+// collectAllQuotaInfo collects cached quota usage for all services across all
+// smart routing rules, keyed by each service's provider UUID (svc.Provider).
+// Deduplicates by serviceID; evaluateRule filters down to per-rule services.
+// Skipped entirely when no QuotaProvider is wired. A service is omitted
+// (not zeroed) when its provider has no cached usage yet or usage is not
+// countable — unknown must never read as 0%.
+//
+// Uses usage.Pct(quota.WindowKindLimit), not the unfiltered usage.Pct():
+// service_quota is meant to react only to standard, self-healing quota
+// (Kind == WindowKindLimit), not to a standing balance/credit (Kind ==
+// WindowKindResource, e.g. OpenRouter's key balance or Kimi Code's booster
+// wallet) that needs a manual top-up rather than time to recover. A rule
+// that trips on balance depletion would keep avoiding that pool
+// indefinitely with no self-correcting signal — see
+// .design/quota-semantics.md §8.1.
+func (s *SmartRoutingStage) collectAllQuotaInfo(ctx context.Context, rules []smartrouting.SmartRouting) []smartrouting.ServiceQuotaInfo {
+	if s.quotaProvider == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var result []smartrouting.ServiceQuotaInfo
+	for _, r := range rules {
+		for _, svc := range r.Services {
+			id := svc.ServiceID()
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+
+			if svc.Provider == "" {
+				continue
+			}
+			usage, err := s.quotaProvider.GetQuotaNoCache(ctx, svc.Provider)
+			if err != nil || usage == nil {
+				continue
+			}
+			pct, ok := usage.Pct(quota.WindowKindLimit)
+			if !ok {
+				continue
+			}
+			result = append(result, smartrouting.ServiceQuotaInfo{
+				ServiceID: id,
+				Pct:       pct,
 			})
 		}
 	}

--- a/internal/routing/stage_smart_routing_quota_test.go
+++ b/internal/routing/stage_smart_routing_quota_test.go
@@ -1,0 +1,102 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
+)
+
+func testServiceQuotaOp(operation smartrouting.SmartOpOperation, value string) smartrouting.SmartOp {
+	return smartrouting.SmartOp{
+		Position:  smartrouting.PositionServiceQuota,
+		Operation: operation,
+		Value:     value,
+		Meta:      smartrouting.SmartOpMeta{Type: smartrouting.ValueTypeInt},
+	}
+}
+
+// TestSmartRouting_ServiceQuota_Match verifies the end-to-end wiring: a
+// QuotaProvider set via SetQuotaProvider is consulted per-request, and a
+// rule whose service is over the configured threshold matches.
+func TestSmartRouting_ServiceQuota_Match(t *testing.T) {
+	services := []*loadbalance.Service{testService("prov-hot", "gpt-4", true)}
+	rule := testSmartRule("rule-1", "gpt-4", services, testServiceQuotaOp(smartrouting.OpServiceQuotaPctGe, "85"))
+	ctx := testContext(rule, "")
+	ctx.Request = testOpenAIRequest("gpt-4")
+
+	qp := newMockQuotaProvider()
+	qp.setPct("prov-hot", 92)
+
+	stage := NewSmartRoutingStage(newMockAffinityStore())
+	stage.SetQuotaProvider(qp)
+
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final)
+	require.Len(t, narrowed, 1)
+	require.Equal(t, "prov-hot", narrowed[0].Provider)
+}
+
+// TestSmartRouting_ServiceQuota_BelowThreshold_NoMatch verifies the rule
+// falls through to the base pool when quota is under the threshold.
+func TestSmartRouting_ServiceQuota_BelowThreshold_NoMatch(t *testing.T) {
+	services := []*loadbalance.Service{testService("prov-cool", "gpt-4", true)}
+	rule := testSmartRule("rule-1", "gpt-4", services, testServiceQuotaOp(smartrouting.OpServiceQuotaPctGe, "85"))
+	ctx := testContext(rule, "")
+	ctx.Request = testOpenAIRequest("gpt-4")
+
+	qp := newMockQuotaProvider()
+	qp.setPct("prov-cool", 10)
+
+	stage := NewSmartRoutingStage(newMockAffinityStore())
+	stage.SetQuotaProvider(qp)
+
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final)
+	require.Equal(t, services, narrowed, "under threshold must fall back to the rule's base pool")
+}
+
+// TestSmartRouting_ServiceQuota_IgnoresResourceKindWindows proves the
+// service_quota op does not trigger avoidance off a standing balance/credit
+// (Kind == WindowKindResource) even though it is fully countable — only
+// self-healing quota (Kind == WindowKindLimit) should drive this op. See
+// Pct's kinds filter in ai/quota/semantic.go and .design/quota-semantics.md §8.1.
+func TestSmartRouting_ServiceQuota_IgnoresResourceKindWindows(t *testing.T) {
+	services := []*loadbalance.Service{testService("prov-balance", "gpt-4", true)}
+	rule := testSmartRule("rule-1", "gpt-4", services, testServiceQuotaOp(smartrouting.OpServiceQuotaPctGe, "85"))
+	ctx := testContext(rule, "")
+	ctx.Request = testOpenAIRequest("gpt-4")
+
+	qp := newMockQuotaProvider()
+	qp.setResourcePct("prov-balance", 95) // a near-exhausted balance, not standard quota
+
+	stage := NewSmartRoutingStage(newMockAffinityStore())
+	stage.SetQuotaProvider(qp)
+
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final)
+	require.Equal(t, services, narrowed, "resource-kind usage must not trigger avoidance")
+}
+
+// TestSmartRouting_ServiceQuota_NoProviderWired_Passes ensures a
+// service_quota op does not block routing when no QuotaProvider was ever
+// set (e.g. quota manager failed to initialize) — the op is optional.
+func TestSmartRouting_ServiceQuota_NoProviderWired_Passes(t *testing.T) {
+	services := []*loadbalance.Service{testService("prov-unknown", "gpt-4", true)}
+	rule := testSmartRule("rule-1", "gpt-4", services, testServiceQuotaOp(smartrouting.OpServiceQuotaPctGe, "85"))
+	ctx := testContext(rule, "")
+	ctx.Request = testOpenAIRequest("gpt-4")
+
+	stage := NewSmartRoutingStage(newMockAffinityStore()) // no SetQuotaProvider call
+
+	narrowed, final, err := stage.Evaluate(ctx, initialCandidateServices(ctx.Rule))
+	require.NoError(t, err)
+	require.Nil(t, final)
+	require.Len(t, narrowed, 1, "op must pass through (match) when quota is unwired, not block routing")
+	require.Equal(t, "prov-unknown", narrowed[0].Provider)
+}

--- a/internal/routing/test_helpers.go
+++ b/internal/routing/test_helpers.go
@@ -1,12 +1,14 @@
 package routing
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tingly-dev/tingly-box/ai/quota"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	smartrouting "github.com/tingly-dev/tingly-box/internal/smart_routing"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -148,6 +150,46 @@ func (m *mockAffinityStore) CountByService(serviceID string) int {
 		}
 	}
 	return count
+}
+
+// mockQuotaProvider implements QuotaProvider for testing service_quota.
+// usage maps providerUUID -> cached usage; a missing entry simulates "no
+// data yet" (GetQuotaNoCache's ErrUsageNotFound path), which the stage
+// treats as unknown and excludes from aggregation.
+type mockQuotaProvider struct {
+	usage map[string]*quota.ProviderUsage
+}
+
+func newMockQuotaProvider() *mockQuotaProvider {
+	return &mockQuotaProvider{usage: make(map[string]*quota.ProviderUsage)}
+}
+
+// setPct registers a single countable, standard-quota (Kind=limit) window at
+// pct% used for providerUUID — mirrors how real fetchers (e.g. Anthropic's
+// 5h/7d) tag their periodic windows so service_quota picks it up.
+func (m *mockQuotaProvider) setPct(providerUUID string, pct float64) {
+	m.usage[providerUUID] = &quota.ProviderUsage{
+		ProviderUUID: providerUUID,
+		Windows:      []*quota.UsageWindow{{Kind: quota.WindowKindLimit, Limit: 100, UsedPercent: pct}},
+	}
+}
+
+// setResourcePct registers a single countable but resource-kind (balance,
+// e.g. OpenRouter's key limit) window — used to prove service_quota ignores
+// it even though ai/quota's general Pct() would happily count it.
+func (m *mockQuotaProvider) setResourcePct(providerUUID string, pct float64) {
+	m.usage[providerUUID] = &quota.ProviderUsage{
+		ProviderUUID: providerUUID,
+		Windows:      []*quota.UsageWindow{{Kind: quota.WindowKindResource, Limit: 100, UsedPercent: pct}},
+	}
+}
+
+func (m *mockQuotaProvider) GetQuotaNoCache(_ context.Context, providerUUID string) (*quota.ProviderUsage, error) {
+	usage, ok := m.usage[providerUUID]
+	if !ok {
+		return nil, quota.ErrUsageNotFound
+	}
+	return usage, nil
 }
 
 // mockConfig implements ProviderResolver for ServiceSelector tests.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -461,6 +461,11 @@ func NewServer(cfg *config.Config, opts ...ServerOption) *Server {
 		logrus.WithError(err).Warn("Failed to initialize provider quota manager")
 	} else {
 		server.quotaManager = quotaMgr
+		// Wire cached quota into smart routing's service_quota op. Done here,
+		// after quota manager init, rather than threading it through the
+		// selector constructor above — quota init can fail independently and
+		// the op is optional (passes through with no provider wired).
+		serviceSelector.SetQuotaProvider(quotaMgr)
 	}
 
 	// Construct the WebUI Management API's control handler. This MUST be the

--- a/internal/smart_routing/README.md
+++ b/internal/smart_routing/README.md
@@ -92,12 +92,36 @@ An **op** (`SmartOp`) is `Position + Operation + Value`:
 | `token` | estimated token count (chars/4) | `ge`, `gt`, `le`, `lt` |
 | `service_ttft` | rule services' TTFT stats (ms) | `avg_le`, `avg_ge`, `max_le`, `max_ge` |
 | `service_capacity` | rule services' seat utilization (%) | `util_le`, `util_ge`, `util_lt`, `util_gt` |
+| `service_quota` | rule services' cached upstream quota usage (%) | `pct_le`, `pct_ge`, `pct_lt`, `pct_gt` |
 | `agent.claude_code` | detected Claude Code request kind | `equals` (`main` / `subagent` / `compact`) |
 | `proxy_vision` | latest user content type (image?) | `enabled` (toggle — see Op-level processors) |
 
-`service_ttft` and `service_capacity` are seeded per-rule before evaluation
-(`collectRuleStats` / `filterCapacityForRule`); both **pass** when the
-underlying data is empty so cold-start traffic isn't blocked.
+`service_ttft`, `service_capacity`, and `service_quota` are seeded per-rule
+before evaluation (`collectRuleStats` / `filterCapacityForRule` /
+`filterQuotaForRule`); all three **pass** when the underlying data is empty
+so cold-start traffic (or a service whose quota was never fetched) isn't
+blocked.
+
+`service_quota` reads cached provider usage from `ai/quota`
+(`.design/quota-semantics.md`) via the optional `QuotaProvider` wired into
+`SmartRoutingStage` — a local DB read, never a live upstream call. It
+compares the **tightest** (highest-used%) service in the rule against the
+threshold, not the average: a rule models one pool of interchangeable
+services, and one of them running hot should make the pool look hot rather
+than being diluted by the others. Rules that want per-service or
+per-tier thresholds should use separate ops/rules instead of relying on
+this op to average across services.
+
+It only sees **standard, self-healing quota** (`ai/quota`'s
+`Pct(quota.WindowKindLimit)`) — a standing balance/credit (OpenRouter's key
+limit, Kimi Code's booster wallet, KimiK2's credits) needs a manual top-up
+rather than time to recover, so it must not silently drive an "avoid this
+pool" decision meant to be temporary. A window only counts here when its
+fetcher explicitly tags it `Kind: WindowKindLimit`; an untagged window is
+excluded rather than assumed safe. Display consumers (statusline, the
+frontend) call the same `Pct()`/`Tightest()` with no kinds filter, so they
+keep seeing resource windows like a balance — only this op's strict call
+is scoped down.
 
 ### Claude Code request-kind detection
 
@@ -214,6 +238,24 @@ SmartRouting{
     Services: []*loadbalance.Service{spillover},
 }
 ```
+
+### Switch to a cheaper pool once quota runs hot
+
+```go
+SmartRouting{
+    Description: "primary pool ≥85% quota → spill to cheap pool",
+    Ops: []SmartOp{
+        {Position: PositionServiceQuota, Operation: OpServiceQuotaPctGe,
+         Value: "85", Meta: SmartOpMeta{Type: ValueTypeInt}},
+    },
+    Services: []*loadbalance.Service{primaryPoolA, primaryPoolB},
+}
+```
+
+This is the "don't want to use" half of quota-aware routing — proactively
+steering away from a pool before it 429s. It does not overlap with
+`stage_health`'s "can't use" exclusion, which reacts to actual rate-limit
+errors; see `.design/quota-semantics.md` §8.
 
 ### Make a text-only model accept image-bearing requests
 

--- a/internal/smart_routing/context.go
+++ b/internal/smart_routing/context.go
@@ -20,6 +20,28 @@ type ServiceCapacityInfo struct {
 	ActiveCount int // active affinity sessions
 }
 
+// ServiceQuotaInfo holds cached quota usage for a single service's upstream
+// provider account (see ai/quota, .design/quota-semantics.md). Pct is the
+// provider's tightest countable *standard* quota window (ai/quota's
+// ProviderUsage.Pct(quota.WindowKindLimit), not the unfiltered Pct()) —
+// 0-100, already the "how much is used" answer, no further unit conversion.
+//
+// Filtered by WindowKindLimit, not unfiltered: a standing balance/credit
+// (Kind == WindowKindResource — OpenRouter's key balance, Kimi Code's
+// booster wallet, KimiK2's credits) needs a manual top-up rather than time
+// to recover, so it must not drive an automatic "avoid this pool" decision
+// the same way a self-healing allowance does — see
+// .design/quota-semantics.md §8.1.
+//
+// Entries only exist for services whose standard quota is currently known:
+// unread (cold cache), unreadable, not-countable (Unknown/Unlimited
+// windows), or resource-only providers are omitted rather than represented
+// as 0%, so they cannot be misread as "quota fully available".
+type ServiceQuotaInfo struct {
+	ServiceID string
+	Pct       float64
+}
+
 // RequestContext holds extracted request data for evaluation
 type RequestContext struct {
 	Model             string
@@ -50,6 +72,7 @@ type RequestContext struct {
 	// These fields are set per-rule inside evaluateRule to avoid cross-rule contamination.
 	ServiceStats    []loadbalance.ServiceStats // TTFT / latency snapshots
 	ServiceCapacity []ServiceCapacityInfo      // seat utilization info
+	ServiceQuota    []ServiceQuotaInfo         // cached upstream-provider quota usage (%)
 }
 
 // GetLatestUserMessage returns the latest user message

--- a/internal/smart_routing/op.go
+++ b/internal/smart_routing/op.go
@@ -223,6 +223,40 @@ var Operations = []SmartOp{
 			Type:        ValueTypeInt,
 		},
 	},
+
+	// Service quota operations (cached upstream provider usage %)
+	{
+		Position:  PositionServiceQuota,
+		Operation: OpServiceQuotaPctLe,
+		Meta: SmartOpMeta{
+			Description: "Avg quota used across services' providers <= value (%)",
+			Type:        ValueTypeInt,
+		},
+	},
+	{
+		Position:  PositionServiceQuota,
+		Operation: OpServiceQuotaPctGe,
+		Meta: SmartOpMeta{
+			Description: "Avg quota used across services' providers >= value (%)",
+			Type:        ValueTypeInt,
+		},
+	},
+	{
+		Position:  PositionServiceQuota,
+		Operation: OpServiceQuotaPctLt,
+		Meta: SmartOpMeta{
+			Description: "Avg quota used across services' providers < value (%)",
+			Type:        ValueTypeInt,
+		},
+	},
+	{
+		Position:  PositionServiceQuota,
+		Operation: OpServiceQuotaPctGt,
+		Meta: SmartOpMeta{
+			Description: "Avg quota used across services' providers > value (%)",
+			Type:        ValueTypeInt,
+		},
+	},
 }
 
 const (
@@ -234,6 +268,7 @@ const (
 	PositionToken           SmartOpPosition = "token"             // Token count
 	PositionServiceTTFT     SmartOpPosition = "service_ttft"      // Service TTFT characteristics
 	PositionServiceCapacity SmartOpPosition = "service_capacity"  // Service seat capacity (affinity utilization)
+	PositionServiceQuota    SmartOpPosition = "service_quota"     // Cached upstream provider quota usage (%)
 	PositionAgentClaudeCode SmartOpPosition = "agent.claude_code" // Claude Code agent request kind (main / subagent / compact)
 	PositionTime            SmartOpPosition = "time"              // Current time in a configured timezone
 )
@@ -280,6 +315,12 @@ const (
 	OpServiceCapacityUtilGe SmartOpOperation = "util_ge" // Avg seat utilization >= value (%)
 	OpServiceCapacityUtilLt SmartOpOperation = "util_lt" // Avg seat utilization < value (%)
 	OpServiceCapacityUtilGt SmartOpOperation = "util_gt" // Avg seat utilization > value (%)
+
+	// Service quota operations (cached upstream provider usage %, see ai/quota)
+	OpServiceQuotaPctLe SmartOpOperation = "pct_le" // Avg quota used% <= value (%)
+	OpServiceQuotaPctGe SmartOpOperation = "pct_ge" // Avg quota used% >= value (%)
+	OpServiceQuotaPctLt SmartOpOperation = "pct_lt" // Avg quota used% < value (%)
+	OpServiceQuotaPctGt SmartOpOperation = "pct_gt" // Avg quota used% > value (%)
 
 	// Agent (Claude Code) request kind operations
 	OpAgentClaudeCodeEquals SmartOpOperation = "equals" // Claude Code request kind equals the value

--- a/internal/smart_routing/routing.go
+++ b/internal/smart_routing/routing.go
@@ -66,11 +66,14 @@ func (r *Router) EvaluateRequestWithIndex(ctx *RequestContext) ([]*loadbalance.S
 func (r *Router) evaluateRule(ctx *RequestContext, rule *SmartRouting, idx int) RuleEvalResult {
 	origStats := ctx.ServiceStats
 	origCap := ctx.ServiceCapacity
+	origQuota := ctx.ServiceQuota
 	ctx.ServiceStats = collectRuleStats(rule.Services)
 	ctx.ServiceCapacity = filterCapacityForRule(ctx.ServiceCapacity, rule.Services)
+	ctx.ServiceQuota = filterQuotaForRule(ctx.ServiceQuota, rule.Services)
 	defer func() {
 		ctx.ServiceStats = origStats
 		ctx.ServiceCapacity = origCap
+		ctx.ServiceQuota = origQuota
 	}()
 
 	res := RuleEvalResult{
@@ -113,6 +116,8 @@ func (r *Router) evaluateOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
 		return r.evaluateServiceTTFTOp(ctx, op)
 	case PositionServiceCapacity:
 		return r.evaluateServiceCapacityOp(ctx, op)
+	case PositionServiceQuota:
+		return r.evaluateServiceQuotaOp(ctx, op)
 	case PositionAgentClaudeCode:
 		return r.evaluateAgentClaudeCodeOp(ctx, op)
 	case PositionTime:
@@ -530,6 +535,68 @@ func (r *Router) evaluateServiceCapacityOp(ctx *RequestContext, op *SmartOp) OpE
 	return res
 }
 
+// evaluateServiceQuotaOp compares the tightest (highest-used%) cached
+// *standard* quota across the rule's services' upstream providers
+// (ctx.ServiceQuota, pre-filtered per-rule by evaluateRule) against a
+// threshold. Quota is read from the local ai/quota cache, never fetched
+// live, and restricted to self-healing allowances (Kind == WindowKindLimit)
+// — see Pct's kinds filter (ai/quota/semantic.go) and collectAllQuotaInfo in
+// internal/routing/stage_smart_routing.go; standing balances/credits are
+// deliberately excluded (see ServiceQuotaInfo in context.go).
+//
+// Aggregation is max, not average: mirrors ai/quota/semantic.go's own
+// window aggregation ("take the tightest, because that's the one that runs
+// out first" — .design/quota-semantics.md §3.3), extended across services.
+// A rule is meant to represent one pool of interchangeable services; if any
+// one of them is running hot, the pool itself should be treated as hot
+// rather than diluted by the others. Rules that want independent
+// thresholds per service/tier should split into separate ops/rules rather
+// than relying on this op to average them.
+//
+// Services with unknown quota (never fetched, unreadable, or not countable
+// — see ai/quota/semantic.go) are absent from ctx.ServiceQuota entirely and
+// excluded from the max, rather than counted as 0% used. Returns
+// Matched=true (pass) when no service in the rule has quota data, so
+// quota-blind rules and cold caches never block routing.
+func (r *Router) evaluateServiceQuotaOp(ctx *RequestContext, op *SmartOp) OpEvalResult {
+	res := newOpResult(op)
+	if len(ctx.ServiceQuota) == 0 {
+		res.Matched = true
+		res.Reason = "no quota info; pass"
+		return res
+	}
+	threshold, err := op.Int()
+	if err != nil {
+		log.Printf("[smart_routing] invalid service_quota value '%s': %v", op.Value, err)
+		res.Reason = fmt.Sprintf("invalid int: %v", err)
+		return res
+	}
+	pctValues := make([]float64, 0, len(ctx.ServiceQuota))
+	for _, q := range ctx.ServiceQuota {
+		pctValues = append(pctValues, q.Pct)
+	}
+	tightest := maxFloat(pctValues)
+	thresholdF := float64(threshold)
+	res.Actual = fmt.Sprintf("%.1f%%", tightest)
+	switch op.Operation {
+	case OpServiceQuotaPctLe:
+		res.Matched = tightest <= thresholdF
+		res.Reason = fmt.Sprintf("tightest quota %.1f%% <= %d%%", tightest, threshold)
+	case OpServiceQuotaPctGe:
+		res.Matched = tightest >= thresholdF
+		res.Reason = fmt.Sprintf("tightest quota %.1f%% >= %d%%", tightest, threshold)
+	case OpServiceQuotaPctLt:
+		res.Matched = tightest < thresholdF
+		res.Reason = fmt.Sprintf("tightest quota %.1f%% < %d%%", tightest, threshold)
+	case OpServiceQuotaPctGt:
+		res.Matched = tightest > thresholdF
+		res.Reason = fmt.Sprintf("tightest quota %.1f%% > %d%%", tightest, threshold)
+	default:
+		res.Reason = fmt.Sprintf("unsupported service_quota op %q", op.Operation)
+	}
+	return res
+}
+
 // evaluateAgentClaudeCodeOp evaluates the agent.claude_code position.
 // ctx.ClaudeCodeRequestKind is populated by SmartRoutingStage only when the
 // request scenario is claude_code; for other scenarios it is empty and no
@@ -618,10 +685,38 @@ func filterCapacityForRule(all []ServiceCapacityInfo, services []*loadbalance.Se
 	return result
 }
 
+// filterQuotaForRule filters all quota info down to services belonging to this rule.
+func filterQuotaForRule(all []ServiceQuotaInfo, services []*loadbalance.Service) []ServiceQuotaInfo {
+	if len(all) == 0 {
+		return nil
+	}
+	ids := make(map[string]struct{}, len(services))
+	for _, svc := range services {
+		ids[svc.ServiceID()] = struct{}{}
+	}
+	var result []ServiceQuotaInfo
+	for _, q := range all {
+		if _, ok := ids[q.ServiceID]; ok {
+			result = append(result, q)
+		}
+	}
+	return result
+}
+
 func minFloat(vals []float64) float64 {
 	m := vals[0]
 	for _, v := range vals[1:] {
 		if v < m {
+			m = v
+		}
+	}
+	return m
+}
+
+func maxFloat(vals []float64) float64 {
+	m := vals[0]
+	for _, v := range vals[1:] {
+		if v > m {
 			m = v
 		}
 	}

--- a/internal/smart_routing/service_quota_test.go
+++ b/internal/smart_routing/service_quota_test.go
@@ -1,0 +1,139 @@
+package smartrouting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+func quotaOp(operation SmartOpOperation, value string) SmartOp {
+	return SmartOp{
+		Position:  PositionServiceQuota,
+		Operation: operation,
+		Value:     value,
+		Meta:      SmartOpMeta{Type: ValueTypeInt},
+	}
+}
+
+func TestEvaluateServiceQuotaOp_PassesWhenNoData(t *testing.T) {
+	r := &Router{}
+	ctx := &RequestContext{}
+	op := quotaOp(OpServiceQuotaPctGe, "85")
+
+	res := r.evaluateServiceQuotaOp(ctx, &op)
+
+	require.True(t, res.Matched, "no quota data must pass, not be read as 0%%")
+}
+
+func TestEvaluateServiceQuotaOp_TakesTightestNotAverage(t *testing.T) {
+	r := &Router{}
+	ctx := &RequestContext{
+		ServiceQuota: []ServiceQuotaInfo{
+			{ServiceID: "svc-a", Pct: 20},
+			{ServiceID: "svc-b", Pct: 90}, // the tightest
+		},
+	}
+
+	geOp := quotaOp(OpServiceQuotaPctGe, "85")
+	res := r.evaluateServiceQuotaOp(ctx, &geOp)
+	require.True(t, res.Matched, "max(20, 90)=90 >= 85 should match; an average (55) would not")
+	require.Equal(t, "90.0%", res.Actual)
+
+	leOp := quotaOp(OpServiceQuotaPctLe, "50")
+	res = r.evaluateServiceQuotaOp(ctx, &leOp)
+	require.False(t, res.Matched, "max(20, 90)=90 is not <= 50")
+}
+
+func TestEvaluateServiceQuotaOp_Thresholds(t *testing.T) {
+	r := &Router{}
+	ctx := &RequestContext{ServiceQuota: []ServiceQuotaInfo{{ServiceID: "svc-a", Pct: 85}}}
+
+	cases := []struct {
+		op      SmartOpOperation
+		value   string
+		matched bool
+	}{
+		{OpServiceQuotaPctGe, "85", true},
+		{OpServiceQuotaPctGe, "86", false},
+		{OpServiceQuotaPctGt, "85", false},
+		{OpServiceQuotaPctGt, "84", true},
+		{OpServiceQuotaPctLe, "85", true},
+		{OpServiceQuotaPctLe, "84", false},
+		{OpServiceQuotaPctLt, "85", false},
+		{OpServiceQuotaPctLt, "86", true},
+	}
+	for _, c := range cases {
+		op := quotaOp(c.op, c.value)
+		res := r.evaluateServiceQuotaOp(ctx, &op)
+		require.Equal(t, c.matched, res.Matched, "op=%s value=%s", c.op, c.value)
+	}
+}
+
+func TestEvaluateServiceQuotaOp_InvalidValue(t *testing.T) {
+	r := &Router{}
+	ctx := &RequestContext{ServiceQuota: []ServiceQuotaInfo{{ServiceID: "svc-a", Pct: 85}}}
+	op := quotaOp(OpServiceQuotaPctGe, "not-a-number")
+
+	res := r.evaluateServiceQuotaOp(ctx, &op)
+
+	require.False(t, res.Matched)
+	require.Contains(t, res.Reason, "invalid int")
+}
+
+func TestFilterQuotaForRule(t *testing.T) {
+	all := []ServiceQuotaInfo{
+		{ServiceID: "svc-a", Pct: 10},
+		{ServiceID: "svc-b", Pct: 90},
+	}
+	services := []*loadbalance.Service{
+		{Provider: "provider-b", Model: "model-b"},
+	}
+	// ServiceID() combines provider+model; build a service whose ServiceID matches "svc-b".
+	// Rather than depend on the exact ServiceID() format, filter using the same
+	// service and assert only entries whose ID is present survive.
+	svc := services[0]
+	filtered := filterQuotaForRule(all, []*loadbalance.Service{svc})
+	for _, q := range filtered {
+		require.Equal(t, svc.ServiceID(), q.ServiceID)
+	}
+
+	require.Nil(t, filterQuotaForRule(nil, services))
+}
+
+// TestSmartRouting_ServiceQuota_RuleLevel exercises the op through a full
+// Router.Evaluate pass, including evaluateRule's per-rule ServiceQuota
+// filtering (a second rule with a different service must not see the first
+// rule's quota data).
+func TestSmartRouting_ServiceQuota_RuleLevel(t *testing.T) {
+	hotService := &loadbalance.Service{Provider: "prov-hot", Model: "m", Weight: 1, Active: true}
+	coldService := &loadbalance.Service{Provider: "prov-cold", Model: "m", Weight: 1, Active: true}
+
+	rules := []SmartRouting{
+		{
+			Description: "hot pool has quota data and is over threshold",
+			Ops: []SmartOp{
+				{Position: PositionServiceQuota, Operation: OpServiceQuotaPctGe, Value: "85", Meta: SmartOpMeta{Type: ValueTypeInt}},
+			},
+			Services: []*loadbalance.Service{hotService},
+		},
+	}
+	router, err := NewRouter(rules)
+	require.NoError(t, err)
+
+	ctx := &RequestContext{
+		ServiceQuota: []ServiceQuotaInfo{
+			{ServiceID: hotService.ServiceID(), Pct: 92},
+			{ServiceID: coldService.ServiceID(), Pct: 5}, // belongs to a different rule/service
+		},
+	}
+
+	services, matched := router.EvaluateRequest(ctx)
+	require.True(t, matched)
+	require.Equal(t, []*loadbalance.Service{hotService}, services)
+
+	// evaluateRule must restore the full ServiceQuota slice after evaluation
+	// so a later stage (or a subsequent rule) still sees every service.
+	require.Len(t, ctx.ServiceQuota, 2)
+}

--- a/internal/smart_routing/type.go
+++ b/internal/smart_routing/type.go
@@ -74,7 +74,7 @@ type SmartRouting struct {
 func (p SmartOpPosition) IsValid() bool {
 	switch p {
 	case PositionModel, PositionThinking, PositionContextSystem, PositionContextUser, PositionLatestUser, PositionToken,
-		PositionServiceTTFT, PositionServiceCapacity, PositionAgentClaudeCode, PositionTime:
+		PositionServiceTTFT, PositionServiceCapacity, PositionServiceQuota, PositionAgentClaudeCode, PositionTime:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary
Adds a new smart-routing position, `service_quota`, so a rule can proactively steer away from a pool once its upstream quota runs hot — the "don't want to use" half of quota-aware routing that `.design/quota-semantics.md` §8 scoped out but left unbuilt.

Stacked on #1587 (`ai/quota`'s `Pct(kinds ...WindowKind)`).

May support #1416.

## Key Changes
- **`service_quota` SmartOp** (`pct_le`/`pct_ge`/`pct_lt`/`pct_gt`): compares the tightest (max, not average) usage across a rule's services against a threshold — one hot service should make the whole pool look hot, not get diluted by cooler ones.
- **Self-healing quota only**: reads `ai/quota`'s `Pct(quota.WindowKindLimit)`, never a standing balance/credit, so the avoidance stays temporary and self-correcting rather than permanent.
- **No live upstream calls**: quota is read from the local cache (`QuotaProvider.GetQuotaNoCache`, wired into `SmartRoutingStage` once the quota manager is available) — a DB read per request, not a network call.
- **Missing/unknown data passes through**: services never fetched, or with no countable quota, are excluded from the comparison rather than read as 0%; the op matches (passes) when a rule has no quota data at all.
- **UI**: `service_quota` catalog entry in `SmartRuleCatalogDialog`.

## Notes
- `internal/server/server.go` wires the quota manager into the service selector after quota-manager init; the op is a no-op when quota isn't configured.
