### PR TITLE
feat(flags): rule-level extra_headers — custom HTTP headers per rule

### DIFF
--- a/.design/provider-flags.md
+++ b/.design/provider-flags.md
@@ -287,26 +287,26 @@ providerHeadersTransport      ← 外层：先写入用户 extra headers
 rule-flags.md §8 的警告——**vendor 链内部永远不得引入
 providerHeadersTransport**。
 
-### 5.3 Header 名校验与 denylist
+### 5.3 Header 校验 —— 用户主导，只查结构
 
-保存时（API 层）校验，而不是发请求时静默丢弃（fail loudly at config
-time，符合"诊断必须走真实链路"原则）。**三个写入口（provider flags、
-model flags、rule flags）共用同一个 `ValidateExtraHeaders` 函数**：
+Extra headers 是**纯用户主导**的编排配置："custom" 就意味着我们无法预判的
+特殊需求，所以**没有 denylist、没有数量/尺寸上限**——`Authorization`、
+`User-Agent`、`anthropic-version`……任何 header 都可以配，配错自负
+（评审定调：把 tingly-box 当编排器，可任意配置，不过度设计）。
 
-- 名字必须是合法 RFC 7230 token；保存时规范化为 canonical 形式
+保存时（API 层）仍拒绝两类**结构性**问题——它们不是限制，而是"这个配置
+本身无定义"：
+
+- 名字必须是合法 RFC 7230 token、值必须是合法 field value（否则
+  net/http 在发送时才失败，报错更晦涩）；保存时规范化为 canonical 形式
   （`textproto.CanonicalMIMEHeaderKey`）。
-- **Denylist（保存即拒绝）**：
-  - 传输层破坏项：`Host`、`Content-Length`、`Transfer-Encoding`、
-    `Connection`、`Upgrade`、`Trailer`、`TE`、`Keep-Alive`
-  - 网关托管的认证项：`Authorization`、`Proxy-Authorization`、
-    `X-Api-Key`（凭证只能走 Token / Credential 字段，不能藏在 header
-    配置里——否则 mask、export 脱敏、OAuth 刷新等一整套凭证治理全部失守）
-  - `User-Agent`：UA 已有独立机制（rule `custom_user_agent` + vendor
-    pin，见 user-agent.md），双入口会重演当年 `provider.UserAgent` 的
-    混乱，明确拒绝。
-- 数量与尺寸限制：每级 ≤ 16 个；name ≤ 128B，value ≤ 4KB。
-- Denylist 在 transport 层做**第二道防御**（跳过 + warn log），防旧数据
-  / import 绕过。
+- 大小写不敏感的重名拒绝（HTTP header 名大小写不敏感，一个 map 里同名
+  两个拼写没有确定胜者）。
+
+与网关自管 header 的冲突**由 transport 链顺序决定，而不是过滤**：
+vendor pin 与 UA 链在更内层（更靠近 wire）后写后胜（§5.2）；通用链上
+用户配置的 `Authorization` 等则会覆盖网关默认——这正是用户显式表达的
+意图。
 
 ### 5.4 各 provider 形态的行为（首版发布范围）
 
@@ -515,8 +515,8 @@ switch/case。实现落点：
 | 注入点 | transport 层（wrapWithLogging 旁，一处） | ClientPool 逐构造器传 option | option 类型按 SDK 分裂（openai/anthropic/google 各一套），transport 一处覆盖所有 auth type 与 style |
 | model/rule 级 ctx 传递 | 单一 ctx key（dispatch 侧合并好） | 每级一个 ctx key | transport 保持哑，合并逻辑集中在 EffectiveExtraHeaders 一处 |
 | vendor pin 冲突 | 物理顺序保证 pin 胜出 | 逐 header 判断 | v1 不触发（api_key only），但顺序不变量零维护成本，为放开 OAuth 保底 |
-| Authorization/X-Api-Key | denylist 拒绝 | 允许（支持自定义认证头） | 凭证必须走 Token/Credential 字段，否则 mask/export 脱敏/凭证治理全失守。真有自定义认证头需求时，作为新 auth type 或专门字段进凭证体系，而不是从 header 后门进 |
-| 校验时机 | 保存时拒绝 + transport 二道防御 | 发请求时静默过滤 | 静默过滤 = 用户以为生效实际没有，违背"诊断走真实链路"；保存时报错教育前置 |
+| denylist / 上限 | **不做**（用户主导，配错自负） | 拒绝 Authorization/UA/传输头 + 数量尺寸上限 | 评审定调：编排器必须可任意配置，"custom" 即特殊需求，过度限制是过度设计。与网关自管 header 的冲突交给 transport 链顺序（pin 在内层后写后胜），不做过滤 |
+| 校验时机 | 保存时拒绝（仅结构合法性） | 发请求时静默失败 | 非法 token/重名在保存时报错比 net/http 发送期报错清晰；结构校验不是限制而是"配置无定义" |
 | API 形态 | typed `flags`/`model_flags` 字段 | 直接暴露 opaque extensions | REST 契约是服务 surface，必须 typed；opaque 容器只是存储与公共 module 之间的运输形态 |
 | 持久化 | 单 `extensions` JSON 列 | 每 flag 一列 | credential/vmodel_detail 先例；增 flag 零 DDL；provider 行不因 flag 增长而加宽 |
 | model key 匹配 | 精确匹配 | 通配/前缀 | 首版从简；registry 与数据形态不阻碍后续加 pattern |

--- a/.design/provider-flags.md
+++ b/.design/provider-flags.md
@@ -1,0 +1,542 @@
+# Provider Extensions & Provider/Model/Rule Flags
+
+> 状态：**分两个 PR 交付**（api_key-only 发布范围）：
+> PR1 — rule 级 `extra_headers`（含前端，已实现）；
+> PR2 — provider & model 级改造（Extensions 容器、db 列、provider API 与前端）。
+> 适用对象：tingly-box 后端 / 前端贡献者。
+> 相关文档：`.design/rule-flags.md`（rule/scenario 级 flag 机制，本设计大量复用其模式）、
+> `.design/user-agent.md`（vendor pin 不可污染的边界，本设计必须尊重）、
+> `.design/dual-provider.md`。
+
+---
+
+## 1. 目标与动机
+
+为 Provider 增加**扩展字段**，并以第一个 flag `extra_headers` 打通
+**三级统一控制**：
+
+1. **Provider 级 flag** —— 作用于该 provider 的所有出站请求；
+2. **Model 级 flag** —— 只作用于该 provider 下某个具体 model 的请求；
+3. **Rule 级 flag** —— 作用于命中该 rule 的请求（复用既有 RuleFlags 机制）。
+
+第一个落地的 flag：**`extra_headers`** —— 为出站请求追加 N 个自定义
+HTTP header（典型场景：OpenRouter 的 `HTTP-Referer`/`X-Title`、
+Cloudflare AI Gateway 的网关 header、企业内网网关的租户/审计 header、
+自建推理服务的自定义路由 header）。三级各自维护一个 header map，
+请求时合并（§3.3），一次性覆盖"上游固有 / 按模型 / 按客户端来源"
+三种粒度的诉求。
+
+**首版发布范围：仅 `api_key` auth type 的 provider**（含空 auth type 的
+向后兼容语义与 dual provider）。OAuth / vendor 特种链、多字段凭证
+（aws_sigv4 / azure_key / gcp_sa）、vmodel 首版不释放（§5.4）。
+
+分层原则（本设计的核心约束）：
+
+> **对 `ai` module 而言，扩展字段是任意的（opaque）；
+> 对 tingly-box 服务而言，扩展字段有明确定义的 schema 与语义。**
+
+`ai/` 是独立 go module、对外公共 API。它不应该知道 tingly-box 服务定义了
+哪些 flag——它只提供一个无 schema 的扩展容器。所有类型化、注册表、校验、
+合并语义都在 `internal/` 落地。
+
+现有 flag 语义由此补全为四层（rule-flags.md §1 的表 + 本设计的前两行）：
+
+| 维度 | 粒度 | 归属 | 例子 |
+|------|------|------|------|
+| Provider flags（**本设计**） | provider 实例 | 供给侧（对上游） | `extra_headers` |
+| Model flags（**本设计**） | provider × model | 供给侧（对上游） | `extra_headers`（model 覆写） |
+| Scenario flags | scenario | 请求侧（对客户端） | `skip_usage`、`smart_compact` |
+| Rule flags | 单条 rule | 请求侧（对客户端） | `cursor_compat`、**`extra_headers`（本设计新增）** |
+
+判断一个新 flag 归哪层："这个行为是**这个上游 provider/model 的固有属性**
+（无论哪个客户端、哪条 rule 打过来都成立）"→ provider/model 级；
+"这个行为取决于**是谁在请求、怎么请求**"→ rule/scenario 级。
+`extra_headers` 是少数三级都有合理语义的 flag（网关 header 是 provider
+固有；模型灰度 header 是 model 维度；按客户端打审计标是 rule 维度），
+所以三级同名同形态、统一合并。但**同一概念多级并存是例外不是常态**——
+UA 的教训（`provider.UserAgent` 移除史，user-agent.md §5）仍然成立：
+新 flag 默认只落一层，三级并存需要像本节这样逐级说清语义。
+
+---
+
+## 2. 分层模型
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  ai module（公共 API，opaque）                                │
+│                                                             │
+│  ai.Provider {                                              │
+│      ...                                                    │
+│      Extensions map[string]json.RawMessage `json:"extensions,omitempty"` │
+│  }                                                          │
+│                                                             │
+│  ai 包不解释内容；任何消费方可用自己的 key 存放任意 JSON。       │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ well-known keys（服务侧独占）
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  tingly-box 服务（internal/，typed）                          │
+│                                                             │
+│  internal/constant:                                         │
+│      ProviderExtKeyFlags      = "provider_flags"  // ProviderFlags │
+│      ProviderExtKeyModelFlags = "model_flags"  // map[model]ProviderFlags │
+│                                                             │
+│  internal/typ:                                              │
+│      type ProviderFlags struct {                            │
+│          ExtraHeaders map[string]string `json:"extra_headers,omitempty"` │
+│          // 后续 flag 在此追加 typed 字段                       │
+│      }                                                      │
+│      RuleFlags 追加同形态字段：                                │
+│          ExtraHeaders map[string]string `json:"extra_headers,omitempty"` │
+│      GetProviderFlags(p)            // 解 "flags" key         │
+│      GetModelFlags(p, model)        // 解 "model_flags"[model]│
+│      EffectiveExtraHeaders(p, model, ruleFlags) // 三级合并（§3.3）│
+│                                                             │
+│  internal/typ/provider_flag_registry.go:                    │
+│      ProviderFlagRegistry() []FlagSpec  // provider/model 级可信源（§4）│
+│  internal/typ/flag_registry.go:                             │
+│      RuleFlagRegistry() 追加 extra_headers 条目（rule 级）      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Rule 级不走 Extensions 容器——RuleFlags 本来就是服务域内的 typed struct
+（rule-flags.md §3），直接加字段即可；Extensions 只解决"公共 module 不能
+认识服务 schema"的问题，Rule 类型不存在这个问题。
+
+### 为什么是 `map[string]json.RawMessage` 而不是 `map[string]any`
+
+- **无损**：RawMessage 原样保存字节，不经历 `any` 的 float64 化 /
+  key 顺序丢失；ai module "任意"的承诺才真正成立。
+- **强制分层**：ai 包物理上无法"顺手"读懂内容，schema 只能在服务侧定义，
+  防止类型定义渗回公共 module。
+- 服务侧解码是一次小 JSON unmarshal，请求路径成本可忽略（provider 对象
+  在 ClientPool / dispatch 中已被缓存与克隆，必要时可在解析处 memoize，
+  首版不做）。
+- 先例差异说明：`ScenarioConfig.Extensions` 用了 `map[string]interface{}`，
+  但它本身就在 internal/typ（服务域内），没有跨 module 分层需求；
+  ai.Provider 是公共 API，取 RawMessage 更严格。
+
+`ResolveStyle` / dual-provider 的 shallow clone 语义不受影响：Extensions
+是引用共享的 map，clone 不深拷贝，所有读取方**只读**（写入只发生在
+usecase 保存路径）。
+
+---
+
+## 3. 数据模型与合并语义
+
+### 3.1 ProviderFlags / RuleFlags.ExtraHeaders
+
+```go
+// internal/typ —— provider 级与 model 级共用
+type ProviderFlags struct {
+    // ExtraHeaders 追加到发往该 provider 的出站请求。
+    // key = header 名（保存时规范化为 canonical form），value = 字面值。
+    ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
+}
+
+// internal/typ/type.go —— RuleFlags 追加同名同形态字段
+//     ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
+```
+
+`map[string]string` vs `[]HeaderKV` 的取舍：map 无法表达重复 header 与
+顺序，但配置型 header 几乎不需要重复（重复 header 的典型是 Cookie/Via，
+不是配置场景）；map 与 probe 的既有形态
+（`internal/client/http.go` `WithProbeHeaders` 的 `map[string]string`）
+一致，UI 也天然是 N 行 KV。选 map。三级同一形态，合并函数只写一个。
+
+### 3.2 Model flags 的 key
+
+`"model_flags"` 是 `map[string]ProviderFlags`，key 为 **provider 侧
+model ID 精确匹配**（即经过 rule 映射后、实际发给该 provider 的 model
+名，与 `Provider.Models` 缓存列表同一命名空间）。理由：provider/model
+flag 是供给侧配置，只应认识 provider 自己的模型词汇，不认识客户端别名。
+通配/前缀匹配（如 `gpt-5*`）留作后续扩展，registry 机制不受影响。
+
+### 3.3 三级合并语义（Effective headers）
+
+```go
+// EffectiveExtraHeaders(p, model, ruleFlags):
+//   provider 级 ∪ model 级 ∪ rule 级，同名时后者胜出：
+//
+//       provider  <  model  <  rule
+//     （最泛化）              （最贴近本次请求）
+```
+
+优先级理由：粒度越贴近"这一次请求"越应胜出。provider 级是全局默认；
+model 级是供给侧对默认的细化；rule 级表达"这一类客户端/用途"的显式
+意图，是三者中最具体的，故最后写入。
+
+对未来的非 map 型 flag（bool/enum），合并模式由 registry 按 flag 声明
+（`MergeMode`：`merge` / `override`），不是全局规则；`extra_headers`
+声明为 `merge`。这与 rule flags 的 `InheritanceMode`（scenario→rule 的
+or/override）同构，但轴不同：`MergeMode` 描述 provider→model→rule 的
+纵向叠加，命名分开以免混淆。
+
+---
+
+## 4. Flag Registry — 复用 rule flags 的唯一可信源模式
+
+### Provider/Model 级：新增 `internal/typ/provider_flag_registry.go`
+
+```go
+// 复用 FlagSpec / FlagValueType / FlagOption（flag_registry.go）
+// FlagSpec 增加两个字段（rule flags 不使用，零值忽略）：
+//   Scope     FlagScope // "provider" | "model" | "both"
+//   MergeMode string    // Scope == "both" 时必填："override" | "merge"
+
+func ProviderFlagRegistry() []FlagSpec {
+    return []FlagSpec{
+        {
+            Key:         "extra_headers",
+            Label:       "Custom Headers",
+            Description: "Append custom HTTP headers to outbound requests ...",
+            Type:        FlagValueHeaders, // 新增的 value type，见下
+            Category:    FlagCategoryRequest,
+            Scope:       "both",
+            MergeMode:   "merge",
+        },
+    }
+}
+```
+
+### Rule 级：`RuleFlagRegistry()` 追加一条
+
+```go
+{
+    Key:         "extra_headers",
+    Label:       "Custom Headers",
+    Description: "Append custom HTTP headers to outbound requests for this rule ...",
+    Type:        FlagValueHeaders,
+    Category:    FlagCategoryRequest,
+    // 无 Shared / InheritanceMode：不做 scenario 级（首版无此需求），
+    // 与 provider/model 级的合并发生在 EffectiveExtraHeaders（§3.3），
+    // 不走 resolveRuleFlagsWithScenario 的 scenario 继承链。
+}
+```
+
+新增 `FlagValueType`：`FlagValueHeaders = "headers"`（值形态
+`map[string]string`，UI 渲染为可增删的 KV 行编辑器）。该控件类型是
+一次性投入，rule / provider / model 三处 UI 共用同一组件。
+
+**约束测试**（镜像 `flag_registry_test.go` 的既有护栏）：
+
+- ProviderFlagRegistry 每个 Key 必须对应 `ProviderFlags` struct 的某个
+  json tag（`TestProviderFlagRegistry_KeysMatchStructFields`）；
+  rule 级 `extra_headers` 由既有 `TestRuleFlagRegistry_KeysMatchStructFields`
+  自动覆盖。
+- `Scope` 必须在枚举内；`Scope == "both"` 必须声明 `MergeMode`，
+  其他 Scope 不得声明。
+- `headers` 类型不允许 Options/Suggestions。
+
+Registry 通过新 endpoint 透出给前端（§7），前端 registry-driven 渲染，
+**不为任何 flag 写 per-flag switch/case**（复用 rule flags 已验证的
+架构，见 rule-flags.md §9）。
+
+---
+
+## 5. `extra_headers` 的注入与安全边界
+
+### 5.1 注入点：全 client 通用的 transport 层
+
+所有 client 构造器都经过唯一的 transport 包装点
+`wrapWithLogging(inner, provider)`
+（`internal/client/logging_roundtripper.go:25`），且该点已持有
+`*typ.Provider`。在同一位置增加一层：
+
+```
+wrapWithLogging( providerHeadersTransport( innerChain, provider ), provider )
+                 └── 新增：读 provider 级 headers + ctx 里的 request 级 headers
+```
+
+`providerHeadersTransport`：
+
+- **api_key 守卫（首版范围）**：`!provider.IsAPIKey()` 时该 transport
+  为纯透传（no-op）。发布范围由这一个判断收口（配置入口另在 API/UI 层
+  拦截，见 §5.4），后续放开 = 调整这一处守卫 + 对应校验。
+- **provider 级 headers**：构造时从 provider 解出（`GetProviderFlags`），
+  每个 RoundTrip 应用。不依赖 ctx —— 因此 probe、model-list 拉取、
+  visionproxy 等不经 protocol dispatch 的路径也自动生效。
+- **model 级 + rule 级 headers**：dispatch 阶段（rule→provider→model
+  已定型）计算 `EffectiveExtraHeaders(p, model, ruleFlags)` 与 provider
+  级的差集，经 Type 2 手法（`internal/typ/id.go` 新增
+  `WithExtraHeaders(ctx, map)` / `GetExtraHeaders(ctx)`）写入 request
+  ctx；transport 读到则叠加（合并优先级已在 dispatch 侧算好，transport
+  只做"provider 级打底、ctx 覆盖"两步）。ctx 缺失时退化为仅 provider
+  级 —— 这是非 dispatch 路径（无 rule、无 model 语境）的预期行为。
+
+rule 级选择与 model 级共用同一个 ctx key 而不是单独一个：transport 只
+认"本次请求的增量 header"一个概念，三级优先级是 dispatch 侧
+`EffectiveExtraHeaders` 的职责——合并逻辑集中一处，transport 保持哑。
+
+### 5.2 顺序不变量：vendor pin 永远胜出（对首版是防御，For 未来是边界）
+
+首版只释放 api_key，generic 链上没有 vendor pin，本节在 v1 实际不触发；
+但机制上 `providerHeadersTransport` 挂在所有构造器的统一包装点，**顺序
+不变量从第一天就要成立**，为后续放开 OAuth 特种链保底：
+
+```
+providerHeadersTransport      ← 外层：先写入用户 extra headers
+  vendorRoundTripper / SDK    ← 内层（更靠近 wire）：后写入 vendor pin
+    wire                          同名时后写者胜 → vendor pin 决定性
+```
+
+`.design/user-agent.md` 的结论在这里同样成立：vendor 特种链上由握手 /
+指纹协议绑定的 header（UA、`x-stainless-*`、`X-Msh-*`、
+`X-ChatGPT-Account-ID`、session header 等）不可被任何用户配置覆盖。
+护栏：给该顺序写回归测试（stub inner 断言最终 header 值）；并延续
+rule-flags.md §8 的警告——**vendor 链内部永远不得引入
+providerHeadersTransport**。
+
+### 5.3 Header 名校验与 denylist
+
+保存时（API 层）校验，而不是发请求时静默丢弃（fail loudly at config
+time，符合"诊断必须走真实链路"原则）。**三个写入口（provider flags、
+model flags、rule flags）共用同一个 `ValidateExtraHeaders` 函数**：
+
+- 名字必须是合法 RFC 7230 token；保存时规范化为 canonical 形式
+  （`textproto.CanonicalMIMEHeaderKey`）。
+- **Denylist（保存即拒绝）**：
+  - 传输层破坏项：`Host`、`Content-Length`、`Transfer-Encoding`、
+    `Connection`、`Upgrade`、`Trailer`、`TE`、`Keep-Alive`
+  - 网关托管的认证项：`Authorization`、`Proxy-Authorization`、
+    `X-Api-Key`（凭证只能走 Token / Credential 字段，不能藏在 header
+    配置里——否则 mask、export 脱敏、OAuth 刷新等一整套凭证治理全部失守）
+  - `User-Agent`：UA 已有独立机制（rule `custom_user_agent` + vendor
+    pin，见 user-agent.md），双入口会重演当年 `provider.UserAgent` 的
+    混乱，明确拒绝。
+- 数量与尺寸限制：每级 ≤ 16 个；name ≤ 128B，value ≤ 4KB。
+- Denylist 在 transport 层做**第二道防御**（跳过 + warn log），防旧数据
+  / import 绕过。
+
+### 5.4 各 provider 形态的行为（首版发布范围）
+
+**首版只对 `api_key` auth type 释放**（含空 auth type 的向后兼容语义）。
+范围由三道闸共同保证，各司其职：
+
+1. **UI**：非 api_key provider 的编辑框不渲染 headers 入口（不是灰置——
+   减少视觉噪音，不解释一个用不了的功能）；rule 级入口始终可见（rule
+   不绑定 provider，同一 rule 可能路由到混合类型的 provider，见下表）。
+2. **API 校验**：对非 api_key provider 保存 `flags` / `model_flags` 中的
+   `extra_headers` → 拒绝并说明原因（防直接调 API / import 绕过 UI）。
+3. **transport 守卫**：`!IsAPIKey()` 时 no-op（§5.1，防旧数据/竞态）。
+
+| Provider 形态 | v1 行为 |
+|---|---|
+| generic api_key（OpenAI/Anthropic style） | 完整生效（provider + model + rule 级） |
+| dual provider（api_key 的子集） | 两个 endpoint 同一份 headers（同一凭证同一供应商，不按 style 拆分；有真实需求再谈） |
+| `no_key_required` 的自建端点 | 属 api_key 语义路径，生效 |
+| OAuth / vendor 特种链（Claude Code、Codex、Kimi、Gemini、Antigravity） | **不释放**：无配置入口 + 校验拒绝 + transport no-op。rule 级 headers 命中此类 provider 时同样被 transport 守卫拦下（对用户的语义即"该 flag 仅对 API-key provider 生效"，写进 rule 级 flag 的 Description） |
+| aws_sigv4 / azure_key / gcp_sa | **不释放**（SigV4 对参与签名的 header 敏感，注入未签名 header 可能直接 403；放开需单独验证） |
+| vmodel | no-op（无出站 HTTP）。UI 不展示入口 |
+| builtin providers | 沿用既有规则：builtin 不可 mutate（只许 toggle Enabled），flags 同样锁定 |
+
+---
+
+## 6. 持久化
+
+Provider / model 级沿用 `credential` / `vmodel_detail` 的既定先例
+（`internal/db/provider_store.go`）：
+
+- `ProviderRecord` 新增一个 `extensions` TEXT 列，内容为
+  `ai.Provider.Extensions` 整个 map 的 JSON。
+- GORM `AutoMigrate` 增列即生效，**无需 migration 脚本、无需回填**
+  （零值 = 无扩展）。
+- `toProvider` / `toRecord` / `updateRecordFromProvider` 三处映射函数
+  各加一段 marshal/unmarshal（与 credential 的处理完全同形）。
+- 服务侧不认识的 key（其他消费方存的任意扩展）随整个 map 原样存取，
+  **update 时必须整 map 读-改-写，不得只写服务自己的两个 key**（否则
+  丢别人的数据）。
+
+Rule 级零持久化改动：RuleFlags 本就以 JSON 列随 rule 行存储
+（rule-flags.md §2），加字段即可。
+
+Provider export / import（`/provider-export`、`/provider-import`）随
+Provider JSON 自然携带 extensions；import 侧对 `flags` / `model_flags`
+两个 well-known key 执行与 API 相同的校验（§5.3 + §5.4 的 auth type
+门），非法拒绝导入并报明确错误。
+
+---
+
+## 7. API 层
+
+对外 API 是**服务的 surface**，暴露 typed 形态而非 opaque blob（opaque
+容器是 ai module 与存储之间的事，不是 REST 契约）：
+
+```
+GET  /api/v1/provider/flags/registry     // ProviderFlagRegistry() → 前端渲染元数据
+                                         // （与既有 GET /rule/flags/registry 同构）
+
+// ProviderResponse 新增：
+//   flags        *ProviderFlags                `json:"flags,omitempty"`
+//   model_flags  map[string]ProviderFlags      `json:"model_flags,omitempty"`
+
+// UpdateProviderRequest 新增（延续全 pointer 的 partial 语义）：
+//   Flags       *ProviderFlags               `json:"flags,omitempty"`
+//   ModelFlags  *map[string]ProviderFlags    `json:"model_flags,omitempty"`
+//   —— nil = 不动；非 nil = 整体替换对应 well-known key（key 内部不做深合并，
+//      语义与前端"整卡片保存"一致，避免 map 深 patch 的歧义）
+
+// CreateProviderRequest 同步新增两个可选字段。
+```
+
+- handler 侧写入路径：读出 provider → 改 `Extensions["flags"]` /
+  `Extensions["model_flags"]` → 保存（整 map 读-改-写，见 §6）。
+- 校验集中在 `ValidateExtraHeaders`（§5.3）+ auth type 门（§5.4），
+  Create / Update / Import 三处共用。
+- `model_flags` 的 model key 不强校验存在于 `Provider.Models`（模型列表
+  是缓存、可过期），但 UI 侧用列表辅助选择；对完全未知的 key 仅
+  warning 不拒绝。
+- **Rule 级零新增 endpoint**：`extra_headers` 走既有 rule 更新路径
+  （`POST /rule/:uuid` 携带 flags），仅在 rule handler 的保存路径挂上
+  同一个 `ValidateExtraHeaders`。registry 由既有
+  `GET /rule/flags/registry` 自然透出（FlagSpec 新增的 `headers` 类型
+  会出现在响应里，前端按类型渲染新控件）。
+- swagger 定义补齐后 `task codegen` 重新生成 openapi.json 与前端 SDK。
+
+---
+
+## 8. 前端
+
+复用 rule flags 的 registry-driven 架构（rule-flags.md §9），零 per-flag
+switch/case。实现落点：
+
+1. **新控件类型 `headers`（一次性投入，三处共用）**：
+   `components/flags/HeadersEditor.tsx` —— 可增删的 KV 行编辑器,行内
+   即时校验(denylist / 非法字符 / 大小写不敏感重复,直接标红并给出
+   原因,教育内嵌于产品;denylist 与后端 `ValidateExtraHeaders` 镜像)。
+   接入 `FlagCatalogDialog` 的类型分发(`spec.Type` 驱动,与 bool/
+   string/enum/int/service_ref 并列新增一个分支)。
+2. **Rule 级入口**：零布局改动——`extra_headers` 出现在既有
+   `RulePluginsCard` / `FlagCatalogDialog`（新增通用 `request` 分类,
+   排在分类栏 App 之后）。`RuleFlags` / `RuleFlagsApi` 加
+   `extraHeaders` / `extra_headers`;`flagHelpers.ts` 补 `headers` 的
+   isActive(map 非空)/ default(undefined)判定 + `headersValue`。
+3. **Provider 级入口**：`ProviderFormDialog` 既有 **Advanced accordion**
+   内(edit 模式)渲染 `ProviderPluginsBlock` —— 与 rule 侧同构的
+   "Plugins 卡片 + 目录弹窗"交互:折叠卡片列出 active flag 与具体值,
+   点击打开共享的 `FlagCatalogDialog`(标题 "Provider Plugins",registry
+   来自 `GET /provider/flags/registry`,按 `Scope` 含 provider 过滤)。
+   该编辑框本身只服务 api_key 域(oauth/cloud 走别的对话框),天然满足
+   §5.4 的 UI 门。
+4. **Model 级入口**：`ModelCard`(模型管理面)hover 工具条加
+   `ModelHeadersTrigger`,点开锚定 **Popover**(`ModelHeaders.tsx`)
+   内嵌 HeadersEditor 就地编辑保存;保存走"重新拉取 provider →
+   读-改-写整个 model_flags map → PUT"防同会话兄弟模型互踩。有覆写的
+   model 常驻左下 badge(tooltip 列出具体 header 名)——"surface the
+   artifact"。`canEditModelHeaders` 按 api_key 门控。
+5. **展示具体值原则**：所有折叠态显示真实 header 名列表（如
+   `HTTP-Referer, X-Title`），不显示 "2 headers configured" 这类别名式
+   摘要。
+6. `useProviderEditDialog`:seed `flags: apiToFlags(provider.flags)`,
+   `buildEditProviderPayload` 附带 `flags: flagsToApi(...)`(整对象
+   替换语义与后端一致);`api.getProviderFlagRegistry` 镜像 rule 侧;
+   MSW mock 补 provider registry endpoint 与 rule mock 的
+   `extra_headers` 条目。
+
+---
+
+## 9. 测试计划
+
+| 层 | 内容 |
+|---|---|
+| registry 护栏 | ProviderFlagRegistry Key ↔ `ProviderFlags` json tag 同步；rule 级由既有 KeysMatchStructFields 覆盖；Scope/MergeMode 约束 |
+| 合并语义 | `EffectiveExtraHeaders`：仅 provider / 仅 model / 仅 rule / 三级同名覆盖顺序（provider < model < rule）/ 都为空 |
+| 校验 | denylist、canonical 化、token 合法性、数量/尺寸上限；非 api_key provider 拒绝；三个写入口都过同一校验 |
+| transport | headers 落到出站请求；ctx 叠加覆盖 provider 级；**非 api_key no-op 守卫**；**vendor pin 胜出的顺序回归**（为未来放开保底）；denylist 第二道防御；vmodel 路径 no-op |
+| db | extensions 列 round-trip；含未知 key 的整 map 读-改-写不丢数据 |
+| API | partial update 语义（nil 不动 / 非 nil 替换）；builtin 拒绝；rule 保存路径校验生效；export→import round-trip 含校验 |
+| e2e（后补） | 三级各配一部分 header → mock upstream 断言合并结果（依赖 mock provider fixture，同 rule flags 的待办） |
+
+---
+
+## 10. 实施步骤（按序，勿乱序）
+
+```
+1. ai/provider.go
+   └─ Provider 增加 Extensions map[string]json.RawMessage（含只读语义注释）
+
+2. internal/constant
+   └─ ProviderExtKeyFlags / ProviderExtKeyModelFlags 常量
+
+3. internal/typ
+   ├─ provider_flags.go：ProviderFlags struct + Get/Set 帮助函数
+   │   （Set 系列负责整 map 读-改-写）+ EffectiveExtraHeaders（三级合并）
+   ├─ type.go：RuleFlags 加 ExtraHeaders 字段（json/yaml tag: extra_headers）
+   ├─ flag_registry.go：FlagSpec 增加 Scope / MergeMode 字段；
+   │   FlagValueType 增加 "headers"；RuleFlagRegistry() 追加 extra_headers
+   ├─ provider_flag_registry.go：ProviderFlagRegistry()
+   └─ id.go：WithExtraHeaders / GetExtraHeaders（Type 2）
+
+4. internal/db/provider_store.go
+   └─ extensions 列 + 三处映射（rule 侧零改动）
+
+5. internal/client
+   ├─ provider_headers_transport.go：providerHeadersTransport
+   │   （含 IsAPIKey 守卫 + denylist 二道防御）
+   └─ 在 wrapWithLogging 接入点外侧统一挂载（一处改动覆盖全部构造器）
+
+6. protocol dispatch
+   └─ provider+model+rule 定型处调用 EffectiveExtraHeaders，
+      与 provider 级的差集写入 ctx
+
+7. internal/server/module/provider + module/rule
+   ├─ provider/types.go / handler.go：请求响应模型 + ValidateExtraHeaders
+   │   + api_key 门
+   ├─ provider/routes.go：GET /provider/flags/registry + swagger 定义
+   ├─ rule handler 保存路径挂 ValidateExtraHeaders
+   └─ import/export 路径接同一校验
+
+8. task codegen（openapi.json + 前端 SDK）
+
+9. frontend
+   ├─ headers KV 控件（FlagCatalogDialog 类型分发 + flagHelpers 扩展）
+   ├─ RuleFlags / RuleFlagsApi 类型加字段（rule 级即完成）
+   ├─ Provider 编辑框 Plugins 区块（registry-driven，仅 api_key 渲染）
+   ├─ 模型列表 per-model flag 入口 + badge
+   └─ buildEditProviderPayload 扩展
+
+10. 测试随各层同 PR 落地（§9）；本文档随实现校正后去掉"规划稿"标记
+```
+
+---
+
+## 11. 设计取舍
+
+| 选项 | 已采纳 | 备择 | 取舍理由 |
+|------|--------|------|----------|
+| ai.Provider 扩展容器形态 | `map[string]json.RawMessage` | typed struct / `map[string]any` | ai 是公共 module，必须对内容不知情；RawMessage 无损且物理隔离 schema。typed struct 会把服务语义泄进公共 API |
+| 服务侧 schema 位置 | internal/typ + registry | 散落各消费点 | 复刻 rule flags 的"唯一可信源"模式，前端零 switch/case，已被验证 |
+| rule 级是否同步支持 | ✅ 三级统一 | 仅 provider/model | headers 三级各有真实语义（网关固有 / 模型灰度 / 客户端标记）；rule 级复用既有 RuleFlags 机制近乎零成本，一次做齐避免二次开口 |
+| rule 级走 Extensions 还是 RuleFlags | RuleFlags 加字段 | Rule 也做 opaque 容器 | Rule 类型在服务域内，不存在跨 module schema 问题；opaque 容器只为公共 module 存在 |
+| 三级合并顺序 | provider < model < rule | rule < model < provider | 粒度越贴近单次请求越应胜出；rule 是显式的请求侧意图 |
+| 首版发布范围 | 仅 api_key | 全 auth type | vendor 特种链有握手/指纹边界、SigV4 有签名敏感性，验证成本高；api_key 覆盖绝大多数真实需求（OpenRouter/网关/自建端点）。范围由 UI 隐藏 + API 校验 + transport 守卫三道闸收口，放开时逐道解除 |
+| extra_headers 形态 | `map[string]string` | `[]HeaderKV`（有序可重复） | 配置型 header 不需要重复/顺序；与 probe headers 先例一致；UI 简单；三级同形态合并函数唯一 |
+| model flag 合并 | 按 flag 声明 MergeMode（headers=merge） | 一律 override | headers 的自然语义是叠加覆写；未来 bool flag 需要 override——语义属于 flag 本身，进 registry |
+| 注入点 | transport 层（wrapWithLogging 旁，一处） | ClientPool 逐构造器传 option | option 类型按 SDK 分裂（openai/anthropic/google 各一套），transport 一处覆盖所有 auth type 与 style |
+| model/rule 级 ctx 传递 | 单一 ctx key（dispatch 侧合并好） | 每级一个 ctx key | transport 保持哑，合并逻辑集中在 EffectiveExtraHeaders 一处 |
+| vendor pin 冲突 | 物理顺序保证 pin 胜出 | 逐 header 判断 | v1 不触发（api_key only），但顺序不变量零维护成本，为放开 OAuth 保底 |
+| Authorization/X-Api-Key | denylist 拒绝 | 允许（支持自定义认证头） | 凭证必须走 Token/Credential 字段，否则 mask/export 脱敏/凭证治理全失守。真有自定义认证头需求时，作为新 auth type 或专门字段进凭证体系，而不是从 header 后门进 |
+| 校验时机 | 保存时拒绝 + transport 二道防御 | 发请求时静默过滤 | 静默过滤 = 用户以为生效实际没有，违背"诊断走真实链路"；保存时报错教育前置 |
+| API 形态 | typed `flags`/`model_flags` 字段 | 直接暴露 opaque extensions | REST 契约是服务 surface，必须 typed；opaque 容器只是存储与公共 module 之间的运输形态 |
+| 持久化 | 单 `extensions` JSON 列 | 每 flag 一列 | credential/vmodel_detail 先例；增 flag 零 DDL；provider 行不因 flag 增长而加宽 |
+| model key 匹配 | 精确匹配 | 通配/前缀 | 首版从简；registry 与数据形态不阻碍后续加 pattern |
+| UI 命名 | 复用 "Plugins" | 新词（Extensions/Custom Headers） | 词汇全局统一：同一交互心智（registry 目录 + 卡片）应同名；scope 差异由所在 surface（provider 编辑框 vs rule 卡片）表达 |
+| 非 api_key 的 UI 呈现 | 隐藏入口 | 灰置 + 提示 | 减少视觉噪音：不解释一个当前用不了的功能；放开时再出现 |
+
+---
+
+## 12. 已决事项与遗留
+
+**已决**（本次规划确认）：
+
+- ✅ rule 级 `extra_headers` 同步加入，三级统一（provider < model < rule）。
+- ✅ 首版仅释放 api_key auth type；OAuth / 多字段凭证 / vmodel 不释放，
+  由 UI + API 校验 + transport 守卫三道闸收口。
+- ✅ builtin provider 沿用"不可 mutate"规则，flags 锁定。
+
+**遗留**（不阻塞实施）：
+
+1. OAuth vendor 链放开时机与形态（依赖真实需求；机制与顺序不变量已就位）。
+2. model key 通配/前缀匹配（依赖真实需求）。
+3. scenario 级 extra_headers（当前无需求；若加，走 FlagSpec.Shared +
+   InheritanceMode 的既有 scenario 继承链，与三级纵向合并正交）。

--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -72,6 +72,7 @@ export interface RuleFlags {
     cleanHeader?: boolean;
     context1m?: boolean;
     claudeOrgId?: string;
+    extraHeaders?: Record<string, string>;
 }
 
 export interface RuleFlagsApi {
@@ -90,9 +91,10 @@ export interface RuleFlagsApi {
     clean_header?: boolean;
     context_1m?: boolean;
     claude_org_id?: string;
+    extra_headers?: Record<string, string>;
 }
 
-export type FlagValueType = 'bool' | 'string' | 'enum' | 'int' | 'service_ref';
+export type FlagValueType = 'bool' | 'string' | 'enum' | 'int' | 'service_ref' | 'headers';
 
 export interface FlagOption {
     value: string;

--- a/frontend/src/components/flags/HeadersEditor.tsx
+++ b/frontend/src/components/flags/HeadersEditor.tsx
@@ -1,0 +1,140 @@
+import { Add as AddIcon, Delete as DeleteIcon } from '@/components/icons';
+import { Box, Button, IconButton, Stack, TextField, Typography } from '@mui/material';
+import React, { useMemo, useState } from 'react';
+
+// Gateway-managed header names (canonical, lowercase for comparison) that the
+// backend rejects on save (typ.ValidateExtraHeaders). Mirrored here so the row
+// turns red with an explanation while typing instead of only failing on save.
+const DENIED_HEADERS = new Set([
+    'host', 'content-length', 'transfer-encoding', 'connection', 'upgrade',
+    'trailer', 'te', 'keep-alive',
+    'authorization', 'proxy-authorization', 'x-api-key',
+    'user-agent',
+]);
+
+// RFC 7230 header-name token characters.
+const TOKEN_RE = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+
+export function headerNameError(name: string, seenLower: Set<string>): string | undefined {
+    if (name === '') return undefined; // incomplete row, not an error yet
+    if (!TOKEN_RE.test(name)) return 'Invalid characters for an HTTP header name';
+    const lower = name.toLowerCase();
+    if (DENIED_HEADERS.has(lower)) {
+        if (lower === 'user-agent') return 'User-Agent has its own control (rule plugin "Custom User-Agent")';
+        if (lower === 'authorization' || lower === 'x-api-key' || lower === 'proxy-authorization') {
+            return 'Credentials go in the API key field, not headers';
+        }
+        return 'This header is managed by the gateway';
+    }
+    if (seenLower.has(lower)) return 'Duplicate header name (names are case-insensitive)';
+    return undefined;
+}
+
+interface HeaderRow {
+    id: number;
+    name: string;
+    value: string;
+}
+
+export interface HeadersEditorProps {
+    /** Current header map (empty/undefined = none configured). */
+    value?: Record<string, string>;
+    /** Called with the full replacement map on every edit (invalid/incomplete rows excluded). */
+    onChange: (next: Record<string, string> | undefined) => void;
+    disabled?: boolean;
+}
+
+let nextRowId = 1;
+
+const rowsFromValue = (value?: Record<string, string>): HeaderRow[] =>
+    Object.entries(value ?? {}).map(([name, v]) => ({ id: nextRowId++, name, value: v }));
+
+/**
+ * HeadersEditor — the shared key/value row editor for headers-type flags,
+ * used by the rule catalog, the provider Plugins section, and the per-model
+ * override popover. Rows validate inline (denylist / illegal characters /
+ * duplicates); rows with an empty or invalid name are kept visible for
+ * editing but excluded from the emitted map.
+ */
+export const HeadersEditor: React.FC<HeadersEditorProps> = ({ value, onChange, disabled }) => {
+    // Seeded once per mount; dialogs/popovers remount per open, so the parent
+    // draft is the single source of truth after the first edit.
+    const [rows, setRows] = useState<HeaderRow[]>(() => rowsFromValue(value));
+
+    const emit = (next: HeaderRow[]) => {
+        setRows(next);
+        const map: Record<string, string> = {};
+        const seen = new Set<string>();
+        for (const row of next) {
+            const name = row.name.trim();
+            if (name === '' || headerNameError(name, new Set()) !== undefined) continue;
+            const lower = name.toLowerCase();
+            if (seen.has(lower)) continue;
+            seen.add(lower);
+            map[name] = row.value;
+        }
+        onChange(Object.keys(map).length > 0 ? map : undefined);
+    };
+
+    const errors = useMemo(() => {
+        const seen = new Set<string>();
+        return rows.map((row) => {
+            const err = headerNameError(row.name.trim(), seen);
+            if (row.name.trim() !== '') seen.add(row.name.trim().toLowerCase());
+            return err;
+        });
+    }, [rows]);
+
+    return (
+        <Stack spacing={0.75}>
+            {rows.map((row, i) => (
+                <Stack key={row.id} direction="row" spacing={0.75} sx={{ alignItems: 'flex-start' }}>
+                    <TextField
+                        size="small"
+                        placeholder="Header-Name"
+                        value={row.name}
+                        disabled={disabled}
+                        error={!!errors[i]}
+                        helperText={errors[i]}
+                        onChange={(e) => emit(rows.map((r) => r.id === row.id ? { ...r, name: e.target.value } : r))}
+                        sx={{ flex: '0 0 40%', '& input': { fontFamily: 'monospace', fontSize: '0.8rem' } }}
+                    />
+                    <TextField
+                        size="small"
+                        placeholder="value"
+                        value={row.value}
+                        disabled={disabled}
+                        onChange={(e) => emit(rows.map((r) => r.id === row.id ? { ...r, value: e.target.value } : r))}
+                        sx={{ flexGrow: 1, '& input': { fontFamily: 'monospace', fontSize: '0.8rem' } }}
+                    />
+                    <IconButton
+                        size="small"
+                        disabled={disabled}
+                        onClick={() => emit(rows.filter((r) => r.id !== row.id))}
+                        sx={{ mt: 0.25, color: 'text.disabled', '&:hover': { color: 'error.main' } }}
+                    >
+                        <DeleteIcon fontSize="small" />
+                    </IconButton>
+                </Stack>
+            ))}
+            {rows.length === 0 && (
+                <Typography variant="caption" sx={{ color: 'text.disabled' }}>
+                    No custom headers.
+                </Typography>
+            )}
+            <Box>
+                <Button
+                    size="small"
+                    startIcon={<AddIcon fontSize="small" />}
+                    disabled={disabled}
+                    onClick={() => emit([...rows, { id: nextRowId++, name: '', value: '' }])}
+                    sx={{ textTransform: 'none' }}
+                >
+                    Add header
+                </Button>
+            </Box>
+        </Stack>
+    );
+};
+
+export default HeadersEditor;

--- a/frontend/src/components/flags/HeadersEditor.tsx
+++ b/frontend/src/components/flags/HeadersEditor.tsx
@@ -2,31 +2,17 @@ import { Add as AddIcon, Delete as DeleteIcon } from '@/components/icons';
 import { Box, Button, IconButton, Stack, TextField, Typography } from '@mui/material';
 import React, { useMemo, useState } from 'react';
 
-// Gateway-managed header names (canonical, lowercase for comparison) that the
-// backend rejects on save (typ.ValidateExtraHeaders). Mirrored here so the row
-// turns red with an explanation while typing instead of only failing on save.
-const DENIED_HEADERS = new Set([
-    'host', 'content-length', 'transfer-encoding', 'connection', 'upgrade',
-    'trailer', 'te', 'keep-alive',
-    'authorization', 'proxy-authorization', 'x-api-key',
-    'user-agent',
-]);
-
 // RFC 7230 header-name token characters.
 const TOKEN_RE = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 
+// Structural validation only — headers are user-driven config, so there is no
+// denylist: any header can be set (including gateway-adjacent ones like
+// Authorization or User-Agent) and the user owns the outcome. Mirrors
+// typ.ValidateExtraHeaders.
 export function headerNameError(name: string, seenLower: Set<string>): string | undefined {
     if (name === '') return undefined; // incomplete row, not an error yet
     if (!TOKEN_RE.test(name)) return 'Invalid characters for an HTTP header name';
-    const lower = name.toLowerCase();
-    if (DENIED_HEADERS.has(lower)) {
-        if (lower === 'user-agent') return 'User-Agent has its own control (rule plugin "Custom User-Agent")';
-        if (lower === 'authorization' || lower === 'x-api-key' || lower === 'proxy-authorization') {
-            return 'Credentials go in the API key field, not headers';
-        }
-        return 'This header is managed by the gateway';
-    }
-    if (seenLower.has(lower)) return 'Duplicate header name (names are case-insensitive)';
+    if (seenLower.has(name.toLowerCase())) return 'Duplicate header name (names are case-insensitive)';
     return undefined;
 }
 
@@ -52,9 +38,9 @@ const rowsFromValue = (value?: Record<string, string>): HeaderRow[] =>
 /**
  * HeadersEditor — the shared key/value row editor for headers-type flags,
  * used by the rule catalog, the provider Plugins section, and the per-model
- * override popover. Rows validate inline (denylist / illegal characters /
- * duplicates); rows with an empty or invalid name are kept visible for
- * editing but excluded from the emitted map.
+ * override popover. Rows validate structure inline (illegal characters /
+ * duplicates — never a denylist); rows with an empty or invalid name are
+ * kept visible for editing but excluded from the emitted map.
  */
 export const HeadersEditor: React.FC<HeadersEditorProps> = ({ value, onChange, disabled }) => {
     // Seeded once per mount; dialogs/popovers remount per open, so the parent

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -30,7 +30,8 @@ import type { FlagSpec, RuleFlags, VisionProxyServiceRef } from '@/components/Ro
 import type { Provider } from '@/types/provider';
 import type { ProviderSelectTabOption } from '@/components/ModelSelectDialog';
 import ModelSelectDialog from '@/components/ModelSelectDialog';
-import { getFlagValue, setFlagValue, flagDefault, enumInactive, isFlagActive, normalizeEnumForStorage } from './flagHelpers';
+import { getFlagValue, setFlagValue, flagDefault, enumInactive, isFlagActive, normalizeEnumForStorage, headersValue } from './flagHelpers';
+import HeadersEditor from '@/components/flags/HeadersEditor';
 
 export interface FlagCatalogDialogProps {
     open: boolean;
@@ -61,10 +62,11 @@ interface CategoryMeta {
 }
 
 // Display order for the category sidebar. Unknown categories are appended.
-const CATEGORY_ORDER = ['app', 'request_openai', 'request_anthropic', 'response', 'reasoning', 'vision', 'routing'];
+const CATEGORY_ORDER = ['app', 'request', 'request_openai', 'request_anthropic', 'response', 'reasoning', 'vision', 'routing'];
 
 const CATEGORY_META: Record<string, CategoryMeta> = {
     app:               { label: 'App',         icon: <TerminalIcon   fontSize="small" /> },
+    request:           { label: 'Request',     icon: <InputIcon      fontSize="small" /> },
     request_openai:    { label: 'Request (O)', icon: <InputIcon      fontSize="small" /> },
     request_anthropic: { label: 'Request (A)', icon: <InputIcon      fontSize="small" /> },
     response:          { label: 'Response',    icon: <OutputIcon     fontSize="small" /> },
@@ -428,6 +430,14 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                                             ))}
                                                         </Select>
                                                     </FormControl>
+                                                )}
+                                                {spec.type === 'headers' && (
+                                                    <Box sx={{ mt: 1 }}>
+                                                        <HeadersEditor
+                                                            value={headersValue(draft, spec.key)}
+                                                            onChange={(next) => setDraft((d) => setFlagValue(d, spec.key, next))}
+                                                        />
+                                                    </Box>
                                                 )}
                                                 {spec.type === 'service_ref' && (() => {
                                                     const ref = flagToServiceRef(draft, spec.key);

--- a/frontend/src/components/rule-card/RulePluginsCard.tsx
+++ b/frontend/src/components/rule-card/RulePluginsCard.tsx
@@ -10,7 +10,7 @@ import {
     MODEL_NODE_STYLES,
 } from '@/components/nodes/styles';
 import type { FlagSpec, RuleFlags, VisionProxyServiceRef } from '@/components/RoutingGraphTypes';
-import { getFlagValue, isFlagActive } from './flagHelpers';
+import { getFlagValue, headersValue, isFlagActive } from './flagHelpers';
 
 const CARD_STYLES = {
     width: MODEL_NODE_STYLES.width,
@@ -156,7 +156,9 @@ export const RulePluginsCard: React.FC<RulePluginsCardProps> = ({
                                 if (opt) displayVal = opt.label;
                             }
                             if (isServiceRef) displayVal = flagServiceRefDisplay(flags, spec.key);
-                            const tooltipTitle = ((isString || isEnum) && stringVal) || (isServiceRef && displayVal)
+                            // Headers: show the concrete header names, not a count.
+                            if (spec.type === 'headers') displayVal = Object.keys(headersValue(flags, spec.key)).join(', ');
+                            const tooltipTitle = ((isString || isEnum) && stringVal) || ((isServiceRef || spec.type === 'headers') && displayVal)
                                 ? `${spec.description}\nValue: ${displayVal}`
                                 : spec.description;
                             return (

--- a/frontend/src/components/rule-card/flagHelpers.ts
+++ b/frontend/src/components/rule-card/flagHelpers.ts
@@ -28,6 +28,7 @@ export function flagDefault(spec: FlagSpec): unknown {
         case 'int': return 0;
         case 'enum': return spec.options?.[0]?.value ?? '';
         case 'service_ref': return undefined;
+        case 'headers': return undefined;
     }
 }
 
@@ -48,6 +49,10 @@ export function isFlagActive(spec: FlagSpec, flags: RuleFlags): boolean {
         case 'service_ref': {
             const ref = value as VisionProxyServiceRef | undefined;
             return !!(ref && ref.provider && ref.model);
+        }
+        case 'headers': {
+            const map = value as Record<string, string> | undefined;
+            return !!map && Object.keys(map).length > 0;
         }
         default: return false;
     }
@@ -75,4 +80,9 @@ export function flagsToApi(flags: RuleFlags | undefined): RuleFlagsApi {
         api[camelToSnake(key)] = value;
     }
     return api as RuleFlagsApi;
+}
+
+// headersValue reads a headers-type flag as a name→value map (empty when unset).
+export function headersValue(flags: RuleFlags | undefined, key: string): Record<string, string> {
+    return (getFlagValue(flags, key) as Record<string, string> | undefined) ?? {};
 }

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2140,6 +2140,7 @@ export const handlers = [
         return HttpResponse.json({
             success: true,
             data: [
+                { key: 'extra_headers', label: 'Custom Headers', description: 'Append custom HTTP headers to the outbound upstream request for this rule. API-key providers only.', type: 'headers', category: 'request' },
                 { key: 'custom_user_agent', label: 'Custom User-Agent', description: 'Override the outbound User-Agent header.', type: 'string', category: 'request_openai', placeholder: 'e.g. MyApp/1.0', suggestions: [{ value: 'claude-cli/2.1.86 (external, cli)', label: 'Claude Code (CLI)' }], shared: true, inheritance_mode: 'override' },
                 { key: 'openai_endpoint_override', label: 'OpenAI endpoint override', description: 'Force Chat or Responses endpoint.', type: 'enum', category: 'request_openai', options: [{ value: 'auto', label: 'Auto' }, { value: 'chat', label: 'Force Chat' }, { value: 'responses', label: 'Force Responses' }] },
                 { key: 'use_max_completion_tokens', label: 'OpenAI: Use max_completion_tokens', description: 'Rewrite max_tokens to max_completion_tokens.', type: 'bool', category: 'request_openai' },

--- a/internal/client/extra_headers_transport.go
+++ b/internal/client/extra_headers_transport.go
@@ -1,0 +1,58 @@
+package client
+
+import (
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// extraHeadersTransport applies user-configured extra headers
+// (.design/provider-flags.md) to outbound requests. It is mounted by
+// wrapWithLogging — the one transport wrapper every client constructor goes
+// through — so it covers all API styles from a single place, sitting OUTSIDE
+// the vendor round-trippers: headers written here are set before the inner
+// (vendor) chain runs, so vendor-pinned headers always win on a name
+// conflict. Never mount this inside a vendor chain.
+//
+// Headers arrive via request context (typ.WithExtraHeaders), resolved at
+// dispatch time from the rule's extra_headers flag. Provider- and
+// model-level headers layer onto the same mechanism in a follow-up.
+//
+// Release gate: extra headers apply to api_key providers only. The gate
+// lives in wrapWithExtraHeaders (non-api_key providers get no transport at
+// all), mirroring the API validation gate.
+type extraHeadersTransport struct {
+	inner http.RoundTripper
+}
+
+// wrapWithExtraHeaders mounts the extra-headers layer for api_key providers.
+// Other auth types return inner unchanged — the release gate: ctx-carried
+// rule headers can never reach a vendor/OAuth/multi-field-credential chain.
+func wrapWithExtraHeaders(inner http.RoundTripper, provider *typ.Provider) http.RoundTripper {
+	if provider == nil || !provider.IsAPIKey() {
+		return inner
+	}
+	return &extraHeadersTransport{inner: inner}
+}
+
+func (t *extraHeadersTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	headers := typ.GetExtraHeaders(req.Context())
+	if len(headers) == 0 {
+		return t.inner.RoundTrip(req)
+	}
+
+	// Clone before mutating: the request may be shared/retried by the SDK.
+	req = req.Clone(req.Context())
+	for name, value := range headers {
+		// Second line of defense behind ValidateExtraHeaders — imports or
+		// pre-validation rows might carry denied names. Skip loudly, never
+		// silently alter gateway-managed headers.
+		if typ.IsDeniedExtraHeader(name) {
+			logrus.WithContext(req.Context()).Warnf("extra header %q is gateway-managed, skipping", name)
+			continue
+		}
+		req.Header.Set(name, value)
+	}
+	return t.inner.RoundTrip(req)
+}

--- a/internal/client/extra_headers_transport.go
+++ b/internal/client/extra_headers_transport.go
@@ -3,7 +3,6 @@ package client
 import (
 	"net/http"
 
-	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -43,15 +42,11 @@ func (t *extraHeadersTransport) RoundTrip(req *http.Request) (*http.Response, er
 	}
 
 	// Clone before mutating: the request may be shared/retried by the SDK.
+	// Headers are applied verbatim — user-driven config, no filtering. Inner
+	// chains (vendor pins, the User-Agent transport) write later and win any
+	// conflict by ordering, which is the only precedence mechanism here.
 	req = req.Clone(req.Context())
 	for name, value := range headers {
-		// Second line of defense behind ValidateExtraHeaders — imports or
-		// pre-validation rows might carry denied names. Skip loudly, never
-		// silently alter gateway-managed headers.
-		if typ.IsDeniedExtraHeader(name) {
-			logrus.WithContext(req.Context()).Warnf("extra header %q is gateway-managed, skipping", name)
-			continue
-		}
 		req.Header.Set(name, value)
 	}
 	return t.inner.RoundTrip(req)

--- a/internal/client/extra_headers_transport_test.go
+++ b/internal/client/extra_headers_transport_test.go
@@ -91,24 +91,23 @@ func TestExtraHeadersTransport_VendorPinWins(t *testing.T) {
 	}
 }
 
-// TestExtraHeadersTransport_DenylistDefense: config normally cannot contain
-// denied names (ValidateExtraHeaders rejects on save), but imports or old
-// rows might — the transport must skip them rather than touch
-// gateway-managed headers.
-func TestExtraHeadersTransport_DenylistDefense(t *testing.T) {
+// TestExtraHeadersTransport_AppliesVerbatim: user-driven config — the
+// transport does not filter, even for gateway-adjacent names like
+// Authorization. The user asked for it; the user owns it.
+func TestExtraHeadersTransport_AppliesVerbatim(t *testing.T) {
 	capture := &captureTransport{}
 	rt := wrapWithExtraHeaders(capture, apiKeyProvider())
 
 	req := newHeadersReq(t, map[string]string{
-		"Authorization": "Bearer attacker",
+		"Authorization": "Bearer custom",
 		"X-Title":       "fine",
 	})
-	req.Header.Set("Authorization", "Bearer real")
+	req.Header.Set("Authorization", "Bearer original")
 	if _, err := rt.RoundTrip(req); err != nil {
 		t.Fatal(err)
 	}
-	if got := capture.lastReq.Header.Get("Authorization"); got != "Bearer real" {
-		t.Errorf("Authorization = %q, want the untouched original", got)
+	if got := capture.lastReq.Header.Get("Authorization"); got != "Bearer custom" {
+		t.Errorf("Authorization = %q, want the user-configured value", got)
 	}
 	if got := capture.lastReq.Header.Get("X-Title"); got != "fine" {
 		t.Errorf("X-Title = %q, want fine", got)

--- a/internal/client/extra_headers_transport_test.go
+++ b/internal/client/extra_headers_transport_test.go
@@ -1,0 +1,145 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// pinTransport simulates a vendor round-tripper: it force-sets a header on
+// its way to the wire (inner chains run after the extra-headers layer).
+type pinTransport struct {
+	inner http.RoundTripper
+	name  string
+	value string
+}
+
+func (p *pinTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set(p.name, p.value)
+	return p.inner.RoundTrip(req)
+}
+
+func apiKeyProvider() *typ.Provider {
+	return &typ.Provider{UUID: "p1", AuthType: ai.AuthTypeAPIKey, Token: "sk-x"}
+}
+
+func newHeadersReq(t *testing.T, headers map[string]string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, "https://upstream.example/v1/chat", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if headers != nil {
+		req = req.WithContext(typ.WithExtraHeaders(req.Context(), headers))
+	}
+	return req
+}
+
+func TestExtraHeadersTransport_AppliesCtxHeaders(t *testing.T) {
+	capture := &captureTransport{}
+	rt := wrapWithExtraHeaders(capture, apiKeyProvider())
+
+	if _, err := rt.RoundTrip(newHeadersReq(t, map[string]string{"X-Title": "tingly"})); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.lastReq.Header.Get("X-Title"); got != "tingly" {
+		t.Errorf("X-Title = %q, want tingly", got)
+	}
+}
+
+func TestExtraHeadersTransport_NonAPIKeyIsNoOp(t *testing.T) {
+	capture := &captureTransport{}
+	oauth := &typ.Provider{UUID: "p2", AuthType: ai.AuthTypeOAuth}
+
+	rt := wrapWithExtraHeaders(capture, oauth)
+	if rt != http.RoundTripper(capture) {
+		t.Fatal("non-api_key provider must get the inner transport unchanged")
+	}
+
+	// Even ctx-carried rule headers cannot reach a non-api_key chain.
+	if _, err := rt.RoundTrip(newHeadersReq(t, map[string]string{"X-Rule": "r"})); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.lastReq.Header.Get("X-Rule"); got != "" {
+		t.Errorf("X-Rule = %q, want unset on non-api_key provider", got)
+	}
+}
+
+// TestExtraHeadersTransport_VendorPinWins is the ordering invariant of
+// .design/provider-flags.md §5.2: the extra-headers layer sits outside vendor
+// round-trippers, which write later (closer to the wire) and therefore win on
+// a name conflict. Moot for the api_key-only release, but it must hold from
+// day one for a future OAuth rollout.
+func TestExtraHeadersTransport_VendorPinWins(t *testing.T) {
+	capture := &captureTransport{}
+	vendor := &pinTransport{inner: capture, name: "X-Vendor-Pin", value: "pinned"}
+	rt := wrapWithExtraHeaders(vendor, apiKeyProvider())
+
+	if _, err := rt.RoundTrip(newHeadersReq(t, map[string]string{
+		"X-Vendor-Pin": "user-tries-to-override",
+		"X-Title":      "tingly",
+	})); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.lastReq.Header.Get("X-Vendor-Pin"); got != "pinned" {
+		t.Errorf("X-Vendor-Pin = %q, want pinned (vendor writes last)", got)
+	}
+	if got := capture.lastReq.Header.Get("X-Title"); got != "tingly" {
+		t.Errorf("X-Title = %q, want tingly (non-conflicting header still applied)", got)
+	}
+}
+
+// TestExtraHeadersTransport_DenylistDefense: config normally cannot contain
+// denied names (ValidateExtraHeaders rejects on save), but imports or old
+// rows might — the transport must skip them rather than touch
+// gateway-managed headers.
+func TestExtraHeadersTransport_DenylistDefense(t *testing.T) {
+	capture := &captureTransport{}
+	rt := wrapWithExtraHeaders(capture, apiKeyProvider())
+
+	req := newHeadersReq(t, map[string]string{
+		"Authorization": "Bearer attacker",
+		"X-Title":       "fine",
+	})
+	req.Header.Set("Authorization", "Bearer real")
+	if _, err := rt.RoundTrip(req); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.lastReq.Header.Get("Authorization"); got != "Bearer real" {
+		t.Errorf("Authorization = %q, want the untouched original", got)
+	}
+	if got := capture.lastReq.Header.Get("X-Title"); got != "fine" {
+		t.Errorf("X-Title = %q, want fine", got)
+	}
+}
+
+func TestExtraHeadersTransport_DoesNotMutateCallerRequest(t *testing.T) {
+	capture := &captureTransport{}
+	rt := wrapWithExtraHeaders(capture, apiKeyProvider())
+
+	orig := newHeadersReq(t, map[string]string{"X-Title": "tingly"})
+	if _, err := rt.RoundTrip(orig); err != nil {
+		t.Fatal(err)
+	}
+	if got := orig.Header.Get("X-Title"); got != "" {
+		t.Errorf("caller's request mutated: X-Title = %q", got)
+	}
+}
+
+// TestWrapWithLogging_MountsExtraHeadersLayer pins the wiring: the single
+// wrapWithLogging choke point mounts the extra-headers layer for api_key
+// providers, so every client constructor picks it up without per-constructor
+// code.
+func TestWrapWithLogging_MountsExtraHeadersLayer(t *testing.T) {
+	capture := &captureTransport{}
+	rt := wrapWithLogging(capture, apiKeyProvider())
+
+	if _, err := rt.RoundTrip(newHeadersReq(t, map[string]string{"X-Title": "tingly"})); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.lastReq.Header.Get("X-Title"); got != "tingly" {
+		t.Errorf("X-Title = %q, want tingly (headers layer not mounted)", got)
+	}
+}

--- a/internal/client/logging_roundtripper.go
+++ b/internal/client/logging_roundtripper.go
@@ -22,13 +22,20 @@ type loggingRoundTripper struct {
 
 // wrapWithLogging wraps a transport so every provider's upstream call is logged
 // uniformly. It is the single place that surfaces proxy + outcome per request.
+//
+// It also mounts the extra-headers layer (extraHeadersTransport) between the
+// log line and the inner chain: this is the unique choke point every client
+// constructor passes through, so user-configured extra headers get one
+// injection site that covers all API styles — while staying OUTSIDE the
+// vendor round-trippers in inner, whose pinned headers must win (see
+// .design/provider-flags.md §5.2).
 func wrapWithLogging(inner http.RoundTripper, provider *typ.Provider) http.RoundTripper {
 	var proxyRaw string
 	if provider != nil {
 		proxyRaw = provider.ProxyURL
 	}
 	return &loggingRoundTripper{
-		inner:    inner,
+		inner:    wrapWithExtraHeaders(inner, provider),
 		provider: provider,
 		proxy:    redactProxy(proxyRaw),
 	}

--- a/internal/protocolserver/rule_flags.go
+++ b/internal/protocolserver/rule_flags.go
@@ -177,7 +177,21 @@ func ResolveRuleFlagsWithScenario(
 	// request and decides whether/what anthropic-organization-id to send.
 	applyClaudeOrgID(c, flags)
 
+	// Attach the rule-level extra headers the same way: the outbound
+	// transport (extraHeadersTransport) reads them at RoundTrip time and
+	// applies them on api_key providers only.
+	applyExtraHeaders(c, flags)
+
 	return flags
+}
+
+// applyExtraHeaders attaches the rule's extra_headers map to the request
+// context for the outbound transport. No-op when the rule configures none.
+func applyExtraHeaders(c *gin.Context, flags typ.RuleFlags) {
+	if len(flags.ExtraHeaders) == 0 || c == nil || c.Request == nil {
+		return
+	}
+	c.Request = c.Request.WithContext(typ.WithExtraHeaders(c.Request.Context(), flags.ExtraHeaders))
 }
 
 // applyClaudeOrgID attaches the claude_org_id flag to the request context so

--- a/internal/protocolserver/rule_flags_test.go
+++ b/internal/protocolserver/rule_flags_test.go
@@ -24,9 +24,8 @@ func newGinContext(t *testing.T) *gin.Context {
 
 func TestResolveRuleFlags_NilRule(t *testing.T) {
 	got := ResolveRuleFlags(newGinContext(t), nil)
-	want := typ.RuleFlags{}
-	if got != want {
-		t.Errorf("resolveRuleFlags(nil) = %#v, want zero value %#v", got, want)
+	if !got.IsZero() {
+		t.Errorf("resolveRuleFlags(nil) = %#v, want zero value", got)
 	}
 }
 
@@ -620,5 +619,26 @@ func TestResolveRuleFlagsWithScenario_ClaudeOrgIDReachesContext(t *testing.T) {
 	}
 	if ctxVal := typ.GetClaudeOrgID(c.Request.Context()); ctxVal != "org-uuid" {
 		t.Errorf("claude org id in ctx = %q, want %q", ctxVal, "org-uuid")
+	}
+}
+
+func TestResolveRuleFlagsWithScenario_ExtraHeaders(t *testing.T) {
+	// Rule-level headers land in the request context for the outbound
+	// transport, verbatim.
+	c := newGinContext(t)
+	rule := &typ.Rule{Flags: typ.RuleFlags{ExtraHeaders: map[string]string{"X-Team-Tag": "research"}}}
+	ResolveRuleFlagsWithScenario(c, rule, typ.ScenarioOpenAI, &typ.ScenarioConfig{},
+		protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, nil)
+	got := typ.GetExtraHeaders(c.Request.Context())
+	if got["X-Team-Tag"] != "research" {
+		t.Errorf("ctx headers = %v, want rule extra_headers attached", got)
+	}
+
+	// Nothing configured → nothing attached.
+	c = newGinContext(t)
+	ResolveRuleFlagsWithScenario(c, &typ.Rule{}, typ.ScenarioOpenAI, &typ.ScenarioConfig{},
+		protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, nil)
+	if got := typ.GetExtraHeaders(c.Request.Context()); got != nil {
+		t.Errorf("ctx headers = %v, want nil when the rule sets none", got)
 	}
 }

--- a/internal/protocoltest/flags.go
+++ b/internal/protocoltest/flags.go
@@ -301,6 +301,30 @@ func ruleFlagCases() []flagCase {
 			}
 		}},
 
+		// ── extra_headers ────────────────────────────────────────────────────
+		// Rule-level custom headers must reach the upstream request on an
+		// api_key provider.
+		{key: "extra_headers", run: func(t flagTB, env *TestEnv) {
+			model := env.SetupRouteWithFlags(protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, flagScenario(),
+				typ.RuleFlags{ExtraHeaders: map[string]string{
+					"X-Team-Tag":   "research",
+					"Http-Referer": "https://myapp.example",
+				}})
+			sendFlag(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, model, false, nil, nil)
+			up := env.virtual.LastRequest(EndpointChat)
+			if up == nil {
+				t.Fatal("no upstream request captured")
+			}
+			for header, want := range map[string]string{
+				"X-Team-Tag":   "research",
+				"Http-Referer": "https://myapp.example",
+			} {
+				if got := up.Headers.Get(header); got != want {
+					t.Errorf("upstream %s = %q, want %q", header, got, want)
+				}
+			}
+		}},
+
 		// ── use_max_completion_tokens ────────────────────────────────────────
 		{key: "use_max_completion_tokens", run: func(t flagTB, env *TestEnv) {
 			model := env.SetupRouteWithFlags(protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, flagScenario(), typ.RuleFlags{UseMaxCompletionTokens: true})

--- a/internal/server/config/rule.go
+++ b/internal/server/config/rule.go
@@ -41,10 +41,22 @@ func (c *Config) GetEffectiveAffinity(rule *typ.Rule) time.Duration {
 // out of the box. Only seed when the caller sent no flags at all, so an explicit
 // payload that sets any flag is left untouched.
 func applyScenarioCreateDefaults(rule *typ.Rule) {
-	if rule.Scenario.Is(typ.ScenarioTeam) && rule.Flags == (typ.RuleFlags{}) {
+	if rule.Scenario.Is(typ.ScenarioTeam) && rule.Flags.IsZero() {
 		rule.Flags.ClaudeCodeCompat = true
 		rule.Flags.CleanHeader = true
 	}
+}
+
+// validateRuleExtraHeaders rejects invalid extra_headers on the rule flags and
+// canonicalizes accepted names. Lives in the AddRule/UpdateRule choke points
+// so every write path (HTTP, CLI, TUI, import) shares the same gate as the
+// provider- and model-level headers (typ.ValidateExtraHeaders).
+func validateRuleExtraHeaders(rule *typ.Rule) error {
+	if err := typ.ValidateExtraHeaders(rule.Flags.ExtraHeaders); err != nil {
+		return fmt.Errorf("extra_headers: %w", err)
+	}
+	rule.Flags.ExtraHeaders = typ.CanonicalizeExtraHeaders(rule.Flags.ExtraHeaders)
+	return nil
 }
 
 // AddRule updates the default Rule
@@ -60,6 +72,9 @@ func (c *Config) AddRule(rule typ.Rule) error {
 		return err
 	}
 	if err := validateSmartRoutingRules(rule); err != nil {
+		return err
+	}
+	if err := validateRuleExtraHeaders(&rule); err != nil {
 		return err
 	}
 
@@ -101,6 +116,9 @@ func (c *Config) UpdateRule(uid string, rule typ.Rule) error {
 		return err
 	}
 	if err := validateSmartRoutingRules(rule); err != nil {
+		return err
+	}
+	if err := validateRuleExtraHeaders(&rule); err != nil {
 		return err
 	}
 

--- a/internal/server/config/rule_test.go
+++ b/internal/server/config/rule_test.go
@@ -204,22 +204,22 @@ func TestAddRule_DuplicateUUID(t *testing.T) {
 }
 
 // TestAddRule_ExtraHeadersValidation: the AddRule/UpdateRule choke points
-// reject denied header names and canonicalize accepted ones, sharing the same
-// gate as provider/model-level headers.
+// reject structurally invalid headers and canonicalize accepted ones. No
+// denylist — extra headers are user-driven config.
 func TestAddRule_ExtraHeadersValidation(t *testing.T) {
 	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewConfig error: %v", err)
 	}
 
-	denied := typ.Rule{
+	malformed := typ.Rule{
 		UUID:         "uuid-hdr-1",
 		Scenario:     "openai",
 		RequestModel: "hdr-model",
-		Flags:        typ.RuleFlags{ExtraHeaders: map[string]string{"Authorization": "Bearer x"}},
+		Flags:        typ.RuleFlags{ExtraHeaders: map[string]string{"X Title": "bad name"}},
 	}
-	if err := cfg.AddRule(denied); err == nil {
-		t.Fatal("expected denied header to be rejected, got nil")
+	if err := cfg.AddRule(malformed); err == nil {
+		t.Fatal("expected malformed header name to be rejected, got nil")
 	}
 
 	ok := typ.Rule{
@@ -241,8 +241,8 @@ func TestAddRule_ExtraHeadersValidation(t *testing.T) {
 
 	// UpdateRule shares the gate.
 	bad := *saved
-	bad.Flags.ExtraHeaders = map[string]string{"user-agent": "x"}
+	bad.Flags.ExtraHeaders = map[string]string{"X-Dup": "1", "x-dup": "2"}
 	if err := cfg.UpdateRule(bad.UUID, bad); err == nil {
-		t.Fatal("expected UpdateRule to reject denied header, got nil")
+		t.Fatal("expected UpdateRule to reject case-insensitive duplicate, got nil")
 	}
 }

--- a/internal/server/config/rule_test.go
+++ b/internal/server/config/rule_test.go
@@ -173,7 +173,7 @@ func TestAddRule_TeamSeedsCreateDefaults(t *testing.T) {
 	if other == nil {
 		t.Fatal("openai rule not found after AddRule")
 	}
-	if other.Flags != (typ.RuleFlags{}) {
+	if !other.Flags.IsZero() {
 		t.Errorf("non-team rule should keep empty flags, got %+v", other.Flags)
 	}
 }
@@ -200,5 +200,49 @@ func TestAddRule_DuplicateUUID(t *testing.T) {
 	}
 	if err := cfg.AddRule(rule2); err == nil {
 		t.Fatal("expected error for duplicate UUID, got nil")
+	}
+}
+
+// TestAddRule_ExtraHeadersValidation: the AddRule/UpdateRule choke points
+// reject denied header names and canonicalize accepted ones, sharing the same
+// gate as provider/model-level headers.
+func TestAddRule_ExtraHeadersValidation(t *testing.T) {
+	cfg, err := NewConfig(WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig error: %v", err)
+	}
+
+	denied := typ.Rule{
+		UUID:         "uuid-hdr-1",
+		Scenario:     "openai",
+		RequestModel: "hdr-model",
+		Flags:        typ.RuleFlags{ExtraHeaders: map[string]string{"Authorization": "Bearer x"}},
+	}
+	if err := cfg.AddRule(denied); err == nil {
+		t.Fatal("expected denied header to be rejected, got nil")
+	}
+
+	ok := typ.Rule{
+		UUID:         "uuid-hdr-2",
+		Scenario:     "openai",
+		RequestModel: "hdr-model-2",
+		Flags:        typ.RuleFlags{ExtraHeaders: map[string]string{"x-title": "tingly"}},
+	}
+	if err := cfg.AddRule(ok); err != nil {
+		t.Fatalf("valid header rejected: %v", err)
+	}
+	saved := cfg.GetRuleByUUID("uuid-hdr-2")
+	if saved == nil {
+		t.Fatal("rule not saved")
+	}
+	if _, exists := saved.Flags.ExtraHeaders["X-Title"]; !exists {
+		t.Errorf("header name not canonicalized on save: %v", saved.Flags.ExtraHeaders)
+	}
+
+	// UpdateRule shares the gate.
+	bad := *saved
+	bad.Flags.ExtraHeaders = map[string]string{"user-agent": "x"}
+	if err := cfg.UpdateRule(bad.UUID, bad); err == nil {
+		t.Fatal("expected UpdateRule to reject denied header, got nil")
 	}
 }

--- a/internal/server/module/rule/handler_test.go
+++ b/internal/server/module/rule/handler_test.go
@@ -356,7 +356,7 @@ func TestCreateRule_NonTeamNoDefaultFlags(t *testing.T) {
 	if saved == nil {
 		t.Fatal("rule not found after create")
 	}
-	if saved.Flags != (typ.RuleFlags{}) {
+	if !saved.Flags.IsZero() {
 		t.Errorf("non-team rule should keep empty flags, got %+v", saved.Flags)
 	}
 }

--- a/internal/typ/extra_headers.go
+++ b/internal/typ/extra_headers.go
@@ -7,75 +7,36 @@ import (
 	"golang.org/x/net/http/httpguts"
 )
 
-// Extra-header limits enforced by ValidateExtraHeaders, per level.
-const (
-	MaxExtraHeadersPerLevel = 16
-	MaxExtraHeaderNameLen   = 128
-	MaxExtraHeaderValueLen  = 4096
-)
-
-// deniedExtraHeaders lists header names (canonical form) that extra_headers
-// may never set, at any level:
-//   - transport-breaking headers the HTTP stack owns
-//   - credential-carrying headers — credentials must go through the
-//     Token/Credential fields so masking, export scrubbing, and refresh keep
-//     working (never through header config)
-//   - User-Agent, which has its own dedicated mechanism (rule
-//     custom_user_agent + vendor pins; see .design/user-agent.md)
-var deniedExtraHeaders = map[string]bool{
-	"Host":                true,
-	"Content-Length":      true,
-	"Transfer-Encoding":   true,
-	"Connection":          true,
-	"Upgrade":             true,
-	"Trailer":             true,
-	"Te":                  true,
-	"Keep-Alive":          true,
-	"Authorization":       true,
-	"Proxy-Authorization": true,
-	"X-Api-Key":           true,
-	"User-Agent":          true,
-}
-
-// IsDeniedExtraHeader reports whether the header name (any case) is on the
-// denylist. The outbound transport uses this as a second line of defense
-// against pre-validation data (imports, old rows).
-func IsDeniedExtraHeader(name string) bool {
-	return deniedExtraHeaders[textproto.CanonicalMIMEHeaderKey(name)]
-}
-
-// ValidateExtraHeaders checks one level's extra-header map at config-save
-// time. All write entry points share this function so a header rejected in
-// one place is rejected everywhere. Fail-loudly-on-save: the request path
-// never filters silently except through the denylist defense above.
+// Extra headers are deliberately user-driven: tingly-box is an orchestrator,
+// and "custom" implies needs we cannot predict, so there is no denylist and
+// no size/count cap — the user can configure any header, including ones the
+// gateway also manages (Authorization, User-Agent, …), and owns the outcome.
+// What still wins over a user header is decided by transport ordering, not
+// by filtering: vendor-pinned headers and the User-Agent chain write later
+// (closer to the wire) and therefore take precedence on generic conflicts
+// (see .design/provider-flags.md §5).
+//
+// ValidateExtraHeaders therefore checks structural validity only — things
+// that would make the HTTP request itself malformed or the config ambiguous:
+//   - header names must be RFC 7230 tokens, values must be valid field values
+//     (net/http would otherwise fail the request at send time with a less
+//     helpful error);
+//   - case-insensitively duplicate names are rejected, because HTTP header
+//     names are case-insensitive and a map carrying both spellings has no
+//     defined winner.
 func ValidateExtraHeaders(headers map[string]string) error {
-	if len(headers) == 0 {
-		return nil
-	}
-	if len(headers) > MaxExtraHeadersPerLevel {
-		return fmt.Errorf("too many extra headers: %d (max %d)", len(headers), MaxExtraHeadersPerLevel)
-	}
 	seen := make(map[string]bool, len(headers))
 	for name, value := range headers {
 		if name == "" {
 			return fmt.Errorf("extra header with empty name")
 		}
-		if len(name) > MaxExtraHeaderNameLen {
-			return fmt.Errorf("extra header name %q too long: %d bytes (max %d)", name, len(name), MaxExtraHeaderNameLen)
-		}
 		if !httpguts.ValidHeaderFieldName(name) {
 			return fmt.Errorf("invalid extra header name %q", name)
-		}
-		if len(value) > MaxExtraHeaderValueLen {
-			return fmt.Errorf("extra header %q value too long: %d bytes (max %d)", name, len(value), MaxExtraHeaderValueLen)
 		}
 		if !httpguts.ValidHeaderFieldValue(value) {
 			return fmt.Errorf("extra header %q has an invalid value", name)
 		}
 		canonical := textproto.CanonicalMIMEHeaderKey(name)
-		if deniedExtraHeaders[canonical] {
-			return fmt.Errorf("extra header %q is not allowed: it is managed by the gateway", canonical)
-		}
 		if seen[canonical] {
 			return fmt.Errorf("duplicate extra header %q (names are case-insensitive)", canonical)
 		}

--- a/internal/typ/extra_headers.go
+++ b/internal/typ/extra_headers.go
@@ -1,0 +1,99 @@
+package typ
+
+import (
+	"fmt"
+	"net/textproto"
+
+	"golang.org/x/net/http/httpguts"
+)
+
+// Extra-header limits enforced by ValidateExtraHeaders, per level.
+const (
+	MaxExtraHeadersPerLevel = 16
+	MaxExtraHeaderNameLen   = 128
+	MaxExtraHeaderValueLen  = 4096
+)
+
+// deniedExtraHeaders lists header names (canonical form) that extra_headers
+// may never set, at any level:
+//   - transport-breaking headers the HTTP stack owns
+//   - credential-carrying headers — credentials must go through the
+//     Token/Credential fields so masking, export scrubbing, and refresh keep
+//     working (never through header config)
+//   - User-Agent, which has its own dedicated mechanism (rule
+//     custom_user_agent + vendor pins; see .design/user-agent.md)
+var deniedExtraHeaders = map[string]bool{
+	"Host":                true,
+	"Content-Length":      true,
+	"Transfer-Encoding":   true,
+	"Connection":          true,
+	"Upgrade":             true,
+	"Trailer":             true,
+	"Te":                  true,
+	"Keep-Alive":          true,
+	"Authorization":       true,
+	"Proxy-Authorization": true,
+	"X-Api-Key":           true,
+	"User-Agent":          true,
+}
+
+// IsDeniedExtraHeader reports whether the header name (any case) is on the
+// denylist. The outbound transport uses this as a second line of defense
+// against pre-validation data (imports, old rows).
+func IsDeniedExtraHeader(name string) bool {
+	return deniedExtraHeaders[textproto.CanonicalMIMEHeaderKey(name)]
+}
+
+// ValidateExtraHeaders checks one level's extra-header map at config-save
+// time. All write entry points share this function so a header rejected in
+// one place is rejected everywhere. Fail-loudly-on-save: the request path
+// never filters silently except through the denylist defense above.
+func ValidateExtraHeaders(headers map[string]string) error {
+	if len(headers) == 0 {
+		return nil
+	}
+	if len(headers) > MaxExtraHeadersPerLevel {
+		return fmt.Errorf("too many extra headers: %d (max %d)", len(headers), MaxExtraHeadersPerLevel)
+	}
+	seen := make(map[string]bool, len(headers))
+	for name, value := range headers {
+		if name == "" {
+			return fmt.Errorf("extra header with empty name")
+		}
+		if len(name) > MaxExtraHeaderNameLen {
+			return fmt.Errorf("extra header name %q too long: %d bytes (max %d)", name, len(name), MaxExtraHeaderNameLen)
+		}
+		if !httpguts.ValidHeaderFieldName(name) {
+			return fmt.Errorf("invalid extra header name %q", name)
+		}
+		if len(value) > MaxExtraHeaderValueLen {
+			return fmt.Errorf("extra header %q value too long: %d bytes (max %d)", name, len(value), MaxExtraHeaderValueLen)
+		}
+		if !httpguts.ValidHeaderFieldValue(value) {
+			return fmt.Errorf("extra header %q has an invalid value", name)
+		}
+		canonical := textproto.CanonicalMIMEHeaderKey(name)
+		if deniedExtraHeaders[canonical] {
+			return fmt.Errorf("extra header %q is not allowed: it is managed by the gateway", canonical)
+		}
+		if seen[canonical] {
+			return fmt.Errorf("duplicate extra header %q (names are case-insensitive)", canonical)
+		}
+		seen[canonical] = true
+	}
+	return nil
+}
+
+// CanonicalizeExtraHeaders returns a copy of the map with every name in
+// canonical form. Called on the save path after validation so stored config
+// always shows the concrete on-wire spelling.
+func CanonicalizeExtraHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(headers))
+	for name, value := range headers {
+		out[textproto.CanonicalMIMEHeaderKey(name)] = value
+	}
+	return out
+}

--- a/internal/typ/extra_headers_test.go
+++ b/internal/typ/extra_headers_test.go
@@ -1,0 +1,77 @@
+package typ
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateExtraHeaders(t *testing.T) {
+	valid := map[string]string{
+		"HTTP-Referer": "https://example.com",
+		"X-Title":      "tingly-box",
+	}
+	if err := ValidateExtraHeaders(valid); err != nil {
+		t.Fatalf("valid headers rejected: %v", err)
+	}
+	if err := ValidateExtraHeaders(nil); err != nil {
+		t.Fatalf("nil headers rejected: %v", err)
+	}
+
+	rejected := []struct {
+		name    string
+		headers map[string]string
+	}{
+		{"empty name", map[string]string{"": "v"}},
+		{"invalid name chars", map[string]string{"X Title": "v"}},
+		{"invalid value", map[string]string{"X-A": "bad\nvalue"}},
+		{"denied Authorization", map[string]string{"Authorization": "Bearer x"}},
+		{"denied authorization (case)", map[string]string{"authorization": "Bearer x"}},
+		{"denied X-Api-Key", map[string]string{"x-api-key": "sk-1"}},
+		{"denied User-Agent", map[string]string{"User-Agent": "me/1.0"}},
+		{"denied Host", map[string]string{"Host": "evil.example"}},
+		{"denied Content-Length", map[string]string{"Content-Length": "0"}},
+		{"case-insensitive duplicate", map[string]string{"X-Dup": "1", "x-dup": "2"}},
+		{"name too long", map[string]string{strings.Repeat("A", MaxExtraHeaderNameLen+1): "v"}},
+		{"value too long", map[string]string{"X-A": strings.Repeat("v", MaxExtraHeaderValueLen+1)}},
+	}
+	for _, tc := range rejected {
+		if err := ValidateExtraHeaders(tc.headers); err == nil {
+			t.Errorf("%s: expected rejection, got nil", tc.name)
+		}
+	}
+
+	tooMany := map[string]string{}
+	for i := 0; i <= MaxExtraHeadersPerLevel; i++ {
+		tooMany["X-H-"+strings.Repeat("a", i+1)] = "v"
+	}
+	if err := ValidateExtraHeaders(tooMany); err == nil {
+		t.Error("count over limit: expected rejection, got nil")
+	}
+}
+
+func TestIsDeniedExtraHeader(t *testing.T) {
+	for _, name := range []string{"Authorization", "authorization", "x-api-key", "user-agent", "HOST"} {
+		if !IsDeniedExtraHeader(name) {
+			t.Errorf("IsDeniedExtraHeader(%q) = false, want true", name)
+		}
+	}
+	if IsDeniedExtraHeader("X-Title") {
+		t.Error("X-Title should not be denied")
+	}
+}
+
+func TestCanonicalizeExtraHeaders(t *testing.T) {
+	out := CanonicalizeExtraHeaders(map[string]string{
+		"http-referer": "https://example.com",
+		"X-TITLE":      "t",
+	})
+	if _, ok := out["Http-Referer"]; !ok {
+		t.Errorf("http-referer not canonicalized: %v", out)
+	}
+	if _, ok := out["X-Title"]; !ok {
+		t.Errorf("X-TITLE not canonicalized: %v", out)
+	}
+	if got := CanonicalizeExtraHeaders(nil); got != nil {
+		t.Errorf("nil should canonicalize to nil, got %v", got)
+	}
+}

--- a/internal/typ/extra_headers_test.go
+++ b/internal/typ/extra_headers_test.go
@@ -1,22 +1,30 @@
 package typ
 
 import (
-	"strings"
 	"testing"
 )
 
 func TestValidateExtraHeaders(t *testing.T) {
-	valid := map[string]string{
-		"HTTP-Referer": "https://example.com",
-		"X-Title":      "tingly-box",
+	// User-driven: any structurally valid header is accepted — including
+	// gateway-adjacent names like Authorization or User-Agent. The user owns
+	// the outcome; precedence with managed headers is decided by transport
+	// ordering, not filtering.
+	accepted := []map[string]string{
+		nil,
+		{"HTTP-Referer": "https://example.com", "X-Title": "tingly-box"},
+		{"Authorization": "Bearer custom"},
+		{"User-Agent": "me/1.0"},
+		{"X-Api-Key": "k"},
+		{"X-Empty-Value": ""},
 	}
-	if err := ValidateExtraHeaders(valid); err != nil {
-		t.Fatalf("valid headers rejected: %v", err)
-	}
-	if err := ValidateExtraHeaders(nil); err != nil {
-		t.Fatalf("nil headers rejected: %v", err)
+	for i, headers := range accepted {
+		if err := ValidateExtraHeaders(headers); err != nil {
+			t.Errorf("accepted[%d] rejected: %v", i, err)
+		}
 	}
 
+	// Structural rejections only: malformed names/values would fail the HTTP
+	// request itself; case-insensitive duplicates have no defined winner.
 	rejected := []struct {
 		name    string
 		headers map[string]string
@@ -24,39 +32,12 @@ func TestValidateExtraHeaders(t *testing.T) {
 		{"empty name", map[string]string{"": "v"}},
 		{"invalid name chars", map[string]string{"X Title": "v"}},
 		{"invalid value", map[string]string{"X-A": "bad\nvalue"}},
-		{"denied Authorization", map[string]string{"Authorization": "Bearer x"}},
-		{"denied authorization (case)", map[string]string{"authorization": "Bearer x"}},
-		{"denied X-Api-Key", map[string]string{"x-api-key": "sk-1"}},
-		{"denied User-Agent", map[string]string{"User-Agent": "me/1.0"}},
-		{"denied Host", map[string]string{"Host": "evil.example"}},
-		{"denied Content-Length", map[string]string{"Content-Length": "0"}},
 		{"case-insensitive duplicate", map[string]string{"X-Dup": "1", "x-dup": "2"}},
-		{"name too long", map[string]string{strings.Repeat("A", MaxExtraHeaderNameLen+1): "v"}},
-		{"value too long", map[string]string{"X-A": strings.Repeat("v", MaxExtraHeaderValueLen+1)}},
 	}
 	for _, tc := range rejected {
 		if err := ValidateExtraHeaders(tc.headers); err == nil {
 			t.Errorf("%s: expected rejection, got nil", tc.name)
 		}
-	}
-
-	tooMany := map[string]string{}
-	for i := 0; i <= MaxExtraHeadersPerLevel; i++ {
-		tooMany["X-H-"+strings.Repeat("a", i+1)] = "v"
-	}
-	if err := ValidateExtraHeaders(tooMany); err == nil {
-		t.Error("count over limit: expected rejection, got nil")
-	}
-}
-
-func TestIsDeniedExtraHeader(t *testing.T) {
-	for _, name := range []string{"Authorization", "authorization", "x-api-key", "user-agent", "HOST"} {
-		if !IsDeniedExtraHeader(name) {
-			t.Errorf("IsDeniedExtraHeader(%q) = false, want true", name)
-		}
-	}
-	if IsDeniedExtraHeader("X-Title") {
-		t.Error("X-Title should not be denied")
 	}
 }
 

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -110,7 +110,7 @@ func RuleFlagRegistry() []FlagSpec {
 		{
 			Key:         "extra_headers",
 			Label:       "Custom Headers",
-			Description: "Append custom HTTP headers to the outbound upstream request for requests matched by this rule. Applies to API-key providers only — OAuth/vendor providers (Claude Code, Codex, Kimi, Gemini, Antigravity) keep their handshake headers and ignore this. Headers managed by the gateway (Authorization, User-Agent, transport headers) cannot be set here.",
+			Description: "Append custom HTTP headers to the outbound upstream request for requests matched by this rule. Applies to API-key providers only — OAuth/vendor providers (Claude Code, Codex, Kimi, Gemini, Antigravity) keep their handshake headers and ignore this. Headers are sent as configured, including ones the gateway also sets (Authorization, User-Agent, …) — overriding those is your call and your responsibility.",
 			Type:        FlagTypeHeaders,
 			Category:    FlagCategoryRequest,
 		},

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -15,6 +15,10 @@ const (
 	// pair is treated as inactive. Backed by a typed struct on RuleFlags, not
 	// a scalar.
 	FlagTypeServiceRef FlagValueType = "service_ref"
+	// FlagTypeHeaders is a name→value HTTP header map. The UI renders an
+	// editable key/value row list (add/remove rows); an empty map is treated
+	// as inactive. Backed by a map[string]string on the flags struct.
+	FlagTypeHeaders FlagValueType = "headers"
 )
 
 // FlagCategory groups flags for presentation in the UI.
@@ -23,6 +27,9 @@ type FlagCategory string
 const (
 	// FlagCategoryApp — flags that target a specific client application (IDE, CLI tool, etc).
 	FlagCategoryApp FlagCategory = "app"
+	// FlagCategoryRequest — protocol-agnostic request-level adjustments that
+	// apply regardless of the upstream's API style (e.g. extra HTTP headers).
+	FlagCategoryRequest FlagCategory = "request"
 	// FlagCategoryRequestOpenAI — request-level adjustments for OpenAI-compatible upstreams:
 	// endpoint routing, field rewrites, tool blocking, user-agent overrides.
 	FlagCategoryRequestOpenAI FlagCategory = "request_openai"
@@ -99,6 +106,14 @@ func DefaultUserAgents() []FlagOption {
 // by adjacent entries sharing the same Category value.
 func RuleFlagRegistry() []FlagSpec {
 	return []FlagSpec{
+		// ── Request (protocol-agnostic) ────────────────────────────────────
+		{
+			Key:         "extra_headers",
+			Label:       "Custom Headers",
+			Description: "Append custom HTTP headers to the outbound upstream request for requests matched by this rule. Applies to API-key providers only — OAuth/vendor providers (Claude Code, Codex, Kimi, Gemini, Antigravity) keep their handshake headers and ignore this. Headers managed by the gateway (Authorization, User-Agent, transport headers) cannot be set here.",
+			Type:        FlagTypeHeaders,
+			Category:    FlagCategoryRequest,
+		},
 		// ── Request (OpenAI) ───────────────────────────────────────────────
 		{
 			Key:             "custom_user_agent",

--- a/internal/typ/flag_registry_test.go
+++ b/internal/typ/flag_registry_test.go
@@ -73,6 +73,7 @@ func TestRuleFlagRegistry_TypesAreValid(t *testing.T) {
 		FlagTypeEnum:       true,
 		FlagTypeInt:        true,
 		FlagTypeServiceRef: true,
+		FlagTypeHeaders:    true,
 	}
 	for _, spec := range RuleFlagRegistry() {
 		if !allowed[spec.Type] {

--- a/internal/typ/id.go
+++ b/internal/typ/id.go
@@ -189,6 +189,33 @@ func GetClientUserAgent(ctx context.Context) string {
 	return ""
 }
 
+// ExtraHeadersKey carries the request-scoped extra headers (resolved at
+// dispatch time from the rule's extra_headers flag) down to the outbound
+// HTTP transport, which applies them on api_key providers only. See
+// .design/provider-flags.md.
+const ExtraHeadersKey contextKey = "extra_headers"
+
+// WithExtraHeaders attaches request-scoped extra headers for the outbound
+// transport. Empty maps are not attached.
+func WithExtraHeaders(ctx context.Context, headers map[string]string) context.Context {
+	if len(headers) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, ExtraHeadersKey, headers)
+}
+
+// GetExtraHeaders returns the request-scoped extra headers, or nil if none.
+// Callers must treat the returned map as read-only.
+func GetExtraHeaders(ctx context.Context) map[string]string {
+	if ctx == nil {
+		return nil
+	}
+	if h, ok := ctx.Value(ExtraHeadersKey).(map[string]string); ok {
+		return h
+	}
+	return nil
+}
+
 // Context1MKey carries the rule-level 1M-context hint down to the Anthropic
 // client, whose Beta/Messages methods add the context-1m beta flag per request.
 const Context1MKey contextKey = "context_1m"

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -2,6 +2,7 @@ package typ
 
 import (
 	"encoding/json"
+	"reflect"
 	"time"
 
 	"github.com/tingly-dev/tingly-box/ai"
@@ -274,6 +275,13 @@ type RuleFlags struct {
 	// only the beta header changes behavior.
 	Context1M bool `json:"context_1m,omitempty" yaml:"context_1m,omitempty"`
 
+	// ExtraHeaders are appended to the outbound upstream request for requests
+	// matched by this rule. Merged with the provider- and model-level
+	// extra_headers (see typ.EffectiveExtraHeaders): provider < model < rule,
+	// the rule value winning on name conflicts. Applied on api_key providers
+	// only (vendor/OAuth chains keep their handshake headers untouched).
+	ExtraHeaders map[string]string `json:"extra_headers,omitempty" yaml:"extra_headers,omitempty"`
+
 	// ClaudeOrgID controls the anthropic-organization-id header sent upstream
 	// for Claude OAuth providers. Organization attribution is opt-in: empty
 	// (default) sends no organization header at all. "auto"
@@ -282,6 +290,13 @@ type RuleFlags struct {
 	// entitlements (e.g. Cyber Verification) rely on. Any other value sends
 	// that organization id verbatim.
 	ClaudeOrgID string `json:"claude_org_id,omitempty" yaml:"claude_org_id,omitempty"`
+}
+
+// IsZero reports whether no flag is set at all. RuleFlags stopped being
+// comparable with == once it grew map fields (ExtraHeaders), so zero checks
+// go through here.
+func (f RuleFlags) IsZero() bool {
+	return reflect.DeepEqual(f, RuleFlags{})
 }
 
 // VisionProxyService identifies the upstream used to describe images for the

--- a/openapi.json
+++ b/openapi.json
@@ -13234,6 +13234,13 @@
             "type": "string",
             "description": "Field custom_user_agent"
           },
+          "extra_headers": {
+            "type": "object",
+            "description": "Field extra_headers",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
           "openai_endpoint_override": {
             "type": "string",
             "description": "Field openai_endpoint_override"


### PR DESCRIPTION
## Summary
Upstreams like OpenRouter, AI gateways, and self-hosted endpoints gate features on custom HTTP headers the gateway had no way to send. This adds a rule-level `extra_headers` flag that appends N custom headers to the outbound upstream request, released for api_key providers only. Design: `.design/provider-flags.md` (provider/model levels follow in a stacked PR).

## Key Changes

- **Rule flag `extra_headers`**: new `headers` value type in the registry (KV map), rendered registry-driven in the existing Rule Plugins catalog with a shared `HeadersEditor` KV-row control.
- **User-driven, no denylist**: any header can be configured (Authorization, User-Agent, …) and the user owns the outcome; save-time validation checks structure only (RFC 7230 name/value validity, case-insensitive duplicate rejection, canonicalized names) at the AddRule/UpdateRule choke points.
- **Transport injection**: `extraHeadersTransport` mounted at the single `wrapWithLogging` choke point covers every client constructor, applying headers verbatim; api_key-only gate, sits outside vendor round-trippers so pinned headers win by ordering (regression-tested), not by filtering.
- **e2e coverage**: behavior case drives rule headers through the real gateway and asserts them on the captured upstream request (`TestRuleFlagRegistry_FullyCovered` keeps it in lockstep with the registry).

## Notes
- UI shows literal header names (not counts); inline row validation mirrors the backend structural checks.