### PR TITLE
feat(flags): provider- and model-level extra_headers (backend)

### DIFF
--- a/.design/provider-flags.md
+++ b/.design/provider-flags.md
@@ -77,8 +77,11 @@ UA 的教训（`provider.UserAgent` 移除史，user-agent.md §5）仍然成立
 │  }                                                          │
 │                                                             │
 │  type ProviderFlags struct {                                │
-│      ExtraHeaders map[string]string `json:"extra_headers"`   │
-│      // 后续字段须通过"准入规则"（见下）                        │
+│      ExtraHeaders map[string]string                         │
+│      CustomUserAgent / BlockTools / ThinkingEffort  …        │
+│      UseMaxTokens / UseMaxCompletionTokens / SkipUsage       │
+│      ClaudeCodeCompat / CleanHeader / Cursor* / Context1M    │
+│      // 字段集是 RuleFlags 的供给侧镜像（见下）                  │
 │  }                                                          │
 └──────────────────────────┬──────────────────────────────────┘
                            │ typ.ProviderFlags = ai.ProviderFlags（别名）
@@ -125,11 +128,32 @@ UA 的教训（`provider.UserAgent` 移除史，user-agent.md §5）仍然成立
 extensions wire shape）。
 
 **代价与护栏**：ai 从此认识 flag schema，新增 provider flag 要动公共
-module；真正的风险是先例——一个开放的 `Flags` 结构会招揽产品语义。护栏
-是一条写进 `ai/README.md` 与本文档的准入规则：
+module；真正的风险是先例——一个开放的 `Flags` 结构会招揽产品语义。
 
-> **ai 只接受"描述如何抵达上游"的字段；网关的产品行为（响应改写、客户端
-> 兼容垫片、路由策略……）一律留在 rule flags。**
+护栏最初写成一条准入规则（"ai 只接受描述如何抵达上游的字段"）。实施到
+一半发现它把 provider flags 卡死在了一个 flag 上：按字面执行，
+`use_max_tokens`（老 provider 不认新字段名）、`claude_code_compat`
+（第三方 Anthropic 兼容端拒绝 system role）这类**明明是上游属性、描述
+里自己就写着 "providers" / "model family"** 的 flag 也被挡在门外，用户
+只能在每一条 rule 上重复配置同一个上游的怪癖。于是护栏换成一条更强也更
+好执行的规则：
+
+> **`ProviderFlags` 的字段集是消费者请求侧 flag 集（`typ.RuleFlags`）的
+> 供给侧镜像。同一个 knob 在哪一级都是同一个意思，只有"作用范围"不同；
+> 不为供给侧发明新词汇。**
+
+这条规则同时解决了准入和命名两个问题：能不能加，看请求侧有没有这个
+knob；叫什么，就叫请求侧那个名字。它把"ai 认识产品语义"的风险从"任意
+膨胀"收窄成"跟随一个已存在的、被评审过的集合"。
+
+**没有镜像的三类**（`ProviderFlagRegistry` 的注释里同样列着，
+`TestProviderFlagRegistry_ExcludesRequestOnlyFlags` 钉住）：
+
+| flag | 不镜像的理由 |
+|------|--------------|
+| `session_affinity` / `vision_proxy_service` | 在**选中上游之前**就已消费（负载均衡 / 入站改写），挂在上游身上的值永远读不到 |
+| `openai_endpoint_override` | provider 已有一等字段 `OpenAIEndpointMode` 表达同一件事，再开一个控件就是重复 mode picker（ux-principles） |
+| `claude_org_id` | Claude OAuth 专用，而 provider flags 首版仅 api_key |
 
 Rule 级不受影响：RuleFlags 本来就是服务域内的 typed struct（rule-flags.md
 §3），直接加字段即可。
@@ -182,15 +206,43 @@ flag 是供给侧配置，只应认识 provider 自己的模型词汇，不认�
 model 级是供给侧对默认的细化；rule 级表达"这一类客户端/用途"的显式
 意图，是三者中最具体的，故最后写入。
 
-**没有"三级合并函数"**：供给侧两级在构造期合并一次，rule 级在写 header
-时叠加，`req.Header.Set` 的 canonical 化保证同名（含大小写不同）覆盖。
-详见 §5.1。
+**headers 没有"三级合并函数"**：供给侧两级在构造期合并一次，rule 级在写
+header 时叠加，`req.Header.Set` 的 canonical 化保证同名（含大小写不同）
+覆盖。详见 §5.1。
 
-合并语义是**层级的属性，不是每个 flag 的属性**：model 级覆盖同名的
-provider 级，就这一条。曾经给 FlagSpec 加过 `Scope` / `MergeMode` 两个轴
-（"这个 flag 存在于哪几级 / 两级怎么合"），但唯一的 flag 两级都有、合法
-只有 merge 一种，没有任何生产代码读它们——纯为想象中的第二个 flag 预留，
-已删除。真出现语义不同的 flag 时再加轴，届时有真实约束可依。
+**其余 flag 走一次显式合并**：它们不是 header，注入点在 transform 链和
+SDK 层（rule-flags.md 的 Type 1b-pre / 1b-post / Type 2），没有"写入
+顺序"可借。合并放在 `typ.ApplyProviderFlags(flags, provider, model)`，
+由 `ResolveRuleFlagsWithScenario` 这一个点调用——即 rule/scenario 合并
+之后、`applyRuleFlags` 写进 ctx 之前：
+
+```
+rule.Flags ──┬─ + scenario 继承 ──┬─ + ApplyProviderFlags(provider, model) ──┬─ ctx
+             │  （既有）           │   （供给侧，最低优先级）                    │
+             └────────────────────┴──────────────────────────────────────────┘
+                                        ↓
+                        RulePreBaseTransforms / RulePreVendorTransforms /
+                        outbound clients / response 处理 —— 全部免费拿到
+```
+
+合并语义按**值的种类**统一，不按 flag 声明：
+
+| 种类 | 语义 |
+|------|------|
+| bool | 三级 OR（任一级打开即生效） |
+| 标量（string / enum / int） | 取最窄的非零值：rule → model → provider |
+| map（headers） | 逐 key 合并，窄的一级赢同名 key（走 §5.1 的写入顺序） |
+
+因此 `FlagSpec` 上不需要 `Scope` / `MergeMode` 两个轴（曾经加过又删掉：
+唯一的 flag 两级都有、只有一种合法合并，无任何生产读取方）。bool 用 OR
+而不是"窄级可以关掉宽级"，与既有的 scenario→rule `InheritanceMode: "or"`
+一致；真出现需要"下级关闭上级"的 flag 时再引入三态，届时有真实约束可依。
+
+**为什么合并在 dispatch 侧而不是各注入点**：`ResolveRuleFlagsWithScenario`
+已经是"本次请求的有效 flag"的唯一收敛点（scenario 继承、cursor 自动检测、
+CleanHeader 自动应用与 OAuth 抑制都在这里），供给侧插在同一处，下游没有
+任何一个消费点需要知道 flag 是从哪一级来的。代价是该函数多了一个 `model`
+形参（四个 attempt 入口各自把已解析的 provider 侧 model ID 传进来）。
 
 ---
 
@@ -198,25 +250,28 @@ provider 级，就这一条。曾经给 FlagSpec 加过 `Scope` / `MergeMode` �
 
 ### Provider/Model 级：新增 `internal/typ/provider_flag_registry.go`
 
-```go
-// 直接复用 FlagSpec / FlagValueType / FlagOption（flag_registry.go），
-// 不给 FlagSpec 加任何 provider 专用字段——与 rule spec 完全同形。
+既然字段集是 RuleFlags 的镜像（§2），registry 也不重抄一遍：provider
+registry **由 rule registry 派生**，本文件里只写一张 `key → 供给侧文案`
+的表，其余（Label / Type / Category / Placeholder / Options /
+Suggestions）全部取自同 key 的 rule spec：
 
+```go
+// providerFlagDescriptions：按展示顺序列出可在 provider/model 级配置的
+// flag + 它的供给侧描述；不在表里的 key 就是"没有供给侧语义"（§2 三类）。
 func ProviderFlagRegistry() []FlagSpec {
-    return []FlagSpec{
-        {
-            Key:         "extra_headers",
-            Label:       "Custom Headers",
-            Description: "Append custom HTTP headers to outbound requests ...",
-            Type:        FlagValueHeaders, // 新增的 value type，见下
-            Category:    FlagCategoryRequest,
-        },
-    }
+    // 取同 key 的 rule spec → 换掉 Description → 清掉 scenario 轴
+    // （Shared / InheritanceMode 属于 rule 轴）
 }
 ```
 
-**每个 spec 都是 provider + model 两级可配**（model 级同名覆盖 provider
-级）。不做 per-spec 的 scope 声明：两个 UI 面都渲染整个 registry。
+这样两个面渲染的控件天生一致（同一个 knob 不会一边是下拉一边是文本框），
+新增 rule flag 时若要开到供给侧，只需在表里加一行文案。
+`TestProviderFlagRegistry_SharesRuleControlShape` 钉住"控件同形、文案不同"，
+`TestProviderFlagRegistry_KeysExistInRuleRegistry` 钉住表里不会出现 rule
+registry 没有的 key（否则会被静默丢弃）。
+
+**每个 spec 都是 provider + model 两级可配**（合并语义见 §3.3）。不做
+per-spec 的 scope 声明：两个 UI 面都渲染整个 registry。
 
 ### Rule 级：`RuleFlagRegistry()` 追加一条
 
@@ -519,6 +574,10 @@ switch/case。实现落点：
 |------|--------|------|----------|
 | ai.Provider 扩展容器形态 | `map[string]json.RawMessage` | typed struct / `map[string]any` | ai 是公共 module，必须对内容不知情；RawMessage 无损且物理隔离 schema。typed struct 会把服务语义泄进公共 API |
 | provider flag 的存放位置 | `ai.Provider` 上的 typed 字段 | `Extensions map[string]json.RawMessage` 不透明容器 + 服务侧 well-known key | 容器只有一个消费者，"保护别人 key"的读-改-写保护的是假想消费者（评审意见）。塌缩省 ~135 行；ai 的依赖独立性不变（不引入新 import），语义上 headers 本就属于"如何抵达上游"。代价是 ai 认识 flag schema，用准入规则约束（§2）|
+| provider flag 的字段集 | RuleFlags 的供给侧镜像（12 个），排除三类无供给侧语义的 | 只做 `extra_headers` / 自定义一套供给侧词汇 | 只做 headers 把"上游怪癖"留在了 rule 上重复配置——`use_max_tokens`、`claude_code_compat` 的描述里自己就写着 providers / model family（评审意见：整个 provider flag 系统没实现完）。镜像同时解决准入与命名：能不能加看请求侧有没有，叫什么就叫请求侧的名字 |
+| provider registry 的来源 | 由 `RuleFlagRegistry()` 派生，只覆写 Description | 手写 12 条完整 spec | 同一 knob 两个面必须渲染同一控件；派生让"漂移"在结构上不可能发生，新增一条只写一行文案 |
+| 非 header flag 的合并 | dispatch 侧一次 `ApplyProviderFlags`，在 `ResolveRuleFlagsWithScenario` 内 | 各注入点自行读三级 / 像 headers 一样靠写入顺序 | 它们注入在 transform 链与 SDK 层，没有"写入顺序"可借；而请求的有效 flag 已有唯一收敛点，插在那里下游零改动。代价：该函数多一个 `model` 形参 |
+| bool 的三级语义 | 三级 OR | 三态（`*bool`，窄级可关掉宽级） | 与既有 scenario→rule `InheritanceMode: "or"` 一致，零新概念；三态要给每个 bool 加指针 + UI 加"继承/开/关"三档，为一个尚未出现的需求付全额成本 |
 | 服务侧 schema 位置 | internal/typ + registry | 散落各消费点 | 复刻 rule flags 的"唯一可信源"模式，前端零 switch/case，已被验证 |
 | rule 级是否同步支持 | ✅ 三级统一 | 仅 provider/model | headers 三级各有真实语义（网关固有 / 模型灰度 / 客户端标记）；rule 级复用既有 RuleFlags 机制近乎零成本，一次做齐避免二次开口 |
 | 三级合并顺序 | provider < model < rule | rule < model < provider | 粒度越贴近单次请求越应胜出；rule 是显式的请求侧意图 |
@@ -546,6 +605,11 @@ switch/case。实现落点：
 - ✅ 首版仅释放 api_key auth type；OAuth / 多字段凭证 / vmodel 不释放，
   由 UI + API 校验 + transport 守卫三道闸收口。
 - ✅ builtin provider 沿用"不可 mutate"规则，flags 锁定。
+- ✅ `ProviderFlags` 的字段集是 `RuleFlags` 的供给侧镜像，而非仅
+  `extra_headers`；准入规则从"只接受如何抵达上游"改为"镜像请求侧集合"
+  （§2）。三类无供给侧语义的 flag 显式排除并有测试钉住。
+- ✅ 非 header flag 的三级合并落在 `typ.ApplyProviderFlags`，由
+  `ResolveRuleFlagsWithScenario` 单点调用；bool 三级 OR，标量取最窄非零值。
 
 **遗留**（不阻塞实施）：
 
@@ -553,3 +617,13 @@ switch/case。实现落点：
 2. model key 通配/前缀匹配（依赖真实需求）。
 3. scenario 级 extra_headers（当前无需求；若加，走 FlagSpec.Shared +
    InheritanceMode 的既有 scenario 继承链，与三级纵向合并正交）。
+4. 供给侧 flag 的"生效范围"提示。镜像集合里有几个 flag 只在特定形态的
+   上游上有意义（`context_1m` 只对 Anthropic、`use_max_*` 只对 OpenAI、
+   `cursor_compat*` 取决于入站客户端）。当前**不加门禁**：配在用不上的
+   地方就是静默无效，与 rule 级同一行为，也符合"编排器可任意配置、配错
+   自负"的定调。若后续要提示，registry 已有 `Category`（如
+   `request_openai` / `request_anthropic`）可直接驱动 UI 分组或灰置，
+   不需要新的数据结构。
+5. 前端 Plugins 目录当前只渲染 headers 控件（PR #1591 的范围）；registry
+   现在返回 bool / string / enum 三种 Type，前端需补齐对应控件才能把这
+   一批 flag 露出——后端契约已就位，属纯 UI 工作。

--- a/.design/provider-flags.md
+++ b/.design/provider-flags.md
@@ -95,10 +95,10 @@ UA 的教训（`provider.UserAgent` 移除史，user-agent.md §5）仍然成立
 │      SupplyExtraHeaders(p, model)   // provider ∪ model（§3.3）│
 │      PruneModelFlags(m)             // 清空的 model 不留空对象  │
 │                                                             │
-│  internal/typ/provider_flag_registry.go:                    │
-│      ProviderFlagRegistry() []FlagSpec  // provider/model 级可信源（§4）│
 │  internal/typ/flag_registry.go:                             │
-│      RuleFlagRegistry() 追加 extra_headers 条目（rule 级）      │
+│      RuleFlagRegistry()  // 唯一定义，每条声明 Levels（§4）      │
+│  internal/typ/provider_flag_registry.go:                    │
+│      ProviderFlagRegistry()  // 按 provider 级过滤出的切片      │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -146,7 +146,7 @@ module；真正的风险是先例——一个开放的 `Flags` 结构会招揽�
 knob；叫什么，就叫请求侧那个名字。它把"ai 认识产品语义"的风险从"任意
 膨胀"收窄成"跟随一个已存在的、被评审过的集合"。
 
-**没有镜像的三类**（`ProviderFlagRegistry` 的注释里同样列着，
+**没有镜像的三类**（在 registry 里表现为只声明 `FlagLevelRule`，
 `TestProviderFlagRegistry_ExcludesRequestOnlyFlags` 钉住）：
 
 | flag | 不镜像的理由 |
@@ -163,11 +163,12 @@ Rule 级不受影响：RuleFlags 本来就是服务域内的 typed struct（rule
 ### 3.1 ProviderFlags / RuleFlags.ExtraHeaders
 
 ```go
-// internal/typ —— provider 级与 model 级共用
+// internal/typ —— provider 级与 model 级共用同一个结构
 type ProviderFlags struct {
     // ExtraHeaders 追加到发往该 provider 的出站请求。
     // key = header 名（保存时规范化为 canonical form），value = 字面值。
     ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
+    // 其余字段是 RuleFlags 的镜像（§2），字段名与 json tag 逐一对应。
 }
 
 // internal/typ/type.go —— RuleFlags 追加同名同形态字段
@@ -250,28 +251,48 @@ CleanHeader 自动应用与 OAuth 抑制都在这里），供给侧插在同一�
 
 ### Provider/Model 级：新增 `internal/typ/provider_flag_registry.go`
 
-既然字段集是 RuleFlags 的镜像（§2），registry 也不重抄一遍：provider
-registry **由 rule registry 派生**，本文件里只写一张 `key → 供给侧文案`
-的表，其余（Label / Type / Category / Placeholder / Options /
-Suggestions）全部取自同 key 的 rule spec：
+既然字段集是 RuleFlags 的镜像（§2），registry 就**只定义一次**：
+`FlagSpec` 加一个 `Levels []FlagLevel` 轴，声明这个 flag 能配在哪几级；
+`RuleFlagRegistry()` 是唯一的定义，`ProviderFlagRegistry()` 只是按
+`FlagLevelProvider` 过滤出来的一个切片。
 
 ```go
-// providerFlagDescriptions：按展示顺序列出可在 provider/model 级配置的
-// flag + 它的供给侧描述；不在表里的 key 就是"没有供给侧语义"（§2 三类）。
+type FlagLevel string   // "provider" | "model" | "rule"，由宽到窄
+
+type FlagSpec struct {
+    ...
+    Levels []FlagLevel `json:"levels"`
+}
+
 func ProviderFlagRegistry() []FlagSpec {
-    // 取同 key 的 rule spec → 换掉 Description → 清掉 scenario 轴
-    // （Shared / InheritanceMode 属于 rule 轴）
+    // RuleFlagRegistry() 中 HasLevel(FlagLevelProvider) 的那些，
+    // 清掉 scenario 轴（Shared / InheritanceMode 属于 rule 轴）
 }
 ```
 
-这样两个面渲染的控件天生一致（同一个 knob 不会一边是下拉一边是文本框），
-新增 rule flag 时若要开到供给侧，只需在表里加一行文案。
-`TestProviderFlagRegistry_SharesRuleControlShape` 钉住"控件同形、文案不同"，
-`TestProviderFlagRegistry_KeysExistInRuleRegistry` 钉住表里不会出现 rule
-registry 没有的 key（否则会被静默丢弃）。
+**曾经的做法与为何放弃**：最初 provider registry 是一张独立的
+`key → 供给侧文案` 表 + 从 rule spec 取控件形态。评审意见"我们为何不统一
+定义，而是重启定义"——两处定义即使派生了控件形态，仍有两处要维护、两份
+文案要对齐，而"这个 flag 能配在哪几级"本来就是 flag 自己的属性，写在
+spec 上才是它的家。改成 `Levels` 后表整个消失。
 
-**每个 spec 都是 provider + model 两级可配**（合并语义见 §3.3）。不做
-per-spec 的 scope 声明：两个 UI 面都渲染整个 registry。
+**顺带修掉的一件事**：既然一个 flag 只有一条 Description，文案就必须
+**level-neutral**——用户所在的界面已经说明了在编辑哪一级，不需要文案再
+说一遍"for this rule"。改造时发现 16 条里只有 2 条（`extra_headers`、
+`custom_user_agent`）真的写死了 rule 视角，其余本来就是中性的；这反过来
+说明当初那张文案表大部分是在复制粘贴。
+
+**注意**：这不是被删掉的 `Scope`/`MergeMode` 的复活。那两个轴当时没有任何
+生产读取方（唯一的 flag 两级都有、只有一种合法合并），是纯预留；`Levels`
+有 16 条真实数据（12 条三级、4 条仅 rule）、有唯一读取方
+（`ProviderFlagRegistry()`）、且直接决定前端渲染哪些控件。**合并语义**仍然
+不上 spec（那确实是层级的属性，见 §3.3）——`Levels` 声明的是"在哪配"，不是
+"怎么合"。
+
+`TestProviderFlagRegistry_IsARuleRegistrySlice` 钉住派生关系（除 scenario
+轴外逐字段相等），`TestFlagRegistry_LevelsAreDeclared` 钉住每条都声明了
+levels、rule 级普遍存在、且 provider 与 model 同时出现（两级共用同一个
+`ProviderFlags` 结构，不可能只有其一）。
 
 ### Rule 级：`RuleFlagRegistry()` 追加一条
 
@@ -575,7 +596,8 @@ switch/case。实现落点：
 | ai.Provider 扩展容器形态 | `map[string]json.RawMessage` | typed struct / `map[string]any` | ai 是公共 module，必须对内容不知情；RawMessage 无损且物理隔离 schema。typed struct 会把服务语义泄进公共 API |
 | provider flag 的存放位置 | `ai.Provider` 上的 typed 字段 | `Extensions map[string]json.RawMessage` 不透明容器 + 服务侧 well-known key | 容器只有一个消费者，"保护别人 key"的读-改-写保护的是假想消费者（评审意见）。塌缩省 ~135 行；ai 的依赖独立性不变（不引入新 import），语义上 headers 本就属于"如何抵达上游"。代价是 ai 认识 flag schema，用准入规则约束（§2）|
 | provider flag 的字段集 | RuleFlags 的供给侧镜像（12 个），排除三类无供给侧语义的 | 只做 `extra_headers` / 自定义一套供给侧词汇 | 只做 headers 把"上游怪癖"留在了 rule 上重复配置——`use_max_tokens`、`claude_code_compat` 的描述里自己就写着 providers / model family（评审意见：整个 provider flag 系统没实现完）。镜像同时解决准入与命名：能不能加看请求侧有没有，叫什么就叫请求侧的名字 |
-| provider registry 的来源 | 由 `RuleFlagRegistry()` 派生，只覆写 Description | 手写 12 条完整 spec | 同一 knob 两个面必须渲染同一控件；派生让"漂移"在结构上不可能发生，新增一条只写一行文案 |
+| flag 定义的组织方式 | 单一 registry + `FlagSpec.Levels` 声明可配级别 | 每级一个 registry（provider 侧另立文案表，从 rule spec 派生控件形态） | 评审意见："我们为何不统一定义，而是重启定义"。"能配在哪几级"是 flag 自身的属性，写在 spec 上；两处定义即使派生控件形态也仍有两份文案要对齐。副产品：Description 必须 level-neutral，而 16 条里本就有 14 条是中性的 |
+| `Levels` 与被删掉的 `Scope`/`MergeMode` | 加 `Levels`，仍不加 merge 轴 | 一起加回 / 都不加 | `Scope`/`MergeMode` 当时零生产读取方、零真实数据，是预留；`Levels` 有 16 条真实数据、有唯一读取方、直接决定前端渲染。"怎么合"仍是层级属性（§3.3），不上 spec |
 | 非 header flag 的合并 | dispatch 侧一次 `ApplyProviderFlags`，在 `ResolveRuleFlagsWithScenario` 内 | 各注入点自行读三级 / 像 headers 一样靠写入顺序 | 它们注入在 transform 链与 SDK 层，没有"写入顺序"可借；而请求的有效 flag 已有唯一收敛点，插在那里下游零改动。代价：该函数多一个 `model` 形参 |
 | bool 的三级语义 | 三级 OR | 三态（`*bool`，窄级可关掉宽级） | 与既有 scenario→rule `InheritanceMode: "or"` 一致，零新概念；三态要给每个 bool 加指针 + UI 加"继承/开/关"三档，为一个尚未出现的需求付全额成本 |
 | 服务侧 schema 位置 | internal/typ + registry | 散落各消费点 | 复刻 rule flags 的"唯一可信源"模式，前端零 switch/case，已被验证 |
@@ -610,6 +632,8 @@ switch/case。实现落点：
   （§2）。三类无供给侧语义的 flag 显式排除并有测试钉住。
 - ✅ 非 header flag 的三级合并落在 `typ.ApplyProviderFlags`，由
   `ResolveRuleFlagsWithScenario` 单点调用；bool 三级 OR，标量取最窄非零值。
+- ✅ registry 只定义一次：`FlagSpec.Levels` 声明可配级别，
+  `ProviderFlagRegistry()` 退化为按级别过滤的切片；文案改为 level-neutral。
 
 **遗留**（不阻塞实施）：
 

--- a/.design/provider-flags.md
+++ b/.design/provider-flags.md
@@ -1,8 +1,12 @@
-# Provider Extensions & Provider/Model/Rule Flags
+# Provider / Model / Rule Flags
 
-> 状态：**分两个 PR 交付**（api_key-only 发布范围）：
-> PR1 — rule 级 `extra_headers`（含前端，已实现）；
-> PR2 — provider & model 级改造（Extensions 容器、db 列、provider API 与前端）。
+> 状态：**分三段交付**（api_key-only 发布范围）：
+> ① rule 级 `extra_headers`（含前端）—— 已合并 (#1589)；
+> ② provider & model 级后端（Provider.Flags/ModelFlags、db 列、三级合并、provider API）—— 本分支；
+> ③ provider & model 级前端（Plugins 区块、per-model popover）—— 独立 PR，可后续升级。
+>
+> ②③ 拆开的原因：后端能力（含 API 与 registry endpoint）可独立落地并被
+> CLI / 直接调用 API 的使用者消费；UI 是纯增量，晚一步不影响功能可用性。
 > 适用对象：tingly-box 后端 / 前端贡献者。
 > 相关文档：`.design/rule-flags.md`（rule/scenario 级 flag 机制，本设计大量复用其模式）、
 > `.design/user-agent.md`（vendor pin 不可污染的边界，本设计必须尊重）、
@@ -30,14 +34,15 @@ Cloudflare AI Gateway 的网关 header、企业内网网关的租户/审计 head
 向后兼容语义与 dual provider）。OAuth / vendor 特种链、多字段凭证
 （aws_sigv4 / azure_key / gcp_sa）、vmodel 首版不释放（§5.4）。
 
-分层原则（本设计的核心约束）：
+分层原则：
 
-> **对 `ai` module 而言，扩展字段是任意的（opaque）；
-> 对 tingly-box 服务而言，扩展字段有明确定义的 schema 与语义。**
+> **provider/model 级 flag 是"如何抵达这个上游"的属性，与 base URL、auth
+> 一样属于 `ai.Provider`；rule/scenario 级 flag 是网关的产品行为，留在
+> `internal/`。**
 
-`ai/` 是独立 go module、对外公共 API。它不应该知道 tingly-box 服务定义了
-哪些 flag——它只提供一个无 schema 的扩展容器。所有类型化、注册表、校验、
-合并语义都在 `internal/` 落地。
+最初规划过一个不透明扩展容器（"对 ai module 而言是任意的"），实现后按
+评审意见塌缩为 typed 字段——理由与代价见 §2。校验、注册表、合并语义仍全部
+在 `internal/`，ai 只持有数据。
 
 现有 flag 语义由此补全为四层（rule-flags.md §1 的表 + 本设计的前两行）：
 
@@ -63,34 +68,29 @@ UA 的教训（`provider.UserAgent` 移除史，user-agent.md §5）仍然成立
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│  ai module（公共 API，opaque）                                │
+│  ai module（公共 API）                                        │
 │                                                             │
 │  ai.Provider {                                              │
 │      ...                                                    │
-│      Extensions map[string]json.RawMessage `json:"extensions,omitempty"` │
+│      Flags      ProviderFlags            `json:"flags"`      │
+│      ModelFlags map[string]ProviderFlags `json:"model_flags"`│
 │  }                                                          │
 │                                                             │
-│  ai 包不解释内容；任何消费方可用自己的 key 存放任意 JSON。       │
+│  type ProviderFlags struct {                                │
+│      ExtraHeaders map[string]string `json:"extra_headers"`   │
+│      // 后续字段须通过"准入规则"（见下）                        │
+│  }                                                          │
 └──────────────────────────┬──────────────────────────────────┘
-                           │ well-known keys（服务侧独占）
+                           │ typ.ProviderFlags = ai.ProviderFlags（别名）
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
-│  tingly-box 服务（internal/，typed）                          │
-│                                                             │
-│  internal/constant:                                         │
-│      ProviderExtKeyFlags      = "provider_flags"  // ProviderFlags │
-│      ProviderExtKeyModelFlags = "model_flags"  // map[model]ProviderFlags │
+│  tingly-box 服务（internal/）                                 │
 │                                                             │
 │  internal/typ:                                              │
-│      type ProviderFlags struct {                            │
-│          ExtraHeaders map[string]string `json:"extra_headers,omitempty"` │
-│          // 后续 flag 在此追加 typed 字段                       │
-│      }                                                      │
 │      RuleFlags 追加同形态字段：                                │
-│          ExtraHeaders map[string]string `json:"extra_headers,omitempty"` │
-│      GetProviderFlags(p)            // 解 "flags" key         │
-│      GetModelFlags(p, model)        // 解 "model_flags"[model]│
-│      EffectiveExtraHeaders(p, model, ruleFlags) // 三级合并（§3.3）│
+│          ExtraHeaders map[string]string `json:"extra_headers"`│
+│      SupplyExtraHeaders(p, model)   // provider ∪ model（§3.3）│
+│      PruneModelFlags(m)             // 清空的 model 不留空对象  │
 │                                                             │
 │  internal/typ/provider_flag_registry.go:                    │
 │      ProviderFlagRegistry() []FlagSpec  // provider/model 级可信源（§4）│
@@ -99,28 +99,40 @@ UA 的教训（`provider.UserAgent` 移除史，user-agent.md §5）仍然成立
 └─────────────────────────────────────────────────────────────┘
 ```
 
-Rule 级不走 Extensions 容器——RuleFlags 本来就是服务域内的 typed struct
-（rule-flags.md §3），直接加字段即可；Extensions 只解决"公共 module 不能
-认识服务 schema"的问题，Rule 类型不存在这个问题。
+访问方式与 rule flags 完全一致：`p.Flags.ExtraHeaders` / `rule.Flags.ExtraHeaders`，
+没有访问器、没有容器、没有 well-known key。
 
-### 为什么是 `map[string]json.RawMessage` 而不是 `map[string]any`
+### 为什么字段直接放在 ai（而不是不透明扩展容器）
 
-- **无损**：RawMessage 原样保存字节，不经历 `any` 的 float64 化 /
-  key 顺序丢失；ai module "任意"的承诺才真正成立。
-- **强制分层**：ai 包物理上无法"顺手"读懂内容，schema 只能在服务侧定义，
-  防止类型定义渗回公共 module。
-- 服务侧解码是一次小 JSON unmarshal，请求路径成本可忽略（provider 对象
-  在 ClientPool / dispatch 中已被缓存与克隆，必要时可在解析处 memoize，
-  首版不做）。
-- 先例差异说明：`ScenarioConfig.Extensions` 用了 `map[string]interface{}`，
-  但它本身就在 internal/typ（服务域内），没有跨 module 分层需求；
-  ai.Provider 是公共 API，取 RawMessage 更严格。
+最初的规划是给 `ai.Provider` 一个 `Extensions map[string]json.RawMessage`
+不透明容器，服务在两个 well-known key 下放自己的 typed schema——理由是
+"对 ai module 而言扩展字段是任意的"。实现出来后评审判定这是过度设计，
+改为 typed 字段，依据是：
 
-`ResolveStyle` / dual-provider 的 shallow clone 语义不受影响：Extensions
-是引用共享的 map，clone 不深拷贝，所有读取方**只读**（写入只发生在
-usecase 保存路径）。
+1. **容器只有一个消费者**。除 provider flags 外没有任何代码读写它；为
+   "保护别人的 key"而做的读-改-写和它的测试（测试里的 key 字面就叫
+   `someone_elses_key`）保护的是一个假想消费者——与被删掉的
+   `Scope`/`MergeMode` 是同一种投机，只是体量更大。
+2. **ai 的依赖独立性不受影响**。`ProviderFlags` 内部只是
+   `map[string]string`，不引入任何新 import，ai 仍然零依赖 `internal/`。
+3. **语义上并不越界**。ai 自述的职责就是"provider + 如何抵达这个上游"，
+   它已经装着 `OpenAIEndpointMode`、`VModelDetail`、`CredentialBundle`、
+   `Issuer`；`extra_headers`（OpenRouter 的 `HTTP-Referer`、网关租户头）
+   正属于这一类，而不是网关的产品行为。
 
----
+塌缩省掉约 135 行：5 个访问器 + `setExtension` 的读-改-写、db 的
+`cloneExtensions`、以及三个纯容器测试（外键保序 / 畸形 JSON 兜底 /
+extensions wire shape）。
+
+**代价与护栏**：ai 从此认识 flag schema，新增 provider flag 要动公共
+module；真正的风险是先例——一个开放的 `Flags` 结构会招揽产品语义。护栏
+是一条写进 `ai/README.md` 与本文档的准入规则：
+
+> **ai 只接受"描述如何抵达上游"的字段；网关的产品行为（响应改写、客户端
+> 兼容垫片、路由策略……）一律留在 rule flags。**
+
+Rule 级不受影响：RuleFlags 本来就是服务域内的 typed struct（rule-flags.md
+§3），直接加字段即可。
 
 ## 3. 数据模型与合并语义
 
@@ -152,25 +164,33 @@ model ID 精确匹配**（即经过 rule 映射后、实际发给该 provider �
 flag 是供给侧配置，只应认识 provider 自己的模型词汇，不认识客户端别名。
 通配/前缀匹配（如 `gpt-5*`）留作后续扩展，registry 机制不受影响。
 
-### 3.3 三级合并语义（Effective headers）
+### 3.3 三级合并语义
 
-```go
-// EffectiveExtraHeaders(p, model, ruleFlags):
-//   provider 级 ∪ model 级 ∪ rule 级，同名时后者胜出：
-//
-//       provider  <  model  <  rule
-//     （最泛化）              （最贴近本次请求）
+```
+供给侧（客户端构造期，按 (provider, model) 缓存）：
+    SupplyExtraHeaders(p, model) = provider 级 ∪ model 级，model 胜
+
+请求侧（每次 RoundTrip）：
+    GetRuleFlags(ctx).ExtraHeaders                 ← rule 级
+
+最终优先级 = transport 的写入顺序：
+    provider  <  model  <  rule
+  （最泛化）              （最贴近本次请求）
 ```
 
 优先级理由：粒度越贴近"这一次请求"越应胜出。provider 级是全局默认；
 model 级是供给侧对默认的细化；rule 级表达"这一类客户端/用途"的显式
 意图，是三者中最具体的，故最后写入。
 
-对未来的非 map 型 flag（bool/enum），合并模式由 registry 按 flag 声明
-（`MergeMode`：`merge` / `override`），不是全局规则；`extra_headers`
-声明为 `merge`。这与 rule flags 的 `InheritanceMode`（scenario→rule 的
-or/override）同构，但轴不同：`MergeMode` 描述 provider→model→rule 的
-纵向叠加，命名分开以免混淆。
+**没有"三级合并函数"**：供给侧两级在构造期合并一次，rule 级在写 header
+时叠加，`req.Header.Set` 的 canonical 化保证同名（含大小写不同）覆盖。
+详见 §5.1。
+
+合并语义是**层级的属性，不是每个 flag 的属性**：model 级覆盖同名的
+provider 级，就这一条。曾经给 FlagSpec 加过 `Scope` / `MergeMode` 两个轴
+（"这个 flag 存在于哪几级 / 两级怎么合"），但唯一的 flag 两级都有、合法
+只有 merge 一种，没有任何生产代码读它们——纯为想象中的第二个 flag 预留，
+已删除。真出现语义不同的 flag 时再加轴，届时有真实约束可依。
 
 ---
 
@@ -179,10 +199,8 @@ or/override）同构，但轴不同：`MergeMode` 描述 provider→model→rule
 ### Provider/Model 级：新增 `internal/typ/provider_flag_registry.go`
 
 ```go
-// 复用 FlagSpec / FlagValueType / FlagOption（flag_registry.go）
-// FlagSpec 增加两个字段（rule flags 不使用，零值忽略）：
-//   Scope     FlagScope // "provider" | "model" | "both"
-//   MergeMode string    // Scope == "both" 时必填："override" | "merge"
+// 直接复用 FlagSpec / FlagValueType / FlagOption（flag_registry.go），
+// 不给 FlagSpec 加任何 provider 专用字段——与 rule spec 完全同形。
 
 func ProviderFlagRegistry() []FlagSpec {
     return []FlagSpec{
@@ -192,12 +210,13 @@ func ProviderFlagRegistry() []FlagSpec {
             Description: "Append custom HTTP headers to outbound requests ...",
             Type:        FlagValueHeaders, // 新增的 value type，见下
             Category:    FlagCategoryRequest,
-            Scope:       "both",
-            MergeMode:   "merge",
         },
     }
 }
 ```
+
+**每个 spec 都是 provider + model 两级可配**（model 级同名覆盖 provider
+级）。不做 per-spec 的 scope 声明：两个 UI 面都渲染整个 registry。
 
 ### Rule 级：`RuleFlagRegistry()` 追加一条
 
@@ -208,8 +227,8 @@ func ProviderFlagRegistry() []FlagSpec {
     Description: "Append custom HTTP headers to outbound requests for this rule ...",
     Type:        FlagValueHeaders,
     Category:    FlagCategoryRequest,
-    // 无 Shared / InheritanceMode：不做 scenario 级（首版无此需求），
-    // 与 provider/model 级的合并发生在 EffectiveExtraHeaders（§3.3），
+    // 无 Shared / InheritanceMode：不做 scenario 级（首版无此需求）。
+    // 与 provider/model 级的叠加发生在出站 transport（§5.1），
     // 不走 resolveRuleFlagsWithScenario 的 scenario 继承链。
 }
 ```
@@ -224,8 +243,6 @@ func ProviderFlagRegistry() []FlagSpec {
   json tag（`TestProviderFlagRegistry_KeysMatchStructFields`）；
   rule 级 `extra_headers` 由既有 `TestRuleFlagRegistry_KeysMatchStructFields`
   自动覆盖。
-- `Scope` 必须在枚举内；`Scope == "both"` 必须声明 `MergeMode`，
-  其他 Scope 不得声明。
 - `headers` 类型不允许 Options/Suggestions。
 
 Registry 通过新 endpoint 透出给前端（§7），前端 registry-driven 渲染，
@@ -236,56 +253,58 @@ Registry 通过新 endpoint 透出给前端（§7），前端 registry-driven �
 
 ## 5. `extra_headers` 的注入与安全边界
 
-### 5.1 注入点：transport 层
+### 5.1 注入点：统一的 `ruleFlagTransport`，供给侧静态 + rule 级随 ctx
 
-rule 级 `extra_headers` 已由统一的 `ruleFlagTransport`
-（`internal/client/rule_flag_transport.go`，见 rule-flags.md §5 Type 2）
-承载：pass-through 构造器（openai / anthropic / google）显式挂载，
-vendor 链不挂。provider 级 headers（本文档规划部分）沿同一策略加一层：
-
-```
-wrapWithLogging( providerHeadersTransport( ruleFlagTransport( base ) ) )
-                 └── 新增：读 provider 级 headers（构造期解出，不依赖 ctx）
-```
-
-`providerHeadersTransport`：
-
-- **api_key 守卫（首版范围）**：`!provider.IsAPIKey()` 时该 transport
-  为纯透传（no-op）。发布范围由这一个判断收口（配置入口另在 API/UI 层
-  拦截，见 §5.4），后续放开 = 调整这一处守卫 + 对应校验。
-- **provider 级 headers**：构造时从 provider 解出（`GetProviderFlags`），
-  每个 RoundTrip 应用。不依赖 ctx —— 因此 probe、model-list 拉取、
-  visionproxy 等不经 protocol dispatch 的路径也自动生效。
-- **model 级 + rule 级 headers**：dispatch 阶段（rule→provider→model
-  已定型）计算 `EffectiveExtraHeaders(p, model, ruleFlags)` 与 provider
-  级的差集，经 Type 2 手法写入 request
-  ctx——rule 级 headers 是 RuleFlags 的字段，随 `typ.WithRuleFlags`
-  整包挂 ctx，transport 读 `typ.GetRuleFlags(ctx).ExtraHeaders`；transport 读到则叠加（合并优先级已在 dispatch 侧算好，transport
-  只做"provider 级打底、ctx 覆盖"两步）。ctx 缺失时退化为仅 provider
-  级 —— 这是非 dispatch 路径（无 rule、无 model 语境）的预期行为。
-
-rule 级选择与 model 级共用同一个 ctx key 而不是单独一个：transport 只
-认"本次请求的增量 header"一个概念，三级优先级是 dispatch 侧
-`EffectiveExtraHeaders` 的职责——合并逻辑集中一处，transport 保持哑。
-
-### 5.2 顺序不变量：vendor pin 永远胜出（对首版是防御，For 未来是边界）
-
-首版只释放 api_key，generic 链上没有 vendor pin，本节在 v1 实际不触发；
-但机制上 `providerHeadersTransport` 挂在所有构造器的统一包装点，**顺序
-不变量从第一天就要成立**，为后续放开 OAuth 特种链保底：
+上游把出站 rule flag 收敛成一个 ctx key + 一个 transport
+（`internal/client/rule_flag_transport.go`，见 rule-flags.md §5 Type 2）：
+pass-through 构造器（openai / anthropic / google）显式挂载 `wrapWithRuleFlags`，
+vendor 链一律不挂。三级 headers **复用这一层**，不新增 transport：
 
 ```
-providerHeadersTransport      ← 外层：先写入用户 extra headers
-  vendorRoundTripper / SDK    ← 内层（更靠近 wire）：后写入 vendor pin
-    wire                          同名时后写者胜 → vendor pin 决定性
+wrapWithRuleFlags(base, provider, model, resolveUA)
+   ├── 构造期：supplyHeaders = typ.SupplyExtraHeaders(provider, model)   ← 供给侧两级
+   └── RoundTrip：先写 supplyHeaders，再写 GetRuleFlags(ctx).ExtraHeaders ← rule 级
 ```
 
-`.design/user-agent.md` 的结论在这里同样成立：vendor 特种链上由握手 /
-指纹协议绑定的 header（UA、`x-stainless-*`、`X-Msh-*`、
-`X-ChatGPT-Account-ID`、session header 等）不可被任何用户配置覆盖。
-护栏：给该顺序写回归测试（stub inner 断言最终 header 值）；并延续
-rule-flags.md §8 的警告——**vendor 链内部永远不得引入
-providerHeadersTransport**。
+关键点：
+
+- **供给侧（provider ∪ model）在构造期解出**。client 本就按
+  `(provider, model)` 缓存（`ClientKey`），三个挂载点全都持有 `model`，
+  所以模型级 headers 不需要经过 dispatch——`typ.SupplyExtraHeaders` 在
+  wrap 时算一次，之后每个 RoundTrip 直接用，JSON 不重复解码。
+  不依赖 ctx 也意味着 probe、model-list 拉取、visionproxy 等不经
+  protocol dispatch 的路径同样带上上游配置的 header。
+- **rule 级仍是 rule flag**，随 `typ.WithRuleFlags` 整包挂 ctx，transport
+  读 `typ.GetRuleFlags(ctx).ExtraHeaders`。**不把三级合并塞进这个 ctx
+  值**：它的契约是"本次请求解析出的 RuleFlags"，混入供给侧配置会让
+  `X-Tingly-Applied-Flags` 之类的诊断把 provider 配置报成 rule flag。
+- **优先级由写入顺序产生，没有第四方合并函数**：supply 先写、rule 后写、
+  UA 最后写，`req.Header.Set` 自带 canonical 化，于是
+  `provider < model < rule < UA 解析 < 内层链` 自然成立。
+- **api_key 守卫沿用同一处**：`wrapWithRuleFlags` 在 wrap 时判定
+  `provider.IsAPIKey()`，false 则 supply headers 根本不装载（且当该链也
+  不需要 UA 解析时直接返回 inner）。发布范围由这一个判断收口，配置入口
+  另在 API 层拦截（§5.4）。
+
+### 5.2 顺序不变量：vendor pin 永远胜出
+
+vendor 链（Claude OAuth / Codex / Kimi / Gemini / Antigravity）**根本不挂
+这一层**——上游重构后这条边界由结构保证，不再依赖注释里的不变量，因此
+任何级别的 headers 都到不了 vendor 握手。
+
+在挂载了该层的 pass-through 链上，内层（更靠近 wire）仍然后写后胜：
+
+```
+ruleFlagTransport             ← 外层：supply → rule → UA
+  SDK / inner round-tripper   ← 内层：后写者胜
+    wire
+```
+
+`.design/user-agent.md` 的结论同样成立：握手 / 指纹绑定的 header
+（UA、`x-stainless-*`、`X-Msh-*`、`X-ChatGPT-Account-ID`、session header）
+不可被用户配置覆盖。护栏：`rule_flag_transport_test.go` 里的
+`TestRuleFlagTransport_VendorPinWins`（stub inner 断言最终值）+
+**vendor 链内部永远不得挂 `wrapWithRuleFlags`**。
 
 ### 5.3 Header 校验 —— 用户主导，只查结构
 
@@ -337,21 +356,15 @@ vendor pin 与 UA 链在更内层（更靠近 wire）后写后胜（§5.2）；�
 Provider / model 级沿用 `credential` / `vmodel_detail` 的既定先例
 （`internal/db/provider_store.go`）：
 
-- `ProviderRecord` 新增一个 `extensions` TEXT 列，内容为
-  `ai.Provider.Extensions` 整个 map 的 JSON。
+- `ProviderRecord` 新增 `flags` / `model_flags` 两个 TEXT 列
+  （`serializer:json`，与 `credential` / `vmodel_detail` 同模式）。
 - GORM `AutoMigrate` 增列即生效，**无需 migration 脚本、无需回填**
-  （零值 = 无扩展）。
-- `toProvider` / `toRecord` / `updateRecordFromProvider` 三处映射函数
-  各加一段 marshal/unmarshal（与 credential 的处理完全同形）。
-- 服务侧不认识的 key（其他消费方存的任意扩展）随整个 map 原样存取，
-  **update 时必须整 map 读-改-写，不得只写服务自己的两个 key**（否则
-  丢别人的数据）。
-
-Rule 级零持久化改动：RuleFlags 本就以 JSON 列随 rule 行存储
-（rule-flags.md §2），加字段即可。
+  （零值 = 未配置）。
+- `toProvider` / `toRecord` / `updateRecordFromProvider` 三处映射各加两行
+  clone（与其他 JSON 列一样做缓存隔离）。
 
 Provider export / import（`/provider-export`、`/provider-import`）随
-Provider JSON 自然携带 extensions；import 侧对 `flags` / `model_flags`
+Provider JSON 自然携带这两个字段；import 侧对 `flags` / `model_flags`
 两个 well-known key 执行与 API 相同的校验（§5.3 + §5.4 的 auth type
 门），非法拒绝导入并报明确错误。
 
@@ -379,8 +392,7 @@ GET  /api/v1/provider/flags/registry     // ProviderFlagRegistry() → 前端渲
 // CreateProviderRequest 同步新增两个可选字段。
 ```
 
-- handler 侧写入路径：读出 provider → 改 `Extensions["flags"]` /
-  `Extensions["model_flags"]` → 保存（整 map 读-改-写，见 §6）。
+- handler 侧写入路径：读出 provider → 赋 `p.Flags` / `p.ModelFlags` → 保存。
 - 校验集中在 `ValidateExtraHeaders`（§5.3）+ auth type 门（§5.4），
   Create / Update / Import 三处共用。
 - `model_flags` 的 model key 不强校验存在于 `Provider.Models`（模型列表
@@ -402,8 +414,8 @@ switch/case。实现落点：
 
 1. **新控件类型 `headers`（一次性投入，三处共用）**：
    `components/flags/HeadersEditor.tsx` —— 可增删的 KV 行编辑器,行内
-   即时校验(denylist / 非法字符 / 大小写不敏感重复,直接标红并给出
-   原因,教育内嵌于产品;denylist 与后端 `ValidateExtraHeaders` 镜像)。
+   即时校验(非法字符 / 大小写不敏感重复,直接标红并给出原因——仅结构
+   校验,无 denylist,与后端 `ValidateExtraHeaders` 镜像,见 §5.3)。
    接入 `FlagCatalogDialog` 的类型分发(`spec.Type` 驱动,与 bool/
    string/enum/int/service_ref 并列新增一个分支)。
 2. **Rule 级入口**：零布局改动——`extra_headers` 出现在既有
@@ -415,7 +427,7 @@ switch/case。实现落点：
    内(edit 模式)渲染 `ProviderPluginsBlock` —— 与 rule 侧同构的
    "Plugins 卡片 + 目录弹窗"交互:折叠卡片列出 active flag 与具体值,
    点击打开共享的 `FlagCatalogDialog`(标题 "Provider Plugins",registry
-   来自 `GET /provider/flags/registry`,按 `Scope` 含 provider 过滤)。
+   来自 `GET /provider/flags/registry`)。
    该编辑框本身只服务 api_key 域(oauth/cloud 走别的对话框),天然满足
    §5.4 的 UI 门。
 4. **Model 级入口**：`ModelCard`(模型管理面)hover 工具条加
@@ -439,11 +451,11 @@ switch/case。实现落点：
 
 | 层 | 内容 |
 |---|---|
-| registry 护栏 | ProviderFlagRegistry Key ↔ `ProviderFlags` json tag 同步；rule 级由既有 KeysMatchStructFields 覆盖；Scope/MergeMode 约束 |
-| 合并语义 | `EffectiveExtraHeaders`：仅 provider / 仅 model / 仅 rule / 三级同名覆盖顺序（provider < model < rule）/ 都为空 |
-| 校验 | denylist、canonical 化、token 合法性、数量/尺寸上限；非 api_key provider 拒绝；三个写入口都过同一校验 |
-| transport | headers 落到出站请求；ctx 叠加覆盖 provider 级；**非 api_key no-op 守卫**；**vendor pin 胜出的顺序回归**（为未来放开保底）；denylist 第二道防御；vmodel 路径 no-op |
-| db | extensions 列 round-trip；含未知 key 的整 map 读-改-写不丢数据 |
+| registry 护栏 | ProviderFlagRegistry Key ↔ `ProviderFlags` json tag 同步；rule 级由既有 KeysMatchStructFields 覆盖 |
+| 合并语义 | `SupplyExtraHeaders`：仅 provider / 仅 model / model 不匹配 / 大小写碰撞 / 都为空；transport 侧再验三级同名覆盖顺序（provider < model < rule）|
+| 校验 | 仅结构性:token/值合法性、大小写不敏感重名、canonical 化(无 denylist/上限,§5.3);非 api_key provider 拒绝;三个写入口都过同一校验 |
+| transport | headers 逐字落到出站请求(无过滤);ctx 叠加覆盖 provider 级;**非 api_key no-op 守卫**;**vendor pin 胜出的顺序回归**(为未来放开保底);vmodel 路径 no-op |
+| db | flags / model_flags 列 round-trip；缓存隔离（调用方改动不回灌 store）|
 | API | partial update 语义（nil 不动 / 非 nil 替换）；builtin 拒绝；rule 保存路径校验生效；export→import round-trip 含校验 |
 | e2e（后补） | 三级各配一部分 header → mock upstream 断言合并结果（依赖 mock provider fixture，同 rule flags 的待办） |
 
@@ -453,31 +465,32 @@ switch/case。实现落点：
 
 ```
 1. ai/provider.go
-   └─ Provider 增加 Extensions map[string]json.RawMessage（含只读语义注释）
+   └─ Provider 增加 Flags / ModelFlags + ProviderFlags struct（含准入规则注释）
 
 2. internal/constant
    └─ ProviderExtKeyFlags / ProviderExtKeyModelFlags 常量
 
 3. internal/typ
    ├─ provider_flags.go：ProviderFlags struct + Get/Set 帮助函数
-   │   （Set 系列负责整 map 读-改-写）+ EffectiveExtraHeaders（三级合并）
+   │   （Set 系列负责整 map 读-改-写）+ SupplyExtraHeaders（供给侧合并）
    ├─ type.go：RuleFlags 加 ExtraHeaders 字段（json/yaml tag: extra_headers）
-   ├─ flag_registry.go：FlagSpec 增加 Scope / MergeMode 字段；
-   │   FlagValueType 增加 "headers"；RuleFlagRegistry() 追加 extra_headers
+   ├─ flag_registry.go：FlagValueType 增加 "headers"；RuleFlagRegistry()
+   │   追加 extra_headers（FlagSpec 本身不加任何 provider 专用字段）
    ├─ provider_flag_registry.go：ProviderFlagRegistry()
-   └─ id.go：rule 级 headers 随 WithRuleFlags / GetRuleFlags 整包传递（Type 2）
+   └─ （ctx 侧无需新增：rule 级 headers 已随 typ.WithRuleFlags 整包传递）
 
 4. internal/db/provider_store.go
-   └─ extensions 列 + 三处映射（rule 侧零改动）
+   └─ flags / model_flags 两列 + 三处映射（rule 侧零改动）
 
 5. internal/client
-   ├─ provider_headers_transport.go：providerHeadersTransport
-   │   （含 IsAPIKey 守卫 + denylist 二道防御）
-   └─ 挂载策略同 rule 级 ruleFlagTransport：pass-through 构造器显式挂载，vendor 链不挂
+   ├─ rule_flag_transport.go：wrapWithRuleFlags 增 model 入参
+   │   （含 IsAPIKey 守卫;逐字应用,无过滤）
+   └─ 在 wrapWithLogging 接入点外侧统一挂载（一处改动覆盖全部构造器）
 
-6. protocol dispatch
-   └─ provider+model+rule 定型处调用 EffectiveExtraHeaders，
-      与 provider 级的差集写入 ctx
+6. protocol dispatch —— 无需改动
+   └─ 旧规划让 dispatch 计算三级合并再写 ctx；上游把出站 rule flag 收敛成
+      单一 ctx key 后，供给侧改在 client 构造期解出，`ResolveRuleFlagsWithScenario`
+      与 4 个 handler 的签名都不用动
 
 7. internal/server/module/provider + module/rule
    ├─ provider/types.go / handler.go：请求响应模型 + ValidateExtraHeaders
@@ -505,22 +518,22 @@ switch/case。实现落点：
 | 选项 | 已采纳 | 备择 | 取舍理由 |
 |------|--------|------|----------|
 | ai.Provider 扩展容器形态 | `map[string]json.RawMessage` | typed struct / `map[string]any` | ai 是公共 module，必须对内容不知情；RawMessage 无损且物理隔离 schema。typed struct 会把服务语义泄进公共 API |
+| provider flag 的存放位置 | `ai.Provider` 上的 typed 字段 | `Extensions map[string]json.RawMessage` 不透明容器 + 服务侧 well-known key | 容器只有一个消费者，"保护别人 key"的读-改-写保护的是假想消费者（评审意见）。塌缩省 ~135 行；ai 的依赖独立性不变（不引入新 import），语义上 headers 本就属于"如何抵达上游"。代价是 ai 认识 flag schema，用准入规则约束（§2）|
 | 服务侧 schema 位置 | internal/typ + registry | 散落各消费点 | 复刻 rule flags 的"唯一可信源"模式，前端零 switch/case，已被验证 |
 | rule 级是否同步支持 | ✅ 三级统一 | 仅 provider/model | headers 三级各有真实语义（网关固有 / 模型灰度 / 客户端标记）；rule 级复用既有 RuleFlags 机制近乎零成本，一次做齐避免二次开口 |
-| rule 级走 Extensions 还是 RuleFlags | RuleFlags 加字段 | Rule 也做 opaque 容器 | Rule 类型在服务域内，不存在跨 module schema 问题；opaque 容器只为公共 module 存在 |
 | 三级合并顺序 | provider < model < rule | rule < model < provider | 粒度越贴近单次请求越应胜出；rule 是显式的请求侧意图 |
 | 首版发布范围 | 仅 api_key | 全 auth type | vendor 特种链有握手/指纹边界、SigV4 有签名敏感性，验证成本高；api_key 覆盖绝大多数真实需求（OpenRouter/网关/自建端点）。范围由 UI 隐藏 + API 校验 + transport 守卫三道闸收口，放开时逐道解除 |
 | extra_headers 形态 | `map[string]string` | `[]HeaderKV`（有序可重复） | 配置型 header 不需要重复/顺序；与 probe headers 先例一致；UI 简单；三级同形态合并函数唯一 |
-| model flag 合并 | 按 flag 声明 MergeMode（headers=merge） | 一律 override | headers 的自然语义是叠加覆写；未来 bool flag 需要 override——语义属于 flag 本身，进 registry |
-| 注入点 | transport 层（ruleFlagTransport，一处） | ClientPool 逐构造器传 option | option 类型按 SDK 分裂（openai/anthropic/google 各一套），transport 一处覆盖所有 auth type 与 style |
-| model/rule 级 ctx 传递 | 单一 ctx key（dispatch 侧合并好） | 每级一个 ctx key | transport 保持哑，合并逻辑集中在 EffectiveExtraHeaders 一处 |
+| model flag 合并 | 层级属性：model 级同名覆盖 provider 级 | 每个 flag 用 registry 的 `MergeMode` 声明 | 曾按 flag 声明（Scope/MergeMode 两个轴），但唯一的 flag 两级都有、只有 merge 合法，无任何生产读取方——纯预留结构，已删。有语义不同的 flag 时再加，届时有真实约束 |
+| 注入点 | transport 层（wrapWithLogging 旁，一处） | ClientPool 逐构造器传 option | option 类型按 SDK 分裂（openai/anthropic/google 各一套），transport 一处覆盖所有 auth type 与 style |
+| 供给侧 headers 的解析时机 | client 构造期（wrap 时按 (provider, model) 解出） | dispatch 侧算好三级合并写进 ctx | client 本就按 provider+model 缓存，构造期解一次即可，JSON 不重复解码；且 rule flags 的 ctx key 契约保持"只装 RuleFlags"，诊断不会把 provider 配置报成 rule flag。代价是优先级由写入顺序表达，需在 transport 注释与测试中写清 |
 | vendor pin 冲突 | 物理顺序保证 pin 胜出 | 逐 header 判断 | v1 不触发（api_key only），但顺序不变量零维护成本，为放开 OAuth 保底 |
 | denylist / 上限 | **不做**（用户主导，配错自负） | 拒绝 Authorization/UA/传输头 + 数量尺寸上限 | 评审定调：编排器必须可任意配置，"custom" 即特殊需求，过度限制是过度设计。与网关自管 header 的冲突交给 transport 链顺序（pin 在内层后写后胜），不做过滤 |
 | 校验时机 | 保存时拒绝（仅结构合法性） | 发请求时静默失败 | 非法 token/重名在保存时报错比 net/http 发送期报错清晰；结构校验不是限制而是"配置无定义" |
-| API 形态 | typed `flags`/`model_flags` 字段 | 直接暴露 opaque extensions | REST 契约是服务 surface，必须 typed；opaque 容器只是存储与公共 module 之间的运输形态 |
-| 持久化 | 单 `extensions` JSON 列 | 每 flag 一列 | credential/vmodel_detail 先例；增 flag 零 DDL；provider 行不因 flag 增长而加宽 |
+| API 形态 | typed `flags`/`model_flags` 字段 | —— | 与存储、与 ai 的字段同形，DTO 不再需要编解码 |
+| 持久化 | `flags` / `model_flags` 两个 JSON 列 | 每 flag 一列 | credential/vmodel_detail 先例；增 flag 零 DDL |
 | model key 匹配 | 精确匹配 | 通配/前缀 | 首版从简；registry 与数据形态不阻碍后续加 pattern |
-| UI 命名 | 复用 "Plugins" | 新词（Extensions/Custom Headers） | 词汇全局统一：同一交互心智（registry 目录 + 卡片）应同名；scope 差异由所在 surface（provider 编辑框 vs rule 卡片）表达 |
+| UI 命名 | 复用 "Plugins" | 新词（Custom Headers 等） | 词汇全局统一：同一交互心智（registry 目录 + 卡片）应同名；scope 差异由所在 surface（provider 编辑框 vs rule 卡片）表达 |
 | 非 api_key 的 UI 呈现 | 隐藏入口 | 灰置 + 提示 | 减少视觉噪音：不解释一个当前用不了的功能；放开时再出现 |
 
 ---

--- a/ai/README.md
+++ b/ai/README.md
@@ -169,6 +169,26 @@ concepts are separate — a future builtin could carry a real API key.
 
 ---
 
+## `Flags` / `ModelFlags`
+
+`ProviderFlags` carries options that describe **how to reach this upstream**,
+at two levels: `Provider.Flags` applies to every request to the provider, and
+`Provider.ModelFlags[model]` overrides it for one provider-side model.
+
+| Field | Meaning |
+|---|---|
+| `extra_headers` | Extra HTTP headers appended to outbound requests, verbatim. For upstreams that gate on their own headers (OpenRouter's `HTTP-Referer` / `X-Title`, gateway tenant or audit headers). |
+
+**Admission rule for new fields.** This struct is deliberately narrow: only
+things a caller must know *to talk to the upstream* belong here — the same
+job the rest of `Provider` does (base URLs, auth, protocol metadata). Product
+behaviour of a gateway sitting in front of the upstream (response rewriting,
+client compatibility shims, routing policy, …) does **not** belong here; in
+tingly-box that is what rule flags are for. Without this line the struct
+becomes a dumping ground and this package stops being reusable on its own.
+
+---
+
 ## Model ordering in the UI
 
 When the model-select dialog lists providers, `auth_type` determines sort

--- a/ai/provider.go
+++ b/ai/provider.go
@@ -80,73 +80,34 @@ func (c *CredentialBundle) Field(key string) string {
 	return c.Fields[key]
 }
 
-// ProviderFlags carries the supply-side flags for one upstream. It exists at
-// two levels on Provider: provider-wide (Provider.Flags) and per-model
-// (Provider.ModelFlags), and a consumer combines them with its own
-// request-side flags in the order
+// ProviderFlags carries the supply-side flags for one upstream, at two levels
+// on Provider: provider-wide (Flags) and per-model (ModelFlags). A consumer
+// combines them with its own request-side flags, narrowest level winning.
 //
-//	provider  <  model  <  request
-//
-// so the narrower level always wins. The field set deliberately mirrors the
-// consumer's request-side flag set (in tingly-box: typ.RuleFlags) rather than
-// being a separate vocabulary — the same knob means the same thing wherever
-// it is set, and only the level changes. Fields whose effect is decided
-// before an upstream is picked (routing, load balancing) have no supply-side
-// meaning and are absent.
-//
-// Combination semantics, uniform per field kind and therefore not declared
-// per field: bools OR together (any level enabling it activates the flag);
-// scalars take the narrowest non-zero value; maps merge per key with the
-// narrower level winning a key conflict.
-//
+// The field set mirrors the consumer's request-side flag set (in tingly-box:
+// typ.RuleFlags) instead of inventing a supply-side vocabulary — the same knob
+// means the same thing wherever it is set. Flags decided before an upstream is
+// picked (routing, load balancing) have no meaning here and are absent.
 // See .design/provider-flags.md.
 type ProviderFlags struct {
-	// ExtraHeaders are appended to outbound requests, verbatim. Header names
-	// are stored in canonical form. Typical uses are upstreams that gate on
-	// their own headers (OpenRouter's HTTP-Referer / X-Title, gateway tenant
-	// or audit headers).
+	// ExtraHeaders are appended to outbound requests verbatim, names in
+	// canonical form (OpenRouter's HTTP-Referer / X-Title, tenant headers, …).
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
 
-	// CustomUserAgent overrides the User-Agent sent to this upstream. Empty
-	// means do not override.
 	CustomUserAgent string `json:"custom_user_agent,omitempty"`
 
-	// UseMaxCompletionTokens rewrites `max_tokens` → `max_completion_tokens`
-	// for this upstream; UseMaxTokens rewrites it the other way. Which one an
-	// upstream needs is a property of the upstream (or of one model family on
-	// it), which is why both live here as well as request-side.
 	UseMaxCompletionTokens bool `json:"use_max_completion_tokens,omitempty"`
 	UseMaxTokens           bool `json:"use_max_tokens,omitempty"`
 
-	// BlockTools is a comma-separated list of tool names to strip before
-	// forwarding, for upstreams that reject or mishandle specific tools.
-	BlockTools string `json:"block_tools,omitempty"`
-
-	// ThinkingEffort forces extended thinking on/off at a given level for this
-	// upstream. Empty means "leave it to the request side".
+	BlockTools     string `json:"block_tools,omitempty"`
 	ThinkingEffort string `json:"thinking_effort,omitempty"`
+	SkipUsage      bool   `json:"skip_usage,omitempty"`
 
-	// SkipUsage strips the usage block from this upstream's responses, for
-	// upstreams whose usage accounting is absent or wrong.
-	SkipUsage bool `json:"skip_usage,omitempty"`
-
-	// ClaudeCodeCompat folds Claude Code's mid-conversation system-role
-	// messages into neighbouring user turns — required by Anthropic-compatible
-	// upstreams that reject that role.
 	ClaudeCodeCompat bool `json:"claude_code_compat,omitempty"`
-
-	// CleanHeader strips Claude Code's billing header blocks and geolocation
-	// markers from system messages before they reach this upstream.
-	CleanHeader bool `json:"clean_header,omitempty"`
-
-	// CursorCompat / CursorCompatAuto apply the Cursor normalizations for
-	// upstreams that need them, always or on header detection.
+	CleanHeader      bool `json:"clean_header,omitempty"`
 	CursorCompat     bool `json:"cursor_compat,omitempty"`
 	CursorCompatAuto bool `json:"cursor_compat_auto,omitempty"`
-
-	// Context1M requests Anthropic's 1M context window. Support is a property
-	// of the model, which is why this is most useful at the model level.
-	Context1M bool `json:"context_1m,omitempty"`
+	Context1M        bool `json:"context_1m,omitempty"`
 }
 
 // IsZero reports whether the flags carry no configuration at all.

--- a/ai/provider.go
+++ b/ai/provider.go
@@ -80,28 +80,89 @@ func (c *CredentialBundle) Field(key string) string {
 	return c.Fields[key]
 }
 
-// ProviderFlags carries per-provider options that describe *how to reach this
-// upstream* — the same job the rest of this type does (base URLs, auth,
-// protocol metadata). It exists at two levels on Provider: provider-wide
-// (Provider.Flags) and per-model (Provider.ModelFlags), where a model-level
-// value overrides the provider-level one for that model.
+// ProviderFlags carries the supply-side flags for one upstream. It exists at
+// two levels on Provider: provider-wide (Provider.Flags) and per-model
+// (Provider.ModelFlags), and a consumer combines them with its own
+// request-side flags in the order
 //
-// Admission rule for new fields, so this struct cannot drift into a dumping
-// ground: only things a caller must know to talk to the upstream belong
-// here. Product behaviour of a gateway in front of it (response rewriting,
-// client compatibility shims, routing policy, …) does not — in tingly-box
-// that is what rule flags are for. See .design/provider-flags.md.
+//	provider  <  model  <  request
+//
+// so the narrower level always wins. The field set deliberately mirrors the
+// consumer's request-side flag set (in tingly-box: typ.RuleFlags) rather than
+// being a separate vocabulary — the same knob means the same thing wherever
+// it is set, and only the level changes. Fields whose effect is decided
+// before an upstream is picked (routing, load balancing) have no supply-side
+// meaning and are absent.
+//
+// Combination semantics, uniform per field kind and therefore not declared
+// per field: bools OR together (any level enabling it activates the flag);
+// scalars take the narrowest non-zero value; maps merge per key with the
+// narrower level winning a key conflict.
+//
+// See .design/provider-flags.md.
 type ProviderFlags struct {
 	// ExtraHeaders are appended to outbound requests, verbatim. Header names
 	// are stored in canonical form. Typical uses are upstreams that gate on
 	// their own headers (OpenRouter's HTTP-Referer / X-Title, gateway tenant
 	// or audit headers).
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
+
+	// CustomUserAgent overrides the User-Agent sent to this upstream. Empty
+	// means do not override.
+	CustomUserAgent string `json:"custom_user_agent,omitempty"`
+
+	// UseMaxCompletionTokens rewrites `max_tokens` → `max_completion_tokens`
+	// for this upstream; UseMaxTokens rewrites it the other way. Which one an
+	// upstream needs is a property of the upstream (or of one model family on
+	// it), which is why both live here as well as request-side.
+	UseMaxCompletionTokens bool `json:"use_max_completion_tokens,omitempty"`
+	UseMaxTokens           bool `json:"use_max_tokens,omitempty"`
+
+	// BlockTools is a comma-separated list of tool names to strip before
+	// forwarding, for upstreams that reject or mishandle specific tools.
+	BlockTools string `json:"block_tools,omitempty"`
+
+	// ThinkingEffort forces extended thinking on/off at a given level for this
+	// upstream. Empty means "leave it to the request side".
+	ThinkingEffort string `json:"thinking_effort,omitempty"`
+
+	// SkipUsage strips the usage block from this upstream's responses, for
+	// upstreams whose usage accounting is absent or wrong.
+	SkipUsage bool `json:"skip_usage,omitempty"`
+
+	// ClaudeCodeCompat folds Claude Code's mid-conversation system-role
+	// messages into neighbouring user turns — required by Anthropic-compatible
+	// upstreams that reject that role.
+	ClaudeCodeCompat bool `json:"claude_code_compat,omitempty"`
+
+	// CleanHeader strips Claude Code's billing header blocks and geolocation
+	// markers from system messages before they reach this upstream.
+	CleanHeader bool `json:"clean_header,omitempty"`
+
+	// CursorCompat / CursorCompatAuto apply the Cursor normalizations for
+	// upstreams that need them, always or on header detection.
+	CursorCompat     bool `json:"cursor_compat,omitempty"`
+	CursorCompatAuto bool `json:"cursor_compat_auto,omitempty"`
+
+	// Context1M requests Anthropic's 1M context window. Support is a property
+	// of the model, which is why this is most useful at the model level.
+	Context1M bool `json:"context_1m,omitempty"`
 }
 
 // IsZero reports whether the flags carry no configuration at all.
 func (f ProviderFlags) IsZero() bool {
-	return len(f.ExtraHeaders) == 0
+	return len(f.ExtraHeaders) == 0 &&
+		f.CustomUserAgent == "" &&
+		!f.UseMaxCompletionTokens &&
+		!f.UseMaxTokens &&
+		f.BlockTools == "" &&
+		f.ThinkingEffort == "" &&
+		!f.SkipUsage &&
+		!f.ClaudeCodeCompat &&
+		!f.CleanHeader &&
+		!f.CursorCompat &&
+		!f.CursorCompatAuto &&
+		!f.Context1M
 }
 
 // OAuthDetail contains OAuth-specific authentication information

--- a/ai/provider.go
+++ b/ai/provider.go
@@ -80,6 +80,30 @@ func (c *CredentialBundle) Field(key string) string {
 	return c.Fields[key]
 }
 
+// ProviderFlags carries per-provider options that describe *how to reach this
+// upstream* — the same job the rest of this type does (base URLs, auth,
+// protocol metadata). It exists at two levels on Provider: provider-wide
+// (Provider.Flags) and per-model (Provider.ModelFlags), where a model-level
+// value overrides the provider-level one for that model.
+//
+// Admission rule for new fields, so this struct cannot drift into a dumping
+// ground: only things a caller must know to talk to the upstream belong
+// here. Product behaviour of a gateway in front of it (response rewriting,
+// client compatibility shims, routing policy, …) does not — in tingly-box
+// that is what rule flags are for. See .design/provider-flags.md.
+type ProviderFlags struct {
+	// ExtraHeaders are appended to outbound requests, verbatim. Header names
+	// are stored in canonical form. Typical uses are upstreams that gate on
+	// their own headers (OpenRouter's HTTP-Referer / X-Title, gateway tenant
+	// or audit headers).
+	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
+}
+
+// IsZero reports whether the flags carry no configuration at all.
+func (f ProviderFlags) IsZero() bool {
+	return len(f.ExtraHeaders) == 0
+}
+
 // OAuthDetail contains OAuth-specific authentication information
 type OAuthDetail struct {
 	AccessToken  string                 `json:"access_token"`           // OAuth access token
@@ -218,6 +242,13 @@ type Provider struct {
 	// Codex OAuth completion. Routing reads this; users do not edit it
 	// directly. See the OpenAIEndpointMode constants for semantics.
 	OpenAIEndpointMode OpenAIEndpointMode `json:"openai_endpoint_mode,omitempty"`
+
+	// Flags carries provider-level options, and ModelFlags the per-model
+	// overrides keyed by the provider-side model ID. Both are shared by
+	// shallow clones (ResolveStyle etc.), so readers must treat them as
+	// read-only and writers replace whole values on the save path.
+	Flags      ProviderFlags            `json:"flags,omitempty"`
+	ModelFlags map[string]ProviderFlags `json:"model_flags,omitempty"`
 }
 
 // OpenAIEndpointMode declares this provider's support for the OpenAI Chat

--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -133,7 +133,7 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 // vertexAnthropicOptions).
 func anthropicTransport(provider *typ.Provider, model string, sessionID typ.SessionID) http.RoundTripper {
 	base := GetGlobalTransportPool().GetTransport(provider.UUID, model, provider.ProxyURL, ai.Issuer(""), sessionID)
-	return wrapWithLogging(wrapWithAdvisorLoopback(wrapWithRuleFlags(base, provider, true)), provider)
+	return wrapWithLogging(wrapWithAdvisorLoopback(wrapWithRuleFlags(base, provider, model, true)), provider)
 }
 
 // ProviderType returns the provider type

--- a/internal/client/google.go
+++ b/internal/client/google.go
@@ -61,7 +61,7 @@ func NewGoogleClient(provider *typ.Provider, model string, sessionID typ.Session
 	httpClient := &http.Client{
 		// resolveUA=false: the generic Google path has never forwarded
 		// rule/client UA.
-		Transport: wrapWithLogging(wrapWithRuleFlags(transport, provider, false), provider),
+		Transport: wrapWithLogging(wrapWithRuleFlags(transport, provider, model, false), provider),
 		Timeout:   timeout,
 	}
 	return newGoogleClientFromHTTPClient(provider, httpClient)

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -74,7 +74,7 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 	// proxy variables (HTTP_PROXY / HTTPS_PROXY) are not inherited when no
 	// proxy is explicitly configured for the provider.
 	base := GetGlobalTransportPool().GetTransport(provider.UUID, model, provider.ProxyURL, ai.Issuer(""), sessionID)
-	transport = wrapWithRuleFlags(base, provider, true)
+	transport = wrapWithRuleFlags(base, provider, model, true)
 	transport = wrapWithAdvisorLoopback(transport)
 	transport = wrapWithLogging(transport, provider)
 

--- a/internal/client/rule_flag_transport.go
+++ b/internal/client/rule_flag_transport.go
@@ -15,7 +15,13 @@ import (
 //
 //   - extra_headers: api_key providers only (release gate, mirroring the API
 //     validation gate). Vendor/OAuth/multi-field-credential chains never see
-//     rule-configured headers.
+//     configured headers. Two sources meet here: the supply-side
+//     provider ∪ model headers, resolved once at wrap time (this transport is
+//     built per client, and clients are keyed by provider + model), and the
+//     rule's own extra_headers off the request context. Supply-side headers
+//     are written first and the rule's second, so the documented precedence
+//     provider < model < rule falls out of the write order — nothing merges
+//     all three levels.
 //   - custom_user_agent + inbound client UA forwarding: only chains mounted
 //     with resolveUA=true (the generic OpenAI and non-OAuth Anthropic
 //     pass-through chains). Vendor-specialized chains (Claude Code OAuth,
@@ -29,6 +35,11 @@ import (
 // construction (claude_client.go).
 type ruleFlagTransport struct {
 	inner http.RoundTripper
+	// supplyHeaders is the provider ∪ model extra_headers for the client this
+	// transport belongs to. Independent of the request context, so paths that
+	// never pass through protocol dispatch (probes, model-list fetch, vision
+	// proxy) still send the upstream's configured headers.
+	supplyHeaders map[string]string
 	// resolveUA marks a generic pass-through chain: resolve the UA precedence
 	// (rule/scenario custom_user_agent > inbound client UA > SDK default) at
 	// this layer. Chains whose UA is owned elsewhere mount with false.
@@ -50,12 +61,20 @@ type ruleFlagTransport struct {
 // Returns inner unchanged when no flag can ever apply on this chain
 // (non-api_key provider and no UA resolution) — same zero-cost no-op the old
 // per-flag wrappers provided.
-func wrapWithRuleFlags(inner http.RoundTripper, provider *typ.Provider, resolveUA bool) http.RoundTripper {
+//
+// model is the provider-side model this client is built for; it selects the
+// model-level supply headers. Empty for clients not bound to one model (the
+// provider level still applies).
+func wrapWithRuleFlags(inner http.RoundTripper, provider *typ.Provider, model string, resolveUA bool) http.RoundTripper {
 	applyExtraHeaders := provider != nil && provider.IsAPIKey()
 	if !resolveUA && !applyExtraHeaders {
 		return inner
 	}
-	return &ruleFlagTransport{inner: inner, resolveUA: resolveUA, applyExtraHeaders: applyExtraHeaders}
+	t := &ruleFlagTransport{inner: inner, resolveUA: resolveUA, applyExtraHeaders: applyExtraHeaders}
+	if applyExtraHeaders {
+		t.supplyHeaders = typ.SupplyExtraHeaders(provider, model)
+	}
+	return t
 }
 
 func (t *ruleFlagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -69,8 +88,9 @@ func (t *ruleFlagTransport) RoundTrip(req *http.Request) (*http.Response, error)
 
 	// extra_headers: api_key providers only. Applied verbatim — user-driven
 	// config, no filtering.
-	var extra map[string]string
+	var supply, extra map[string]string
 	if t.applyExtraHeaders {
+		supply = t.supplyHeaders
 		extra = flags.ExtraHeaders
 	}
 
@@ -84,17 +104,21 @@ func (t *ruleFlagTransport) RoundTrip(req *http.Request) (*http.Response, error)
 		}
 	}
 
-	if len(extra) == 0 && ua == "" {
+	if len(supply) == 0 && len(extra) == 0 && ua == "" {
 		return inner.RoundTrip(req)
 	}
 
 	// Clone before mutating so concurrent retries never race on shared headers.
 	req = req.Clone(ctx)
 
-	// Extra headers first, UA second: on a User-Agent name conflict the UA
-	// resolution wins, same precedence the old two-transport stack produced
-	// (extra headers outermost, UA innermost). Inner chains still write after
-	// this layer and win any remaining conflict by ordering.
+	// Write order is the precedence: supply-side (provider ∪ model) first, the
+	// rule's headers over them, UA last — so on a User-Agent name conflict the
+	// UA resolution wins, the same precedence the old two-transport stack
+	// produced (extra headers outermost, UA innermost). Inner chains still
+	// write after this layer and win any remaining conflict by ordering.
+	for name, value := range supply {
+		req.Header.Set(name, value)
+	}
 	for name, value := range extra {
 		req.Header.Set(name, value)
 	}

--- a/internal/client/rule_flag_transport_test.go
+++ b/internal/client/rule_flag_transport_test.go
@@ -68,7 +68,7 @@ func newReq(t *testing.T, ctx context.Context, ua string) *http.Request {
 
 func TestRuleFlagTransport_NoContextValue_PassesThrough(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	// Simulate the SDK having already stamped its default UA on the request.
 	req := newReq(t, context.Background(), "sdk-default/1.0")
 
@@ -82,7 +82,7 @@ func TestRuleFlagTransport_NoContextValue_PassesThrough(t *testing.T) {
 
 func TestRuleFlagTransport_RuleOverride(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	ctx := typ.WithRuleFlags(context.Background(), typ.RuleFlags{CustomUserAgent: "RuleUA/1.0"})
 	req := newReq(t, ctx, "sdk-default/1.0")
 
@@ -96,7 +96,7 @@ func TestRuleFlagTransport_RuleOverride(t *testing.T) {
 
 func TestRuleFlagTransport_ForwardsInboundClientUA(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	// Client sent "cherry-studio/1.2"; SDK stamped its own default. With no rule
 	// override, the inbound client UA must be forwarded so upstream sees the real
 	// caller instead of the generic SDK UA.
@@ -113,7 +113,7 @@ func TestRuleFlagTransport_ForwardsInboundClientUA(t *testing.T) {
 
 func TestRuleFlagTransport_RuleWinsOverClient(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	// Both present: the rule/scenario override wins over the inbound client UA.
 	ctx := typ.WithClientUserAgent(context.Background(), "cherry-studio/1.2")
 	ctx = typ.WithRuleFlags(ctx, typ.RuleFlags{CustomUserAgent: "RuleUA/1.0"})
@@ -129,7 +129,7 @@ func TestRuleFlagTransport_RuleWinsOverClient(t *testing.T) {
 
 func TestRuleFlagTransport_NoneSentinelStripsEvenWithClientUA(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	// The `none` sentinel is a rule/scenario value; it must strip the UA entirely
 	// and still win over a present inbound client UA.
 	ctx := typ.WithClientUserAgent(context.Background(), "cherry-studio/1.2")
@@ -155,7 +155,7 @@ func TestRuleFlagTransport_NoneSentinelStripsEvenWithClientUA(t *testing.T) {
 
 func TestRuleFlagTransport_DoesNotMutateOriginalRequest(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	ctx := typ.WithRuleFlags(context.Background(), typ.RuleFlags{CustomUserAgent: "RuleUA/1.0"})
 	req := newReq(t, ctx, "sdk-default/1.0")
 
@@ -171,7 +171,7 @@ func TestRuleFlagTransport_DoesNotMutateOriginalRequest(t *testing.T) {
 
 func TestRuleFlagTransport_EmptyFlagsAreNoOp(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	// Zero-value flags attached (the merge point attaches unconditionally), so
 	// an existing SDK UA header is left untouched.
 	ctx := typ.WithRuleFlags(context.Background(), typ.RuleFlags{})
@@ -190,7 +190,7 @@ func TestRuleFlagTransport_NoResolveUA_IgnoresUAFlags(t *testing.T) {
 	cap := &captureTransport{}
 	// resolveUA=false (e.g. the generic Google chain): UA flags must not apply
 	// even when present in ctx.
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), false)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", false)
 	ctx := typ.WithClientUserAgent(context.Background(), "cherry-studio/1.2")
 	ctx = typ.WithRuleFlags(ctx, typ.RuleFlags{CustomUserAgent: "RuleUA/1.0"})
 	req := newReq(t, ctx, "sdk-default/1.0")
@@ -211,7 +211,7 @@ func TestRuleFlagTransport_NilInnerFallsBackToDefault(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	wrapped := wrapWithRuleFlags(nil, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(nil, apiKeyProvider(), "", true)
 	req, _ := http.NewRequest("GET", srv.URL, nil)
 	resp, err := wrapped.RoundTrip(req)
 	if err != nil {
@@ -232,7 +232,7 @@ func newHeadersReq(t *testing.T, headers map[string]string) *http.Request {
 
 func TestRuleFlagTransport_AppliesExtraHeaders(t *testing.T) {
 	capture := &captureTransport{}
-	rt := wrapWithRuleFlags(capture, apiKeyProvider(), true)
+	rt := wrapWithRuleFlags(capture, apiKeyProvider(), "", true)
 
 	if _, err := rt.RoundTrip(newHeadersReq(t, map[string]string{"X-Title": "tingly"})); err != nil {
 		t.Fatal(err)
@@ -245,7 +245,7 @@ func TestRuleFlagTransport_AppliesExtraHeaders(t *testing.T) {
 func TestRuleFlagTransport_ExtraHeadersNonAPIKeyIsNoOp(t *testing.T) {
 	capture := &captureTransport{}
 	oauth := &typ.Provider{UUID: "p2", AuthType: ai.AuthTypeOAuth}
-	rt := wrapWithRuleFlags(capture, oauth, false)
+	rt := wrapWithRuleFlags(capture, oauth, "", false)
 	if rt != http.RoundTripper(capture) {
 		t.Fatal("a chain where no flag can apply must get the inner transport unchanged")
 	}
@@ -267,7 +267,7 @@ func TestRuleFlagTransport_ExtraHeadersNonAPIKeyIsNoOp(t *testing.T) {
 func TestRuleFlagTransport_VendorPinWins(t *testing.T) {
 	capture := &captureTransport{}
 	vendor := &pinTransport{inner: capture, name: "X-Vendor-Pin", value: "pinned"}
-	rt := wrapWithRuleFlags(vendor, apiKeyProvider(), true)
+	rt := wrapWithRuleFlags(vendor, apiKeyProvider(), "", true)
 
 	if _, err := rt.RoundTrip(newHeadersReq(t, map[string]string{
 		"X-Vendor-Pin": "user-tries-to-override",
@@ -288,7 +288,7 @@ func TestRuleFlagTransport_VendorPinWins(t *testing.T) {
 // Authorization. The user asked for it; the user owns it.
 func TestRuleFlagTransport_AppliesExtraHeadersVerbatim(t *testing.T) {
 	capture := &captureTransport{}
-	rt := wrapWithRuleFlags(capture, apiKeyProvider(), true)
+	rt := wrapWithRuleFlags(capture, apiKeyProvider(), "", true)
 
 	req := newHeadersReq(t, map[string]string{
 		"Authorization": "Bearer custom",
@@ -308,7 +308,7 @@ func TestRuleFlagTransport_AppliesExtraHeadersVerbatim(t *testing.T) {
 
 func TestRuleFlagTransport_ExtraHeadersDoNotMutateCallerRequest(t *testing.T) {
 	capture := &captureTransport{}
-	rt := wrapWithRuleFlags(capture, apiKeyProvider(), true)
+	rt := wrapWithRuleFlags(capture, apiKeyProvider(), "", true)
 
 	orig := newHeadersReq(t, map[string]string{"X-Title": "tingly"})
 	if _, err := rt.RoundTrip(orig); err != nil {
@@ -326,7 +326,7 @@ func TestRuleFlagTransport_ExtraHeadersDoNotMutateCallerRequest(t *testing.T) {
 // the old two-transport stack (extra headers outermost, UA innermost).
 func TestRuleFlagTransport_UAWinsOverExtraHeaderUA(t *testing.T) {
 	capture := &captureTransport{}
-	rt := wrapWithRuleFlags(capture, apiKeyProvider(), true)
+	rt := wrapWithRuleFlags(capture, apiKeyProvider(), "", true)
 
 	ctx := typ.WithRuleFlags(context.Background(), typ.RuleFlags{
 		CustomUserAgent: "RuleUA/1.0",
@@ -352,5 +352,103 @@ func TestWrapWithLogging_IsLoggingOnly(t *testing.T) {
 	}
 	if got := capture.lastReq.Header.Get("X-Title"); got != "" {
 		t.Errorf("X-Title = %q, want unset (logging layer must not apply flags)", got)
+	}
+}
+
+// ── Supply-side headers (provider ∪ model) ──────────────────────────────────
+
+func providerWithHeaders(t *testing.T, provider, model map[string]string) *typ.Provider {
+	t.Helper()
+	p := apiKeyProvider()
+	if provider != nil {
+		p.Flags = typ.ProviderFlags{ExtraHeaders: provider}
+	}
+	if model != nil {
+		p.ModelFlags = map[string]typ.ProviderFlags{"m1": {ExtraHeaders: model}}
+	}
+	return p
+}
+
+// Supply-side headers ride the client, not the request context, so paths that
+// never pass through protocol dispatch (probes, model-list fetch) send them.
+func TestRuleFlagTransport_SupplyHeadersWithoutCtx(t *testing.T) {
+	capture := &captureTransport{}
+	rt := wrapWithRuleFlags(capture, providerWithHeaders(t, map[string]string{"X-Title": "tingly"}, nil), "", true)
+
+	if _, err := rt.RoundTrip(newReq(t, context.Background(), "")); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.lastReq.Header.Get("X-Title"); got != "tingly" {
+		t.Errorf("X-Title = %q, want tingly", got)
+	}
+}
+
+// The full precedence provider < model < rule, produced by write order alone.
+func TestRuleFlagTransport_ThreeLevelPrecedence(t *testing.T) {
+	capture := &captureTransport{}
+	provider := providerWithHeaders(t,
+		map[string]string{"X-Shared": "provider", "X-Provider": "p"},
+		map[string]string{"X-Shared": "model", "X-Model": "m"},
+	)
+	rt := wrapWithRuleFlags(capture, provider, "m1", true)
+
+	ctx := typ.WithRuleFlags(context.Background(), typ.RuleFlags{ExtraHeaders: map[string]string{
+		"X-Shared": "rule",
+		"X-Rule":   "r",
+	}})
+	if _, err := rt.RoundTrip(newReq(t, ctx, "")); err != nil {
+		t.Fatal(err)
+	}
+	for header, want := range map[string]string{
+		"X-Shared":   "rule", // provider < model < rule
+		"X-Provider": "p",
+		"X-Model":    "m",
+		"X-Rule":     "r",
+	} {
+		if got := capture.lastReq.Header.Get(header); got != want {
+			t.Errorf("%s = %q, want %q", header, got, want)
+		}
+	}
+}
+
+// A client built for another model gets only the provider level.
+func TestRuleFlagTransport_ModelHeadersAreModelScoped(t *testing.T) {
+	capture := &captureTransport{}
+	provider := providerWithHeaders(t,
+		map[string]string{"X-Provider": "p"},
+		map[string]string{"X-Model": "m"},
+	)
+	rt := wrapWithRuleFlags(capture, provider, "other-model", true)
+
+	if _, err := rt.RoundTrip(newReq(t, context.Background(), "")); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.lastReq.Header.Get("X-Provider"); got != "p" {
+		t.Errorf("X-Provider = %q, want p", got)
+	}
+	if got := capture.lastReq.Header.Get("X-Model"); got != "" {
+		t.Errorf("X-Model = %q, want unset for a different model", got)
+	}
+}
+
+// The api_key gate covers supply-side headers too: a non-api_key provider
+// gets no transport at all, so nothing configured on it can reach the wire.
+func TestRuleFlagTransport_SupplyHeadersRespectAPIKeyGate(t *testing.T) {
+	capture := &captureTransport{}
+	oauth := &typ.Provider{
+		UUID:     "p2",
+		AuthType: ai.AuthTypeOAuth,
+		Flags:    typ.ProviderFlags{ExtraHeaders: map[string]string{"X-Title": "cfg"}},
+	}
+
+	rt := wrapWithRuleFlags(capture, oauth, "m1", false)
+	if rt != http.RoundTripper(capture) {
+		t.Fatal("non-api_key provider with no UA resolution must get the inner transport unchanged")
+	}
+	if _, err := rt.RoundTrip(newReq(t, context.Background(), "")); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.lastReq.Header.Get("X-Title"); got != "" {
+		t.Errorf("X-Title = %q, want unset on a non-api_key provider", got)
 	}
 }

--- a/internal/db/provider_store.go
+++ b/internal/db/provider_store.go
@@ -62,6 +62,12 @@ type ProviderRecord struct {
 	// no backfill required.
 	Credential *typ.CredentialBundle `gorm:"column:credential;type:text;serializer:json"`
 
+	// Flags / ModelFlags hold the provider-level options and the per-model
+	// overrides. Auth-type independent. Added additively; AutoMigrate creates
+	// the columns with no backfill required.
+	Flags      typ.ProviderFlags            `gorm:"column:flags;type:text;serializer:json"`
+	ModelFlags map[string]typ.ProviderFlags `gorm:"column:model_flags;type:text;serializer:json"`
+
 	CreatedAt time.Time `gorm:"column:created_at"`
 	UpdatedAt time.Time `gorm:"column:updated_at"`
 }
@@ -114,6 +120,28 @@ func cloneVModelDetail(d *typ.VModelDetail) *typ.VModelDetail {
 	return &out
 }
 
+// cloneProviderFlags / cloneModelFlags isolate the cached record from
+// callers the same way as the other JSON columns.
+func cloneProviderFlags(f typ.ProviderFlags) typ.ProviderFlags {
+	if len(f.ExtraHeaders) > 0 {
+		f.ExtraHeaders = maps.Clone(f.ExtraHeaders)
+	} else {
+		f.ExtraHeaders = nil
+	}
+	return f
+}
+
+func cloneModelFlags(m map[string]typ.ProviderFlags) map[string]typ.ProviderFlags {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]typ.ProviderFlags, len(m))
+	for model, flags := range m {
+		out[model] = cloneProviderFlags(flags)
+	}
+	return out
+}
+
 func cloneCredential(c *typ.CredentialBundle) *typ.CredentialBundle {
 	if c == nil {
 		return nil
@@ -147,6 +175,8 @@ func (r *ProviderRecord) toProvider() *typ.Provider {
 	}
 
 	provider.Tags = cloneStrings(r.Tags)
+	provider.Flags = cloneProviderFlags(r.Flags)
+	provider.ModelFlags = cloneModelFlags(r.ModelFlags)
 
 	// Set credentials based on auth type
 	switch provider.AuthType {
@@ -202,6 +232,8 @@ func toRecord(p *typ.Provider) *ProviderRecord {
 	}
 
 	record.Tags = cloneStrings(p.Tags)
+	record.Flags = cloneProviderFlags(p.Flags)
+	record.ModelFlags = cloneModelFlags(p.ModelFlags)
 
 	// Set credentials based on auth type
 	switch p.AuthType {
@@ -240,6 +272,8 @@ func updateRecordFromProvider(record *ProviderRecord, p *typ.Provider) {
 	record.UpdatedAt = time.Now()
 
 	record.Tags = cloneStrings(p.Tags)
+	record.Flags = cloneProviderFlags(p.Flags)
+	record.ModelFlags = cloneModelFlags(p.ModelFlags)
 
 	// Set credentials based on auth type
 	switch p.AuthType {

--- a/internal/db/provider_store_test.go
+++ b/internal/db/provider_store_test.go
@@ -797,3 +797,75 @@ func TestProviderStore_FailedWriteDoesNotCorruptCache(t *testing.T) {
 		}
 	})
 }
+
+// TestProviderFlagsRoundTrip verifies the flags / model_flags columns:
+// values survive save/reload, updates rewrite them, and clearing empties them.
+func TestProviderFlagsRoundTrip(t *testing.T) {
+	store, _ := setupTestProviderStore(t)
+	defer store.Close()
+
+	provider := &typ.Provider{
+		UUID:     "flags-uuid-1",
+		Name:     "flags-provider",
+		APIBase:  "https://api.example.com/v1",
+		APIStyle: protocol.APIStyleOpenAI,
+		AuthType: typ.AuthTypeAPIKey,
+		Token:    "sk-flags",
+		Enabled:  true,
+		Flags:    typ.ProviderFlags{ExtraHeaders: map[string]string{"X-Title": "tingly"}},
+		ModelFlags: map[string]typ.ProviderFlags{
+			"gpt-x": {ExtraHeaders: map[string]string{"X-Canary": "on"}},
+		},
+	}
+	if err := store.Save(provider); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := store.GetByUUID("flags-uuid-1")
+	if err != nil {
+		t.Fatalf("GetByUUID: %v", err)
+	}
+	if loaded.Flags.ExtraHeaders["X-Title"] != "tingly" {
+		t.Errorf("provider flags lost on reload: %+v", loaded.Flags)
+	}
+	if loaded.ModelFlags["gpt-x"].ExtraHeaders["X-Canary"] != "on" {
+		t.Errorf("model flags lost on reload: %+v", loaded.ModelFlags)
+	}
+
+	// The cached record must not alias what callers hold.
+	loaded.Flags.ExtraHeaders["X-Title"] = "mutated-by-caller"
+	again, err := store.GetByUUID("flags-uuid-1")
+	if err != nil {
+		t.Fatalf("GetByUUID(again): %v", err)
+	}
+	if again.Flags.ExtraHeaders["X-Title"] != "tingly" {
+		t.Errorf("caller mutation leaked into the store: %+v", again.Flags)
+	}
+
+	// Update path (existing record) rewrites the columns.
+	again.Flags = typ.ProviderFlags{ExtraHeaders: map[string]string{"X-Title": "updated"}}
+	if err := store.Save(again); err != nil {
+		t.Fatalf("Save(update): %v", err)
+	}
+	reloaded, err := store.GetByUUID("flags-uuid-1")
+	if err != nil {
+		t.Fatalf("GetByUUID(update): %v", err)
+	}
+	if reloaded.Flags.ExtraHeaders["X-Title"] != "updated" {
+		t.Errorf("updated flags not persisted: %+v", reloaded.Flags)
+	}
+
+	// Clearing both levels empties the columns.
+	reloaded.Flags = typ.ProviderFlags{}
+	reloaded.ModelFlags = nil
+	if err := store.Save(reloaded); err != nil {
+		t.Fatalf("Save(clear): %v", err)
+	}
+	cleared, err := store.GetByUUID("flags-uuid-1")
+	if err != nil {
+		t.Fatalf("GetByUUID(clear): %v", err)
+	}
+	if !cleared.Flags.IsZero() || cleared.ModelFlags != nil {
+		t.Errorf("cleared flags came back: %+v / %+v", cleared.Flags, cleared.ModelFlags)
+	}
+}

--- a/internal/protocolserver/anthropic_message.go
+++ b/internal/protocolserver/anthropic_message.go
@@ -265,7 +265,7 @@ func (ph *ProtocolHandler) runAnthropicV1Attempt(c *gin.Context, req *protocol.A
 
 	// Resolve flags with scenario injection and auto-apply for CleanHeader.
 	// (This also applies the custom User-Agent to the request context.)
-	ruleFlags := ResolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicV1, target, provider)
+	ruleFlags := ResolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicV1, target, provider, requestModel)
 
 	reqCtx, err := ph.TransformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType, RulePreBaseTransforms(ruleFlags), RulePreVendorTransforms(ruleFlags))
 	if err != nil {
@@ -389,7 +389,7 @@ func (ph *ProtocolHandler) runAnthropicBetaAttempt(c *gin.Context, req *protocol
 
 	// Resolve flags with scenario injection and auto-apply for CleanHeader.
 	// (This also applies the custom User-Agent to the request context.)
-	ruleFlags := ResolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicBeta, target, provider)
+	ruleFlags := ResolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicBeta, target, provider, requestModel)
 
 	reqCtx, err := ph.TransformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType, RulePreBaseTransforms(ruleFlags), RulePreVendorTransforms(ruleFlags))
 	if err != nil {

--- a/internal/protocolserver/openai_chat.go
+++ b/internal/protocolserver/openai_chat.go
@@ -227,7 +227,7 @@ func (ph *ProtocolHandler) runOpenAIChatAttempt(c *gin.Context, req *protocol.Op
 	// === Resolve flags with scenario injection ===
 	// (resolveRuleFlagsWithScenario also applies the custom User-Agent to the
 	// request context, so no separate call is needed here.)
-	ruleFlags := ResolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIChat, target, provider)
+	ruleFlags := ResolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIChat, target, provider, actualModel)
 
 	// === Transform via pipeline ===
 	reqCtx, err := ph.TransformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType, RulePreBaseTransforms(ruleFlags), RulePreVendorTransforms(ruleFlags))

--- a/internal/protocolserver/openai_responses.go
+++ b/internal/protocolserver/openai_responses.go
@@ -223,7 +223,7 @@ func (ph *ProtocolHandler) runOpenAIResponsesAttempt(c *gin.Context, req *protoc
 
 	// Resolve flags with scenario injection, consistent with the chat/v1/beta
 	// handlers (this also applies the custom User-Agent to the request context).
-	ruleFlags := ResolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIResponses, target, provider)
+	ruleFlags := ResolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIResponses, target, provider, actualModel)
 	reqCtx, err := ph.TransformOpenAIResponses(c, req, target, provider, isStreaming, nil, scenarioType, maxAllowed, RulePreBaseTransforms(ruleFlags), RulePreVendorTransforms(ruleFlags))
 	if err != nil {
 		ph.FailAttemptSetup(c, fmt.Errorf("Transform failed: %w", err))

--- a/internal/protocolserver/rule_flags.go
+++ b/internal/protocolserver/rule_flags.go
@@ -103,9 +103,14 @@ func ResolveRuleFlags(c *gin.Context, rule *typ.Rule) typ.RuleFlags {
 // This is the main entry point that merges:
 //  1. Rule-level flags (from the rule definition)
 //  2. Scenario flags (from the scenario configuration)
-//  3. Auto-applied flags (like CleanHeader for protocol transformation)
-//  4. Provider-driven suppressions (CleanHeader is cleared for Claude OAuth providers;
+//  3. Supply-side flags of the chosen (provider, model) pair, folded in at the
+//     lowest precedence — provider < model < rule (typ.ApplyProviderFlags)
+//  4. Auto-applied flags (like CleanHeader for protocol transformation)
+//  5. Provider-driven suppressions (CleanHeader is cleared for Claude OAuth providers;
 //     the billing header must reach Anthropic's billing backend unchanged).
+//
+// model is the provider-side model ID this attempt targets, used to pick the
+// per-model supply flags.
 //
 // Side effect: it attaches the whole resolved flag set to the request context
 // (applyRuleFlags) plus the inbound client UA fallback (applyClientUserAgent),
@@ -117,6 +122,7 @@ func ResolveRuleFlagsWithScenario(
 	scenarioConfig *typ.ScenarioConfig,
 	sourceAPI, targetAPI protocol.APIType,
 	provider *typ.Provider,
+	model string,
 ) typ.RuleFlags {
 	flags := ResolveRuleFlags(c, rule)
 
@@ -142,6 +148,22 @@ func ResolveRuleFlagsWithScenario(
 		// SessionAffinity is rule-only — no scenario-level inheritance. The
 		// built-in Claude Code / Desktop / Codex rules seed it directly (init +
 		// migrate20260610), so there is nothing to inject here.
+	}
+
+	// Fold in the supply-side flags of the chosen provider and model. They sit
+	// at the lowest precedence (provider < model < rule), so this runs after
+	// the rule and scenario values are in place and only fills what they left
+	// unset — see typ.ApplyProviderFlags for the per-kind semantics. Doing it
+	// here rather than at each handler means every consumer of the resolved
+	// flags (transform chains, the outbound clients, the response path) picks
+	// supply-side configuration up for free.
+	//
+	// Cursor auto-detection re-runs afterwards: a provider- or model-level
+	// cursor_compat_auto has to fold into cursor_compat the same way a
+	// rule-level one does in ResolveRuleFlags.
+	flags = typ.ApplyProviderFlags(flags, provider, model)
+	if flags.CursorCompatAuto && isCursorRequest(c) {
+		flags.CursorCompat = true
 	}
 
 	// Auto-apply CleanHeader for protocol transformation in billing scenarios

--- a/internal/protocolserver/rule_flags.go
+++ b/internal/protocolserver/rule_flags.go
@@ -150,17 +150,10 @@ func ResolveRuleFlagsWithScenario(
 		// migrate20260610), so there is nothing to inject here.
 	}
 
-	// Fold in the supply-side flags of the chosen provider and model. They sit
-	// at the lowest precedence (provider < model < rule), so this runs after
-	// the rule and scenario values are in place and only fills what they left
-	// unset — see typ.ApplyProviderFlags for the per-kind semantics. Doing it
-	// here rather than at each handler means every consumer of the resolved
-	// flags (transform chains, the outbound clients, the response path) picks
-	// supply-side configuration up for free.
-	//
-	// Cursor auto-detection re-runs afterwards: a provider- or model-level
-	// cursor_compat_auto has to fold into cursor_compat the same way a
-	// rule-level one does in ResolveRuleFlags.
+	// Fold in the chosen provider's and model's flags at the lowest precedence,
+	// so every consumer of the resolved set picks them up for free. Cursor
+	// auto-detection re-runs because a supply-level cursor_compat_auto has to
+	// fold into cursor_compat the way ResolveRuleFlags does for a rule-level one.
 	flags = typ.ApplyProviderFlags(flags, provider, model)
 	if flags.CursorCompatAuto && isCursorRequest(c) {
 		flags.CursorCompat = true

--- a/internal/protocolserver/rule_flags_test.go
+++ b/internal/protocolserver/rule_flags_test.go
@@ -427,6 +427,7 @@ func TestResolveRuleFlagsWithScenario_ThinkingEffort(t *testing.T) {
 				protocol.TypeAnthropicV1,
 				protocol.TypeOpenAIChat,
 				nil,
+				"",
 			)
 
 			if result.ThinkingEffort != tt.wantThinkingEffort {
@@ -483,6 +484,7 @@ func TestResolveRuleFlagsWithScenario_CustomUserAgent(t *testing.T) {
 				protocol.TypeAnthropicV1,
 				protocol.TypeOpenAIChat,
 				nil,
+				"",
 			)
 
 			if result.CustomUserAgent != tt.wantUA {
@@ -532,7 +534,7 @@ func TestResolveRuleFlagsWithScenario_AttachesClientUserAgent(t *testing.T) {
 		rule := &typ.Rule{Flags: typ.RuleFlags{}}
 
 		ResolveRuleFlagsWithScenario(c, rule, typ.ScenarioAnthropic, &typ.ScenarioConfig{},
-			protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, nil)
+			protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, nil, "")
 
 		if got := typ.GetClientUserAgent(c.Request.Context()); got != "cherry-studio/1.2" {
 			t.Errorf("client UA in ctx = %q, want %q", got, "cherry-studio/1.2")
@@ -545,7 +547,7 @@ func TestResolveRuleFlagsWithScenario_AttachesClientUserAgent(t *testing.T) {
 		rule := &typ.Rule{Flags: typ.RuleFlags{CustomUserAgent: "Rule/2.0"}}
 
 		ResolveRuleFlagsWithScenario(c, rule, typ.ScenarioAnthropic, &typ.ScenarioConfig{},
-			protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, nil)
+			protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, nil, "")
 
 		ctx := c.Request.Context()
 		if got := typ.GetRuleFlags(ctx).CustomUserAgent; got != "Rule/2.0" {
@@ -572,21 +574,21 @@ func TestResolveRuleFlagsWithScenario_CleanHeaderSuppressedForClaudeOAuth(t *tes
 
 	// CleanHeader should be suppressed for Claude OAuth provider.
 	got := ResolveRuleFlagsWithScenario(c, rule, typ.ScenarioClaudeCode, scenarioConfig,
-		protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, oauthProvider)
+		protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, oauthProvider, "")
 	if got.CleanHeader {
 		t.Error("CleanHeader should be suppressed for Claude OAuth provider")
 	}
 
 	// CleanHeader should be preserved for any other provider type.
 	got = ResolveRuleFlagsWithScenario(c, rule, typ.ScenarioClaudeCode, scenarioConfig,
-		protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, otherProvider)
+		protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, otherProvider, "")
 	if !got.CleanHeader {
 		t.Error("CleanHeader should be preserved for non-OAuth provider")
 	}
 
 	// nil provider: no suppression.
 	got = ResolveRuleFlagsWithScenario(c, rule, typ.ScenarioClaudeCode, scenarioConfig,
-		protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, nil)
+		protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, nil, "")
 	if !got.CleanHeader {
 		t.Error("CleanHeader should be preserved when provider is nil")
 	}
@@ -619,7 +621,7 @@ func TestResolveRuleFlagsWithScenario_ClaudeOrgIDReachesContext(t *testing.T) {
 	c := newGinContext(t)
 	rule := &typ.Rule{Flags: typ.RuleFlags{ClaudeOrgID: "org-uuid"}}
 	got := ResolveRuleFlagsWithScenario(c, rule, typ.ScenarioClaudeCode, &typ.ScenarioConfig{},
-		protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, nil)
+		protocol.TypeAnthropicV1, protocol.TypeAnthropicV1, nil, "")
 	if got.ClaudeOrgID != "org-uuid" {
 		t.Errorf("ClaudeOrgID = %q, want %q", got.ClaudeOrgID, "org-uuid")
 	}
@@ -634,7 +636,7 @@ func TestResolveRuleFlagsWithScenario_ExtraHeaders(t *testing.T) {
 	c := newGinContext(t)
 	rule := &typ.Rule{Flags: typ.RuleFlags{ExtraHeaders: map[string]string{"X-Team-Tag": "research"}}}
 	ResolveRuleFlagsWithScenario(c, rule, typ.ScenarioOpenAI, &typ.ScenarioConfig{},
-		protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, nil)
+		protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, nil, "")
 	got := typ.GetRuleFlags(c.Request.Context()).ExtraHeaders
 	if got["X-Team-Tag"] != "research" {
 		t.Errorf("ctx headers = %v, want rule extra_headers attached", got)
@@ -643,8 +645,80 @@ func TestResolveRuleFlagsWithScenario_ExtraHeaders(t *testing.T) {
 	// Nothing configured → nothing attached.
 	c = newGinContext(t)
 	ResolveRuleFlagsWithScenario(c, &typ.Rule{}, typ.ScenarioOpenAI, &typ.ScenarioConfig{},
-		protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, nil)
+		protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, nil, "")
 	if got := typ.GetRuleFlags(c.Request.Context()).ExtraHeaders; got != nil {
 		t.Errorf("ctx headers = %v, want nil when the rule sets none", got)
 	}
+}
+
+// TestResolveRuleFlagsWithScenario_SupplyFlags pins that the chosen provider's
+// and model's flags reach the effective flag set — and the request context the
+// outbound clients read — at the lowest precedence.
+func TestResolveRuleFlagsWithScenario_SupplyFlags(t *testing.T) {
+	provider := &typ.Provider{
+		AuthType: typ.AuthTypeAPIKey,
+		Flags: typ.ProviderFlags{
+			ClaudeCodeCompat: true,
+			CustomUserAgent:  "provider-ua",
+		},
+		ModelFlags: map[string]typ.ProviderFlags{
+			"gpt-5": {UseMaxCompletionTokens: true, CustomUserAgent: "model-ua"},
+		},
+	}
+
+	t.Run("provider and model flags fold into the resolved set", func(t *testing.T) {
+		c := newGinContext(t)
+		got := ResolveRuleFlagsWithScenario(c, &typ.Rule{}, typ.ScenarioOpenAI, &typ.ScenarioConfig{},
+			protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, provider, "gpt-5")
+
+		if !got.ClaudeCodeCompat {
+			t.Error("provider-level claude_code_compat did not reach the resolved flags")
+		}
+		if !got.UseMaxCompletionTokens {
+			t.Error("model-level use_max_completion_tokens did not reach the resolved flags")
+		}
+		if got.CustomUserAgent != "model-ua" {
+			t.Errorf("CustomUserAgent = %q, want the model level to win over the provider", got.CustomUserAgent)
+		}
+		// The same value is what the outbound clients read off the context.
+		if ctxFlags := typ.GetRuleFlags(c.Request.Context()); !ctxFlags.ClaudeCodeCompat || ctxFlags.CustomUserAgent != "model-ua" {
+			t.Errorf("ctx flags = %+v, want the supply-side values attached", ctxFlags)
+		}
+	})
+
+	t.Run("rule outranks both", func(t *testing.T) {
+		c := newGinContext(t)
+		rule := &typ.Rule{Flags: typ.RuleFlags{CustomUserAgent: "rule-ua"}}
+		got := ResolveRuleFlagsWithScenario(c, rule, typ.ScenarioOpenAI, &typ.ScenarioConfig{},
+			protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, provider, "gpt-5")
+		if got.CustomUserAgent != "rule-ua" {
+			t.Errorf("CustomUserAgent = %q, want the rule value", got.CustomUserAgent)
+		}
+	})
+
+	t.Run("a model-level flag stays on its own model", func(t *testing.T) {
+		c := newGinContext(t)
+		got := ResolveRuleFlagsWithScenario(c, &typ.Rule{}, typ.ScenarioOpenAI, &typ.ScenarioConfig{},
+			protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, provider, "gpt-4")
+		if got.UseMaxCompletionTokens {
+			t.Error("model-level flag leaked to a different model")
+		}
+		if got.CustomUserAgent != "provider-ua" {
+			t.Errorf("CustomUserAgent = %q, want the provider value", got.CustomUserAgent)
+		}
+	})
+
+	t.Run("supply-level cursor auto-detection still folds into cursor_compat", func(t *testing.T) {
+		autoProvider := &typ.Provider{
+			AuthType: typ.AuthTypeAPIKey,
+			Flags:    typ.ProviderFlags{CursorCompatAuto: true},
+		}
+		c := newGinContext(t)
+		c.Request.Header.Set("User-Agent", "Cursor/1.0")
+		got := ResolveRuleFlagsWithScenario(c, &typ.Rule{}, typ.ScenarioOpenAI, &typ.ScenarioConfig{},
+			protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, autoProvider, "gpt-5")
+		if !got.CursorCompat {
+			t.Error("provider-level cursor_compat_auto did not fold into cursor_compat")
+		}
+	})
 }

--- a/internal/protocoltest/flags.go
+++ b/internal/protocoltest/flags.go
@@ -417,6 +417,46 @@ func ruleFlagCases() []flagCase {
 			if _, ok := body["max_tokens"]; ok {
 				t.Error("upstream still carries max_tokens after rewrite")
 			}
+
+			// Same effect from the supply side: a model-level flag on the
+			// provider, with the rule setting nothing. This is the non-header
+			// half of the three-level merge — unlike extra_headers these flags
+			// inject through the transform chain, so they are folded into the
+			// effective rule flags by typ.ApplyProviderFlags at dispatch
+			// (.design/provider-flags.md §3.3).
+			s := flagScenario()
+			env.virtual.RegisterScenario(s)
+			const providerName = "flag-supply-max-completion-tokens"
+			providerModel := "virtual-model-" + s.Name
+
+			provider := &typ.Provider{
+				UUID:     providerName,
+				Name:     providerName,
+				APIBase:  env.virtual.URL() + "/v1",
+				APIStyle: protocol.APIStyleOpenAI,
+				AuthType: ai.AuthTypeAPIKey,
+				Token:    "virtual-token",
+				Enabled:  true,
+				Timeout:  int64(constant.DefaultRequestTimeout),
+				ModelFlags: map[string]typ.ProviderFlags{
+					providerModel: {UseMaxCompletionTokens: true},
+				},
+			}
+			_ = env.appConfig.AddProvider(provider)
+
+			const supplyModel = "pv-flag-supply-max-completion-tokens"
+			supplyRule := newHarnessRule(supplyModel, typ.ScenarioOpenAI, supplyModel, providerModel,
+				harnessService(providerName, providerModel))
+			_ = env.appConfig.GetGlobalConfig().AddRequestConfig(supplyRule)
+
+			sendFlag(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, supplyModel, false, nil, nil)
+			body = env.virtual.LastRequest(EndpointChat).JSON()
+			if _, ok := body["max_completion_tokens"]; !ok {
+				t.Errorf("model-level flag did not rewrite the field; body keys=%v", keysOf(body))
+			}
+			if _, ok := body["max_tokens"]; ok {
+				t.Error("upstream still carries max_tokens after the model-level rewrite")
+			}
 		}},
 
 		// ── use_max_tokens ───────────────────────────────────────────────────

--- a/internal/protocoltest/flags.go
+++ b/internal/protocoltest/flags.go
@@ -418,12 +418,10 @@ func ruleFlagCases() []flagCase {
 				t.Error("upstream still carries max_tokens after rewrite")
 			}
 
-			// Same effect from the supply side: a model-level flag on the
-			// provider, with the rule setting nothing. This is the non-header
-			// half of the three-level merge — unlike extra_headers these flags
-			// inject through the transform chain, so they are folded into the
-			// effective rule flags by typ.ApplyProviderFlags at dispatch
-			// (.design/provider-flags.md §3.3).
+			// Same effect from the supply side: a model-level flag, rule empty.
+			// This is the non-header half of the three-level merge — these
+			// inject through the transform chain, so typ.ApplyProviderFlags
+			// folds them into the effective rule flags at dispatch.
 			s := flagScenario()
 			env.virtual.RegisterScenario(s)
 			const providerName = "flag-supply-max-completion-tokens"

--- a/internal/protocoltest/flags.go
+++ b/internal/protocoltest/flags.go
@@ -347,6 +347,62 @@ func ruleFlagCases() []flagCase {
 			} else if got := up.Headers.Get("X-Team-Tag"); got != "research" {
 				t.Errorf("anthropic chain: upstream X-Team-Tag = %q, want research", got)
 			}
+
+			// Three-level precedence (provider < model < rule): the supply-side
+			// levels ride the client (typ.SupplyExtraHeaders at wrap time), the
+			// rule level rides the request context, and the transport's write
+			// order is what resolves conflicts.
+			s := flagScenario()
+			env.virtual.RegisterScenario(s)
+			const providerName = "flag-extra-headers-levels"
+			providerModel := "virtual-model-" + s.Name
+
+			provider := &typ.Provider{
+				UUID:     providerName,
+				Name:     providerName,
+				APIBase:  env.virtual.URL() + "/v1",
+				APIStyle: protocol.APIStyleOpenAI,
+				AuthType: ai.AuthTypeAPIKey,
+				Token:    "virtual-token",
+				Enabled:  true,
+				Timeout:  int64(constant.DefaultRequestTimeout),
+			}
+			provider.Flags = typ.ProviderFlags{ExtraHeaders: map[string]string{
+				"X-Level":         "provider",
+				"X-Provider-Only": "p",
+			}}
+			provider.ModelFlags = map[string]typ.ProviderFlags{
+				providerModel: {ExtraHeaders: map[string]string{
+					"X-Level":      "model",
+					"X-Model-Only": "m",
+				}},
+			}
+			_ = env.appConfig.AddProvider(provider)
+
+			const levelsModel = "pv-flag-extra-headers-levels"
+			levelsRule := newHarnessRule(levelsModel, typ.ScenarioOpenAI, levelsModel, providerModel,
+				harnessService(providerName, providerModel))
+			levelsRule.Flags = typ.RuleFlags{ExtraHeaders: map[string]string{
+				"X-Level":     "rule",
+				"X-Rule-Only": "r",
+			}}
+			_ = env.appConfig.GetGlobalConfig().AddRequestConfig(levelsRule)
+
+			sendFlag(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, levelsModel, false, nil, nil)
+			up = env.virtual.LastRequest(EndpointChat)
+			if up == nil {
+				t.Fatal("no upstream request captured for the three-level route")
+			}
+			for header, want := range map[string]string{
+				"X-Level":         "rule", // provider < model < rule
+				"X-Provider-Only": "p",
+				"X-Model-Only":    "m",
+				"X-Rule-Only":     "r",
+			} {
+				if got := up.Headers.Get(header); got != want {
+					t.Errorf("three-level: upstream %s = %q, want %q", header, got, want)
+				}
+			}
 		}},
 
 		// ── use_max_completion_tokens ────────────────────────────────────────

--- a/internal/server/config/provider.go
+++ b/internal/server/config/provider.go
@@ -272,9 +272,14 @@ func (c *Config) notifyProviderDelete(uuid string) {
 // It sits in the AddProvider/UpdateProvider choke points so every write path
 // — HTTP handlers, CLI, and provider import (dataio) — shares one gate.
 //
-// v1 release scope: extra headers are only supported on api_key providers
+// v1 release scope: provider flags are only supported on api_key providers
 // (see .design/provider-flags.md §5.4); the transport additionally applies
 // nothing on non-api_key rows as a runtime defense.
+//
+// Beyond that gate the only per-flag check is the structural one extra_headers
+// needs (a malformed header name cannot be put on the wire at all). The rest
+// are free-form on purpose: a custom upstream is exactly where an unusual
+// value is legitimate, so the operator owns the outcome.
 func ValidateProviderFlags(p *typ.Provider) error {
 	p.ModelFlags = typ.PruneModelFlags(p.ModelFlags)
 
@@ -284,7 +289,7 @@ func ValidateProviderFlags(p *typ.Provider) error {
 	}
 
 	if !p.IsAPIKey() {
-		return errors.New("custom headers (extra_headers) are only supported on api_key providers")
+		return errors.New("provider flags are only supported on api_key providers")
 	}
 	if err := typ.ValidateExtraHeaders(p.Flags.ExtraHeaders); err != nil {
 		return fmt.Errorf("provider flags: %w", err)

--- a/internal/server/config/provider.go
+++ b/internal/server/config/provider.go
@@ -276,10 +276,9 @@ func (c *Config) notifyProviderDelete(uuid string) {
 // (see .design/provider-flags.md §5.4); the transport additionally applies
 // nothing on non-api_key rows as a runtime defense.
 //
-// Beyond that gate the only per-flag check is the structural one extra_headers
-// needs (a malformed header name cannot be put on the wire at all). The rest
-// are free-form on purpose: a custom upstream is exactly where an unusual
-// value is legitimate, so the operator owns the outcome.
+// Only extra_headers is checked, and only structurally — a malformed header
+// name cannot go on the wire at all. The rest are free-form on purpose: a
+// custom upstream is where an unusual value is legitimate.
 func ValidateProviderFlags(p *typ.Provider) error {
 	p.ModelFlags = typ.PruneModelFlags(p.ModelFlags)
 

--- a/internal/server/config/provider.go
+++ b/internal/server/config/provider.go
@@ -185,6 +185,9 @@ func (c *Config) AddProvider(provider *typ.Provider) error {
 	if provider.APIBase == "" {
 		return errors.New("API base URL cannot be empty")
 	}
+	if err := ValidateProviderFlags(provider); err != nil {
+		return err
+	}
 
 	// Use provider store if available
 	if c.providerStore != nil {
@@ -264,10 +267,49 @@ func (c *Config) notifyProviderDelete(uuid string) {
 	}
 }
 
+// ValidateProviderFlags checks the provider- and model-level flags before a
+// provider is persisted, and canonicalizes accepted header names in place.
+// It sits in the AddProvider/UpdateProvider choke points so every write path
+// — HTTP handlers, CLI, and provider import (dataio) — shares one gate.
+//
+// v1 release scope: extra headers are only supported on api_key providers
+// (see .design/provider-flags.md §5.4); the transport additionally applies
+// nothing on non-api_key rows as a runtime defense.
+func ValidateProviderFlags(p *typ.Provider) error {
+	p.ModelFlags = typ.PruneModelFlags(p.ModelFlags)
+
+	configured := !p.Flags.IsZero() || len(p.ModelFlags) > 0
+	if !configured {
+		return nil
+	}
+
+	if !p.IsAPIKey() {
+		return errors.New("custom headers (extra_headers) are only supported on api_key providers")
+	}
+	if err := typ.ValidateExtraHeaders(p.Flags.ExtraHeaders); err != nil {
+		return fmt.Errorf("provider flags: %w", err)
+	}
+	for model, mf := range p.ModelFlags {
+		if err := typ.ValidateExtraHeaders(mf.ExtraHeaders); err != nil {
+			return fmt.Errorf("model %q flags: %w", model, err)
+		}
+	}
+
+	p.Flags.ExtraHeaders = typ.CanonicalizeExtraHeaders(p.Flags.ExtraHeaders)
+	for model, mf := range p.ModelFlags {
+		mf.ExtraHeaders = typ.CanonicalizeExtraHeaders(mf.ExtraHeaders)
+		p.ModelFlags[model] = mf
+	}
+	return nil
+}
+
 // UpdateProvider updates an existing provider by UUID
 func (c *Config) UpdateProvider(uuid string, provider *typ.Provider) error {
 	// Use provider store if available
 	if c.providerStore != nil {
+		if err := ValidateProviderFlags(provider); err != nil {
+			return err
+		}
 		// Preserve the UUID
 		provider.UUID = uuid
 		if err := c.providerStore.Save(provider); err != nil {

--- a/internal/server/module/provider/handler.go
+++ b/internal/server/module/provider/handler.go
@@ -43,6 +43,25 @@ func badRequest(c *gin.Context, format string, args ...any) {
 	c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": fmt.Sprintf(format, args...)})
 }
 
+// applyProviderFlagsRequest writes the request's optional flag sections onto
+// the provider and validates the result. nil sections leave the stored level
+// untouched; a non-nil section replaces that level wholesale (empty clears
+// it). Validation runs post-merge via the same gate the config layer uses on
+// every write path, so a partial update can't smuggle headers onto a
+// non-api_key provider.
+func applyProviderFlagsRequest(p *typ.Provider, flags *typ.ProviderFlags, modelFlags *map[string]typ.ProviderFlags) error {
+	if flags == nil && modelFlags == nil {
+		return nil
+	}
+	if flags != nil {
+		p.Flags = *flags
+	}
+	if modelFlags != nil {
+		p.ModelFlags = *modelFlags
+	}
+	return config.ValidateProviderFlags(p)
+}
+
 // maskForResponse masks sensitive data and returns a safe ProviderResponse.
 func maskForResponse(p *typ.Provider) ProviderResponse {
 	resp := ProviderResponse{
@@ -63,6 +82,13 @@ func maskForResponse(p *typ.Provider) ProviderResponse {
 	if p.IsVirtual() {
 		resp.VModelDetail = p.VModelDetail
 	}
+
+	// Empty levels stay omitted so an untouched provider carries neither key.
+	if !p.Flags.IsZero() {
+		flags := p.Flags
+		resp.Flags = &flags
+	}
+	resp.ModelFlags = p.ModelFlags
 
 	switch {
 	case p.IsOAuth():
@@ -231,6 +257,13 @@ func (h *Handler) CreateProvider(c *gin.Context) {
 		p.Token = ""
 	}
 
+	// Optional provider/model flags. applyProviderFlagsRequest fails fast with
+	// a 400-worthy error; AddProvider revalidates as the shared backstop.
+	if err := applyProviderFlagsRequest(p, req.Flags, &req.ModelFlags); err != nil {
+		badRequest(c, "%s", err)
+		return
+	}
+
 	if err = h.config.AddProvider(p); err != nil {
 		logrus.WithFields(logrus.Fields{
 			"action":   obs.ActionAddProvider,
@@ -256,6 +289,15 @@ func (h *Handler) CreateProvider(c *gin.Context) {
 		Success: true,
 		Message: "Provider added successfully",
 		Data:    p,
+	})
+}
+
+// GetFlagRegistry returns the catalog of supported provider/model-level
+// flags — the supply-side counterpart of the rule module's flag registry.
+func (h *Handler) GetFlagRegistry(c *gin.Context) {
+	c.JSON(http.StatusOK, FlagRegistryResponse{
+		Success: true,
+		Data:    typ.ProviderFlagRegistry(),
 	})
 }
 
@@ -370,6 +412,12 @@ func (h *Handler) UpdateProvider(c *gin.Context) {
 	}
 	if req.ProxyURL != nil {
 		p.ProxyURL = *req.ProxyURL
+	}
+	// Flags / ModelFlags: nil leaves the stored level untouched, non-nil
+	// replaces it wholesale (empty clears). Validated post-merge below.
+	if err := applyProviderFlagsRequest(p, req.Flags, req.ModelFlags); err != nil {
+		badRequest(c, "%s", err)
+		return
 	}
 
 	// Dual-mode constraints: validate post-merge so we catch combinations

--- a/internal/server/module/provider/handler_test.go
+++ b/internal/server/module/provider/handler_test.go
@@ -289,3 +289,106 @@ func TestImportProviders_MissingData(t *testing.T) {
 		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
 	}
 }
+
+// TestProviderFlags_API drives the flags/model_flags fields through the real
+// HTTP handlers: create with flags, partial-update semantics (nil untouched,
+// non-nil replaces, empty clears), response surfacing, and the api_key gate.
+func TestProviderFlags_API(t *testing.T) {
+	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := NewHandler(cfg, nil)
+	router.POST("/providers", handler.CreateProvider)
+	router.PUT("/providers/:uuid", handler.UpdateProvider)
+	router.GET("/providers/:uuid", handler.GetProvider)
+
+	do := func(method, path string, payload any) *httptest.ResponseRecorder {
+		t.Helper()
+		body, err := json.Marshal(payload)
+		require.NoError(t, err)
+		req, _ := http.NewRequest(method, path, bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	// Create with provider- and model-level flags.
+	w := do("POST", "/providers", CreateProviderRequest{
+		Name:    "flags-provider",
+		APIBase: "https://api.test.com/v1",
+		Token:   "sk-test",
+		Flags:   &typ.ProviderFlags{ExtraHeaders: map[string]string{"x-title": "tingly"}},
+		ModelFlags: map[string]typ.ProviderFlags{
+			"gpt-x": {ExtraHeaders: map[string]string{"X-Canary": "on"}},
+		},
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var created struct {
+		Data typ.Provider `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	uid := created.Data.UUID
+	require.NotEmpty(t, uid)
+
+	// readBack decodes into a fresh struct each time — json.Unmarshal into a
+	// reused struct merges maps instead of replacing them.
+	readBack := func() ProviderResponse {
+		t.Helper()
+		w := do("GET", "/providers/"+uid, nil)
+		require.Equal(t, http.StatusOK, w.Code)
+		var got struct {
+			Data ProviderResponse `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		return got.Data
+	}
+
+	// Read back: names canonicalized, both levels surfaced.
+	resp := readBack()
+	require.NotNil(t, resp.Flags)
+	assert.Equal(t, "tingly", resp.Flags.ExtraHeaders["X-Title"])
+	assert.Equal(t, "on", resp.ModelFlags["gpt-x"].ExtraHeaders["X-Canary"])
+
+	// Partial update with both sections omitted leaves flags untouched.
+	name := "flags-provider-renamed"
+	w = do("PUT", "/providers/"+uid, UpdateProviderRequest{Name: &name})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp = readBack()
+	require.NotNil(t, resp.Flags)
+	assert.Equal(t, "tingly", resp.Flags.ExtraHeaders["X-Title"])
+
+	// Non-nil flags replace wholesale; empty model_flags map clears it.
+	emptyMF := map[string]typ.ProviderFlags{}
+	w = do("PUT", "/providers/"+uid, UpdateProviderRequest{
+		Flags:      &typ.ProviderFlags{ExtraHeaders: map[string]string{"X-New": "v"}},
+		ModelFlags: &emptyMF,
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp = readBack()
+	require.NotNil(t, resp.Flags)
+	assert.Equal(t, "v", resp.Flags.ExtraHeaders["X-New"])
+	assert.NotContains(t, resp.Flags.ExtraHeaders, "X-Title")
+	assert.Empty(t, resp.ModelFlags)
+
+	// Structurally invalid header name rejected with 400 (no denylist —
+	// gateway-adjacent names like Authorization are accepted verbatim).
+	w = do("PUT", "/providers/"+uid, UpdateProviderRequest{
+		Flags: &typ.ProviderFlags{ExtraHeaders: map[string]string{"X Title": "bad name"}},
+	})
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+
+	// api_key gate: headers on a non-api_key provider are rejected.
+	w = do("POST", "/providers", CreateProviderRequest{
+		Name:     "sigv4-provider",
+		APIBase:  "https://bedrock.test",
+		AuthType: "aws_sigv4",
+		APIStyle: "anthropic",
+		Credential: map[string]string{
+			"access_key_id": "AKIA", "secret_access_key": "s", "region": "us-east-1",
+		},
+		Flags: &typ.ProviderFlags{ExtraHeaders: map[string]string{"X-Title": "t"}},
+	})
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "api_key")
+}

--- a/internal/server/module/provider/routes.go
+++ b/internal/server/module/provider/routes.go
@@ -45,6 +45,15 @@ func RegisterRoutes(api *swagger.RouteGroup, h *Handler) {
 		swagger.WithResponseModel(DeleteProviderResponse{}),
 	)
 
+	// GET /provider/flags/registry - Catalog of supported provider/model-level
+	// flags, mirroring GET /rule/flags/registry so the frontend renders the
+	// provider Plugins UI registry-driven.
+	api.GET("/provider/flags/registry", h.GetFlagRegistry,
+		swagger.WithDescription("Get catalog of supported provider/model-level flags"),
+		swagger.WithTags("providers"),
+		swagger.WithResponseModel(FlagRegistryResponse{}),
+	)
+
 	api.GET("/provider-models/:uuid", h.GetProviderModelsByUUID,
 		swagger.WithDescription("Get all provider models"),
 		swagger.WithTags("models"),

--- a/internal/server/module/provider/types.go
+++ b/internal/server/module/provider/types.go
@@ -24,10 +24,9 @@ type ProviderResponse struct {
 	VModelDetail     *typ.VModelDetail `json:"vmodel_detail,omitempty"`               // Virtual-model config (only for vmodel auth type)
 	Credential       map[string]string `json:"credential,omitempty"`                  // Multi-field cloud credentials (only for aws_sigv4/azure_key/gcp_sa)
 	Source           string            `json:"source,omitempty" example:"user"`       // "user" (default) or "builtin"
-	// Flags carries the provider-level flags (extra_headers, …) decoded from
-	// the provider's extension container; ModelFlags the per-model overrides
-	// keyed by provider-side model ID. See GET /provider/flags/registry for
-	// the catalog. api_key providers only.
+	// Flags carries the provider-level flags, ModelFlags the per-model
+	// overrides keyed by provider-side model ID. See
+	// GET /provider/flags/registry for the catalog. api_key providers only.
 	Flags      *typ.ProviderFlags           `json:"flags,omitempty"`
 	ModelFlags map[string]typ.ProviderFlags `json:"model_flags,omitempty"`
 }
@@ -56,7 +55,7 @@ type CreateProviderRequest struct {
 	Credential map[string]string `json:"credential,omitempty" description:"Cloud credential fields (aws_sigv4/azure_key/gcp_sa)"`
 	// Flags / ModelFlags optionally seed the provider-level flags and
 	// per-model overrides (api_key auth only; validated on save).
-	Flags      *typ.ProviderFlags           `json:"flags,omitempty" description:"Provider-level flags (extra_headers, …); api_key auth only"`
+	Flags      *typ.ProviderFlags           `json:"flags,omitempty" description:"Provider-level flags; see GET /provider/flags/registry (api_key auth only)"`
 	ModelFlags map[string]typ.ProviderFlags `json:"model_flags,omitempty" description:"Per-model flag overrides keyed by provider-side model ID; api_key auth only"`
 }
 

--- a/internal/server/module/provider/types.go
+++ b/internal/server/module/provider/types.go
@@ -24,6 +24,12 @@ type ProviderResponse struct {
 	VModelDetail     *typ.VModelDetail `json:"vmodel_detail,omitempty"`               // Virtual-model config (only for vmodel auth type)
 	Credential       map[string]string `json:"credential,omitempty"`                  // Multi-field cloud credentials (only for aws_sigv4/azure_key/gcp_sa)
 	Source           string            `json:"source,omitempty" example:"user"`       // "user" (default) or "builtin"
+	// Flags carries the provider-level flags (extra_headers, …) decoded from
+	// the provider's extension container; ModelFlags the per-model overrides
+	// keyed by provider-side model ID. See GET /provider/flags/registry for
+	// the catalog. api_key providers only.
+	Flags      *typ.ProviderFlags           `json:"flags,omitempty"`
+	ModelFlags map[string]typ.ProviderFlags `json:"model_flags,omitempty"`
 }
 
 // ProvidersResponse represents the response for listing providers.
@@ -48,6 +54,10 @@ type CreateProviderRequest struct {
 	// aws_sigv4 (AWS Bedrock), azure_key (Azure OpenAI), and gcp_sa (GCP Vertex).
 	// Ignored for api_key/oauth/vmodel. See ai.CredentialSchema for the field keys.
 	Credential map[string]string `json:"credential,omitempty" description:"Cloud credential fields (aws_sigv4/azure_key/gcp_sa)"`
+	// Flags / ModelFlags optionally seed the provider-level flags and
+	// per-model overrides (api_key auth only; validated on save).
+	Flags      *typ.ProviderFlags           `json:"flags,omitempty" description:"Provider-level flags (extra_headers, …); api_key auth only"`
+	ModelFlags map[string]typ.ProviderFlags `json:"model_flags,omitempty" description:"Per-model flag overrides keyed by provider-side model ID; api_key auth only"`
 }
 
 // CreateProviderResponse represents the response for adding a provider.
@@ -72,6 +82,13 @@ type UpdateProviderRequest struct {
 	// types (aws_sigv4/azure_key/gcp_sa). Omit (null) to leave it unchanged; the
 	// edit UI resends the complete map since the read path returns it in full.
 	Credential map[string]string `json:"credential,omitempty" description:"Replacement cloud credential fields (aws_sigv4/azure_key/gcp_sa)"`
+	// Flags / ModelFlags follow the same partial semantics as the other
+	// fields: omit (null) to leave the stored value unchanged; a non-null
+	// value replaces the corresponding level wholesale (an empty object /
+	// map clears it). No deep per-key merge — the edit UI saves whole
+	// sections, and deep map patches are ambiguous.
+	Flags      *typ.ProviderFlags            `json:"flags,omitempty" description:"Replacement provider-level flags; empty object clears them (api_key auth only)"`
+	ModelFlags *map[string]typ.ProviderFlags `json:"model_flags,omitempty" description:"Replacement per-model flag overrides; empty map clears them (api_key auth only)"`
 }
 
 // UpdateProviderResponse represents the response for updating a provider.
@@ -94,6 +111,14 @@ type ToggleProviderResponse struct {
 type DeleteProviderResponse struct {
 	Success bool   `json:"success" example:"true"`
 	Message string `json:"message" example:"Provider deleted successfully"`
+}
+
+// FlagRegistryResponse exposes the catalog of supported provider/model-level
+// flags so the frontend can render the provider Plugins UI generically —
+// the supply-side counterpart of the rule module's flag registry endpoint.
+type FlagRegistryResponse struct {
+	Success bool           `json:"success" example:"true"`
+	Data    []typ.FlagSpec `json:"data"`
 }
 
 // ModelCacheSource identifies where the model list was sourced from.

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -47,20 +47,37 @@ const (
 	FlagCategoryVision FlagCategory = "vision"
 )
 
+// FlagLevel is a level a flag can be set at, ordered widest to narrowest: a
+// whole upstream, one of its models, or the requests a rule matches. When
+// several set the same flag the narrower wins — bools OR, scalars take the
+// narrowest non-zero value (.design/provider-flags.md §3.3).
+type FlagLevel string
+
+const (
+	FlagLevelProvider FlagLevel = "provider"
+	FlagLevelModel    FlagLevel = "model"
+	FlagLevelRule     FlagLevel = "rule"
+)
+
 // FlagOption is one selectable value for a FlagTypeEnum spec.
 type FlagOption struct {
 	Value string `json:"value"`
 	Label string `json:"label"`
 }
 
-// FlagSpec describes a single rule-level flag's metadata for the UI catalog.
-// Keys must match the JSON tag name on RuleFlags.
+// FlagSpec describes a single flag's metadata for the UI catalog. Keys must
+// match the JSON tag name on the struct backing each of the flag's levels
+// (RuleFlags for the rule level, ProviderFlags for provider/model).
 type FlagSpec struct {
 	Key         string        `json:"key"`
 	Label       string        `json:"label"`
 	Description string        `json:"description"`
 	Type        FlagValueType `json:"type"`
 	Category    FlagCategory  `json:"category"`
+	// Levels lists every level this flag can be set at, widest first. Every
+	// flag is settable at the rule level; a flag that also describes a
+	// property of the upstream adds the provider and model levels.
+	Levels []FlagLevel `json:"levels"`
 	// Placeholder is the hint text shown in string-type input fields.
 	Placeholder string `json:"placeholder,omitempty"`
 	// Options enumerates the selectable values for FlagTypeEnum flags.
@@ -83,6 +100,16 @@ type FlagSpec struct {
 	InheritanceMode string `json:"inheritance_mode,omitempty"`
 }
 
+// HasLevel reports whether the flag can be set at the given level.
+func (s FlagSpec) HasLevel(level FlagLevel) bool {
+	for _, l := range s.Levels {
+		if l == level {
+			return true
+		}
+	}
+	return false
+}
+
 // DefaultUserAgents returns a curated, non-exhaustive list of recommended
 // User-Agent strings for the custom_user_agent flag (both rule- and
 // scenario-level). The values mirror the vendor-pinned User-Agents the built-in
@@ -101,30 +128,46 @@ func DefaultUserAgents() []FlagOption {
 	}
 }
 
-// RuleFlagRegistry returns the catalog of supported rule flags. The order is
-// the recommended display order in the UI — categories are grouped implicitly
-// by adjacent entries sharing the same Category value.
+// supplyAndRuleLevels / ruleOnlyLevels spell out the two level sets the
+// registry actually uses. Functions rather than shared slices so no caller can
+// mutate every spec's Levels at once.
+func supplyAndRuleLevels() []FlagLevel {
+	return []FlagLevel{FlagLevelProvider, FlagLevelModel, FlagLevelRule}
+}
+
+func ruleOnlyLevels() []FlagLevel { return []FlagLevel{FlagLevelRule} }
+
+// RuleFlagRegistry returns the catalog of every supported flag — the single
+// definition each level's catalog is derived from (ProviderFlagRegistry
+// filters it by FlagLevelProvider). The order is the recommended display order
+// in the UI; categories are grouped implicitly by adjacent entries sharing the
+// same Category value.
+//
+// Descriptions are written level-neutrally: the surface the user is on already
+// says which level they are editing.
 func RuleFlagRegistry() []FlagSpec {
 	return []FlagSpec{
 		// ── Request (protocol-agnostic) ────────────────────────────────────
 		{
 			Key:         "extra_headers",
 			Label:       "Custom Headers",
-			Description: "Append custom HTTP headers to the outbound upstream request for this rule. Merged with the provider- and model-level Custom Headers; on a name conflict the rule value wins (provider < model < rule). Applies to API-key providers only — OAuth/vendor providers (Claude Code, Codex, Kimi, Gemini, Antigravity) keep their handshake headers and ignore this. Headers are sent as configured, including ones the gateway also sets (Authorization, User-Agent, …) — overriding those is your call and your responsibility.",
+			Description: "Append custom HTTP headers to the outbound upstream request. Typical uses are upstreams that gate on their own headers (OpenRouter's HTTP-Referer / X-Title, gateway tenant or audit headers). Headers set at more than one level merge per name, the narrower level winning (provider < model < rule). API-key providers only — OAuth/vendor providers (Claude Code, Codex, Kimi, Gemini, Antigravity) keep their handshake headers and ignore this. Headers are sent as configured, including ones the gateway also sets (Authorization, User-Agent, …) — overriding those is your call and your responsibility.",
 			Type:        FlagTypeHeaders,
 			Category:    FlagCategoryRequest,
+			Levels:      supplyAndRuleLevels(),
 		},
 		// ── Request (OpenAI) ───────────────────────────────────────────────
 		{
 			Key:             "custom_user_agent",
 			Label:           "Custom User-Agent",
-			Description:     "Override the outbound User-Agent header sent to the upstream provider, for generic OpenAI / Anthropic clients. Takes precedence over the inbound client's own User-Agent; vendor-specific clients (Claude Code OAuth, Codex, Kimi, Gemini, Antigravity) keep their dedicated handshake User-Agent and ignore this. Can also be set scenario-wide (the rule value wins when both are set). Pick a preset to impersonate a known CLI/agent, enter any value, or choose \"None\" to strip the User-Agent header entirely (send no User-Agent).",
+			Description:     "Override the outbound User-Agent header sent to the upstream provider, for generic OpenAI / Anthropic clients. Takes precedence over the inbound client's own User-Agent; vendor-specific clients (Claude Code OAuth, Codex, Kimi, Gemini, Antigravity) keep their dedicated handshake User-Agent and ignore this. Also settable scenario-wide; the narrower level wins when more than one sets it. Pick a preset to impersonate a known CLI/agent, enter any value, or choose \"None\" to strip the User-Agent header entirely (send no User-Agent).",
 			Type:            FlagTypeString,
 			Category:        FlagCategoryRequestOpenAI,
 			Placeholder:     "e.g. MyApp/1.0",
 			Suggestions:     DefaultUserAgents(),
 			Shared:          true,
 			InheritanceMode: "override",
+			Levels:          supplyAndRuleLevels(),
 		},
 		{
 			Key:         "openai_endpoint_override",
@@ -137,6 +180,7 @@ func RuleFlagRegistry() []FlagSpec {
 				{Value: "chat", Label: "Force Chat Completions"},
 				{Value: "responses", Label: "Force Responses API"},
 			},
+			Levels: ruleOnlyLevels(),
 		},
 		{
 			Key:         "use_max_completion_tokens",
@@ -144,6 +188,7 @@ func RuleFlagRegistry() []FlagSpec {
 			Description: "OpenAI only. Rewrite `max_tokens` → `max_completion_tokens` in the outgoing request. Required by the o1/o3/gpt-5 model family, which rejects the older field name.",
 			Type:        FlagTypeBool,
 			Category:    FlagCategoryRequestOpenAI,
+			Levels:      supplyAndRuleLevels(),
 		},
 		{
 			Key:         "use_max_tokens",
@@ -151,6 +196,7 @@ func RuleFlagRegistry() []FlagSpec {
 			Description: "OpenAI only. Rewrite `max_completion_tokens` → `max_tokens` in the outgoing request. Use for older OpenAI-compatible providers that do not yet accept the newer field name.",
 			Type:        FlagTypeBool,
 			Category:    FlagCategoryRequestOpenAI,
+			Levels:      supplyAndRuleLevels(),
 		},
 		{
 			Key:         "block_tools",
@@ -159,6 +205,7 @@ func RuleFlagRegistry() []FlagSpec {
 			Type:        FlagTypeString,
 			Category:    FlagCategoryRequestOpenAI,
 			Placeholder: "e.g. web_search,run_terminal_cmd",
+			Levels:      supplyAndRuleLevels(),
 		},
 		// ── Response ───────────────────────────────────────────────────────
 		{
@@ -169,6 +216,7 @@ func RuleFlagRegistry() []FlagSpec {
 			Category:        FlagCategoryResponse,
 			Shared:          true,
 			InheritanceMode: "or",
+			Levels:          supplyAndRuleLevels(),
 		},
 		// ── Reasoning ──────────────────────────────────────────────────────
 		{
@@ -195,6 +243,7 @@ func RuleFlagRegistry() []FlagSpec {
 				{Value: "high", Label: "High (~20K tokens)"},
 				{Value: "max", Label: "Max (~32K tokens)"},
 			},
+			Levels: supplyAndRuleLevels(),
 		},
 		// ── Vision ─────────────────────────────────────────────────────────
 		{
@@ -203,6 +252,7 @@ func RuleFlagRegistry() []FlagSpec {
 			Description: "Describe images via a vision-capable model so text-only downstream models can read them. Applies only to requests matched by this rule. Same effect as the scenario-level Vision Proxy but scoped to this rule; when both are configured, this rule-level service takes precedence.",
 			Type:        FlagTypeServiceRef,
 			Category:    FlagCategoryVision,
+			Levels:      ruleOnlyLevels(),
 		},
 		// ── Routing ────────────────────────────────────────────────────────
 		{
@@ -212,6 +262,7 @@ func RuleFlagRegistry() []FlagSpec {
 			Type:        FlagTypeInt,
 			Category:    FlagCategoryRouting,
 			Placeholder: "e.g. 3600",
+			Levels:      ruleOnlyLevels(),
 		},
 		// ── App ────────────────────────────────────────────────────────────
 		{
@@ -220,6 +271,7 @@ func RuleFlagRegistry() []FlagSpec {
 			Description: "Normalize rich content, gate tools, and strip stream usage for Cursor clients.",
 			Type:        FlagTypeBool,
 			Category:    FlagCategoryApp,
+			Levels:      supplyAndRuleLevels(),
 		},
 		{
 			Key:         "cursor_compat_auto",
@@ -227,6 +279,7 @@ func RuleFlagRegistry() []FlagSpec {
 			Description: "Apply cursor compatibility automatically when request headers identify Cursor.",
 			Type:        FlagTypeBool,
 			Category:    FlagCategoryApp,
+			Levels:      supplyAndRuleLevels(),
 		},
 		{
 			Key:             "claude_code_compat",
@@ -236,6 +289,7 @@ func RuleFlagRegistry() []FlagSpec {
 			Category:        FlagCategoryApp,
 			Shared:          true,
 			InheritanceMode: "or",
+			Levels:          supplyAndRuleLevels(),
 		},
 		{
 			Key:         "clean_header",
@@ -243,6 +297,7 @@ func RuleFlagRegistry() []FlagSpec {
 			Description: "Strip x-anthropic-billing-header blocks from system messages and neutralize steganographic markers before forwarding. Claude Code injects billing headers for its own billing; they must not leak to third-party providers. Additionally, Claude Code embeds geolocation markers in the system prompt date string (look-alike apostrophes in \"Today's\" and date separator substitution for China timezone users). This flag normalizes both. On by default for the built-in Claude Code rules, and automatically suppressed when the rule routes to a Claude OAuth provider (whose billing backend consumes the header). Turn off only for native Anthropic fidelity.",
 			Type:        FlagTypeBool,
 			Category:    FlagCategoryApp,
+			Levels:      supplyAndRuleLevels(),
 		},
 		{
 			Key:         "claude_org_id",
@@ -255,6 +310,7 @@ func RuleFlagRegistry() []FlagSpec {
 				// Sentinel preset — see typ.ClaudeOrgIDAuto.
 				{Label: "Login organization (from OAuth)", Value: ClaudeOrgIDAuto},
 			},
+			Levels: ruleOnlyLevels(),
 		},
 		{
 			Key:         "context_1m",
@@ -262,6 +318,7 @@ func RuleFlagRegistry() []FlagSpec {
 			Description: "Enable Anthropic's 1M token context window for supported models (Sonnet 4.6+, Opus 4.6+). Injects the context-1m-2025-08-07 beta flag into the upstream anthropic-beta header; the model name sent to the provider is unchanged. Only enable for models that support the 1M context window.",
 			Type:        FlagTypeBool,
 			Category:    FlagCategoryRequestAnthropic,
+			Levels:      supplyAndRuleLevels(),
 		},
 	}
 }

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -110,7 +110,7 @@ func RuleFlagRegistry() []FlagSpec {
 		{
 			Key:         "extra_headers",
 			Label:       "Custom Headers",
-			Description: "Append custom HTTP headers to the outbound upstream request for requests matched by this rule. Applies to API-key providers only — OAuth/vendor providers (Claude Code, Codex, Kimi, Gemini, Antigravity) keep their handshake headers and ignore this. Headers are sent as configured, including ones the gateway also sets (Authorization, User-Agent, …) — overriding those is your call and your responsibility.",
+			Description: "Append custom HTTP headers to the outbound upstream request for this rule. Merged with the provider- and model-level Custom Headers; on a name conflict the rule value wins (provider < model < rule). Applies to API-key providers only — OAuth/vendor providers (Claude Code, Codex, Kimi, Gemini, Antigravity) keep their handshake headers and ignore this. Headers are sent as configured, including ones the gateway also sets (Authorization, User-Agent, …) — overriding those is your call and your responsibility.",
 			Type:        FlagTypeHeaders,
 			Category:    FlagCategoryRequest,
 		},

--- a/internal/typ/provider_flag_registry.go
+++ b/internal/typ/provider_flag_registry.go
@@ -1,100 +1,18 @@
 package typ
 
-// providerFlagDescriptions lists, in display order, every flag configurable at
-// the provider and model levels, together with its supply-side wording.
+// ProviderFlagRegistry returns the catalog of flags configurable on a provider
+// and its models — the FlagLevelProvider slice of the one flag definition in
+// RuleFlagRegistry, not a second catalog. Deriving it means the same knob
+// always renders the same control on both surfaces and the two cannot drift.
 //
-// The keys are a subset of RuleFlagRegistry's — the two levels share one
-// vocabulary on purpose, so a knob means the same thing wherever it is set and
-// only the level changes. Everything except the description (label, value
-// type, category, placeholder, options, suggestions) is taken from the rule
-// spec for the same key, so the UI renders an identical control on both
-// surfaces and the two can never drift apart.
-//
-// Absent on purpose:
-//   - session_affinity, vision_proxy_service — resolved before an upstream is
-//     picked, so a value attached to an upstream could never be read.
-//   - openai_endpoint_override — the provider already carries a first-class
-//     OpenAIEndpointMode for exactly this; a second control for one setting is
-//     the duplicate-mode-picker trap (.design/ux-principles.md).
-//   - claude_org_id — Claude OAuth only, while provider flags are api_key only.
-var providerFlagDescriptions = []struct {
-	Key         string
-	Description string
-}{
-	{
-		Key:         "extra_headers",
-		Description: "Append custom HTTP headers to outbound requests to this provider. Typical uses are upstreams that gate on their own headers (OpenRouter's HTTP-Referer / X-Title, gateway tenant or audit headers). Headers are sent as configured, including ones the gateway also sets (Authorization, User-Agent, …) — overriding those is your call and your responsibility.",
-	},
-	{
-		Key:         "custom_user_agent",
-		Description: "Override the User-Agent sent to this provider, for upstreams that gate on a known client. Pick a preset, enter any value, or choose \"None\" to send no User-Agent at all.",
-	},
-	{
-		Key:         "use_max_completion_tokens",
-		Description: "Rewrite `max_tokens` → `max_completion_tokens` for this provider. Set it at the model level for the o1/o3/gpt-5 family, which rejects the older field name, and provider-wide for an upstream that only accepts the newer one.",
-	},
-	{
-		Key:         "use_max_tokens",
-		Description: "Rewrite `max_completion_tokens` → `max_tokens` for this provider. Use for older OpenAI-compatible upstreams that do not yet accept the newer field name.",
-	},
-	{
-		Key:         "block_tools",
-		Description: "Comma-separated tool names to strip from every request to this provider, for upstreams that reject or mishandle a specific tool.",
-	},
-	{
-		Key:         "thinking_effort",
-		Description: "Force extended thinking on or off for this provider, for upstreams whose thinking support differs from what clients assume. \"By Client\" leaves the decision to the request.",
-	},
-	{
-		Key:         "skip_usage",
-		Description: "Strip the `usage` block from this provider's responses, for upstreams whose usage accounting is absent or wrong.",
-	},
-	{
-		Key:         "claude_code_compat",
-		Description: "Fold Claude Code's mid-conversation \"system\" role messages into neighbouring user turns before forwarding. Third-party Anthropic-compatible providers reject that role, which makes this a property of the upstream rather than of the client.",
-	},
-	{
-		Key:         "clean_header",
-		Description: "Strip Claude Code's billing-header blocks and geolocation markers from system messages before they reach this provider. Those headers are meant for Anthropic's billing backend and must not leak to a third-party upstream.",
-	},
-	{
-		Key:         "cursor_compat",
-		Description: "Apply the Cursor normalizations (rich content, tool gating, stream usage) to every request to this provider.",
-	},
-	{
-		Key:         "cursor_compat_auto",
-		Description: "Apply the Cursor normalizations to requests to this provider only when the inbound headers identify Cursor.",
-	},
-	{
-		Key:         "context_1m",
-		Description: "Request Anthropic's 1M token context window by injecting the context-1m-2025-08-07 beta flag. Support is a property of the model (Sonnet 4.6+, Opus 4.6+), so this is normally set at the model level.",
-	},
-}
-
-// ProviderFlagRegistry returns the catalog of supported provider/model-level
-// flags — the supply-side counterpart of RuleFlagRegistry, with the same
-// contract: keys match the JSON tag names on ProviderFlags, and the UI renders
-// each spec from its Type.
-//
-// Every spec is configurable at both the provider and the model level, and the
-// levels combine uniformly by value kind (bools OR, scalars take the narrowest
-// non-zero value, maps merge per key), so there is no per-spec scope or merge
-// axis to declare. The scenario-inheritance fields (Shared, InheritanceMode)
-// belong to the rule axis and are cleared here. See .design/provider-flags.md.
+// The scenario-inheritance fields belong to the rule axis and are cleared, so
+// the provider UI never offers a scenario default for a supply-side value.
 func ProviderFlagRegistry() []FlagSpec {
-	ruleSpecs := make(map[string]FlagSpec, len(RuleFlagRegistry()))
+	var specs []FlagSpec
 	for _, spec := range RuleFlagRegistry() {
-		ruleSpecs[spec.Key] = spec
-	}
-
-	specs := make([]FlagSpec, 0, len(providerFlagDescriptions))
-	for _, entry := range providerFlagDescriptions {
-		spec, ok := ruleSpecs[entry.Key]
-		if !ok {
-			// Guarded by TestProviderFlagRegistry_KeysExistInRuleRegistry.
+		if !spec.HasLevel(FlagLevelProvider) {
 			continue
 		}
-		spec.Description = entry.Description
 		spec.Shared = false
 		spec.InheritanceMode = ""
 		specs = append(specs, spec)

--- a/internal/typ/provider_flag_registry.go
+++ b/internal/typ/provider_flag_registry.go
@@ -1,19 +1,103 @@
 package typ
 
+// providerFlagDescriptions lists, in display order, every flag configurable at
+// the provider and model levels, together with its supply-side wording.
+//
+// The keys are a subset of RuleFlagRegistry's — the two levels share one
+// vocabulary on purpose, so a knob means the same thing wherever it is set and
+// only the level changes. Everything except the description (label, value
+// type, category, placeholder, options, suggestions) is taken from the rule
+// spec for the same key, so the UI renders an identical control on both
+// surfaces and the two can never drift apart.
+//
+// Absent on purpose:
+//   - session_affinity, vision_proxy_service — resolved before an upstream is
+//     picked, so a value attached to an upstream could never be read.
+//   - openai_endpoint_override — the provider already carries a first-class
+//     OpenAIEndpointMode for exactly this; a second control for one setting is
+//     the duplicate-mode-picker trap (.design/ux-principles.md).
+//   - claude_org_id — Claude OAuth only, while provider flags are api_key only.
+var providerFlagDescriptions = []struct {
+	Key         string
+	Description string
+}{
+	{
+		Key:         "extra_headers",
+		Description: "Append custom HTTP headers to outbound requests to this provider. Typical uses are upstreams that gate on their own headers (OpenRouter's HTTP-Referer / X-Title, gateway tenant or audit headers). Headers are sent as configured, including ones the gateway also sets (Authorization, User-Agent, …) — overriding those is your call and your responsibility.",
+	},
+	{
+		Key:         "custom_user_agent",
+		Description: "Override the User-Agent sent to this provider, for upstreams that gate on a known client. Pick a preset, enter any value, or choose \"None\" to send no User-Agent at all.",
+	},
+	{
+		Key:         "use_max_completion_tokens",
+		Description: "Rewrite `max_tokens` → `max_completion_tokens` for this provider. Set it at the model level for the o1/o3/gpt-5 family, which rejects the older field name, and provider-wide for an upstream that only accepts the newer one.",
+	},
+	{
+		Key:         "use_max_tokens",
+		Description: "Rewrite `max_completion_tokens` → `max_tokens` for this provider. Use for older OpenAI-compatible upstreams that do not yet accept the newer field name.",
+	},
+	{
+		Key:         "block_tools",
+		Description: "Comma-separated tool names to strip from every request to this provider, for upstreams that reject or mishandle a specific tool.",
+	},
+	{
+		Key:         "thinking_effort",
+		Description: "Force extended thinking on or off for this provider, for upstreams whose thinking support differs from what clients assume. \"By Client\" leaves the decision to the request.",
+	},
+	{
+		Key:         "skip_usage",
+		Description: "Strip the `usage` block from this provider's responses, for upstreams whose usage accounting is absent or wrong.",
+	},
+	{
+		Key:         "claude_code_compat",
+		Description: "Fold Claude Code's mid-conversation \"system\" role messages into neighbouring user turns before forwarding. Third-party Anthropic-compatible providers reject that role, which makes this a property of the upstream rather than of the client.",
+	},
+	{
+		Key:         "clean_header",
+		Description: "Strip Claude Code's billing-header blocks and geolocation markers from system messages before they reach this provider. Those headers are meant for Anthropic's billing backend and must not leak to a third-party upstream.",
+	},
+	{
+		Key:         "cursor_compat",
+		Description: "Apply the Cursor normalizations (rich content, tool gating, stream usage) to every request to this provider.",
+	},
+	{
+		Key:         "cursor_compat_auto",
+		Description: "Apply the Cursor normalizations to requests to this provider only when the inbound headers identify Cursor.",
+	},
+	{
+		Key:         "context_1m",
+		Description: "Request Anthropic's 1M token context window by injecting the context-1m-2025-08-07 beta flag. Support is a property of the model (Sonnet 4.6+, Opus 4.6+), so this is normally set at the model level.",
+	},
+}
+
 // ProviderFlagRegistry returns the catalog of supported provider/model-level
 // flags — the supply-side counterpart of RuleFlagRegistry, with the same
-// contract: keys must match the JSON tag names on ProviderFlags, and the UI
-// renders each spec from its Type. Every spec is configurable at both the
-// provider and the model level (the model level wins per key), so there is
-// no per-spec scope or merge axis to declare. See .design/provider-flags.md.
+// contract: keys match the JSON tag names on ProviderFlags, and the UI renders
+// each spec from its Type.
+//
+// Every spec is configurable at both the provider and the model level, and the
+// levels combine uniformly by value kind (bools OR, scalars take the narrowest
+// non-zero value, maps merge per key), so there is no per-spec scope or merge
+// axis to declare. The scenario-inheritance fields (Shared, InheritanceMode)
+// belong to the rule axis and are cleared here. See .design/provider-flags.md.
 func ProviderFlagRegistry() []FlagSpec {
-	return []FlagSpec{
-		{
-			Key:         "extra_headers",
-			Label:       "Custom Headers",
-			Description: "Append custom HTTP headers to outbound requests to this provider. Model-level headers apply only to requests for that model and win over provider-level headers on a name conflict; a rule-level Custom Headers flag wins over both (provider < model < rule). API-key providers only. Headers are sent as configured, including ones the gateway also sets (Authorization, User-Agent, …) — overriding those is your call and your responsibility.",
-			Type:        FlagTypeHeaders,
-			Category:    FlagCategoryRequest,
-		},
+	ruleSpecs := make(map[string]FlagSpec, len(RuleFlagRegistry()))
+	for _, spec := range RuleFlagRegistry() {
+		ruleSpecs[spec.Key] = spec
 	}
+
+	specs := make([]FlagSpec, 0, len(providerFlagDescriptions))
+	for _, entry := range providerFlagDescriptions {
+		spec, ok := ruleSpecs[entry.Key]
+		if !ok {
+			// Guarded by TestProviderFlagRegistry_KeysExistInRuleRegistry.
+			continue
+		}
+		spec.Description = entry.Description
+		spec.Shared = false
+		spec.InheritanceMode = ""
+		specs = append(specs, spec)
+	}
+	return specs
 }

--- a/internal/typ/provider_flag_registry.go
+++ b/internal/typ/provider_flag_registry.go
@@ -1,0 +1,19 @@
+package typ
+
+// ProviderFlagRegistry returns the catalog of supported provider/model-level
+// flags — the supply-side counterpart of RuleFlagRegistry, with the same
+// contract: keys must match the JSON tag names on ProviderFlags, and the UI
+// renders each spec from its Type. Every spec is configurable at both the
+// provider and the model level (the model level wins per key), so there is
+// no per-spec scope or merge axis to declare. See .design/provider-flags.md.
+func ProviderFlagRegistry() []FlagSpec {
+	return []FlagSpec{
+		{
+			Key:         "extra_headers",
+			Label:       "Custom Headers",
+			Description: "Append custom HTTP headers to outbound requests to this provider. Model-level headers apply only to requests for that model and win over provider-level headers on a name conflict; a rule-level Custom Headers flag wins over both (provider < model < rule). API-key providers only. Headers are sent as configured, including ones the gateway also sets (Authorization, User-Agent, …) — overriding those is your call and your responsibility.",
+			Type:        FlagTypeHeaders,
+			Category:    FlagCategoryRequest,
+		},
+	}
+}

--- a/internal/typ/provider_flag_registry_test.go
+++ b/internal/typ/provider_flag_registry_test.go
@@ -80,45 +80,55 @@ func TestProviderFlagRegistry_ExtraHeaders(t *testing.T) {
 	}
 }
 
-// TestProviderFlagRegistry_KeysExistInRuleRegistry guards the shared
-// vocabulary: the provider registry derives every spec but the description
-// from the rule spec of the same key, so a description entry naming a key the
-// rule registry does not have would be silently dropped.
-func TestProviderFlagRegistry_KeysExistInRuleRegistry(t *testing.T) {
-	ruleKeys := map[string]bool{}
+// TestProviderFlagRegistry_IsARuleRegistrySlice pins that the provider catalog
+// is derived, not re-declared: every spec is the FlagLevelProvider entry of the
+// same key in RuleFlagRegistry, unchanged apart from the cleared scenario axis.
+func TestProviderFlagRegistry_IsARuleRegistrySlice(t *testing.T) {
+	ruleSpecs := map[string]FlagSpec{}
+	want := 0
 	for _, spec := range RuleFlagRegistry() {
-		ruleKeys[spec.Key] = true
-	}
-	for _, entry := range providerFlagDescriptions {
-		if !ruleKeys[entry.Key] {
-			t.Errorf("provider flag %q has no rule spec to derive its control from", entry.Key)
+		ruleSpecs[spec.Key] = spec
+		if spec.HasLevel(FlagLevelProvider) {
+			want++
 		}
 	}
-	if got, want := len(ProviderFlagRegistry()), len(providerFlagDescriptions); got != want {
-		t.Errorf("ProviderFlagRegistry() returned %d specs, want %d", got, want)
+
+	specs := ProviderFlagRegistry()
+	if len(specs) != want {
+		t.Errorf("ProviderFlagRegistry() returned %d specs, want the %d provider-level rule specs", len(specs), want)
+	}
+	for _, spec := range specs {
+		rule, ok := ruleSpecs[spec.Key]
+		if !ok {
+			t.Errorf("flag %q is not in RuleFlagRegistry", spec.Key)
+			continue
+		}
+		// The scenario axis is a rule-side concept and must not leak through.
+		rule.Shared, rule.InheritanceMode = false, ""
+		if !reflect.DeepEqual(spec, rule) {
+			t.Errorf("flag %q diverges from its rule spec:\n got %+v\nwant %+v", spec.Key, spec, rule)
+		}
 	}
 }
 
-// TestProviderFlagRegistry_SharesRuleControlShape pins that the two surfaces
-// render the same control for the same key — only the wording differs.
-func TestProviderFlagRegistry_SharesRuleControlShape(t *testing.T) {
-	ruleSpecs := map[string]FlagSpec{}
+// TestFlagRegistry_LevelsAreDeclared pins that every spec declares its levels
+// and that the rule level is universal — a spec with no levels would vanish
+// from every catalog.
+func TestFlagRegistry_LevelsAreDeclared(t *testing.T) {
+	known := map[FlagLevel]bool{FlagLevelProvider: true, FlagLevelModel: true, FlagLevelRule: true}
 	for _, spec := range RuleFlagRegistry() {
-		ruleSpecs[spec.Key] = spec
-	}
-	for _, spec := range ProviderFlagRegistry() {
-		rule := ruleSpecs[spec.Key]
-		if spec.Type != rule.Type {
-			t.Errorf("flag %q type = %q, want the rule spec's %q", spec.Key, spec.Type, rule.Type)
+		if !spec.HasLevel(FlagLevelRule) {
+			t.Errorf("flag %q does not declare the rule level", spec.Key)
 		}
-		if spec.Label != rule.Label {
-			t.Errorf("flag %q label = %q, want the rule spec's %q", spec.Key, spec.Label, rule.Label)
+		// Provider and model share one storage struct, so a flag settable at
+		// one is settable at the other.
+		if spec.HasLevel(FlagLevelProvider) != spec.HasLevel(FlagLevelModel) {
+			t.Errorf("flag %q declares only one of the two supply levels: %v", spec.Key, spec.Levels)
 		}
-		if !reflect.DeepEqual(spec.Options, rule.Options) {
-			t.Errorf("flag %q options = %v, want the rule spec's %v", spec.Key, spec.Options, rule.Options)
-		}
-		if spec.Description == rule.Description {
-			t.Errorf("flag %q reuses the rule wording; provider flags need supply-side wording", spec.Key)
+		for _, level := range spec.Levels {
+			if !known[level] {
+				t.Errorf("flag %q declares unknown level %q", spec.Key, level)
+			}
 		}
 	}
 }

--- a/internal/typ/provider_flag_registry_test.go
+++ b/internal/typ/provider_flag_registry_test.go
@@ -79,3 +79,64 @@ func TestProviderFlagRegistry_ExtraHeaders(t *testing.T) {
 		t.Errorf("extra_headers type = %q, want %q", found.Type, FlagTypeHeaders)
 	}
 }
+
+// TestProviderFlagRegistry_KeysExistInRuleRegistry guards the shared
+// vocabulary: the provider registry derives every spec but the description
+// from the rule spec of the same key, so a description entry naming a key the
+// rule registry does not have would be silently dropped.
+func TestProviderFlagRegistry_KeysExistInRuleRegistry(t *testing.T) {
+	ruleKeys := map[string]bool{}
+	for _, spec := range RuleFlagRegistry() {
+		ruleKeys[spec.Key] = true
+	}
+	for _, entry := range providerFlagDescriptions {
+		if !ruleKeys[entry.Key] {
+			t.Errorf("provider flag %q has no rule spec to derive its control from", entry.Key)
+		}
+	}
+	if got, want := len(ProviderFlagRegistry()), len(providerFlagDescriptions); got != want {
+		t.Errorf("ProviderFlagRegistry() returned %d specs, want %d", got, want)
+	}
+}
+
+// TestProviderFlagRegistry_SharesRuleControlShape pins that the two surfaces
+// render the same control for the same key — only the wording differs.
+func TestProviderFlagRegistry_SharesRuleControlShape(t *testing.T) {
+	ruleSpecs := map[string]FlagSpec{}
+	for _, spec := range RuleFlagRegistry() {
+		ruleSpecs[spec.Key] = spec
+	}
+	for _, spec := range ProviderFlagRegistry() {
+		rule := ruleSpecs[spec.Key]
+		if spec.Type != rule.Type {
+			t.Errorf("flag %q type = %q, want the rule spec's %q", spec.Key, spec.Type, rule.Type)
+		}
+		if spec.Label != rule.Label {
+			t.Errorf("flag %q label = %q, want the rule spec's %q", spec.Key, spec.Label, rule.Label)
+		}
+		if !reflect.DeepEqual(spec.Options, rule.Options) {
+			t.Errorf("flag %q options = %v, want the rule spec's %v", spec.Key, spec.Options, rule.Options)
+		}
+		if spec.Description == rule.Description {
+			t.Errorf("flag %q reuses the rule wording; provider flags need supply-side wording", spec.Key)
+		}
+	}
+}
+
+// TestProviderFlagRegistry_ExcludesRequestOnlyFlags documents the flags that
+// deliberately have no supply-side level, so re-adding one is a conscious act.
+func TestProviderFlagRegistry_ExcludesRequestOnlyFlags(t *testing.T) {
+	// session_affinity / vision_proxy_service are resolved before an upstream
+	// is picked; openai_endpoint_override duplicates Provider.OpenAIEndpointMode;
+	// claude_org_id is Claude OAuth only while provider flags are api_key only.
+	excluded := []string{"session_affinity", "vision_proxy_service", "openai_endpoint_override", "claude_org_id"}
+	present := map[string]bool{}
+	for _, spec := range ProviderFlagRegistry() {
+		present[spec.Key] = true
+	}
+	for _, key := range excluded {
+		if present[key] {
+			t.Errorf("flag %q is exposed at the provider level but has no supply-side meaning", key)
+		}
+	}
+}

--- a/internal/typ/provider_flag_registry_test.go
+++ b/internal/typ/provider_flag_registry_test.go
@@ -1,0 +1,81 @@
+package typ
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestProviderFlagRegistry_KeysMatchStructFields prevents the provider flag
+// registry from drifting away from ProviderFlags — the same safety net
+// TestRuleFlagRegistry_KeysMatchStructFields provides for rule flags.
+func TestProviderFlagRegistry_KeysMatchStructFields(t *testing.T) {
+	flagsType := reflect.TypeOf(ProviderFlags{})
+
+	jsonTags := map[string]bool{}
+	for i := 0; i < flagsType.NumField(); i++ {
+		tag := flagsType.Field(i).Tag.Get("json")
+		name := strings.SplitN(tag, ",", 2)[0]
+		if name != "" && name != "-" {
+			jsonTags[name] = true
+		}
+	}
+
+	for _, spec := range ProviderFlagRegistry() {
+		if !jsonTags[spec.Key] {
+			t.Errorf("FlagSpec key %q has no matching json tag on ProviderFlags", spec.Key)
+		}
+	}
+}
+
+// TestProviderFlagRegistry_SpecsAreValid checks the metadata every spec must
+// carry — the same contract RuleFlagRegistry specs are held to.
+func TestProviderFlagRegistry_SpecsAreValid(t *testing.T) {
+	allowedTypes := map[FlagValueType]bool{
+		FlagTypeBool:       true,
+		FlagTypeString:     true,
+		FlagTypeEnum:       true,
+		FlagTypeInt:        true,
+		FlagTypeServiceRef: true,
+		FlagTypeHeaders:    true,
+	}
+	for _, spec := range ProviderFlagRegistry() {
+		if !allowedTypes[spec.Type] {
+			t.Errorf("flag %q has unsupported value type %q", spec.Key, spec.Type)
+		}
+		if spec.Label == "" {
+			t.Errorf("flag %q has empty label", spec.Key)
+		}
+		if spec.Description == "" {
+			t.Errorf("flag %q has empty description", spec.Key)
+		}
+		// Provider flags have no scenario inheritance axis.
+		if spec.Shared || spec.InheritanceMode != "" {
+			t.Errorf("flag %q must not use the scenario-axis Shared/InheritanceMode fields", spec.Key)
+		}
+		// The headers control renders free-form rows — enum/suggestion
+		// metadata has no meaning for it.
+		if spec.Type == FlagTypeHeaders && (len(spec.Options) > 0 || len(spec.Suggestions) > 0) {
+			t.Errorf("headers flag %q must not declare Options/Suggestions", spec.Key)
+		}
+	}
+}
+
+// TestProviderFlagRegistry_ExtraHeaders pins the first provider flag: present
+// and rendered as the headers control.
+func TestProviderFlagRegistry_ExtraHeaders(t *testing.T) {
+	var found *FlagSpec
+	specs := ProviderFlagRegistry()
+	for i := range specs {
+		if specs[i].Key == "extra_headers" {
+			found = &specs[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("extra_headers missing from ProviderFlagRegistry")
+	}
+	if found.Type != FlagTypeHeaders {
+		t.Errorf("extra_headers type = %q, want %q", found.Type, FlagTypeHeaders)
+	}
+}

--- a/internal/typ/provider_flags.go
+++ b/internal/typ/provider_flags.go
@@ -3,21 +3,13 @@ package typ
 import "net/textproto"
 
 // SupplyExtraHeaders merges the two supply-side header levels for one
-// (provider, model) pair — Provider.Flags ∪ Provider.ModelFlags[model], the
-// model level winning on name conflicts. These are a property of the
-// upstream, not of the request, so the client layer resolves them once per
-// client (which is already keyed by provider + model) instead of per request.
+// (provider, model) pair, the model level winning on name conflicts. Resolved
+// once per client (already keyed by provider + model), not per request.
 //
-// The third level, the rule's extra_headers, is a request-side flag: it
-// rides the request context and the outbound transport applies it *after*
-// this map, which is what makes the full precedence
-//
-//	provider  <  model  <  rule
-//
-// hold without anyone merging all three (see .design/provider-flags.md §5.1).
-//
-// Returns nil when neither supply level configures anything, so callers can
-// cheaply skip injection.
+// The rule's extra_headers are not merged in: the transport writes them after
+// this map, so provider < model < rule falls out of the write order rather
+// than a three-level merge (.design/provider-flags.md §5.1). Returns nil when
+// neither level configures anything.
 func SupplyExtraHeaders(p *Provider, model string) map[string]string {
 	if p == nil {
 		return nil
@@ -36,31 +28,21 @@ func SupplyExtraHeaders(p *Provider, model string) map[string]string {
 	return merged
 }
 
-// ApplyProviderFlags folds the two supply-side flag levels of a (provider,
-// model) pair into an already-resolved rule-side flag set, yielding the
-// effective flags for one request. Precedence is
+// ApplyProviderFlags folds a (provider, model) pair's supply-side flags into
+// an already-resolved rule-side set, giving the effective flags for one
+// request: bools OR across levels, scalars take the narrowest non-zero value
+// (provider < model < rule).
 //
-//	provider  <  model  <  rule
-//
-// applied uniformly by value kind, so no per-flag merge metadata exists:
-// bools OR together (any level enabling it activates the flag), and scalars
-// take the narrowest non-zero value — the rule's if it set one, else the
-// model's, else the provider's.
-//
-// ExtraHeaders is deliberately not merged here. Supply-side headers are
-// resolved per client by SupplyExtraHeaders and written by the outbound
-// transport *before* the rule's, which already produces the same precedence
-// at a lower layer; merging them here as well would double-apply them and
-// would make provider configuration show up as a rule flag in the applied-flag
-// diagnostics. See .design/provider-flags.md §5.1.
+// ExtraHeaders is excluded — it rides SupplyExtraHeaders and the transport's
+// write order instead, so merging it here would double-apply it and report
+// provider config as a rule flag in the applied-flag diagnostics.
 func ApplyProviderFlags(flags RuleFlags, p *Provider, model string) RuleFlags {
 	if p == nil {
 		return flags
 	}
-	// Narrowest level first: bools OR regardless of order, and every scalar
-	// only fills a slot still left at its zero value, so the first level to
-	// offer a value keeps it — model over provider, and the rule over both
-	// since its value is already in flags.
+	// Narrowest first: each scalar only fills a slot still at its zero value,
+	// so the first level offering one keeps it — model over provider, and the
+	// rule over both since its value is already in flags.
 	for _, supply := range []ProviderFlags{p.ModelFlags[model], p.Flags} {
 		flags.CursorCompat = flags.CursorCompat || supply.CursorCompat
 		flags.CursorCompatAuto = flags.CursorCompatAuto || supply.CursorCompatAuto

--- a/internal/typ/provider_flags.go
+++ b/internal/typ/provider_flags.go
@@ -36,6 +36,54 @@ func SupplyExtraHeaders(p *Provider, model string) map[string]string {
 	return merged
 }
 
+// ApplyProviderFlags folds the two supply-side flag levels of a (provider,
+// model) pair into an already-resolved rule-side flag set, yielding the
+// effective flags for one request. Precedence is
+//
+//	provider  <  model  <  rule
+//
+// applied uniformly by value kind, so no per-flag merge metadata exists:
+// bools OR together (any level enabling it activates the flag), and scalars
+// take the narrowest non-zero value — the rule's if it set one, else the
+// model's, else the provider's.
+//
+// ExtraHeaders is deliberately not merged here. Supply-side headers are
+// resolved per client by SupplyExtraHeaders and written by the outbound
+// transport *before* the rule's, which already produces the same precedence
+// at a lower layer; merging them here as well would double-apply them and
+// would make provider configuration show up as a rule flag in the applied-flag
+// diagnostics. See .design/provider-flags.md §5.1.
+func ApplyProviderFlags(flags RuleFlags, p *Provider, model string) RuleFlags {
+	if p == nil {
+		return flags
+	}
+	// Narrowest level first: bools OR regardless of order, and every scalar
+	// only fills a slot still left at its zero value, so the first level to
+	// offer a value keeps it — model over provider, and the rule over both
+	// since its value is already in flags.
+	for _, supply := range []ProviderFlags{p.ModelFlags[model], p.Flags} {
+		flags.CursorCompat = flags.CursorCompat || supply.CursorCompat
+		flags.CursorCompatAuto = flags.CursorCompatAuto || supply.CursorCompatAuto
+		flags.SkipUsage = flags.SkipUsage || supply.SkipUsage
+		flags.UseMaxCompletionTokens = flags.UseMaxCompletionTokens || supply.UseMaxCompletionTokens
+		flags.UseMaxTokens = flags.UseMaxTokens || supply.UseMaxTokens
+		flags.CleanHeader = flags.CleanHeader || supply.CleanHeader
+		flags.ClaudeCodeCompat = flags.ClaudeCodeCompat || supply.ClaudeCodeCompat
+		flags.Context1M = flags.Context1M || supply.Context1M
+
+		if flags.CustomUserAgent == "" {
+			flags.CustomUserAgent = supply.CustomUserAgent
+		}
+		if flags.BlockTools == "" {
+			flags.BlockTools = supply.BlockTools
+		}
+		if flags.ThinkingEffort == ThinkingEffortDefault {
+			flags.ThinkingEffort = supply.ThinkingEffort
+		}
+	}
+	return flags
+}
+
 // PruneModelFlags drops entries carrying no configuration (and the empty
 // model key) so a cleared model does not linger as an empty object in
 // storage and in API responses. Returns nil when nothing is left.

--- a/internal/typ/provider_flags.go
+++ b/internal/typ/provider_flags.go
@@ -1,0 +1,54 @@
+package typ
+
+import "net/textproto"
+
+// SupplyExtraHeaders merges the two supply-side header levels for one
+// (provider, model) pair — Provider.Flags ∪ Provider.ModelFlags[model], the
+// model level winning on name conflicts. These are a property of the
+// upstream, not of the request, so the client layer resolves them once per
+// client (which is already keyed by provider + model) instead of per request.
+//
+// The third level, the rule's extra_headers, is a request-side flag: it
+// rides the request context and the outbound transport applies it *after*
+// this map, which is what makes the full precedence
+//
+//	provider  <  model  <  rule
+//
+// hold without anyone merging all three (see .design/provider-flags.md §5.1).
+//
+// Returns nil when neither supply level configures anything, so callers can
+// cheaply skip injection.
+func SupplyExtraHeaders(p *Provider, model string) map[string]string {
+	if p == nil {
+		return nil
+	}
+	provider := p.Flags.ExtraHeaders
+	modelLevel := p.ModelFlags[model].ExtraHeaders
+	if len(provider) == 0 && len(modelLevel) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(provider)+len(modelLevel))
+	for _, level := range []map[string]string{provider, modelLevel} {
+		for name, value := range level {
+			merged[textproto.CanonicalMIMEHeaderKey(name)] = value
+		}
+	}
+	return merged
+}
+
+// PruneModelFlags drops entries carrying no configuration (and the empty
+// model key) so a cleared model does not linger as an empty object in
+// storage and in API responses. Returns nil when nothing is left.
+func PruneModelFlags(modelFlags map[string]ProviderFlags) map[string]ProviderFlags {
+	pruned := make(map[string]ProviderFlags, len(modelFlags))
+	for model, flags := range modelFlags {
+		if model == "" || flags.IsZero() {
+			continue
+		}
+		pruned[model] = flags
+	}
+	if len(pruned) == 0 {
+		return nil
+	}
+	return pruned
+}

--- a/internal/typ/provider_flags_test.go
+++ b/internal/typ/provider_flags_test.go
@@ -1,6 +1,9 @@
 package typ
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestSupplyExtraHeaders(t *testing.T) {
 	p := &Provider{
@@ -73,4 +76,83 @@ func TestPruneModelFlags(t *testing.T) {
 	if got := PruneModelFlags(nil); got != nil {
 		t.Errorf("nil should prune to nil, got %v", got)
 	}
+}
+
+func TestApplyProviderFlags_Precedence(t *testing.T) {
+	p := &Provider{
+		Flags: ProviderFlags{
+			CustomUserAgent: "provider-ua",
+			BlockTools:      "provider_tool",
+			ThinkingEffort:  "low",
+			UseMaxTokens:    true,
+		},
+		ModelFlags: map[string]ProviderFlags{
+			"gpt-5": {
+				CustomUserAgent:        "model-ua",
+				ThinkingEffort:         "high",
+				UseMaxCompletionTokens: true,
+			},
+		},
+	}
+
+	t.Run("model wins over provider", func(t *testing.T) {
+		got := ApplyProviderFlags(RuleFlags{}, p, "gpt-5")
+		if got.CustomUserAgent != "model-ua" {
+			t.Errorf("CustomUserAgent = %q, want the model value", got.CustomUserAgent)
+		}
+		if got.ThinkingEffort != "high" {
+			t.Errorf("ThinkingEffort = %q, want the model value", got.ThinkingEffort)
+		}
+		// A scalar only the provider sets still falls through to the request.
+		if got.BlockTools != "provider_tool" {
+			t.Errorf("BlockTools = %q, want the provider value", got.BlockTools)
+		}
+		// Bools OR across levels regardless of which one set them.
+		if !got.UseMaxTokens || !got.UseMaxCompletionTokens {
+			t.Errorf("bool flags = %+v, want both levels ORed in", got)
+		}
+	})
+
+	t.Run("rule wins over both", func(t *testing.T) {
+		got := ApplyProviderFlags(RuleFlags{
+			CustomUserAgent: "rule-ua",
+			ThinkingEffort:  "off",
+			BlockTools:      "rule_tool",
+		}, p, "gpt-5")
+		if got.CustomUserAgent != "rule-ua" {
+			t.Errorf("CustomUserAgent = %q, want the rule value", got.CustomUserAgent)
+		}
+		if got.ThinkingEffort != "off" {
+			t.Errorf("ThinkingEffort = %q, want the rule value", got.ThinkingEffort)
+		}
+		if got.BlockTools != "rule_tool" {
+			t.Errorf("BlockTools = %q, want the rule value", got.BlockTools)
+		}
+	})
+
+	t.Run("model level applies only to its own model", func(t *testing.T) {
+		got := ApplyProviderFlags(RuleFlags{}, p, "gpt-4")
+		if got.CustomUserAgent != "provider-ua" {
+			t.Errorf("CustomUserAgent = %q, want the provider value", got.CustomUserAgent)
+		}
+		if got.UseMaxCompletionTokens {
+			t.Error("UseMaxCompletionTokens leaked from another model's flags")
+		}
+	})
+
+	t.Run("extra_headers is not merged here", func(t *testing.T) {
+		// Supply-side headers ride the transport, not the rule flag set —
+		// merging them here too would double-apply them.
+		withHeaders := &Provider{Flags: ProviderFlags{ExtraHeaders: map[string]string{"X-A": "1"}}}
+		if got := ApplyProviderFlags(RuleFlags{}, withHeaders, ""); got.ExtraHeaders != nil {
+			t.Errorf("ExtraHeaders = %v, want nil", got.ExtraHeaders)
+		}
+	})
+
+	t.Run("nil provider is a no-op", func(t *testing.T) {
+		in := RuleFlags{CustomUserAgent: "rule-ua"}
+		if got := ApplyProviderFlags(in, nil, "gpt-5"); !reflect.DeepEqual(got, in) {
+			t.Errorf("ApplyProviderFlags(nil provider) = %+v, want the input unchanged", got)
+		}
+	})
 }

--- a/internal/typ/provider_flags_test.go
+++ b/internal/typ/provider_flags_test.go
@@ -1,0 +1,76 @@
+package typ
+
+import "testing"
+
+func TestSupplyExtraHeaders(t *testing.T) {
+	p := &Provider{
+		Flags: ProviderFlags{ExtraHeaders: map[string]string{
+			"X-Shared":   "provider",
+			"X-Provider": "p",
+		}},
+		ModelFlags: map[string]ProviderFlags{"m1": {ExtraHeaders: map[string]string{
+			"X-Shared": "model",
+			"X-Model":  "m",
+		}}},
+	}
+
+	// provider ∪ model, model wins per name. (The rule level is layered on
+	// top by the outbound transport's write order, not merged here.)
+	got := SupplyExtraHeaders(p, "m1")
+	want := map[string]string{
+		"X-Shared":   "model",
+		"X-Provider": "p",
+		"X-Model":    "m",
+	}
+	for name, value := range want {
+		if got[name] != value {
+			t.Errorf("merged[%q] = %q, want %q", name, got[name], value)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("merged has %d entries, want %d: %v", len(got), len(want), got)
+	}
+
+	// A different model drops the model level, keeping the provider level.
+	got = SupplyExtraHeaders(p, "other")
+	if got["X-Shared"] != "provider" || got["X-Provider"] != "p" || got["X-Model"] != "" {
+		t.Errorf("model-mismatch merge wrong: %v", got)
+	}
+
+	// Names are canonicalized so differently-cased levels collide predictably.
+	p2 := &Provider{
+		Flags:      ProviderFlags{ExtraHeaders: map[string]string{"x-title": "provider"}},
+		ModelFlags: map[string]ProviderFlags{"m1": {ExtraHeaders: map[string]string{"X-TITLE": "model"}}},
+	}
+	got = SupplyExtraHeaders(p2, "m1")
+	if len(got) != 1 || got["X-Title"] != "model" {
+		t.Errorf("case-insensitive collision not resolved to the model level: %v", got)
+	}
+
+	// Nothing configured → nil, so callers can skip injection.
+	if got := SupplyExtraHeaders(&Provider{}, "m"); got != nil {
+		t.Errorf("expected nil for unconfigured provider, got %v", got)
+	}
+	if got := SupplyExtraHeaders(nil, "m"); got != nil {
+		t.Errorf("expected nil for nil provider, got %v", got)
+	}
+}
+
+func TestPruneModelFlags(t *testing.T) {
+	got := PruneModelFlags(map[string]ProviderFlags{
+		"gpt-x":  {ExtraHeaders: map[string]string{"X-Canary": "on"}},
+		"":       {ExtraHeaders: map[string]string{"X-Skip": "empty model key"}},
+		"zeroed": {},
+	})
+	if len(got) != 1 || got["gpt-x"].ExtraHeaders["X-Canary"] != "on" {
+		t.Errorf("empty-key and zero-value entries should be pruned, got %v", got)
+	}
+
+	// An all-pruned map collapses to nil so storage keeps no empty object.
+	if got := PruneModelFlags(map[string]ProviderFlags{"m": {}}); got != nil {
+		t.Errorf("all-zero map should prune to nil, got %v", got)
+	}
+	if got := PruneModelFlags(nil); got != nil {
+		t.Errorf("nil should prune to nil, got %v", got)
+	}
+}

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -277,9 +277,10 @@ type RuleFlags struct {
 
 	// ExtraHeaders are appended to the outbound upstream request for requests
 	// matched by this rule. Applied on api_key providers only (vendor/OAuth
-	// chains keep their handshake headers untouched). Provider- and
-	// model-level extra_headers with a provider < model < rule merge are
-	// planned, not implemented (see .design/provider-flags.md).
+	// chains keep their handshake headers untouched). The provider- and
+	// model-level extra_headers are written first by the same transport, so
+	// a name conflict resolves provider < model < rule (see
+	// .design/provider-flags.md §5.1).
 	ExtraHeaders map[string]string `json:"extra_headers,omitempty" yaml:"extra_headers,omitempty"`
 
 	// ClaudeOrgID controls the anthropic-organization-id header sent upstream

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -388,6 +388,9 @@ type VModelDetail = ai.VModelDetail
 // Type alias for backward compatibility with common/provider
 type CredentialBundle = ai.CredentialBundle
 
+// ProviderFlags re-exports the provider/model flag struct (see ai.ProviderFlags).
+type ProviderFlags = ai.ProviderFlags
+
 // MCPMode defines MCP runtime mode
 type MCPMode string
 

--- a/openapi.json
+++ b/openapi.json
@@ -9863,6 +9863,13 @@
             "type": "string",
             "description": "Field label"
           },
+          "levels": {
+            "type": "array",
+            "description": "Field levels",
+            "items": {
+              "type": "string"
+            }
+          },
           "options": {
             "type": "array",
             "description": "Field options",
@@ -9895,7 +9902,8 @@
           "label",
           "description",
           "type",
-          "category"
+          "category",
+          "levels"
         ]
       },
       "GenerateTokenRequest": {

--- a/openapi.json
+++ b/openapi.json
@@ -6815,6 +6815,28 @@
         }
       }
     },
+    "/api/v2/provider/flags/registry": {
+      "get": {
+        "tags": [
+          "providers"
+        ],
+        "summary": "Get catalog of supported provider/model-level flags",
+        "description": "Get catalog of supported provider/model-level flags",
+        "operationId": "apiV2ProviderFlagsRegistryGet",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlagRegistryResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/providers": {
       "get": {
         "tags": [
@@ -8643,6 +8665,16 @@
             "type": "boolean",
             "description": "Whether provider is enabled",
             "example": true
+          },
+          "flags": {
+            "$ref": "#/components/schemas/ProviderFlags"
+          },
+          "model_flags": {
+            "type": "object",
+            "description": "Per-model flag overrides keyed by provider-side model ID; api_key auth only",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ProviderFlags"
+            }
           },
           "name": {
             "type": "string",
@@ -12376,6 +12408,18 @@
           }
         }
       },
+      "ProviderFlags": {
+        "type": "object",
+        "properties": {
+          "extra_headers": {
+            "type": "object",
+            "description": "Field extra_headers",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "ProviderImportInfo": {
         "type": "object",
         "properties": {
@@ -12535,6 +12579,16 @@
             "type": "boolean",
             "description": "Field enabled",
             "example": true
+          },
+          "flags": {
+            "$ref": "#/components/schemas/ProviderFlags"
+          },
+          "model_flags": {
+            "type": "object",
+            "description": "Field model_flags",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ProviderFlags"
+            }
           },
           "name": {
             "type": "string",
@@ -14962,6 +15016,16 @@
           "enabled": {
             "type": "boolean",
             "description": "New enabled status"
+          },
+          "flags": {
+            "$ref": "#/components/schemas/ProviderFlags"
+          },
+          "model_flags": {
+            "type": "object",
+            "description": "Replacement per-model flag overrides; empty map clears them (api_key auth only)",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ProviderFlags"
+            }
           },
           "name": {
             "type": "string",

--- a/openapi.json
+++ b/openapi.json
@@ -12411,12 +12411,56 @@
       "ProviderFlags": {
         "type": "object",
         "properties": {
+          "block_tools": {
+            "type": "string",
+            "description": "Field block_tools"
+          },
+          "claude_code_compat": {
+            "type": "boolean",
+            "description": "Field claude_code_compat"
+          },
+          "clean_header": {
+            "type": "boolean",
+            "description": "Field clean_header"
+          },
+          "context_1m": {
+            "type": "boolean",
+            "description": "Field context_1m"
+          },
+          "cursor_compat": {
+            "type": "boolean",
+            "description": "Field cursor_compat"
+          },
+          "cursor_compat_auto": {
+            "type": "boolean",
+            "description": "Field cursor_compat_auto"
+          },
+          "custom_user_agent": {
+            "type": "string",
+            "description": "Field custom_user_agent"
+          },
           "extra_headers": {
             "type": "object",
             "description": "Field extra_headers",
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "skip_usage": {
+            "type": "boolean",
+            "description": "Field skip_usage"
+          },
+          "thinking_effort": {
+            "type": "string",
+            "description": "Field thinking_effort"
+          },
+          "use_max_completion_tokens": {
+            "type": "boolean",
+            "description": "Field use_max_completion_tokens"
+          },
+          "use_max_tokens": {
+            "type": "boolean",
+            "description": "Field use_max_tokens"
           }
         }
       },


### PR DESCRIPTION
## Summary
Follows #1589 (rule level, merged) and rebases onto #1592's unified rule-flag path: completes the three-level Custom Headers control (provider < model < rule). Backend only — the UI is a separate PR so the capability and its API can land independently. api_key providers only; design in `.design/provider-flags.md`.

## Key Changes

- **Typed fields on `ai.Provider`**: `Flags` / `ModelFlags` carry the values directly, so the service reads `p.Flags.ExtraHeaders` exactly the way it reads `rule.Flags.ExtraHeaders` — no container, no accessors, no well-known keys. `ai` documents an admission rule to keep that struct narrow: only "how to reach the upstream" belongs there, gateway product behaviour stays in rule flags.
- **Same shape as rule flags**: `ProviderFlagRegistry` mirrors `RuleFlagRegistry` with no per-spec scope or merge axis, because merging is a property of the levels (model overrides provider), not of each flag.
- **Supply side rides the client, not the request**: `wrapWithRuleFlags` takes the model and resolves `typ.SupplyExtraHeaders(provider, model)` once per client — clients are already keyed by provider + model — so probe / model-list / vision-proxy paths get upstream headers too and dispatch needs no changes at all.
- **Precedence from write order**: the transport writes supply-side headers, then the rule's, then the UA, so provider < model < rule holds without any three-level merge, and the rule-flag context key stays strictly "the resolved RuleFlags" — `X-Tingly-Applied-Flags` never reports provider config as a rule flag.
- **Persistence**: additive `flags` / `model_flags` columns (`serializer:json`, same pattern as `credential` / `vmodel_detail`), no migration script.
- **api_key scope**: `Config.AddProvider/UpdateProvider` reject on save (HTTP, CLI, import), `wrapWithRuleFlags` loads no supply headers for a non-api_key provider, and vendor chains mount nothing at all.
- **Provider API**: typed `flags` / `model_flags` with partial-update semantics (nil untouched, non-null replaces wholesale) plus `GET /provider/flags/registry`.

## Notes
- Review trail, recorded in the design doc's trade-off table: an opaque `Extensions` container and per-spec `Scope`/`MergeMode` axes were built first and then removed — the container had exactly one consumer and the axes had no production reader, so both were structure kept for an imagined second flag (~135 lines).
- Until the UI PR lands, provider/model headers are configured through the API; rule-level headers already have their UI from #1589.