### PR TITLE
feat(frontend): provider- and model-level Custom Headers UI

### DIFF
--- a/.design/provider-flags.md
+++ b/.design/provider-flags.md
@@ -1,8 +1,12 @@
-# Provider Extensions & Provider/Model/Rule Flags
+# Provider / Model / Rule Flags
 
-> 状态：**分两个 PR 交付**（api_key-only 发布范围）：
-> PR1 — rule 级 `extra_headers`（含前端，已实现）；
-> PR2 — provider & model 级改造（Extensions 容器、db 列、provider API 与前端）。
+> 状态：**分三段交付**（api_key-only 发布范围）：
+> ① rule 级 `extra_headers`（含前端）—— 已合并 (#1589)；
+> ② provider & model 级后端（Provider.Flags/ModelFlags、db 列、三级合并、provider API）—— 本分支；
+> ③ provider & model 级前端（Plugins 区块、per-model popover）—— 独立 PR，可后续升级。
+>
+> ②③ 拆开的原因：后端能力（含 API 与 registry endpoint）可独立落地并被
+> CLI / 直接调用 API 的使用者消费；UI 是纯增量，晚一步不影响功能可用性。
 > 适用对象：tingly-box 后端 / 前端贡献者。
 > 相关文档：`.design/rule-flags.md`（rule/scenario 级 flag 机制，本设计大量复用其模式）、
 > `.design/user-agent.md`（vendor pin 不可污染的边界，本设计必须尊重）、
@@ -30,14 +34,15 @@ Cloudflare AI Gateway 的网关 header、企业内网网关的租户/审计 head
 向后兼容语义与 dual provider）。OAuth / vendor 特种链、多字段凭证
 （aws_sigv4 / azure_key / gcp_sa）、vmodel 首版不释放（§5.4）。
 
-分层原则（本设计的核心约束）：
+分层原则：
 
-> **对 `ai` module 而言，扩展字段是任意的（opaque）；
-> 对 tingly-box 服务而言，扩展字段有明确定义的 schema 与语义。**
+> **provider/model 级 flag 是"如何抵达这个上游"的属性，与 base URL、auth
+> 一样属于 `ai.Provider`；rule/scenario 级 flag 是网关的产品行为，留在
+> `internal/`。**
 
-`ai/` 是独立 go module、对外公共 API。它不应该知道 tingly-box 服务定义了
-哪些 flag——它只提供一个无 schema 的扩展容器。所有类型化、注册表、校验、
-合并语义都在 `internal/` 落地。
+最初规划过一个不透明扩展容器（"对 ai module 而言是任意的"），实现后按
+评审意见塌缩为 typed 字段——理由与代价见 §2。校验、注册表、合并语义仍全部
+在 `internal/`，ai 只持有数据。
 
 现有 flag 语义由此补全为四层（rule-flags.md §1 的表 + 本设计的前两行）：
 
@@ -63,34 +68,29 @@ UA 的教训（`provider.UserAgent` 移除史，user-agent.md §5）仍然成立
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│  ai module（公共 API，opaque）                                │
+│  ai module（公共 API）                                        │
 │                                                             │
 │  ai.Provider {                                              │
 │      ...                                                    │
-│      Extensions map[string]json.RawMessage `json:"extensions,omitempty"` │
+│      Flags      ProviderFlags            `json:"flags"`      │
+│      ModelFlags map[string]ProviderFlags `json:"model_flags"`│
 │  }                                                          │
 │                                                             │
-│  ai 包不解释内容；任何消费方可用自己的 key 存放任意 JSON。       │
+│  type ProviderFlags struct {                                │
+│      ExtraHeaders map[string]string `json:"extra_headers"`   │
+│      // 后续字段须通过"准入规则"（见下）                        │
+│  }                                                          │
 └──────────────────────────┬──────────────────────────────────┘
-                           │ well-known keys（服务侧独占）
+                           │ typ.ProviderFlags = ai.ProviderFlags（别名）
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
-│  tingly-box 服务（internal/，typed）                          │
-│                                                             │
-│  internal/constant:                                         │
-│      ProviderExtKeyFlags      = "provider_flags"  // ProviderFlags │
-│      ProviderExtKeyModelFlags = "model_flags"  // map[model]ProviderFlags │
+│  tingly-box 服务（internal/）                                 │
 │                                                             │
 │  internal/typ:                                              │
-│      type ProviderFlags struct {                            │
-│          ExtraHeaders map[string]string `json:"extra_headers,omitempty"` │
-│          // 后续 flag 在此追加 typed 字段                       │
-│      }                                                      │
 │      RuleFlags 追加同形态字段：                                │
-│          ExtraHeaders map[string]string `json:"extra_headers,omitempty"` │
-│      GetProviderFlags(p)            // 解 "flags" key         │
-│      GetModelFlags(p, model)        // 解 "model_flags"[model]│
-│      EffectiveExtraHeaders(p, model, ruleFlags) // 三级合并（§3.3）│
+│          ExtraHeaders map[string]string `json:"extra_headers"`│
+│      SupplyExtraHeaders(p, model)   // provider ∪ model（§3.3）│
+│      PruneModelFlags(m)             // 清空的 model 不留空对象  │
 │                                                             │
 │  internal/typ/provider_flag_registry.go:                    │
 │      ProviderFlagRegistry() []FlagSpec  // provider/model 级可信源（§4）│
@@ -99,28 +99,40 @@ UA 的教训（`provider.UserAgent` 移除史，user-agent.md §5）仍然成立
 └─────────────────────────────────────────────────────────────┘
 ```
 
-Rule 级不走 Extensions 容器——RuleFlags 本来就是服务域内的 typed struct
-（rule-flags.md §3），直接加字段即可；Extensions 只解决"公共 module 不能
-认识服务 schema"的问题，Rule 类型不存在这个问题。
+访问方式与 rule flags 完全一致：`p.Flags.ExtraHeaders` / `rule.Flags.ExtraHeaders`，
+没有访问器、没有容器、没有 well-known key。
 
-### 为什么是 `map[string]json.RawMessage` 而不是 `map[string]any`
+### 为什么字段直接放在 ai（而不是不透明扩展容器）
 
-- **无损**：RawMessage 原样保存字节，不经历 `any` 的 float64 化 /
-  key 顺序丢失；ai module "任意"的承诺才真正成立。
-- **强制分层**：ai 包物理上无法"顺手"读懂内容，schema 只能在服务侧定义，
-  防止类型定义渗回公共 module。
-- 服务侧解码是一次小 JSON unmarshal，请求路径成本可忽略（provider 对象
-  在 ClientPool / dispatch 中已被缓存与克隆，必要时可在解析处 memoize，
-  首版不做）。
-- 先例差异说明：`ScenarioConfig.Extensions` 用了 `map[string]interface{}`，
-  但它本身就在 internal/typ（服务域内），没有跨 module 分层需求；
-  ai.Provider 是公共 API，取 RawMessage 更严格。
+最初的规划是给 `ai.Provider` 一个 `Extensions map[string]json.RawMessage`
+不透明容器，服务在两个 well-known key 下放自己的 typed schema——理由是
+"对 ai module 而言扩展字段是任意的"。实现出来后评审判定这是过度设计，
+改为 typed 字段，依据是：
 
-`ResolveStyle` / dual-provider 的 shallow clone 语义不受影响：Extensions
-是引用共享的 map，clone 不深拷贝，所有读取方**只读**（写入只发生在
-usecase 保存路径）。
+1. **容器只有一个消费者**。除 provider flags 外没有任何代码读写它；为
+   "保护别人的 key"而做的读-改-写和它的测试（测试里的 key 字面就叫
+   `someone_elses_key`）保护的是一个假想消费者——与被删掉的
+   `Scope`/`MergeMode` 是同一种投机，只是体量更大。
+2. **ai 的依赖独立性不受影响**。`ProviderFlags` 内部只是
+   `map[string]string`，不引入任何新 import，ai 仍然零依赖 `internal/`。
+3. **语义上并不越界**。ai 自述的职责就是"provider + 如何抵达这个上游"，
+   它已经装着 `OpenAIEndpointMode`、`VModelDetail`、`CredentialBundle`、
+   `Issuer`；`extra_headers`（OpenRouter 的 `HTTP-Referer`、网关租户头）
+   正属于这一类，而不是网关的产品行为。
 
----
+塌缩省掉约 135 行：5 个访问器 + `setExtension` 的读-改-写、db 的
+`cloneExtensions`、以及三个纯容器测试（外键保序 / 畸形 JSON 兜底 /
+extensions wire shape）。
+
+**代价与护栏**：ai 从此认识 flag schema，新增 provider flag 要动公共
+module；真正的风险是先例——一个开放的 `Flags` 结构会招揽产品语义。护栏
+是一条写进 `ai/README.md` 与本文档的准入规则：
+
+> **ai 只接受"描述如何抵达上游"的字段；网关的产品行为（响应改写、客户端
+> 兼容垫片、路由策略……）一律留在 rule flags。**
+
+Rule 级不受影响：RuleFlags 本来就是服务域内的 typed struct（rule-flags.md
+§3），直接加字段即可。
 
 ## 3. 数据模型与合并语义
 
@@ -152,25 +164,33 @@ model ID 精确匹配**（即经过 rule 映射后、实际发给该 provider �
 flag 是供给侧配置，只应认识 provider 自己的模型词汇，不认识客户端别名。
 通配/前缀匹配（如 `gpt-5*`）留作后续扩展，registry 机制不受影响。
 
-### 3.3 三级合并语义（Effective headers）
+### 3.3 三级合并语义
 
-```go
-// EffectiveExtraHeaders(p, model, ruleFlags):
-//   provider 级 ∪ model 级 ∪ rule 级，同名时后者胜出：
-//
-//       provider  <  model  <  rule
-//     （最泛化）              （最贴近本次请求）
+```
+供给侧（客户端构造期，按 (provider, model) 缓存）：
+    SupplyExtraHeaders(p, model) = provider 级 ∪ model 级，model 胜
+
+请求侧（每次 RoundTrip）：
+    GetRuleFlags(ctx).ExtraHeaders                 ← rule 级
+
+最终优先级 = transport 的写入顺序：
+    provider  <  model  <  rule
+  （最泛化）              （最贴近本次请求）
 ```
 
 优先级理由：粒度越贴近"这一次请求"越应胜出。provider 级是全局默认；
 model 级是供给侧对默认的细化；rule 级表达"这一类客户端/用途"的显式
 意图，是三者中最具体的，故最后写入。
 
-对未来的非 map 型 flag（bool/enum），合并模式由 registry 按 flag 声明
-（`MergeMode`：`merge` / `override`），不是全局规则；`extra_headers`
-声明为 `merge`。这与 rule flags 的 `InheritanceMode`（scenario→rule 的
-or/override）同构，但轴不同：`MergeMode` 描述 provider→model→rule 的
-纵向叠加，命名分开以免混淆。
+**没有"三级合并函数"**：供给侧两级在构造期合并一次，rule 级在写 header
+时叠加，`req.Header.Set` 的 canonical 化保证同名（含大小写不同）覆盖。
+详见 §5.1。
+
+合并语义是**层级的属性，不是每个 flag 的属性**：model 级覆盖同名的
+provider 级，就这一条。曾经给 FlagSpec 加过 `Scope` / `MergeMode` 两个轴
+（"这个 flag 存在于哪几级 / 两级怎么合"），但唯一的 flag 两级都有、合法
+只有 merge 一种，没有任何生产代码读它们——纯为想象中的第二个 flag 预留，
+已删除。真出现语义不同的 flag 时再加轴，届时有真实约束可依。
 
 ---
 
@@ -179,10 +199,8 @@ or/override）同构，但轴不同：`MergeMode` 描述 provider→model→rule
 ### Provider/Model 级：新增 `internal/typ/provider_flag_registry.go`
 
 ```go
-// 复用 FlagSpec / FlagValueType / FlagOption（flag_registry.go）
-// FlagSpec 增加两个字段（rule flags 不使用，零值忽略）：
-//   Scope     FlagScope // "provider" | "model" | "both"
-//   MergeMode string    // Scope == "both" 时必填："override" | "merge"
+// 直接复用 FlagSpec / FlagValueType / FlagOption（flag_registry.go），
+// 不给 FlagSpec 加任何 provider 专用字段——与 rule spec 完全同形。
 
 func ProviderFlagRegistry() []FlagSpec {
     return []FlagSpec{
@@ -192,12 +210,13 @@ func ProviderFlagRegistry() []FlagSpec {
             Description: "Append custom HTTP headers to outbound requests ...",
             Type:        FlagValueHeaders, // 新增的 value type，见下
             Category:    FlagCategoryRequest,
-            Scope:       "both",
-            MergeMode:   "merge",
         },
     }
 }
 ```
+
+**每个 spec 都是 provider + model 两级可配**（model 级同名覆盖 provider
+级）。不做 per-spec 的 scope 声明：两个 UI 面都渲染整个 registry。
 
 ### Rule 级：`RuleFlagRegistry()` 追加一条
 
@@ -208,8 +227,8 @@ func ProviderFlagRegistry() []FlagSpec {
     Description: "Append custom HTTP headers to outbound requests for this rule ...",
     Type:        FlagValueHeaders,
     Category:    FlagCategoryRequest,
-    // 无 Shared / InheritanceMode：不做 scenario 级（首版无此需求），
-    // 与 provider/model 级的合并发生在 EffectiveExtraHeaders（§3.3），
+    // 无 Shared / InheritanceMode：不做 scenario 级（首版无此需求）。
+    // 与 provider/model 级的叠加发生在出站 transport（§5.1），
     // 不走 resolveRuleFlagsWithScenario 的 scenario 继承链。
 }
 ```
@@ -224,8 +243,6 @@ func ProviderFlagRegistry() []FlagSpec {
   json tag（`TestProviderFlagRegistry_KeysMatchStructFields`）；
   rule 级 `extra_headers` 由既有 `TestRuleFlagRegistry_KeysMatchStructFields`
   自动覆盖。
-- `Scope` 必须在枚举内；`Scope == "both"` 必须声明 `MergeMode`，
-  其他 Scope 不得声明。
 - `headers` 类型不允许 Options/Suggestions。
 
 Registry 通过新 endpoint 透出给前端（§7），前端 registry-driven 渲染，
@@ -236,56 +253,58 @@ Registry 通过新 endpoint 透出给前端（§7），前端 registry-driven �
 
 ## 5. `extra_headers` 的注入与安全边界
 
-### 5.1 注入点：transport 层
+### 5.1 注入点：统一的 `ruleFlagTransport`，供给侧静态 + rule 级随 ctx
 
-rule 级 `extra_headers` 已由统一的 `ruleFlagTransport`
-（`internal/client/rule_flag_transport.go`，见 rule-flags.md §5 Type 2）
-承载：pass-through 构造器（openai / anthropic / google）显式挂载，
-vendor 链不挂。provider 级 headers（本文档规划部分）沿同一策略加一层：
-
-```
-wrapWithLogging( providerHeadersTransport( ruleFlagTransport( base ) ) )
-                 └── 新增：读 provider 级 headers（构造期解出，不依赖 ctx）
-```
-
-`providerHeadersTransport`：
-
-- **api_key 守卫（首版范围）**：`!provider.IsAPIKey()` 时该 transport
-  为纯透传（no-op）。发布范围由这一个判断收口（配置入口另在 API/UI 层
-  拦截，见 §5.4），后续放开 = 调整这一处守卫 + 对应校验。
-- **provider 级 headers**：构造时从 provider 解出（`GetProviderFlags`），
-  每个 RoundTrip 应用。不依赖 ctx —— 因此 probe、model-list 拉取、
-  visionproxy 等不经 protocol dispatch 的路径也自动生效。
-- **model 级 + rule 级 headers**：dispatch 阶段（rule→provider→model
-  已定型）计算 `EffectiveExtraHeaders(p, model, ruleFlags)` 与 provider
-  级的差集，经 Type 2 手法写入 request
-  ctx——rule 级 headers 是 RuleFlags 的字段，随 `typ.WithRuleFlags`
-  整包挂 ctx，transport 读 `typ.GetRuleFlags(ctx).ExtraHeaders`；transport 读到则叠加（合并优先级已在 dispatch 侧算好，transport
-  只做"provider 级打底、ctx 覆盖"两步）。ctx 缺失时退化为仅 provider
-  级 —— 这是非 dispatch 路径（无 rule、无 model 语境）的预期行为。
-
-rule 级选择与 model 级共用同一个 ctx key 而不是单独一个：transport 只
-认"本次请求的增量 header"一个概念，三级优先级是 dispatch 侧
-`EffectiveExtraHeaders` 的职责——合并逻辑集中一处，transport 保持哑。
-
-### 5.2 顺序不变量：vendor pin 永远胜出（对首版是防御，For 未来是边界）
-
-首版只释放 api_key，generic 链上没有 vendor pin，本节在 v1 实际不触发；
-但机制上 `providerHeadersTransport` 挂在所有构造器的统一包装点，**顺序
-不变量从第一天就要成立**，为后续放开 OAuth 特种链保底：
+上游把出站 rule flag 收敛成一个 ctx key + 一个 transport
+（`internal/client/rule_flag_transport.go`，见 rule-flags.md §5 Type 2）：
+pass-through 构造器（openai / anthropic / google）显式挂载 `wrapWithRuleFlags`，
+vendor 链一律不挂。三级 headers **复用这一层**，不新增 transport：
 
 ```
-providerHeadersTransport      ← 外层：先写入用户 extra headers
-  vendorRoundTripper / SDK    ← 内层（更靠近 wire）：后写入 vendor pin
-    wire                          同名时后写者胜 → vendor pin 决定性
+wrapWithRuleFlags(base, provider, model, resolveUA)
+   ├── 构造期：supplyHeaders = typ.SupplyExtraHeaders(provider, model)   ← 供给侧两级
+   └── RoundTrip：先写 supplyHeaders，再写 GetRuleFlags(ctx).ExtraHeaders ← rule 级
 ```
 
-`.design/user-agent.md` 的结论在这里同样成立：vendor 特种链上由握手 /
-指纹协议绑定的 header（UA、`x-stainless-*`、`X-Msh-*`、
-`X-ChatGPT-Account-ID`、session header 等）不可被任何用户配置覆盖。
-护栏：给该顺序写回归测试（stub inner 断言最终 header 值）；并延续
-rule-flags.md §8 的警告——**vendor 链内部永远不得引入
-providerHeadersTransport**。
+关键点：
+
+- **供给侧（provider ∪ model）在构造期解出**。client 本就按
+  `(provider, model)` 缓存（`ClientKey`），三个挂载点全都持有 `model`，
+  所以模型级 headers 不需要经过 dispatch——`typ.SupplyExtraHeaders` 在
+  wrap 时算一次，之后每个 RoundTrip 直接用，JSON 不重复解码。
+  不依赖 ctx 也意味着 probe、model-list 拉取、visionproxy 等不经
+  protocol dispatch 的路径同样带上上游配置的 header。
+- **rule 级仍是 rule flag**，随 `typ.WithRuleFlags` 整包挂 ctx，transport
+  读 `typ.GetRuleFlags(ctx).ExtraHeaders`。**不把三级合并塞进这个 ctx
+  值**：它的契约是"本次请求解析出的 RuleFlags"，混入供给侧配置会让
+  `X-Tingly-Applied-Flags` 之类的诊断把 provider 配置报成 rule flag。
+- **优先级由写入顺序产生，没有第四方合并函数**：supply 先写、rule 后写、
+  UA 最后写，`req.Header.Set` 自带 canonical 化，于是
+  `provider < model < rule < UA 解析 < 内层链` 自然成立。
+- **api_key 守卫沿用同一处**：`wrapWithRuleFlags` 在 wrap 时判定
+  `provider.IsAPIKey()`，false 则 supply headers 根本不装载（且当该链也
+  不需要 UA 解析时直接返回 inner）。发布范围由这一个判断收口，配置入口
+  另在 API 层拦截（§5.4）。
+
+### 5.2 顺序不变量：vendor pin 永远胜出
+
+vendor 链（Claude OAuth / Codex / Kimi / Gemini / Antigravity）**根本不挂
+这一层**——上游重构后这条边界由结构保证，不再依赖注释里的不变量，因此
+任何级别的 headers 都到不了 vendor 握手。
+
+在挂载了该层的 pass-through 链上，内层（更靠近 wire）仍然后写后胜：
+
+```
+ruleFlagTransport             ← 外层：supply → rule → UA
+  SDK / inner round-tripper   ← 内层：后写者胜
+    wire
+```
+
+`.design/user-agent.md` 的结论同样成立：握手 / 指纹绑定的 header
+（UA、`x-stainless-*`、`X-Msh-*`、`X-ChatGPT-Account-ID`、session header）
+不可被用户配置覆盖。护栏：`rule_flag_transport_test.go` 里的
+`TestRuleFlagTransport_VendorPinWins`（stub inner 断言最终值）+
+**vendor 链内部永远不得挂 `wrapWithRuleFlags`**。
 
 ### 5.3 Header 校验 —— 用户主导，只查结构
 
@@ -337,21 +356,15 @@ vendor pin 与 UA 链在更内层（更靠近 wire）后写后胜（§5.2）；�
 Provider / model 级沿用 `credential` / `vmodel_detail` 的既定先例
 （`internal/db/provider_store.go`）：
 
-- `ProviderRecord` 新增一个 `extensions` TEXT 列，内容为
-  `ai.Provider.Extensions` 整个 map 的 JSON。
+- `ProviderRecord` 新增 `flags` / `model_flags` 两个 TEXT 列
+  （`serializer:json`，与 `credential` / `vmodel_detail` 同模式）。
 - GORM `AutoMigrate` 增列即生效，**无需 migration 脚本、无需回填**
-  （零值 = 无扩展）。
-- `toProvider` / `toRecord` / `updateRecordFromProvider` 三处映射函数
-  各加一段 marshal/unmarshal（与 credential 的处理完全同形）。
-- 服务侧不认识的 key（其他消费方存的任意扩展）随整个 map 原样存取，
-  **update 时必须整 map 读-改-写，不得只写服务自己的两个 key**（否则
-  丢别人的数据）。
-
-Rule 级零持久化改动：RuleFlags 本就以 JSON 列随 rule 行存储
-（rule-flags.md §2），加字段即可。
+  （零值 = 未配置）。
+- `toProvider` / `toRecord` / `updateRecordFromProvider` 三处映射各加两行
+  clone（与其他 JSON 列一样做缓存隔离）。
 
 Provider export / import（`/provider-export`、`/provider-import`）随
-Provider JSON 自然携带 extensions；import 侧对 `flags` / `model_flags`
+Provider JSON 自然携带这两个字段；import 侧对 `flags` / `model_flags`
 两个 well-known key 执行与 API 相同的校验（§5.3 + §5.4 的 auth type
 门），非法拒绝导入并报明确错误。
 
@@ -379,8 +392,7 @@ GET  /api/v1/provider/flags/registry     // ProviderFlagRegistry() → 前端渲
 // CreateProviderRequest 同步新增两个可选字段。
 ```
 
-- handler 侧写入路径：读出 provider → 改 `Extensions["flags"]` /
-  `Extensions["model_flags"]` → 保存（整 map 读-改-写，见 §6）。
+- handler 侧写入路径：读出 provider → 赋 `p.Flags` / `p.ModelFlags` → 保存。
 - 校验集中在 `ValidateExtraHeaders`（§5.3）+ auth type 门（§5.4），
   Create / Update / Import 三处共用。
 - `model_flags` 的 model key 不强校验存在于 `Provider.Models`（模型列表
@@ -402,8 +414,8 @@ switch/case。实现落点：
 
 1. **新控件类型 `headers`（一次性投入，三处共用）**：
    `components/flags/HeadersEditor.tsx` —— 可增删的 KV 行编辑器,行内
-   即时校验(denylist / 非法字符 / 大小写不敏感重复,直接标红并给出
-   原因,教育内嵌于产品;denylist 与后端 `ValidateExtraHeaders` 镜像)。
+   即时校验(非法字符 / 大小写不敏感重复,直接标红并给出原因——仅结构
+   校验,无 denylist,与后端 `ValidateExtraHeaders` 镜像,见 §5.3)。
    接入 `FlagCatalogDialog` 的类型分发(`spec.Type` 驱动,与 bool/
    string/enum/int/service_ref 并列新增一个分支)。
 2. **Rule 级入口**：零布局改动——`extra_headers` 出现在既有
@@ -415,7 +427,7 @@ switch/case。实现落点：
    内(edit 模式)渲染 `ProviderPluginsBlock` —— 与 rule 侧同构的
    "Plugins 卡片 + 目录弹窗"交互:折叠卡片列出 active flag 与具体值,
    点击打开共享的 `FlagCatalogDialog`(标题 "Provider Plugins",registry
-   来自 `GET /provider/flags/registry`,按 `Scope` 含 provider 过滤)。
+   来自 `GET /provider/flags/registry`)。
    该编辑框本身只服务 api_key 域(oauth/cloud 走别的对话框),天然满足
    §5.4 的 UI 门。
 4. **Model 级入口**：`ModelCard`(模型管理面)hover 工具条加
@@ -439,11 +451,11 @@ switch/case。实现落点：
 
 | 层 | 内容 |
 |---|---|
-| registry 护栏 | ProviderFlagRegistry Key ↔ `ProviderFlags` json tag 同步；rule 级由既有 KeysMatchStructFields 覆盖；Scope/MergeMode 约束 |
-| 合并语义 | `EffectiveExtraHeaders`：仅 provider / 仅 model / 仅 rule / 三级同名覆盖顺序（provider < model < rule）/ 都为空 |
-| 校验 | denylist、canonical 化、token 合法性、数量/尺寸上限；非 api_key provider 拒绝；三个写入口都过同一校验 |
-| transport | headers 落到出站请求；ctx 叠加覆盖 provider 级；**非 api_key no-op 守卫**；**vendor pin 胜出的顺序回归**（为未来放开保底）；denylist 第二道防御；vmodel 路径 no-op |
-| db | extensions 列 round-trip；含未知 key 的整 map 读-改-写不丢数据 |
+| registry 护栏 | ProviderFlagRegistry Key ↔ `ProviderFlags` json tag 同步；rule 级由既有 KeysMatchStructFields 覆盖 |
+| 合并语义 | `SupplyExtraHeaders`：仅 provider / 仅 model / model 不匹配 / 大小写碰撞 / 都为空；transport 侧再验三级同名覆盖顺序（provider < model < rule）|
+| 校验 | 仅结构性:token/值合法性、大小写不敏感重名、canonical 化(无 denylist/上限,§5.3);非 api_key provider 拒绝;三个写入口都过同一校验 |
+| transport | headers 逐字落到出站请求(无过滤);ctx 叠加覆盖 provider 级;**非 api_key no-op 守卫**;**vendor pin 胜出的顺序回归**(为未来放开保底);vmodel 路径 no-op |
+| db | flags / model_flags 列 round-trip；缓存隔离（调用方改动不回灌 store）|
 | API | partial update 语义（nil 不动 / 非 nil 替换）；builtin 拒绝；rule 保存路径校验生效；export→import round-trip 含校验 |
 | e2e（后补） | 三级各配一部分 header → mock upstream 断言合并结果（依赖 mock provider fixture，同 rule flags 的待办） |
 
@@ -453,31 +465,32 @@ switch/case。实现落点：
 
 ```
 1. ai/provider.go
-   └─ Provider 增加 Extensions map[string]json.RawMessage（含只读语义注释）
+   └─ Provider 增加 Flags / ModelFlags + ProviderFlags struct（含准入规则注释）
 
 2. internal/constant
    └─ ProviderExtKeyFlags / ProviderExtKeyModelFlags 常量
 
 3. internal/typ
    ├─ provider_flags.go：ProviderFlags struct + Get/Set 帮助函数
-   │   （Set 系列负责整 map 读-改-写）+ EffectiveExtraHeaders（三级合并）
+   │   （Set 系列负责整 map 读-改-写）+ SupplyExtraHeaders（供给侧合并）
    ├─ type.go：RuleFlags 加 ExtraHeaders 字段（json/yaml tag: extra_headers）
-   ├─ flag_registry.go：FlagSpec 增加 Scope / MergeMode 字段；
-   │   FlagValueType 增加 "headers"；RuleFlagRegistry() 追加 extra_headers
+   ├─ flag_registry.go：FlagValueType 增加 "headers"；RuleFlagRegistry()
+   │   追加 extra_headers（FlagSpec 本身不加任何 provider 专用字段）
    ├─ provider_flag_registry.go：ProviderFlagRegistry()
-   └─ id.go：rule 级 headers 随 WithRuleFlags / GetRuleFlags 整包传递（Type 2）
+   └─ （ctx 侧无需新增：rule 级 headers 已随 typ.WithRuleFlags 整包传递）
 
 4. internal/db/provider_store.go
-   └─ extensions 列 + 三处映射（rule 侧零改动）
+   └─ flags / model_flags 两列 + 三处映射（rule 侧零改动）
 
 5. internal/client
-   ├─ provider_headers_transport.go：providerHeadersTransport
-   │   （含 IsAPIKey 守卫 + denylist 二道防御）
-   └─ 挂载策略同 rule 级 ruleFlagTransport：pass-through 构造器显式挂载，vendor 链不挂
+   ├─ rule_flag_transport.go：wrapWithRuleFlags 增 model 入参
+   │   （含 IsAPIKey 守卫;逐字应用,无过滤）
+   └─ 在 wrapWithLogging 接入点外侧统一挂载（一处改动覆盖全部构造器）
 
-6. protocol dispatch
-   └─ provider+model+rule 定型处调用 EffectiveExtraHeaders，
-      与 provider 级的差集写入 ctx
+6. protocol dispatch —— 无需改动
+   └─ 旧规划让 dispatch 计算三级合并再写 ctx；上游把出站 rule flag 收敛成
+      单一 ctx key 后，供给侧改在 client 构造期解出，`ResolveRuleFlagsWithScenario`
+      与 4 个 handler 的签名都不用动
 
 7. internal/server/module/provider + module/rule
    ├─ provider/types.go / handler.go：请求响应模型 + ValidateExtraHeaders
@@ -505,22 +518,22 @@ switch/case。实现落点：
 | 选项 | 已采纳 | 备择 | 取舍理由 |
 |------|--------|------|----------|
 | ai.Provider 扩展容器形态 | `map[string]json.RawMessage` | typed struct / `map[string]any` | ai 是公共 module，必须对内容不知情；RawMessage 无损且物理隔离 schema。typed struct 会把服务语义泄进公共 API |
+| provider flag 的存放位置 | `ai.Provider` 上的 typed 字段 | `Extensions map[string]json.RawMessage` 不透明容器 + 服务侧 well-known key | 容器只有一个消费者，"保护别人 key"的读-改-写保护的是假想消费者（评审意见）。塌缩省 ~135 行；ai 的依赖独立性不变（不引入新 import），语义上 headers 本就属于"如何抵达上游"。代价是 ai 认识 flag schema，用准入规则约束（§2）|
 | 服务侧 schema 位置 | internal/typ + registry | 散落各消费点 | 复刻 rule flags 的"唯一可信源"模式，前端零 switch/case，已被验证 |
 | rule 级是否同步支持 | ✅ 三级统一 | 仅 provider/model | headers 三级各有真实语义（网关固有 / 模型灰度 / 客户端标记）；rule 级复用既有 RuleFlags 机制近乎零成本，一次做齐避免二次开口 |
-| rule 级走 Extensions 还是 RuleFlags | RuleFlags 加字段 | Rule 也做 opaque 容器 | Rule 类型在服务域内，不存在跨 module schema 问题；opaque 容器只为公共 module 存在 |
 | 三级合并顺序 | provider < model < rule | rule < model < provider | 粒度越贴近单次请求越应胜出；rule 是显式的请求侧意图 |
 | 首版发布范围 | 仅 api_key | 全 auth type | vendor 特种链有握手/指纹边界、SigV4 有签名敏感性，验证成本高；api_key 覆盖绝大多数真实需求（OpenRouter/网关/自建端点）。范围由 UI 隐藏 + API 校验 + transport 守卫三道闸收口，放开时逐道解除 |
 | extra_headers 形态 | `map[string]string` | `[]HeaderKV`（有序可重复） | 配置型 header 不需要重复/顺序；与 probe headers 先例一致；UI 简单；三级同形态合并函数唯一 |
-| model flag 合并 | 按 flag 声明 MergeMode（headers=merge） | 一律 override | headers 的自然语义是叠加覆写；未来 bool flag 需要 override——语义属于 flag 本身，进 registry |
-| 注入点 | transport 层（ruleFlagTransport，一处） | ClientPool 逐构造器传 option | option 类型按 SDK 分裂（openai/anthropic/google 各一套），transport 一处覆盖所有 auth type 与 style |
-| model/rule 级 ctx 传递 | 单一 ctx key（dispatch 侧合并好） | 每级一个 ctx key | transport 保持哑，合并逻辑集中在 EffectiveExtraHeaders 一处 |
+| model flag 合并 | 层级属性：model 级同名覆盖 provider 级 | 每个 flag 用 registry 的 `MergeMode` 声明 | 曾按 flag 声明（Scope/MergeMode 两个轴），但唯一的 flag 两级都有、只有 merge 合法，无任何生产读取方——纯预留结构，已删。有语义不同的 flag 时再加，届时有真实约束 |
+| 注入点 | transport 层（wrapWithLogging 旁，一处） | ClientPool 逐构造器传 option | option 类型按 SDK 分裂（openai/anthropic/google 各一套），transport 一处覆盖所有 auth type 与 style |
+| 供给侧 headers 的解析时机 | client 构造期（wrap 时按 (provider, model) 解出） | dispatch 侧算好三级合并写进 ctx | client 本就按 provider+model 缓存，构造期解一次即可，JSON 不重复解码；且 rule flags 的 ctx key 契约保持"只装 RuleFlags"，诊断不会把 provider 配置报成 rule flag。代价是优先级由写入顺序表达，需在 transport 注释与测试中写清 |
 | vendor pin 冲突 | 物理顺序保证 pin 胜出 | 逐 header 判断 | v1 不触发（api_key only），但顺序不变量零维护成本，为放开 OAuth 保底 |
 | denylist / 上限 | **不做**（用户主导，配错自负） | 拒绝 Authorization/UA/传输头 + 数量尺寸上限 | 评审定调：编排器必须可任意配置，"custom" 即特殊需求，过度限制是过度设计。与网关自管 header 的冲突交给 transport 链顺序（pin 在内层后写后胜），不做过滤 |
 | 校验时机 | 保存时拒绝（仅结构合法性） | 发请求时静默失败 | 非法 token/重名在保存时报错比 net/http 发送期报错清晰；结构校验不是限制而是"配置无定义" |
-| API 形态 | typed `flags`/`model_flags` 字段 | 直接暴露 opaque extensions | REST 契约是服务 surface，必须 typed；opaque 容器只是存储与公共 module 之间的运输形态 |
-| 持久化 | 单 `extensions` JSON 列 | 每 flag 一列 | credential/vmodel_detail 先例；增 flag 零 DDL；provider 行不因 flag 增长而加宽 |
+| API 形态 | typed `flags`/`model_flags` 字段 | —— | 与存储、与 ai 的字段同形，DTO 不再需要编解码 |
+| 持久化 | `flags` / `model_flags` 两个 JSON 列 | 每 flag 一列 | credential/vmodel_detail 先例；增 flag 零 DDL |
 | model key 匹配 | 精确匹配 | 通配/前缀 | 首版从简；registry 与数据形态不阻碍后续加 pattern |
-| UI 命名 | 复用 "Plugins" | 新词（Extensions/Custom Headers） | 词汇全局统一：同一交互心智（registry 目录 + 卡片）应同名；scope 差异由所在 surface（provider 编辑框 vs rule 卡片）表达 |
+| UI 命名 | 复用 "Plugins" | 新词（Custom Headers 等） | 词汇全局统一：同一交互心智（registry 目录 + 卡片）应同名；scope 差异由所在 surface（provider 编辑框 vs rule 卡片）表达 |
 | 非 api_key 的 UI 呈现 | 隐藏入口 | 灰置 + 提示 | 减少视觉噪音：不解释一个当前用不了的功能；放开时再出现 |
 
 ---

--- a/ai/README.md
+++ b/ai/README.md
@@ -169,6 +169,26 @@ concepts are separate — a future builtin could carry a real API key.
 
 ---
 
+## `Flags` / `ModelFlags`
+
+`ProviderFlags` carries options that describe **how to reach this upstream**,
+at two levels: `Provider.Flags` applies to every request to the provider, and
+`Provider.ModelFlags[model]` overrides it for one provider-side model.
+
+| Field | Meaning |
+|---|---|
+| `extra_headers` | Extra HTTP headers appended to outbound requests, verbatim. For upstreams that gate on their own headers (OpenRouter's `HTTP-Referer` / `X-Title`, gateway tenant or audit headers). |
+
+**Admission rule for new fields.** This struct is deliberately narrow: only
+things a caller must know *to talk to the upstream* belong here — the same
+job the rest of `Provider` does (base URLs, auth, protocol metadata). Product
+behaviour of a gateway sitting in front of the upstream (response rewriting,
+client compatibility shims, routing policy, …) does **not** belong here; in
+tingly-box that is what rule flags are for. Without this line the struct
+becomes a dumping ground and this package stops being reusable on its own.
+
+---
+
 ## Model ordering in the UI
 
 When the model-select dialog lists providers, `auth_type` determines sort

--- a/ai/provider.go
+++ b/ai/provider.go
@@ -80,6 +80,30 @@ func (c *CredentialBundle) Field(key string) string {
 	return c.Fields[key]
 }
 
+// ProviderFlags carries per-provider options that describe *how to reach this
+// upstream* — the same job the rest of this type does (base URLs, auth,
+// protocol metadata). It exists at two levels on Provider: provider-wide
+// (Provider.Flags) and per-model (Provider.ModelFlags), where a model-level
+// value overrides the provider-level one for that model.
+//
+// Admission rule for new fields, so this struct cannot drift into a dumping
+// ground: only things a caller must know to talk to the upstream belong
+// here. Product behaviour of a gateway in front of it (response rewriting,
+// client compatibility shims, routing policy, …) does not — in tingly-box
+// that is what rule flags are for. See .design/provider-flags.md.
+type ProviderFlags struct {
+	// ExtraHeaders are appended to outbound requests, verbatim. Header names
+	// are stored in canonical form. Typical uses are upstreams that gate on
+	// their own headers (OpenRouter's HTTP-Referer / X-Title, gateway tenant
+	// or audit headers).
+	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
+}
+
+// IsZero reports whether the flags carry no configuration at all.
+func (f ProviderFlags) IsZero() bool {
+	return len(f.ExtraHeaders) == 0
+}
+
 // OAuthDetail contains OAuth-specific authentication information
 type OAuthDetail struct {
 	AccessToken  string                 `json:"access_token"`           // OAuth access token
@@ -218,6 +242,13 @@ type Provider struct {
 	// Codex OAuth completion. Routing reads this; users do not edit it
 	// directly. See the OpenAIEndpointMode constants for semantics.
 	OpenAIEndpointMode OpenAIEndpointMode `json:"openai_endpoint_mode,omitempty"`
+
+	// Flags carries provider-level options, and ModelFlags the per-model
+	// overrides keyed by the provider-side model ID. Both are shared by
+	// shallow clones (ResolveStyle etc.), so readers must treat them as
+	// read-only and writers replace whole values on the save path.
+	Flags      ProviderFlags            `json:"flags,omitempty"`
+	ModelFlags map[string]ProviderFlags `json:"model_flags,omitempty"`
 }
 
 // OpenAIEndpointMode declares this provider's support for the OpenAI Chat

--- a/frontend/src/components/ProviderFormDialog.tsx
+++ b/frontend/src/components/ProviderFormDialog.tsx
@@ -30,6 +30,8 @@ import ProxyUrlField from '@/components/provider-form-dialog/ProxyUrlField';
 import VerificationResultPanel from '@/components/provider-form-dialog/VerificationResultPanel';
 import {type VerificationResult, runProviderProbe} from '@/components/provider-form-dialog/probe';
 import ProviderIcon from '@/components/ProviderIcon';
+import ProviderPluginsBlock from '@/components/provider-form-dialog/ProviderPluginsBlock';
+import type {RuleFlags} from '@/components/RoutingGraphTypes';
 import RegionBadge from '@/components/RegionBadge';
 import ProviderExportButton from '@/components/ProviderExportButton';
 
@@ -51,6 +53,8 @@ export interface EnhancedProviderFormData {
     /** If set, prefer this exact provider ID when resolving the template.
      *  Avoids mismatches when multiple providers share the same base URL. */
     selectedProviderId?: string;
+    /** Provider-level flags (camelCase form, see flagHelpers.apiToFlags). */
+    flags?: RuleFlags;
 }
 
 interface PresetProviderFormDialogProps {
@@ -713,10 +717,15 @@ const ProviderFormDialog = ({
                                     {t('providerDialog.advanced.title')}
                                 </Typography>
                             </AccordionSummary>
-                            {/* Empty for now — reserved for future advanced options
-                                (enabled toggle moved to the dialog title). */}
                             <AccordionDetails sx={{px: 0, pb: 1}}>
-                                <Stack spacing={2.5} />
+                                <Stack spacing={2.5}>
+                                    {mode === 'edit' && (
+                                        <ProviderPluginsBlock
+                                            flags={data.flags}
+                                            onChange={(next) => onChange('flags', next)}
+                                        />
+                                    )}
+                                </Stack>
                             </AccordionDetails>
                         </Accordion>
                     </Stack>

--- a/frontend/src/components/model-select/ModelCard.tsx
+++ b/frontend/src/components/model-select/ModelCard.tsx
@@ -1,4 +1,5 @@
 import { CheckCircle } from '@/components/icons';
+import { useState } from 'react';
 import { Box, Card, CardContent, CircularProgress, Tooltip, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
@@ -8,6 +9,12 @@ import { ModelTestStatusBadge } from '../probe/ModelTestStatusBadge';
 import { ProbeDialog } from '../probe/ProbeDialog';
 import { useModelTestProbe } from '../probe/useModelTestProbe';
 import { ControlBar } from './ControlBar';
+import {
+    canEditModelHeaders,
+    ModelHeadersBadge,
+    ModelHeadersPopover,
+    ModelHeadersTrigger,
+} from './ModelHeaders';
 import { getModelCardActiveColor, getModelCardStateStyles, modelCardTransition } from './cardStyles';
 
 interface ModelCardProps {
@@ -35,6 +42,16 @@ export default function ModelCard({
     description,
 }: ModelCardProps) {
     const probe = useModelTestProbe();
+
+    // Per-model Custom Headers override (api_key providers only). Local state
+    // mirrors the last-saved value so the badge updates without a provider
+    // refetch; the save path itself re-reads the provider (see ModelHeaders).
+    const [headerOverride, setHeaderOverride] = useState<Record<string, string> | undefined>(
+        () => provider.model_flags?.[model]?.extra_headers,
+    );
+    const [headersAnchor, setHeadersAnchor] = useState<HTMLElement | null>(null);
+    const headersEditable = canEditModelHeaders(provider);
+    const overrideNames = Object.keys(headerOverride ?? {});
 
     const getCardStyles = () => {
         const baseStyles = {
@@ -182,14 +199,28 @@ export default function ModelCard({
                 )}
                 {!loading && (
                     <ControlBar>
+                        {headersEditable && <ModelHeadersTrigger onOpen={setHeadersAnchor} />}
                         <ModelTestTrigger onOpen={probe.openDialog} />
                     </ControlBar>
+                )}
+                {!loading && overrideNames.length > 0 && (
+                    <ModelHeadersBadge names={overrideNames} onOpen={setHeadersAnchor} />
                 )}
                 {!loading && probe.result && (
                     <ModelTestStatusBadge result={probe.result} onOpen={probe.openDialog} />
                 )}
             </CardContent>
         </Card>
+        {headersAnchor !== null && (
+            <ModelHeadersPopover
+                provider={provider}
+                model={model}
+                anchorEl={headersAnchor}
+                initial={headerOverride}
+                onClose={() => setHeadersAnchor(null)}
+                onSaved={setHeaderOverride}
+            />
+        )}
         <ProbeDialog
             open={probe.dialogOpen}
             onClose={probe.closeDialog}

--- a/frontend/src/components/model-select/ModelHeaders.tsx
+++ b/frontend/src/components/model-select/ModelHeaders.tsx
@@ -1,0 +1,157 @@
+import { Extension as ExtensionIcon } from '@/components/icons';
+import {
+    Alert,
+    Box,
+    Button,
+    CircularProgress,
+    IconButton,
+    Popover,
+    Stack,
+    Tooltip,
+    Typography,
+} from '@mui/material';
+import React, { useState } from 'react';
+import HeadersEditor from '@/components/flags/HeadersEditor';
+import { api } from '@/services/api';
+import type { Provider } from '@/types/provider';
+
+// canEditModelHeaders gates the per-model Custom Headers UI to api_key
+// providers — the only auth type the extra_headers release covers (the
+// backend rejects and the transport no-ops on everything else).
+export const canEditModelHeaders = (provider: Provider): boolean =>
+    (provider.auth_type ?? 'api_key') === 'api_key';
+
+interface ModelHeadersTriggerProps {
+    onOpen: (anchor: HTMLElement) => void;
+}
+
+// The control-bar entry that opens the per-model Custom Headers popover.
+export const ModelHeadersTrigger: React.FC<ModelHeadersTriggerProps> = ({ onOpen }) => (
+    <Tooltip title="Custom headers for this model">
+        <IconButton
+            size="small"
+            onClick={(e) => onOpen(e.currentTarget)}
+            sx={{
+                p: 0.3,
+                color: 'text.secondary',
+                '&:hover': { backgroundColor: 'action.hover', color: 'primary.main' },
+            }}
+        >
+            <ExtensionIcon sx={{ fontSize: 14 }} />
+        </IconButton>
+    </Tooltip>
+);
+
+interface ModelHeadersBadgeProps {
+    /** Configured header names — shown in the tooltip so the concrete values are visible without opening. */
+    names: string[];
+    onOpen: (anchor: HTMLElement) => void;
+}
+
+// Always-visible marker (bottom-left) for models carrying header overrides,
+// so overrides are discoverable while scanning the list, not only on hover.
+export const ModelHeadersBadge: React.FC<ModelHeadersBadgeProps> = ({ names, onOpen }) => (
+    <Tooltip title={`Custom headers: ${names.join(', ')}`} arrow>
+        <Box
+            onClick={(e) => { e.stopPropagation(); onOpen(e.currentTarget); }}
+            sx={{
+                position: 'absolute',
+                bottom: 2,
+                left: 4,
+                display: 'flex',
+                alignItems: 'center',
+                color: 'primary.main',
+                cursor: 'pointer',
+                zIndex: 5,
+            }}
+        >
+            <ExtensionIcon sx={{ fontSize: 12 }} />
+        </Box>
+    </Tooltip>
+);
+
+export interface ModelHeadersPopoverProps {
+    provider: Provider;
+    model: string;
+    anchorEl: HTMLElement | null;
+    /** Current override map for this model (drives the editor's initial rows). */
+    initial?: Record<string, string>;
+    onClose: () => void;
+    /** Called with the saved map (undefined = override cleared) after a successful save. */
+    onSaved: (next: Record<string, string> | undefined) => void;
+}
+
+/**
+ * ModelHeadersPopover — inline editor for one model's extra_headers override.
+ * Saves via a read-modify-write of the provider's model_flags map: the
+ * provider is re-fetched first so concurrent edits to sibling models in the
+ * same session are not clobbered.
+ */
+export const ModelHeadersPopover: React.FC<ModelHeadersPopoverProps> = ({
+    provider,
+    model,
+    anchorEl,
+    initial,
+    onClose,
+    onSaved,
+}) => {
+    const [draft, setDraft] = useState<Record<string, string> | undefined>(initial);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleSave = async () => {
+        setSaving(true);
+        setError(null);
+        try {
+            const fresh = await api.getProvider(provider.uuid);
+            const all: Record<string, { extra_headers?: Record<string, string> }> = {
+                ...((fresh?.data as Provider | undefined)?.model_flags ?? {}),
+            };
+            if (draft && Object.keys(draft).length > 0) {
+                all[model] = { extra_headers: draft };
+            } else {
+                delete all[model];
+            }
+            const result = await api.updateProvider(provider.uuid, { model_flags: all });
+            if (result.success) {
+                onSaved(draft && Object.keys(draft).length > 0 ? draft : undefined);
+                onClose();
+            } else {
+                setError(result.error || 'Failed to save');
+            }
+        } catch (e: any) {
+            setError(e?.message || 'Failed to save');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <Popover
+            open={anchorEl !== null}
+            anchorEl={anchorEl}
+            onClose={onClose}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+            slotProps={{ paper: { sx: { p: 1.5, width: 380 } } }}
+            // The popover lives inside a clickable model card — keep its
+            // gestures to itself.
+            onClick={(e) => e.stopPropagation()}
+        >
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                Custom Headers
+            </Typography>
+            <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 1 }}>
+                Sent only with requests for <Box component="span" sx={{ fontFamily: 'monospace' }}>{model}</Box>.
+                Overrides same-name provider-level headers; a rule-level header still wins.
+            </Typography>
+            <HeadersEditor value={draft} onChange={setDraft} disabled={saving} />
+            {error && <Alert severity="error" sx={{ mt: 1, py: 0 }}>{error}</Alert>}
+            <Stack direction="row" spacing={1} sx={{ justifyContent: 'flex-end', mt: 1.5 }}>
+                <Button size="small" onClick={onClose} disabled={saving}>Cancel</Button>
+                <Button size="small" variant="contained" onClick={handleSave} disabled={saving}>
+                    {saving ? <CircularProgress size={16} thickness={4} /> : 'Save'}
+                </Button>
+            </Stack>
+        </Popover>
+    );
+};

--- a/frontend/src/components/provider-form-dialog/ProviderPluginsBlock.tsx
+++ b/frontend/src/components/provider-form-dialog/ProviderPluginsBlock.tsx
@@ -1,0 +1,138 @@
+import { Add as AddIcon, Extension as ExtensionIcon } from '@/components/icons';
+import { Box, Stack, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import React, { useEffect, useState } from 'react';
+import type { FlagSpec, RuleFlags } from '@/components/RoutingGraphTypes';
+import FlagCatalogDialog from '@/components/rule-card/FlagCatalogDialog';
+import { headersValue, isFlagActive } from '@/components/rule-card/flagHelpers';
+import { api } from '@/services/api';
+
+// Session-level registry cache, same pattern as RuleCard's rule registry.
+let registryCache: FlagSpec[] | undefined = undefined;
+let registryPromise: Promise<FlagSpec[]> | null = null;
+
+async function loadProviderFlagRegistry(): Promise<FlagSpec[]> {
+    if (registryCache !== undefined) return registryCache;
+    if (registryPromise) return registryPromise;
+    registryPromise = (async () => {
+        try {
+            const result = await api.getProviderFlagRegistry();
+            const data: FlagSpec[] = Array.isArray(result?.data) ? result.data : [];
+            registryCache = data;
+            return data;
+        } catch {
+            // Don't cache failures — allow retry on next mount.
+            return [];
+        } finally {
+            registryPromise = null;
+        }
+    })();
+    return registryPromise;
+}
+
+export interface ProviderPluginsBlockProps {
+    /** Provider-level flags in camelCase form (apiToFlags of the stored value). */
+    flags?: RuleFlags;
+    onChange: (next: RuleFlags) => void;
+}
+
+/**
+ * ProviderPluginsBlock — the provider-level Plugins surface inside the
+ * provider form's Advanced accordion: a compact card listing active
+ * provider-level flags (concrete values, e.g. header names), opening the
+ * shared flag catalog dialog fed by the provider registry. Same interaction
+ * as the rule-side Plugins card, so the two levels share one mental model.
+ */
+export const ProviderPluginsBlock: React.FC<ProviderPluginsBlockProps> = ({ flags, onChange }) => {
+    const [registry, setRegistry] = useState<FlagSpec[] | undefined>(registryCache);
+    const [catalogOpen, setCatalogOpen] = useState(false);
+
+    useEffect(() => {
+        let mounted = true;
+        loadProviderFlagRegistry().then((specs) => { if (mounted) setRegistry(specs); });
+        return () => { mounted = false; };
+    }, []);
+
+    // Every provider-registry spec is configurable at this level (the model
+    // list edits the same specs per model), so the whole registry renders here.
+    const providerSpecs = registry || [];
+    const enabled = providerSpecs.filter((spec) => isFlagActive(spec, flags ?? {}));
+
+    return (
+        <>
+            <Box
+                onClick={() => setCatalogOpen(true)}
+                sx={(theme) => ({
+                    p: 1,
+                    border: '1px dashed',
+                    borderColor: 'divider',
+                    borderRadius: 1,
+                    cursor: 'pointer',
+                    transition: 'border-color 0.16s ease, background-color 0.16s ease',
+                    '&:hover': {
+                        borderColor: 'primary.main',
+                        backgroundColor: alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.06 : 0.03),
+                    },
+                })}
+            >
+                <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+                    <ExtensionIcon sx={{ fontSize: 15, color: 'text.secondary' }} />
+                    <Typography variant="caption" sx={{ fontWeight: 700, color: 'text.secondary', flexGrow: 1 }}>
+                        Plugins{enabled.length > 0 ? ` (${enabled.length})` : ''}
+                    </Typography>
+                    <AddIcon sx={{ fontSize: 15, color: 'text.secondary' }} />
+                </Stack>
+                {enabled.length === 0 ? (
+                    <Typography variant="caption" sx={{ color: 'text.disabled', display: 'block', mt: 0.5 }}>
+                        None enabled. Click to configure custom headers and other provider plugins.
+                    </Typography>
+                ) : (
+                    <Stack sx={{ gap: 0.4, mt: 0.75 }}>
+                        {enabled.map((spec) => {
+                            // Show the concrete configured values (e.g. the
+                            // literal header names), never a bare count.
+                            const detail = spec.type === 'headers'
+                                ? Object.keys(headersValue(flags, spec.key)).join(', ')
+                                : '';
+                            return (
+                                <Stack key={spec.key} direction="row" spacing={0.5} sx={{ alignItems: 'baseline', minWidth: 0 }}>
+                                    <Typography variant="caption" sx={{ fontWeight: 700, color: 'primary.main', flexShrink: 0 }}>
+                                        {spec.label}
+                                    </Typography>
+                                    {detail && (
+                                        <Typography
+                                            variant="caption"
+                                            sx={{
+                                                fontFamily: 'monospace',
+                                                color: 'text.primary',
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                whiteSpace: 'nowrap',
+                                            }}
+                                        >
+                                            : {detail}
+                                        </Typography>
+                                    )}
+                                </Stack>
+                            );
+                        })}
+                    </Stack>
+                )}
+            </Box>
+            <FlagCatalogDialog
+                open={catalogOpen}
+                flags={flags}
+                registry={providerSpecs}
+                title="Provider Plugins"
+                subtitle="Plugin flags applied to every request to this provider."
+                onClose={() => setCatalogOpen(false)}
+                onSave={(next) => {
+                    onChange(next);
+                    setCatalogOpen(false);
+                }}
+            />
+        </>
+    );
+};
+
+export default ProviderPluginsBlock;

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -40,6 +40,10 @@ export interface FlagCatalogDialogProps {
     loading?: boolean;
     /** Providers for service_ref flags (e.g. vision_proxy_service model picker). */
     providers?: Provider[];
+    /** Dialog title/subtitle — defaults to the rule-level wording; the provider
+     *  Plugins surface reuses this dialog with its own copy. */
+    title?: string;
+    subtitle?: string;
     onClose: () => void;
     onSave: (next: RuleFlags) => void;
 }
@@ -86,6 +90,8 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
     registry,
     loading,
     providers,
+    title,
+    subtitle,
     onClose,
     onSave,
 }) => {
@@ -168,11 +174,11 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
     return (
         <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
             <DialogTitle sx={{ pb: 1 }}>
-                Rule Plugins
+                {title ?? 'Rule Plugins'}
                 <Typography variant="caption" component="div" sx={{
                     color: "text.secondary"
                 }}>
-                    Plugin flags applied at the rule level.
+                    {subtitle ?? 'Plugin flags applied at the rule level.'}
                 </Typography>
             </DialogTitle>
             {/* Active flags strip — empty state stays hidden to save vertical space. */}

--- a/frontend/src/hooks/useProviderEditDialog.tsx
+++ b/frontend/src/hooks/useProviderEditDialog.tsx
@@ -2,6 +2,7 @@ import OAuthDetailDialog from '@/components/OAuthDetailDialog';
 import ProviderFormDialog, { type EnhancedProviderFormData } from '@/components/ProviderFormDialog';
 import { isCloudAuthType } from '@/components/cloud/cloudCredentialSchema';
 import { api } from '@/services/api';
+import { apiToFlags, flagsToApi } from '@/components/rule-card/flagHelpers';
 import type { Provider } from '@/types/provider';
 import { type FormEvent, useCallback, useMemo, useState } from 'react';
 
@@ -51,6 +52,10 @@ export function useProviderEditDialog({ onUpdated, showNotification }: UseProvid
             proxy_url: fd.proxyUrl ?? '',
             api_base_openai: fd.apiBaseOpenAI ?? '',
             api_base_anthropic: fd.apiBaseAnthropic ?? '',
+            // Whole-object replace, mirroring the form's edit surface: the
+            // dialog seeded the stored flags, so an empty object here means
+            // the user cleared them (backend: non-null replaces wholesale).
+            flags: flagsToApi(fd.flags),
         };
     }, [providerFormData]);
 
@@ -95,6 +100,7 @@ export function useProviderEditDialog({ onUpdated, showNotification }: UseProvid
                     noKeyRequired: provider.no_key_required || false,
                     proxyUrl: provider.proxy_url || '',
                     authType: provider.auth_type || 'api_key',
+                    flags: apiToFlags(provider.flags),
                 } as any);
                 setApiKeyDialogOpen(true);
             }

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2136,11 +2136,19 @@ export const handlers = [
     // ============================================
     // Rule Flag Registry
     // ============================================
+    http.get('/api/v2/provider/flags/registry', () => {
+        return HttpResponse.json({
+            success: true,
+            data: [
+                { key: 'extra_headers', label: 'Custom Headers', description: 'Append custom HTTP headers to outbound requests to this provider. Model-level headers win over provider-level on a name conflict; a rule-level Custom Headers flag wins over both. API-key providers only.', type: 'headers', category: 'request' },
+            ],
+        });
+    }),
     http.get('/api/v1/rule/flags/registry', () => {
         return HttpResponse.json({
             success: true,
             data: [
-                { key: 'extra_headers', label: 'Custom Headers', description: 'Append custom HTTP headers to the outbound upstream request for this rule. API-key providers only.', type: 'headers', category: 'request' },
+                { key: 'extra_headers', label: 'Custom Headers', description: 'Append custom HTTP headers to the outbound upstream request for this rule. Merged with the provider- and model-level Custom Headers; the rule value wins on a name conflict. API-key providers only.', type: 'headers', category: 'request' },
                 { key: 'custom_user_agent', label: 'Custom User-Agent', description: 'Override the outbound User-Agent header.', type: 'string', category: 'request_openai', placeholder: 'e.g. MyApp/1.0', suggestions: [{ value: 'claude-cli/2.1.86 (external, cli)', label: 'Claude Code (CLI)' }], shared: true, inheritance_mode: 'override' },
                 { key: 'openai_endpoint_override', label: 'OpenAI endpoint override', description: 'Force Chat or Responses endpoint.', type: 'enum', category: 'request_openai', options: [{ value: 'auto', label: 'Auto' }, { value: 'chat', label: 'Force Chat' }, { value: 'responses', label: 'Force Responses' }] },
                 { key: 'use_max_completion_tokens', label: 'OpenAI: Use max_completion_tokens', description: 'Rewrite max_tokens to max_completion_tokens.', type: 'bool', category: 'request_openai' },

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -416,6 +416,12 @@ export const api = {
         return controlApi((client, headers) => client.GET('/api/v1/rule/flags/registry', {headers}));
     },
 
+    // Catalog of provider/model-level flags (supply-side counterpart of the
+    // rule flag registry); drives the provider Plugins UI.
+    getProviderFlagRegistry: async (): Promise<any> => {
+        return controlApi((client, headers) => client.GET('/api/v2/provider/flags/registry', {headers}));
+    },
+
     // Imports providers from a base64/JSONL export bundle.
     importProvider: async (data: string, onProviderConflict: string = 'use'): Promise<any> => {
         try {

--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -134,7 +134,7 @@ func NewAnthropicClient(provider *typ.Provider, model string, sessionID typ.Sess
 // rebuild this chain under its OAuth transport (see vertexAnthropicOptions).
 func anthropicTransport(provider *typ.Provider, model string, sessionID typ.SessionID) http.RoundTripper {
 	base := GetGlobalTransportPool().GetTransport(provider.UUID, model, provider.ProxyURL, ai.Issuer(""), sessionID)
-	return wrapWithLogging(wrapWithRuleFlags(base, provider, true), provider)
+	return wrapWithLogging(wrapWithRuleFlags(base, provider, model, true), provider)
 }
 
 // ProviderType returns the provider type

--- a/internal/client/google.go
+++ b/internal/client/google.go
@@ -63,7 +63,7 @@ func NewGoogleClient(provider *typ.Provider, model string, sessionID typ.Session
 	httpClient := &http.Client{
 		// resolveUA=false: the generic Google path has never forwarded
 		// rule/client UA.
-		Transport: wrapWithLogging(wrapWithRuleFlags(transport, provider, false), provider),
+		Transport: wrapWithLogging(wrapWithRuleFlags(transport, provider, model, false), provider),
 		Timeout:   timeout,
 	}
 	return newGoogleClientFromHTTPClient(provider, httpClient)

--- a/internal/client/openai.go
+++ b/internal/client/openai.go
@@ -77,7 +77,7 @@ func NewOpenAIClient(provider *typ.Provider, model string, sessionID typ.Session
 	// proxy variables (HTTP_PROXY / HTTPS_PROXY) are not inherited when no
 	// proxy is explicitly configured for the provider.
 	base := GetGlobalTransportPool().GetTransport(provider.UUID, model, provider.ProxyURL, ai.Issuer(""), sessionID)
-	transport = wrapWithRuleFlags(base, provider, true)
+	transport = wrapWithRuleFlags(base, provider, model, true)
 	transport = wrapWithLogging(transport, provider)
 
 	httpClient := &http.Client{

--- a/internal/client/rule_flag_transport.go
+++ b/internal/client/rule_flag_transport.go
@@ -15,7 +15,13 @@ import (
 //
 //   - extra_headers: api_key providers only (release gate, mirroring the API
 //     validation gate). Vendor/OAuth/multi-field-credential chains never see
-//     rule-configured headers.
+//     configured headers. Two sources meet here: the supply-side
+//     provider ∪ model headers, resolved once at wrap time (this transport is
+//     built per client, and clients are keyed by provider + model), and the
+//     rule's own extra_headers off the request context. Supply-side headers
+//     are written first and the rule's second, so the documented precedence
+//     provider < model < rule falls out of the write order — nothing merges
+//     all three levels.
 //   - custom_user_agent + inbound client UA forwarding: only chains mounted
 //     with resolveUA=true (the generic OpenAI and non-OAuth Anthropic
 //     pass-through chains). Vendor-specialized chains (Claude Code OAuth,
@@ -29,6 +35,11 @@ import (
 // construction (claude_client.go).
 type ruleFlagTransport struct {
 	inner http.RoundTripper
+	// supplyHeaders is the provider ∪ model extra_headers for the client this
+	// transport belongs to. Independent of the request context, so paths that
+	// never pass through protocol dispatch (probes, model-list fetch, vision
+	// proxy) still send the upstream's configured headers.
+	supplyHeaders map[string]string
 	// resolveUA marks a generic pass-through chain: resolve the UA precedence
 	// (rule/scenario custom_user_agent > inbound client UA > SDK default) at
 	// this layer. Chains whose UA is owned elsewhere mount with false.
@@ -50,12 +61,20 @@ type ruleFlagTransport struct {
 // Returns inner unchanged when no flag can ever apply on this chain
 // (non-api_key provider and no UA resolution) — same zero-cost no-op the old
 // per-flag wrappers provided.
-func wrapWithRuleFlags(inner http.RoundTripper, provider *typ.Provider, resolveUA bool) http.RoundTripper {
+//
+// model is the provider-side model this client is built for; it selects the
+// model-level supply headers. Empty for clients not bound to one model (the
+// provider level still applies).
+func wrapWithRuleFlags(inner http.RoundTripper, provider *typ.Provider, model string, resolveUA bool) http.RoundTripper {
 	applyExtraHeaders := provider != nil && provider.IsAPIKey()
 	if !resolveUA && !applyExtraHeaders {
 		return inner
 	}
-	return &ruleFlagTransport{inner: inner, resolveUA: resolveUA, applyExtraHeaders: applyExtraHeaders}
+	t := &ruleFlagTransport{inner: inner, resolveUA: resolveUA, applyExtraHeaders: applyExtraHeaders}
+	if applyExtraHeaders {
+		t.supplyHeaders = typ.SupplyExtraHeaders(provider, model)
+	}
+	return t
 }
 
 func (t *ruleFlagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -69,8 +88,9 @@ func (t *ruleFlagTransport) RoundTrip(req *http.Request) (*http.Response, error)
 
 	// extra_headers: api_key providers only. Applied verbatim — user-driven
 	// config, no filtering.
-	var extra map[string]string
+	var supply, extra map[string]string
 	if t.applyExtraHeaders {
+		supply = t.supplyHeaders
 		extra = flags.ExtraHeaders
 	}
 
@@ -84,17 +104,21 @@ func (t *ruleFlagTransport) RoundTrip(req *http.Request) (*http.Response, error)
 		}
 	}
 
-	if len(extra) == 0 && ua == "" {
+	if len(supply) == 0 && len(extra) == 0 && ua == "" {
 		return inner.RoundTrip(req)
 	}
 
 	// Clone before mutating so concurrent retries never race on shared headers.
 	req = req.Clone(ctx)
 
-	// Extra headers first, UA second: on a User-Agent name conflict the UA
-	// resolution wins, same precedence the old two-transport stack produced
-	// (extra headers outermost, UA innermost). Inner chains still write after
-	// this layer and win any remaining conflict by ordering.
+	// Write order is the precedence: supply-side (provider ∪ model) first, the
+	// rule's headers over them, UA last — so on a User-Agent name conflict the
+	// UA resolution wins, the same precedence the old two-transport stack
+	// produced (extra headers outermost, UA innermost). Inner chains still
+	// write after this layer and win any remaining conflict by ordering.
+	for name, value := range supply {
+		req.Header.Set(name, value)
+	}
 	for name, value := range extra {
 		req.Header.Set(name, value)
 	}

--- a/internal/client/rule_flag_transport_test.go
+++ b/internal/client/rule_flag_transport_test.go
@@ -68,7 +68,7 @@ func newReq(t *testing.T, ctx context.Context, ua string) *http.Request {
 
 func TestRuleFlagTransport_NoContextValue_PassesThrough(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	// Simulate the SDK having already stamped its default UA on the request.
 	req := newReq(t, context.Background(), "sdk-default/1.0")
 
@@ -82,7 +82,7 @@ func TestRuleFlagTransport_NoContextValue_PassesThrough(t *testing.T) {
 
 func TestRuleFlagTransport_RuleOverride(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	ctx := typ.WithRuleFlags(context.Background(), typ.RuleFlags{CustomUserAgent: "RuleUA/1.0"})
 	req := newReq(t, ctx, "sdk-default/1.0")
 
@@ -96,7 +96,7 @@ func TestRuleFlagTransport_RuleOverride(t *testing.T) {
 
 func TestRuleFlagTransport_ForwardsInboundClientUA(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	// Client sent "cherry-studio/1.2"; SDK stamped its own default. With no rule
 	// override, the inbound client UA must be forwarded so upstream sees the real
 	// caller instead of the generic SDK UA.
@@ -113,7 +113,7 @@ func TestRuleFlagTransport_ForwardsInboundClientUA(t *testing.T) {
 
 func TestRuleFlagTransport_RuleWinsOverClient(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	// Both present: the rule/scenario override wins over the inbound client UA.
 	ctx := typ.WithClientUserAgent(context.Background(), "cherry-studio/1.2")
 	ctx = typ.WithRuleFlags(ctx, typ.RuleFlags{CustomUserAgent: "RuleUA/1.0"})
@@ -129,7 +129,7 @@ func TestRuleFlagTransport_RuleWinsOverClient(t *testing.T) {
 
 func TestRuleFlagTransport_NoneSentinelStripsEvenWithClientUA(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	// The `none` sentinel is a rule/scenario value; it must strip the UA entirely
 	// and still win over a present inbound client UA.
 	ctx := typ.WithClientUserAgent(context.Background(), "cherry-studio/1.2")
@@ -155,7 +155,7 @@ func TestRuleFlagTransport_NoneSentinelStripsEvenWithClientUA(t *testing.T) {
 
 func TestRuleFlagTransport_DoesNotMutateOriginalRequest(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	ctx := typ.WithRuleFlags(context.Background(), typ.RuleFlags{CustomUserAgent: "RuleUA/1.0"})
 	req := newReq(t, ctx, "sdk-default/1.0")
 
@@ -171,7 +171,7 @@ func TestRuleFlagTransport_DoesNotMutateOriginalRequest(t *testing.T) {
 
 func TestRuleFlagTransport_EmptyFlagsAreNoOp(t *testing.T) {
 	cap := &captureTransport{}
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", true)
 	// Zero-value flags attached (the merge point attaches unconditionally), so
 	// an existing SDK UA header is left untouched.
 	ctx := typ.WithRuleFlags(context.Background(), typ.RuleFlags{})
@@ -190,7 +190,7 @@ func TestRuleFlagTransport_NoResolveUA_IgnoresUAFlags(t *testing.T) {
 	cap := &captureTransport{}
 	// resolveUA=false (e.g. the generic Google chain): UA flags must not apply
 	// even when present in ctx.
-	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), false)
+	wrapped := wrapWithRuleFlags(cap, apiKeyProvider(), "", false)
 	ctx := typ.WithClientUserAgent(context.Background(), "cherry-studio/1.2")
 	ctx = typ.WithRuleFlags(ctx, typ.RuleFlags{CustomUserAgent: "RuleUA/1.0"})
 	req := newReq(t, ctx, "sdk-default/1.0")
@@ -211,7 +211,7 @@ func TestRuleFlagTransport_NilInnerFallsBackToDefault(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	wrapped := wrapWithRuleFlags(nil, apiKeyProvider(), true)
+	wrapped := wrapWithRuleFlags(nil, apiKeyProvider(), "", true)
 	req, _ := http.NewRequest("GET", srv.URL, nil)
 	resp, err := wrapped.RoundTrip(req)
 	if err != nil {
@@ -232,7 +232,7 @@ func newHeadersReq(t *testing.T, headers map[string]string) *http.Request {
 
 func TestRuleFlagTransport_AppliesExtraHeaders(t *testing.T) {
 	capture := &captureTransport{}
-	rt := wrapWithRuleFlags(capture, apiKeyProvider(), true)
+	rt := wrapWithRuleFlags(capture, apiKeyProvider(), "", true)
 
 	if _, err := rt.RoundTrip(newHeadersReq(t, map[string]string{"X-Title": "tingly"})); err != nil {
 		t.Fatal(err)
@@ -245,7 +245,7 @@ func TestRuleFlagTransport_AppliesExtraHeaders(t *testing.T) {
 func TestRuleFlagTransport_ExtraHeadersNonAPIKeyIsNoOp(t *testing.T) {
 	capture := &captureTransport{}
 	oauth := &typ.Provider{UUID: "p2", AuthType: ai.AuthTypeOAuth}
-	rt := wrapWithRuleFlags(capture, oauth, false)
+	rt := wrapWithRuleFlags(capture, oauth, "", false)
 	if rt != http.RoundTripper(capture) {
 		t.Fatal("a chain where no flag can apply must get the inner transport unchanged")
 	}
@@ -267,7 +267,7 @@ func TestRuleFlagTransport_ExtraHeadersNonAPIKeyIsNoOp(t *testing.T) {
 func TestRuleFlagTransport_VendorPinWins(t *testing.T) {
 	capture := &captureTransport{}
 	vendor := &pinTransport{inner: capture, name: "X-Vendor-Pin", value: "pinned"}
-	rt := wrapWithRuleFlags(vendor, apiKeyProvider(), true)
+	rt := wrapWithRuleFlags(vendor, apiKeyProvider(), "", true)
 
 	if _, err := rt.RoundTrip(newHeadersReq(t, map[string]string{
 		"X-Vendor-Pin": "user-tries-to-override",
@@ -288,7 +288,7 @@ func TestRuleFlagTransport_VendorPinWins(t *testing.T) {
 // Authorization. The user asked for it; the user owns it.
 func TestRuleFlagTransport_AppliesExtraHeadersVerbatim(t *testing.T) {
 	capture := &captureTransport{}
-	rt := wrapWithRuleFlags(capture, apiKeyProvider(), true)
+	rt := wrapWithRuleFlags(capture, apiKeyProvider(), "", true)
 
 	req := newHeadersReq(t, map[string]string{
 		"Authorization": "Bearer custom",
@@ -308,7 +308,7 @@ func TestRuleFlagTransport_AppliesExtraHeadersVerbatim(t *testing.T) {
 
 func TestRuleFlagTransport_ExtraHeadersDoNotMutateCallerRequest(t *testing.T) {
 	capture := &captureTransport{}
-	rt := wrapWithRuleFlags(capture, apiKeyProvider(), true)
+	rt := wrapWithRuleFlags(capture, apiKeyProvider(), "", true)
 
 	orig := newHeadersReq(t, map[string]string{"X-Title": "tingly"})
 	if _, err := rt.RoundTrip(orig); err != nil {
@@ -326,7 +326,7 @@ func TestRuleFlagTransport_ExtraHeadersDoNotMutateCallerRequest(t *testing.T) {
 // the old two-transport stack (extra headers outermost, UA innermost).
 func TestRuleFlagTransport_UAWinsOverExtraHeaderUA(t *testing.T) {
 	capture := &captureTransport{}
-	rt := wrapWithRuleFlags(capture, apiKeyProvider(), true)
+	rt := wrapWithRuleFlags(capture, apiKeyProvider(), "", true)
 
 	ctx := typ.WithRuleFlags(context.Background(), typ.RuleFlags{
 		CustomUserAgent: "RuleUA/1.0",
@@ -352,5 +352,103 @@ func TestWrapWithLogging_IsLoggingOnly(t *testing.T) {
 	}
 	if got := capture.lastReq.Header.Get("X-Title"); got != "" {
 		t.Errorf("X-Title = %q, want unset (logging layer must not apply flags)", got)
+	}
+}
+
+// ── Supply-side headers (provider ∪ model) ──────────────────────────────────
+
+func providerWithHeaders(t *testing.T, provider, model map[string]string) *typ.Provider {
+	t.Helper()
+	p := apiKeyProvider()
+	if provider != nil {
+		p.Flags = typ.ProviderFlags{ExtraHeaders: provider}
+	}
+	if model != nil {
+		p.ModelFlags = map[string]typ.ProviderFlags{"m1": {ExtraHeaders: model}}
+	}
+	return p
+}
+
+// Supply-side headers ride the client, not the request context, so paths that
+// never pass through protocol dispatch (probes, model-list fetch) send them.
+func TestRuleFlagTransport_SupplyHeadersWithoutCtx(t *testing.T) {
+	capture := &captureTransport{}
+	rt := wrapWithRuleFlags(capture, providerWithHeaders(t, map[string]string{"X-Title": "tingly"}, nil), "", true)
+
+	if _, err := rt.RoundTrip(newReq(t, context.Background(), "")); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.lastReq.Header.Get("X-Title"); got != "tingly" {
+		t.Errorf("X-Title = %q, want tingly", got)
+	}
+}
+
+// The full precedence provider < model < rule, produced by write order alone.
+func TestRuleFlagTransport_ThreeLevelPrecedence(t *testing.T) {
+	capture := &captureTransport{}
+	provider := providerWithHeaders(t,
+		map[string]string{"X-Shared": "provider", "X-Provider": "p"},
+		map[string]string{"X-Shared": "model", "X-Model": "m"},
+	)
+	rt := wrapWithRuleFlags(capture, provider, "m1", true)
+
+	ctx := typ.WithRuleFlags(context.Background(), typ.RuleFlags{ExtraHeaders: map[string]string{
+		"X-Shared": "rule",
+		"X-Rule":   "r",
+	}})
+	if _, err := rt.RoundTrip(newReq(t, ctx, "")); err != nil {
+		t.Fatal(err)
+	}
+	for header, want := range map[string]string{
+		"X-Shared":   "rule", // provider < model < rule
+		"X-Provider": "p",
+		"X-Model":    "m",
+		"X-Rule":     "r",
+	} {
+		if got := capture.lastReq.Header.Get(header); got != want {
+			t.Errorf("%s = %q, want %q", header, got, want)
+		}
+	}
+}
+
+// A client built for another model gets only the provider level.
+func TestRuleFlagTransport_ModelHeadersAreModelScoped(t *testing.T) {
+	capture := &captureTransport{}
+	provider := providerWithHeaders(t,
+		map[string]string{"X-Provider": "p"},
+		map[string]string{"X-Model": "m"},
+	)
+	rt := wrapWithRuleFlags(capture, provider, "other-model", true)
+
+	if _, err := rt.RoundTrip(newReq(t, context.Background(), "")); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.lastReq.Header.Get("X-Provider"); got != "p" {
+		t.Errorf("X-Provider = %q, want p", got)
+	}
+	if got := capture.lastReq.Header.Get("X-Model"); got != "" {
+		t.Errorf("X-Model = %q, want unset for a different model", got)
+	}
+}
+
+// The api_key gate covers supply-side headers too: a non-api_key provider
+// gets no transport at all, so nothing configured on it can reach the wire.
+func TestRuleFlagTransport_SupplyHeadersRespectAPIKeyGate(t *testing.T) {
+	capture := &captureTransport{}
+	oauth := &typ.Provider{
+		UUID:     "p2",
+		AuthType: ai.AuthTypeOAuth,
+		Flags:    typ.ProviderFlags{ExtraHeaders: map[string]string{"X-Title": "cfg"}},
+	}
+
+	rt := wrapWithRuleFlags(capture, oauth, "m1", false)
+	if rt != http.RoundTripper(capture) {
+		t.Fatal("non-api_key provider with no UA resolution must get the inner transport unchanged")
+	}
+	if _, err := rt.RoundTrip(newReq(t, context.Background(), "")); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.lastReq.Header.Get("X-Title"); got != "" {
+		t.Errorf("X-Title = %q, want unset on a non-api_key provider", got)
 	}
 }

--- a/internal/db/provider_store.go
+++ b/internal/db/provider_store.go
@@ -62,6 +62,12 @@ type ProviderRecord struct {
 	// no backfill required.
 	Credential *typ.CredentialBundle `gorm:"column:credential;type:text;serializer:json"`
 
+	// Flags / ModelFlags hold the provider-level options and the per-model
+	// overrides. Auth-type independent. Added additively; AutoMigrate creates
+	// the columns with no backfill required.
+	Flags      typ.ProviderFlags            `gorm:"column:flags;type:text;serializer:json"`
+	ModelFlags map[string]typ.ProviderFlags `gorm:"column:model_flags;type:text;serializer:json"`
+
 	CreatedAt time.Time `gorm:"column:created_at"`
 	UpdatedAt time.Time `gorm:"column:updated_at"`
 }
@@ -114,6 +120,28 @@ func cloneVModelDetail(d *typ.VModelDetail) *typ.VModelDetail {
 	return &out
 }
 
+// cloneProviderFlags / cloneModelFlags isolate the cached record from
+// callers the same way as the other JSON columns.
+func cloneProviderFlags(f typ.ProviderFlags) typ.ProviderFlags {
+	if len(f.ExtraHeaders) > 0 {
+		f.ExtraHeaders = maps.Clone(f.ExtraHeaders)
+	} else {
+		f.ExtraHeaders = nil
+	}
+	return f
+}
+
+func cloneModelFlags(m map[string]typ.ProviderFlags) map[string]typ.ProviderFlags {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]typ.ProviderFlags, len(m))
+	for model, flags := range m {
+		out[model] = cloneProviderFlags(flags)
+	}
+	return out
+}
+
 func cloneCredential(c *typ.CredentialBundle) *typ.CredentialBundle {
 	if c == nil {
 		return nil
@@ -147,6 +175,8 @@ func (r *ProviderRecord) toProvider() *typ.Provider {
 	}
 
 	provider.Tags = cloneStrings(r.Tags)
+	provider.Flags = cloneProviderFlags(r.Flags)
+	provider.ModelFlags = cloneModelFlags(r.ModelFlags)
 
 	// Set credentials based on auth type
 	switch provider.AuthType {
@@ -202,6 +232,8 @@ func toRecord(p *typ.Provider) *ProviderRecord {
 	}
 
 	record.Tags = cloneStrings(p.Tags)
+	record.Flags = cloneProviderFlags(p.Flags)
+	record.ModelFlags = cloneModelFlags(p.ModelFlags)
 
 	// Set credentials based on auth type
 	switch p.AuthType {
@@ -240,6 +272,8 @@ func updateRecordFromProvider(record *ProviderRecord, p *typ.Provider) {
 	record.UpdatedAt = time.Now()
 
 	record.Tags = cloneStrings(p.Tags)
+	record.Flags = cloneProviderFlags(p.Flags)
+	record.ModelFlags = cloneModelFlags(p.ModelFlags)
 
 	// Set credentials based on auth type
 	switch p.AuthType {

--- a/internal/db/provider_store_test.go
+++ b/internal/db/provider_store_test.go
@@ -797,3 +797,75 @@ func TestProviderStore_FailedWriteDoesNotCorruptCache(t *testing.T) {
 		}
 	})
 }
+
+// TestProviderFlagsRoundTrip verifies the flags / model_flags columns:
+// values survive save/reload, updates rewrite them, and clearing empties them.
+func TestProviderFlagsRoundTrip(t *testing.T) {
+	store, _ := setupTestProviderStore(t)
+	defer store.Close()
+
+	provider := &typ.Provider{
+		UUID:     "flags-uuid-1",
+		Name:     "flags-provider",
+		APIBase:  "https://api.example.com/v1",
+		APIStyle: protocol.APIStyleOpenAI,
+		AuthType: typ.AuthTypeAPIKey,
+		Token:    "sk-flags",
+		Enabled:  true,
+		Flags:    typ.ProviderFlags{ExtraHeaders: map[string]string{"X-Title": "tingly"}},
+		ModelFlags: map[string]typ.ProviderFlags{
+			"gpt-x": {ExtraHeaders: map[string]string{"X-Canary": "on"}},
+		},
+	}
+	if err := store.Save(provider); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := store.GetByUUID("flags-uuid-1")
+	if err != nil {
+		t.Fatalf("GetByUUID: %v", err)
+	}
+	if loaded.Flags.ExtraHeaders["X-Title"] != "tingly" {
+		t.Errorf("provider flags lost on reload: %+v", loaded.Flags)
+	}
+	if loaded.ModelFlags["gpt-x"].ExtraHeaders["X-Canary"] != "on" {
+		t.Errorf("model flags lost on reload: %+v", loaded.ModelFlags)
+	}
+
+	// The cached record must not alias what callers hold.
+	loaded.Flags.ExtraHeaders["X-Title"] = "mutated-by-caller"
+	again, err := store.GetByUUID("flags-uuid-1")
+	if err != nil {
+		t.Fatalf("GetByUUID(again): %v", err)
+	}
+	if again.Flags.ExtraHeaders["X-Title"] != "tingly" {
+		t.Errorf("caller mutation leaked into the store: %+v", again.Flags)
+	}
+
+	// Update path (existing record) rewrites the columns.
+	again.Flags = typ.ProviderFlags{ExtraHeaders: map[string]string{"X-Title": "updated"}}
+	if err := store.Save(again); err != nil {
+		t.Fatalf("Save(update): %v", err)
+	}
+	reloaded, err := store.GetByUUID("flags-uuid-1")
+	if err != nil {
+		t.Fatalf("GetByUUID(update): %v", err)
+	}
+	if reloaded.Flags.ExtraHeaders["X-Title"] != "updated" {
+		t.Errorf("updated flags not persisted: %+v", reloaded.Flags)
+	}
+
+	// Clearing both levels empties the columns.
+	reloaded.Flags = typ.ProviderFlags{}
+	reloaded.ModelFlags = nil
+	if err := store.Save(reloaded); err != nil {
+		t.Fatalf("Save(clear): %v", err)
+	}
+	cleared, err := store.GetByUUID("flags-uuid-1")
+	if err != nil {
+		t.Fatalf("GetByUUID(clear): %v", err)
+	}
+	if !cleared.Flags.IsZero() || cleared.ModelFlags != nil {
+		t.Errorf("cleared flags came back: %+v / %+v", cleared.Flags, cleared.ModelFlags)
+	}
+}

--- a/internal/protocoltest/flags.go
+++ b/internal/protocoltest/flags.go
@@ -347,6 +347,62 @@ func ruleFlagCases() []flagCase {
 			} else if got := up.Headers.Get("X-Team-Tag"); got != "research" {
 				t.Errorf("anthropic chain: upstream X-Team-Tag = %q, want research", got)
 			}
+
+			// Three-level precedence (provider < model < rule): the supply-side
+			// levels ride the client (typ.SupplyExtraHeaders at wrap time), the
+			// rule level rides the request context, and the transport's write
+			// order is what resolves conflicts.
+			s := flagScenario()
+			env.virtual.RegisterScenario(s)
+			const providerName = "flag-extra-headers-levels"
+			providerModel := "virtual-model-" + s.Name
+
+			provider := &typ.Provider{
+				UUID:     providerName,
+				Name:     providerName,
+				APIBase:  env.virtual.URL() + "/v1",
+				APIStyle: protocol.APIStyleOpenAI,
+				AuthType: ai.AuthTypeAPIKey,
+				Token:    "virtual-token",
+				Enabled:  true,
+				Timeout:  int64(constant.DefaultRequestTimeout),
+			}
+			provider.Flags = typ.ProviderFlags{ExtraHeaders: map[string]string{
+				"X-Level":         "provider",
+				"X-Provider-Only": "p",
+			}}
+			provider.ModelFlags = map[string]typ.ProviderFlags{
+				providerModel: {ExtraHeaders: map[string]string{
+					"X-Level":      "model",
+					"X-Model-Only": "m",
+				}},
+			}
+			_ = env.appConfig.AddProvider(provider)
+
+			const levelsModel = "pv-flag-extra-headers-levels"
+			levelsRule := newHarnessRule(levelsModel, typ.ScenarioOpenAI, levelsModel, providerModel,
+				harnessService(providerName, providerModel))
+			levelsRule.Flags = typ.RuleFlags{ExtraHeaders: map[string]string{
+				"X-Level":     "rule",
+				"X-Rule-Only": "r",
+			}}
+			_ = env.appConfig.GetGlobalConfig().AddRequestConfig(levelsRule)
+
+			sendFlag(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, levelsModel, false, nil, nil)
+			up = env.virtual.LastRequest(EndpointChat)
+			if up == nil {
+				t.Fatal("no upstream request captured for the three-level route")
+			}
+			for header, want := range map[string]string{
+				"X-Level":         "rule", // provider < model < rule
+				"X-Provider-Only": "p",
+				"X-Model-Only":    "m",
+				"X-Rule-Only":     "r",
+			} {
+				if got := up.Headers.Get(header); got != want {
+					t.Errorf("three-level: upstream %s = %q, want %q", header, got, want)
+				}
+			}
 		}},
 
 		// ── use_max_completion_tokens ────────────────────────────────────────

--- a/internal/server/config/provider.go
+++ b/internal/server/config/provider.go
@@ -185,6 +185,9 @@ func (c *Config) AddProvider(provider *typ.Provider) error {
 	if provider.APIBase == "" {
 		return errors.New("API base URL cannot be empty")
 	}
+	if err := ValidateProviderFlags(provider); err != nil {
+		return err
+	}
 
 	// Use provider store if available
 	if c.providerStore != nil {
@@ -264,10 +267,49 @@ func (c *Config) notifyProviderDelete(uuid string) {
 	}
 }
 
+// ValidateProviderFlags checks the provider- and model-level flags before a
+// provider is persisted, and canonicalizes accepted header names in place.
+// It sits in the AddProvider/UpdateProvider choke points so every write path
+// — HTTP handlers, CLI, and provider import (dataio) — shares one gate.
+//
+// v1 release scope: extra headers are only supported on api_key providers
+// (see .design/provider-flags.md §5.4); the transport additionally applies
+// nothing on non-api_key rows as a runtime defense.
+func ValidateProviderFlags(p *typ.Provider) error {
+	p.ModelFlags = typ.PruneModelFlags(p.ModelFlags)
+
+	configured := !p.Flags.IsZero() || len(p.ModelFlags) > 0
+	if !configured {
+		return nil
+	}
+
+	if !p.IsAPIKey() {
+		return errors.New("custom headers (extra_headers) are only supported on api_key providers")
+	}
+	if err := typ.ValidateExtraHeaders(p.Flags.ExtraHeaders); err != nil {
+		return fmt.Errorf("provider flags: %w", err)
+	}
+	for model, mf := range p.ModelFlags {
+		if err := typ.ValidateExtraHeaders(mf.ExtraHeaders); err != nil {
+			return fmt.Errorf("model %q flags: %w", model, err)
+		}
+	}
+
+	p.Flags.ExtraHeaders = typ.CanonicalizeExtraHeaders(p.Flags.ExtraHeaders)
+	for model, mf := range p.ModelFlags {
+		mf.ExtraHeaders = typ.CanonicalizeExtraHeaders(mf.ExtraHeaders)
+		p.ModelFlags[model] = mf
+	}
+	return nil
+}
+
 // UpdateProvider updates an existing provider by UUID
 func (c *Config) UpdateProvider(uuid string, provider *typ.Provider) error {
 	// Use provider store if available
 	if c.providerStore != nil {
+		if err := ValidateProviderFlags(provider); err != nil {
+			return err
+		}
 		// Preserve the UUID
 		provider.UUID = uuid
 		if err := c.providerStore.Save(provider); err != nil {

--- a/internal/server/module/provider/handler.go
+++ b/internal/server/module/provider/handler.go
@@ -43,6 +43,25 @@ func badRequest(c *gin.Context, format string, args ...any) {
 	c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": fmt.Sprintf(format, args...)})
 }
 
+// applyProviderFlagsRequest writes the request's optional flag sections onto
+// the provider and validates the result. nil sections leave the stored level
+// untouched; a non-nil section replaces that level wholesale (empty clears
+// it). Validation runs post-merge via the same gate the config layer uses on
+// every write path, so a partial update can't smuggle headers onto a
+// non-api_key provider.
+func applyProviderFlagsRequest(p *typ.Provider, flags *typ.ProviderFlags, modelFlags *map[string]typ.ProviderFlags) error {
+	if flags == nil && modelFlags == nil {
+		return nil
+	}
+	if flags != nil {
+		p.Flags = *flags
+	}
+	if modelFlags != nil {
+		p.ModelFlags = *modelFlags
+	}
+	return config.ValidateProviderFlags(p)
+}
+
 // maskForResponse masks sensitive data and returns a safe ProviderResponse.
 func maskForResponse(p *typ.Provider) ProviderResponse {
 	resp := ProviderResponse{
@@ -63,6 +82,13 @@ func maskForResponse(p *typ.Provider) ProviderResponse {
 	if p.IsVirtual() {
 		resp.VModelDetail = p.VModelDetail
 	}
+
+	// Empty levels stay omitted so an untouched provider carries neither key.
+	if !p.Flags.IsZero() {
+		flags := p.Flags
+		resp.Flags = &flags
+	}
+	resp.ModelFlags = p.ModelFlags
 
 	switch {
 	case p.IsOAuth():
@@ -231,6 +257,13 @@ func (h *Handler) CreateProvider(c *gin.Context) {
 		p.Token = ""
 	}
 
+	// Optional provider/model flags. applyProviderFlagsRequest fails fast with
+	// a 400-worthy error; AddProvider revalidates as the shared backstop.
+	if err := applyProviderFlagsRequest(p, req.Flags, &req.ModelFlags); err != nil {
+		badRequest(c, "%s", err)
+		return
+	}
+
 	if err = h.config.AddProvider(p); err != nil {
 		logrus.WithFields(logrus.Fields{
 			"action":   obs.ActionAddProvider,
@@ -256,6 +289,15 @@ func (h *Handler) CreateProvider(c *gin.Context) {
 		Success: true,
 		Message: "Provider added successfully",
 		Data:    p,
+	})
+}
+
+// GetFlagRegistry returns the catalog of supported provider/model-level
+// flags — the supply-side counterpart of the rule module's flag registry.
+func (h *Handler) GetFlagRegistry(c *gin.Context) {
+	c.JSON(http.StatusOK, FlagRegistryResponse{
+		Success: true,
+		Data:    typ.ProviderFlagRegistry(),
 	})
 }
 
@@ -370,6 +412,12 @@ func (h *Handler) UpdateProvider(c *gin.Context) {
 	}
 	if req.ProxyURL != nil {
 		p.ProxyURL = *req.ProxyURL
+	}
+	// Flags / ModelFlags: nil leaves the stored level untouched, non-nil
+	// replaces it wholesale (empty clears). Validated post-merge below.
+	if err := applyProviderFlagsRequest(p, req.Flags, req.ModelFlags); err != nil {
+		badRequest(c, "%s", err)
+		return
 	}
 
 	// Dual-mode constraints: validate post-merge so we catch combinations

--- a/internal/server/module/provider/handler_test.go
+++ b/internal/server/module/provider/handler_test.go
@@ -343,3 +343,106 @@ func TestImportProviders_MissingData(t *testing.T) {
 		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
 	}
 }
+
+// TestProviderFlags_API drives the flags/model_flags fields through the real
+// HTTP handlers: create with flags, partial-update semantics (nil untouched,
+// non-nil replaces, empty clears), response surfacing, and the api_key gate.
+func TestProviderFlags_API(t *testing.T) {
+	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	handler := NewHandler(cfg, nil)
+	router.POST("/providers", handler.CreateProvider)
+	router.PUT("/providers/:uuid", handler.UpdateProvider)
+	router.GET("/providers/:uuid", handler.GetProvider)
+
+	do := func(method, path string, payload any) *httptest.ResponseRecorder {
+		t.Helper()
+		body, err := json.Marshal(payload)
+		require.NoError(t, err)
+		req, _ := http.NewRequest(method, path, bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	// Create with provider- and model-level flags.
+	w := do("POST", "/providers", CreateProviderRequest{
+		Name:    "flags-provider",
+		APIBase: "https://api.test.com/v1",
+		Token:   "sk-test",
+		Flags:   &typ.ProviderFlags{ExtraHeaders: map[string]string{"x-title": "tingly"}},
+		ModelFlags: map[string]typ.ProviderFlags{
+			"gpt-x": {ExtraHeaders: map[string]string{"X-Canary": "on"}},
+		},
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var created struct {
+		Data typ.Provider `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	uid := created.Data.UUID
+	require.NotEmpty(t, uid)
+
+	// readBack decodes into a fresh struct each time — json.Unmarshal into a
+	// reused struct merges maps instead of replacing them.
+	readBack := func() ProviderResponse {
+		t.Helper()
+		w := do("GET", "/providers/"+uid, nil)
+		require.Equal(t, http.StatusOK, w.Code)
+		var got struct {
+			Data ProviderResponse `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		return got.Data
+	}
+
+	// Read back: names canonicalized, both levels surfaced.
+	resp := readBack()
+	require.NotNil(t, resp.Flags)
+	assert.Equal(t, "tingly", resp.Flags.ExtraHeaders["X-Title"])
+	assert.Equal(t, "on", resp.ModelFlags["gpt-x"].ExtraHeaders["X-Canary"])
+
+	// Partial update with both sections omitted leaves flags untouched.
+	name := "flags-provider-renamed"
+	w = do("PUT", "/providers/"+uid, UpdateProviderRequest{Name: &name})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp = readBack()
+	require.NotNil(t, resp.Flags)
+	assert.Equal(t, "tingly", resp.Flags.ExtraHeaders["X-Title"])
+
+	// Non-nil flags replace wholesale; empty model_flags map clears it.
+	emptyMF := map[string]typ.ProviderFlags{}
+	w = do("PUT", "/providers/"+uid, UpdateProviderRequest{
+		Flags:      &typ.ProviderFlags{ExtraHeaders: map[string]string{"X-New": "v"}},
+		ModelFlags: &emptyMF,
+	})
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	resp = readBack()
+	require.NotNil(t, resp.Flags)
+	assert.Equal(t, "v", resp.Flags.ExtraHeaders["X-New"])
+	assert.NotContains(t, resp.Flags.ExtraHeaders, "X-Title")
+	assert.Empty(t, resp.ModelFlags)
+
+	// Structurally invalid header name rejected with 400 (no denylist —
+	// gateway-adjacent names like Authorization are accepted verbatim).
+	w = do("PUT", "/providers/"+uid, UpdateProviderRequest{
+		Flags: &typ.ProviderFlags{ExtraHeaders: map[string]string{"X Title": "bad name"}},
+	})
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+
+	// api_key gate: headers on a non-api_key provider are rejected.
+	w = do("POST", "/providers", CreateProviderRequest{
+		Name:     "sigv4-provider",
+		APIBase:  "https://bedrock.test",
+		AuthType: "aws_sigv4",
+		APIStyle: "anthropic",
+		Credential: map[string]string{
+			"access_key_id": "AKIA", "secret_access_key": "s", "region": "us-east-1",
+		},
+		Flags: &typ.ProviderFlags{ExtraHeaders: map[string]string{"X-Title": "t"}},
+	})
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "api_key")
+}

--- a/internal/server/module/provider/routes.go
+++ b/internal/server/module/provider/routes.go
@@ -45,6 +45,15 @@ func RegisterRoutes(api *swagger.RouteGroup, h *Handler) {
 		swagger.WithResponseModel(DeleteProviderResponse{}),
 	)
 
+	// GET /provider/flags/registry - Catalog of supported provider/model-level
+	// flags, mirroring GET /rule/flags/registry so the frontend renders the
+	// provider Plugins UI registry-driven.
+	api.GET("/provider/flags/registry", h.GetFlagRegistry,
+		swagger.WithDescription("Get catalog of supported provider/model-level flags"),
+		swagger.WithTags("providers"),
+		swagger.WithResponseModel(FlagRegistryResponse{}),
+	)
+
 	api.GET("/provider-models/:uuid", h.GetProviderModelsByUUID,
 		swagger.WithDescription("Get all provider models"),
 		swagger.WithTags("models"),

--- a/internal/server/module/provider/types.go
+++ b/internal/server/module/provider/types.go
@@ -24,6 +24,12 @@ type ProviderResponse struct {
 	VModelDetail     *typ.VModelDetail `json:"vmodel_detail,omitempty"`               // Virtual-model config (only for vmodel auth type)
 	Credential       map[string]string `json:"credential,omitempty"`                  // Multi-field cloud credentials (only for aws_sigv4/azure_key/gcp_sa)
 	Source           string            `json:"source,omitempty" example:"user"`       // "user" (default) or "builtin"
+	// Flags carries the provider-level flags (extra_headers, …) decoded from
+	// the provider's extension container; ModelFlags the per-model overrides
+	// keyed by provider-side model ID. See GET /provider/flags/registry for
+	// the catalog. api_key providers only.
+	Flags      *typ.ProviderFlags           `json:"flags,omitempty"`
+	ModelFlags map[string]typ.ProviderFlags `json:"model_flags,omitempty"`
 }
 
 // ProvidersResponse represents the response for listing providers.
@@ -48,6 +54,10 @@ type CreateProviderRequest struct {
 	// aws_sigv4 (AWS Bedrock), azure_key (Azure OpenAI), and gcp_sa (GCP Vertex).
 	// Ignored for api_key/oauth/vmodel. See ai.CredentialSchema for the field keys.
 	Credential map[string]string `json:"credential,omitempty" description:"Cloud credential fields (aws_sigv4/azure_key/gcp_sa)"`
+	// Flags / ModelFlags optionally seed the provider-level flags and
+	// per-model overrides (api_key auth only; validated on save).
+	Flags      *typ.ProviderFlags           `json:"flags,omitempty" description:"Provider-level flags (extra_headers, …); api_key auth only"`
+	ModelFlags map[string]typ.ProviderFlags `json:"model_flags,omitempty" description:"Per-model flag overrides keyed by provider-side model ID; api_key auth only"`
 }
 
 // CreateProviderResponse represents the response for adding a provider.
@@ -72,6 +82,13 @@ type UpdateProviderRequest struct {
 	// types (aws_sigv4/azure_key/gcp_sa). Omit (null) to leave it unchanged; the
 	// edit UI resends the complete map since the read path returns it in full.
 	Credential map[string]string `json:"credential,omitempty" description:"Replacement cloud credential fields (aws_sigv4/azure_key/gcp_sa)"`
+	// Flags / ModelFlags follow the same partial semantics as the other
+	// fields: omit (null) to leave the stored value unchanged; a non-null
+	// value replaces the corresponding level wholesale (an empty object /
+	// map clears it). No deep per-key merge — the edit UI saves whole
+	// sections, and deep map patches are ambiguous.
+	Flags      *typ.ProviderFlags            `json:"flags,omitempty" description:"Replacement provider-level flags; empty object clears them (api_key auth only)"`
+	ModelFlags *map[string]typ.ProviderFlags `json:"model_flags,omitempty" description:"Replacement per-model flag overrides; empty map clears them (api_key auth only)"`
 }
 
 // UpdateProviderResponse represents the response for updating a provider.
@@ -94,6 +111,14 @@ type ToggleProviderResponse struct {
 type DeleteProviderResponse struct {
 	Success bool   `json:"success" example:"true"`
 	Message string `json:"message" example:"Provider deleted successfully"`
+}
+
+// FlagRegistryResponse exposes the catalog of supported provider/model-level
+// flags so the frontend can render the provider Plugins UI generically —
+// the supply-side counterpart of the rule module's flag registry endpoint.
+type FlagRegistryResponse struct {
+	Success bool           `json:"success" example:"true"`
+	Data    []typ.FlagSpec `json:"data"`
 }
 
 // ModelCacheSource identifies where the model list was sourced from.

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -110,7 +110,7 @@ func RuleFlagRegistry() []FlagSpec {
 		{
 			Key:         "extra_headers",
 			Label:       "Custom Headers",
-			Description: "Append custom HTTP headers to the outbound upstream request for requests matched by this rule. Applies to API-key providers only — OAuth/vendor providers (Claude Code, Codex, Kimi, Gemini, Antigravity) keep their handshake headers and ignore this. Headers are sent as configured, including ones the gateway also sets (Authorization, User-Agent, …) — overriding those is your call and your responsibility.",
+			Description: "Append custom HTTP headers to the outbound upstream request for this rule. Merged with the provider- and model-level Custom Headers; on a name conflict the rule value wins (provider < model < rule). Applies to API-key providers only — OAuth/vendor providers (Claude Code, Codex, Kimi, Gemini, Antigravity) keep their handshake headers and ignore this. Headers are sent as configured, including ones the gateway also sets (Authorization, User-Agent, …) — overriding those is your call and your responsibility.",
 			Type:        FlagTypeHeaders,
 			Category:    FlagCategoryRequest,
 		},

--- a/internal/typ/provider_flag_registry.go
+++ b/internal/typ/provider_flag_registry.go
@@ -1,0 +1,19 @@
+package typ
+
+// ProviderFlagRegistry returns the catalog of supported provider/model-level
+// flags — the supply-side counterpart of RuleFlagRegistry, with the same
+// contract: keys must match the JSON tag names on ProviderFlags, and the UI
+// renders each spec from its Type. Every spec is configurable at both the
+// provider and the model level (the model level wins per key), so there is
+// no per-spec scope or merge axis to declare. See .design/provider-flags.md.
+func ProviderFlagRegistry() []FlagSpec {
+	return []FlagSpec{
+		{
+			Key:         "extra_headers",
+			Label:       "Custom Headers",
+			Description: "Append custom HTTP headers to outbound requests to this provider. Model-level headers apply only to requests for that model and win over provider-level headers on a name conflict; a rule-level Custom Headers flag wins over both (provider < model < rule). API-key providers only. Headers are sent as configured, including ones the gateway also sets (Authorization, User-Agent, …) — overriding those is your call and your responsibility.",
+			Type:        FlagTypeHeaders,
+			Category:    FlagCategoryRequest,
+		},
+	}
+}

--- a/internal/typ/provider_flag_registry_test.go
+++ b/internal/typ/provider_flag_registry_test.go
@@ -1,0 +1,81 @@
+package typ
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestProviderFlagRegistry_KeysMatchStructFields prevents the provider flag
+// registry from drifting away from ProviderFlags — the same safety net
+// TestRuleFlagRegistry_KeysMatchStructFields provides for rule flags.
+func TestProviderFlagRegistry_KeysMatchStructFields(t *testing.T) {
+	flagsType := reflect.TypeOf(ProviderFlags{})
+
+	jsonTags := map[string]bool{}
+	for i := 0; i < flagsType.NumField(); i++ {
+		tag := flagsType.Field(i).Tag.Get("json")
+		name := strings.SplitN(tag, ",", 2)[0]
+		if name != "" && name != "-" {
+			jsonTags[name] = true
+		}
+	}
+
+	for _, spec := range ProviderFlagRegistry() {
+		if !jsonTags[spec.Key] {
+			t.Errorf("FlagSpec key %q has no matching json tag on ProviderFlags", spec.Key)
+		}
+	}
+}
+
+// TestProviderFlagRegistry_SpecsAreValid checks the metadata every spec must
+// carry — the same contract RuleFlagRegistry specs are held to.
+func TestProviderFlagRegistry_SpecsAreValid(t *testing.T) {
+	allowedTypes := map[FlagValueType]bool{
+		FlagTypeBool:       true,
+		FlagTypeString:     true,
+		FlagTypeEnum:       true,
+		FlagTypeInt:        true,
+		FlagTypeServiceRef: true,
+		FlagTypeHeaders:    true,
+	}
+	for _, spec := range ProviderFlagRegistry() {
+		if !allowedTypes[spec.Type] {
+			t.Errorf("flag %q has unsupported value type %q", spec.Key, spec.Type)
+		}
+		if spec.Label == "" {
+			t.Errorf("flag %q has empty label", spec.Key)
+		}
+		if spec.Description == "" {
+			t.Errorf("flag %q has empty description", spec.Key)
+		}
+		// Provider flags have no scenario inheritance axis.
+		if spec.Shared || spec.InheritanceMode != "" {
+			t.Errorf("flag %q must not use the scenario-axis Shared/InheritanceMode fields", spec.Key)
+		}
+		// The headers control renders free-form rows — enum/suggestion
+		// metadata has no meaning for it.
+		if spec.Type == FlagTypeHeaders && (len(spec.Options) > 0 || len(spec.Suggestions) > 0) {
+			t.Errorf("headers flag %q must not declare Options/Suggestions", spec.Key)
+		}
+	}
+}
+
+// TestProviderFlagRegistry_ExtraHeaders pins the first provider flag: present
+// and rendered as the headers control.
+func TestProviderFlagRegistry_ExtraHeaders(t *testing.T) {
+	var found *FlagSpec
+	specs := ProviderFlagRegistry()
+	for i := range specs {
+		if specs[i].Key == "extra_headers" {
+			found = &specs[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("extra_headers missing from ProviderFlagRegistry")
+	}
+	if found.Type != FlagTypeHeaders {
+		t.Errorf("extra_headers type = %q, want %q", found.Type, FlagTypeHeaders)
+	}
+}

--- a/internal/typ/provider_flags.go
+++ b/internal/typ/provider_flags.go
@@ -1,0 +1,54 @@
+package typ
+
+import "net/textproto"
+
+// SupplyExtraHeaders merges the two supply-side header levels for one
+// (provider, model) pair — Provider.Flags ∪ Provider.ModelFlags[model], the
+// model level winning on name conflicts. These are a property of the
+// upstream, not of the request, so the client layer resolves them once per
+// client (which is already keyed by provider + model) instead of per request.
+//
+// The third level, the rule's extra_headers, is a request-side flag: it
+// rides the request context and the outbound transport applies it *after*
+// this map, which is what makes the full precedence
+//
+//	provider  <  model  <  rule
+//
+// hold without anyone merging all three (see .design/provider-flags.md §5.1).
+//
+// Returns nil when neither supply level configures anything, so callers can
+// cheaply skip injection.
+func SupplyExtraHeaders(p *Provider, model string) map[string]string {
+	if p == nil {
+		return nil
+	}
+	provider := p.Flags.ExtraHeaders
+	modelLevel := p.ModelFlags[model].ExtraHeaders
+	if len(provider) == 0 && len(modelLevel) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(provider)+len(modelLevel))
+	for _, level := range []map[string]string{provider, modelLevel} {
+		for name, value := range level {
+			merged[textproto.CanonicalMIMEHeaderKey(name)] = value
+		}
+	}
+	return merged
+}
+
+// PruneModelFlags drops entries carrying no configuration (and the empty
+// model key) so a cleared model does not linger as an empty object in
+// storage and in API responses. Returns nil when nothing is left.
+func PruneModelFlags(modelFlags map[string]ProviderFlags) map[string]ProviderFlags {
+	pruned := make(map[string]ProviderFlags, len(modelFlags))
+	for model, flags := range modelFlags {
+		if model == "" || flags.IsZero() {
+			continue
+		}
+		pruned[model] = flags
+	}
+	if len(pruned) == 0 {
+		return nil
+	}
+	return pruned
+}

--- a/internal/typ/provider_flags_test.go
+++ b/internal/typ/provider_flags_test.go
@@ -1,0 +1,76 @@
+package typ
+
+import "testing"
+
+func TestSupplyExtraHeaders(t *testing.T) {
+	p := &Provider{
+		Flags: ProviderFlags{ExtraHeaders: map[string]string{
+			"X-Shared":   "provider",
+			"X-Provider": "p",
+		}},
+		ModelFlags: map[string]ProviderFlags{"m1": {ExtraHeaders: map[string]string{
+			"X-Shared": "model",
+			"X-Model":  "m",
+		}}},
+	}
+
+	// provider ∪ model, model wins per name. (The rule level is layered on
+	// top by the outbound transport's write order, not merged here.)
+	got := SupplyExtraHeaders(p, "m1")
+	want := map[string]string{
+		"X-Shared":   "model",
+		"X-Provider": "p",
+		"X-Model":    "m",
+	}
+	for name, value := range want {
+		if got[name] != value {
+			t.Errorf("merged[%q] = %q, want %q", name, got[name], value)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("merged has %d entries, want %d: %v", len(got), len(want), got)
+	}
+
+	// A different model drops the model level, keeping the provider level.
+	got = SupplyExtraHeaders(p, "other")
+	if got["X-Shared"] != "provider" || got["X-Provider"] != "p" || got["X-Model"] != "" {
+		t.Errorf("model-mismatch merge wrong: %v", got)
+	}
+
+	// Names are canonicalized so differently-cased levels collide predictably.
+	p2 := &Provider{
+		Flags:      ProviderFlags{ExtraHeaders: map[string]string{"x-title": "provider"}},
+		ModelFlags: map[string]ProviderFlags{"m1": {ExtraHeaders: map[string]string{"X-TITLE": "model"}}},
+	}
+	got = SupplyExtraHeaders(p2, "m1")
+	if len(got) != 1 || got["X-Title"] != "model" {
+		t.Errorf("case-insensitive collision not resolved to the model level: %v", got)
+	}
+
+	// Nothing configured → nil, so callers can skip injection.
+	if got := SupplyExtraHeaders(&Provider{}, "m"); got != nil {
+		t.Errorf("expected nil for unconfigured provider, got %v", got)
+	}
+	if got := SupplyExtraHeaders(nil, "m"); got != nil {
+		t.Errorf("expected nil for nil provider, got %v", got)
+	}
+}
+
+func TestPruneModelFlags(t *testing.T) {
+	got := PruneModelFlags(map[string]ProviderFlags{
+		"gpt-x":  {ExtraHeaders: map[string]string{"X-Canary": "on"}},
+		"":       {ExtraHeaders: map[string]string{"X-Skip": "empty model key"}},
+		"zeroed": {},
+	})
+	if len(got) != 1 || got["gpt-x"].ExtraHeaders["X-Canary"] != "on" {
+		t.Errorf("empty-key and zero-value entries should be pruned, got %v", got)
+	}
+
+	// An all-pruned map collapses to nil so storage keeps no empty object.
+	if got := PruneModelFlags(map[string]ProviderFlags{"m": {}}); got != nil {
+		t.Errorf("all-zero map should prune to nil, got %v", got)
+	}
+	if got := PruneModelFlags(nil); got != nil {
+		t.Errorf("nil should prune to nil, got %v", got)
+	}
+}

--- a/internal/typ/type.go
+++ b/internal/typ/type.go
@@ -388,6 +388,9 @@ type VModelDetail = ai.VModelDetail
 // Type alias for backward compatibility with common/provider
 type CredentialBundle = ai.CredentialBundle
 
+// ProviderFlags re-exports the provider/model flag struct (see ai.ProviderFlags).
+type ProviderFlags = ai.ProviderFlags
+
 // MCPMode defines MCP runtime mode
 type MCPMode string
 

--- a/openapi.json
+++ b/openapi.json
@@ -6782,6 +6782,28 @@
         }
       }
     },
+    "/api/v2/provider/flags/registry": {
+      "get": {
+        "tags": [
+          "providers"
+        ],
+        "summary": "Get catalog of supported provider/model-level flags",
+        "description": "Get catalog of supported provider/model-level flags",
+        "operationId": "apiV2ProviderFlagsRegistryGet",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlagRegistryResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/providers": {
       "get": {
         "tags": [
@@ -8601,6 +8623,16 @@
             "type": "boolean",
             "description": "Whether provider is enabled",
             "example": true
+          },
+          "flags": {
+            "$ref": "#/components/schemas/ProviderFlags"
+          },
+          "model_flags": {
+            "type": "object",
+            "description": "Per-model flag overrides keyed by provider-side model ID; api_key auth only",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ProviderFlags"
+            }
           },
           "name": {
             "type": "string",
@@ -12271,6 +12303,18 @@
           }
         }
       },
+      "ProviderFlags": {
+        "type": "object",
+        "properties": {
+          "extra_headers": {
+            "type": "object",
+            "description": "Field extra_headers",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "ProviderImportInfo": {
         "type": "object",
         "properties": {
@@ -12424,6 +12468,16 @@
             "type": "boolean",
             "description": "Field enabled",
             "example": true
+          },
+          "flags": {
+            "$ref": "#/components/schemas/ProviderFlags"
+          },
+          "model_flags": {
+            "type": "object",
+            "description": "Field model_flags",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ProviderFlags"
+            }
           },
           "name": {
             "type": "string",
@@ -14831,6 +14885,16 @@
           "enabled": {
             "type": "boolean",
             "description": "New enabled status"
+          },
+          "flags": {
+            "$ref": "#/components/schemas/ProviderFlags"
+          },
+          "model_flags": {
+            "type": "object",
+            "description": "Replacement per-model flag overrides; empty map clears them (api_key auth only)",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ProviderFlags"
+            }
           },
           "name": {
             "type": "string",


### PR DESCRIPTION
## Summary
Stacked on #1590: the UI for provider- and model-level Custom Headers, which that PR exposes over the API. Registry-driven, reusing the `HeadersEditor` control shipped with the rule level in #1589 — no new control types, no per-flag branching, and no new fields on `FlagSpec`.

## Key Changes

- **Provider level**: `ProviderPluginsBlock` inside the edit dialog's Advanced accordion — a plugins card listing active flags with their concrete values (literal header names, not counts), opening the shared flag catalog dialog fed by `GET /provider/flags/registry`; same interaction as the rule Plugins card so both levels read as one mechanism.
- **Model level**: hover trigger on `ModelCard` opening an anchored popover for that model's headers; overridden models carry an always-visible badge so overrides are discoverable while scanning the list.
- **Safe concurrent saves**: the popover re-fetches the provider and rewrites the whole `model_flags` map, so editing one model never clobbers a sibling edited earlier in the session.
- **Plumbing**: edit dialog seeds flags from the provider and submits them as a whole object; `FlagCatalogDialog` takes title/subtitle so the provider surface reuses it verbatim; MSW mock serves the provider registry.

## Notes
- `CustomModelCard` has no per-model entry yet; the backend matches custom model names the same way, so it can be added on demand.