### PR TITLE
feat(claude-code): add a toggle for settings.json's showThinkingSummaries

### DIFF
--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -3048,6 +3048,7 @@ export const handlers = [
             preferences: mockMainClaudeCodePreferences,
             defaultMode: 'acceptEdits',
             installStatusLine: true,
+            showThinkingSummaries: true,
         })
     }),
 

--- a/frontend/src/pages/scenario/UseClaudeCodePage.tsx
+++ b/frontend/src/pages/scenario/UseClaudeCodePage.tsx
@@ -184,10 +184,11 @@ const UseClaudeCodePageContent: React.FC = () => {
         prefs: Record<string, string>,
         installStatusLine: boolean,
         defaultMode: ClaudeCodeDefaultMode = 'acceptEdits',
+        showThinkingSummaries: boolean = true,
     ): Promise<AgentApplyResult> => {
         try {
             setIsApplyLoading(true);
-            const result = await api.applyClaudeConfig(prefs, installStatusLine, defaultMode);
+            const result = await api.applyClaudeConfig(prefs, installStatusLine, defaultMode, showThinkingSummaries);
             if (result?.success) {
                 const created = result.createdFiles || [];
                 const updated = result.updatedFiles || [];
@@ -334,8 +335,8 @@ const UseClaudeCodePageContent: React.FC = () => {
                     baseUrl={baseUrl}
                     rules={rules}
                     copyToClipboard={copyToClipboard}
-                    onApplyWithPrefs={(prefs, installStatusLine, defaultMode) =>
-                        applyPrefs(prefs as Record<string, string>, installStatusLine, defaultMode)
+                    onApplyWithPrefs={(prefs, installStatusLine, defaultMode, showThinkingSummaries) =>
+                        applyPrefs(prefs as Record<string, string>, installStatusLine, defaultMode, showThinkingSummaries)
                     }
                     isApplyLoading={isApplyLoading}
                     pendingContext1MChange={pendingContext1MChange}

--- a/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeConfigModal.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import CodeBlock from '@/components/CodeBlock';
 import { isFullEdition } from '@/utils/edition';
 import { useScenarioPageModal } from '@/pages/scenario/context/ScenarioPageContext';
-import ClaudeCodeQuickConfig, { derivePrefsFromRules, prefsToEnvPreview } from './ClaudeCodeQuickConfig';
+import ClaudeCodeQuickConfig, { CLAUDE_CODE_DEFAULT_SHOW_THINKING_SUMMARIES, derivePrefsFromRules, prefsToEnvPreview } from './ClaudeCodeQuickConfig';
 import type { ClaudeCodeDefaultMode, ClaudeCodePrefs } from './ClaudeCodeQuickConfig';
 import type { AgentApplyResult } from './AgentSetupCard';
 import Context1MChangeBanner from './Context1MChangeBanner';
@@ -28,7 +28,7 @@ interface ClaudeCodeConfigModalProps {
     // this callback is what writes them to ~/.claude/settings.json. The
     // returned AgentApplyResult is rendered in-modal so the user sees
     // which files were touched and where the backup landed.
-    onApplyWithPrefs?: (prefs: ClaudeCodePrefs, installStatusLine: boolean, defaultMode: ClaudeCodeDefaultMode) => Promise<AgentApplyResult>;
+    onApplyWithPrefs?: (prefs: ClaudeCodePrefs, installStatusLine: boolean, defaultMode: ClaudeCodeDefaultMode, showThinkingSummaries: boolean) => Promise<AgentApplyResult>;
     isApplyLoading?: boolean;
     // Pending 1M context change (scoped to the toggled rule) to preview in the modal
     pendingContext1MChange?: { enabled: boolean; ruleUuid?: string } | null;
@@ -120,6 +120,7 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
     const [applyResult, setApplyResult] = React.useState<AgentApplyResult | null>(null);
     const [installStatusLine, setInstallStatusLine] = React.useState(true);
     const [defaultMode, setDefaultMode] = React.useState<ClaudeCodeDefaultMode>('acceptEdits');
+    const [showThinkingSummaries, setShowThinkingSummaries] = React.useState(CLAUDE_CODE_DEFAULT_SHOW_THINKING_SUMMARIES);
     const [isConfigLoading, setIsConfigLoading] = React.useState(false);
 
     // Prefs is the single source of truth for both tabs. On open, restore the
@@ -132,6 +133,7 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
         if (!open) {
             setPrefs(derivePrefsFromRules({ rules, mode: configMode }));
             setDefaultMode('acceptEdits');
+            setShowThinkingSummaries(CLAUDE_CODE_DEFAULT_SHOW_THINKING_SUMMARIES);
             setInstallStatusLine(true);
             setApplyResult(null);
             setIsConfigLoading(false);
@@ -169,10 +171,12 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
                     applied: result.preferences || {},
                 }));
                 setDefaultMode((result.defaultMode || 'acceptEdits') as ClaudeCodeDefaultMode);
+                setShowThinkingSummaries(result.showThinkingSummaries ?? CLAUDE_CODE_DEFAULT_SHOW_THINKING_SUMMARIES);
                 setInstallStatusLine(!!result.installStatusLine);
             } else {
                 setPrefs(generated);
                 setDefaultMode('acceptEdits');
+                setShowThinkingSummaries(CLAUDE_CODE_DEFAULT_SHOW_THINKING_SUMMARIES);
                 setInstallStatusLine(true);
                 if (result?.success === false) {
                     setApplyResult({ success: false, error: result.error || 'Failed to load the applied Claude Code configuration' });
@@ -199,6 +203,11 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
         setApplyResult(null);
     }, []);
 
+    const setShowThinkingSummariesAndClearResult = React.useCallback((next: boolean) => {
+        setShowThinkingSummaries(next);
+        setApplyResult(null);
+    }, []);
+
     const claudeJsonConfig = { hasCompletedOnboarding: true };
 
     // Env map for both the manual tab (display/copy) and the preview dialog.
@@ -209,8 +218,8 @@ const ClaudeCodeConfigModal: React.FC<ClaudeCodeConfigModalProps> = ({
     );
 
     const settingsConfig = React.useMemo(
-        () => ({ env: envConfig, defaultMode }),
-        [envConfig, defaultMode],
+        () => ({ env: envConfig, defaultMode, showThinkingSummaries }),
+        [envConfig, defaultMode, showThinkingSummaries],
     );
 
     const generateSettingsConfig = React.useCallback(() => {
@@ -322,14 +331,15 @@ node -e '${nodeCode.replace(/'/g, "'\\''")}'`;
 
     const handleApply = async (installStatusLine: boolean) => {
         if (!onApplyWithPrefs) return;
-        const result = await onApplyWithPrefs(prefs, installStatusLine, defaultMode);
+        const result = await onApplyWithPrefs(prefs, installStatusLine, defaultMode, showThinkingSummaries);
         setApplyResult(result);
     };
 
     const handleResetDefaults = React.useCallback(() => {
         setPrefsAndClearResult(derivePrefsFromRules({ rules, mode: configMode }));
         setDefaultModeAndClearResult('acceptEdits');
-    }, [configMode, rules, setDefaultModeAndClearResult, setPrefsAndClearResult]);
+        setShowThinkingSummariesAndClearResult(CLAUDE_CODE_DEFAULT_SHOW_THINKING_SUMMARIES);
+    }, [configMode, rules, setDefaultModeAndClearResult, setPrefsAndClearResult, setShowThinkingSummariesAndClearResult]);
 
     const canApply = isFullEdition && !!onApplyWithPrefs;
 
@@ -443,6 +453,8 @@ node -e '${nodeCode.replace(/'/g, "'\\''")}'`;
                             setPrefs={setPrefsAndClearResult}
                             defaultMode={defaultMode}
                             setDefaultMode={setDefaultModeAndClearResult}
+                            showThinkingSummaries={showThinkingSummaries}
+                            setShowThinkingSummaries={setShowThinkingSummariesAndClearResult}
                         />
                     )}
 

--- a/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
@@ -838,6 +838,46 @@ interface QuickConfigPanelProps {
     setDefaultMode: (mode: ClaudeCodeDefaultMode) => void;
 }
 
+// Shared shell for a single "top-level settings.json key" row: a titled card
+// with one label/key-badge/control row. Both DefaultModeSection (Select) and
+// ShowThinkingSummariesSection (Switch) are peers of this — same JSON layer
+// (not an env var, unlike the FieldRow-driven prefs groups below), just a
+// different control in column 3.
+const SettingsRowSection: React.FC<{
+    title: string;
+    hint: string;
+    label: string;
+    tooltip: string;
+    settingsKey: string;
+    control: React.ReactNode;
+}> = ({ title, hint, label, tooltip, settingsKey, control }) => (
+    <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1.5, overflow: 'hidden' }}>
+        <Box sx={{ px: 1.5, py: 1.15, bgcolor: 'action.hover' }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 700, color: 'text.primary', lineHeight: 1.35 }}>{title}</Typography>
+            <Typography variant="body2" sx={{ mt: 0.25, color: 'text.secondary', lineHeight: 1.45 }}>{hint}</Typography>
+        </Box>
+        <Box sx={{ display: 'grid', gridTemplateColumns: CLAUDE_CONFIG_ROW_COLUMNS, alignItems: 'center', columnGap: 2, rowGap: 1, px: 1.5, py: 1.1, minHeight: 56, borderTop: '1px solid', borderColor: 'divider' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                <Typography variant="body2" noWrap sx={{
+                    fontWeight: 600,
+                    color: 'text.primary',
+                }}>{label}</Typography>
+                <Tooltip placement="top" arrow title={tooltip}>
+                    <InfoOutlinedIcon sx={{ fontSize: 14, color: 'text.disabled', cursor: 'help' }} />
+                </Tooltip>
+            </Box>
+            <Box sx={{ minWidth: 0 }}>
+                <Box component="span" sx={CLAUDE_CONFIG_KEY_SX}>
+                    {settingsKey}
+                </Box>
+            </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', minWidth: 0 }}>
+                {control}
+            </Box>
+        </Box>
+    </Box>
+);
+
 const DefaultModeSection: React.FC<{
     lang: Lang;
     defaultMode: ClaudeCodeDefaultMode;
@@ -848,78 +888,63 @@ const DefaultModeSection: React.FC<{
     const selectedText = text[defaultMode];
 
     return (
-        <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1.5, overflow: 'hidden' }}>
-            <Box sx={{ px: 1.5, py: 1.15, bgcolor: 'action.hover' }}>
-                <Typography variant="subtitle1" sx={{ fontWeight: 700, color: 'text.primary', lineHeight: 1.35 }}>{meta.title}</Typography>
-                <Typography variant="body2" sx={{ mt: 0.25, color: 'text.secondary', lineHeight: 1.45 }}>{meta.hint}</Typography>
-            </Box>
-            <Box sx={{ display: 'grid', gridTemplateColumns: CLAUDE_CONFIG_ROW_COLUMNS, alignItems: 'center', columnGap: 2, rowGap: 1, px: 1.5, py: 1.1, minHeight: 56, borderTop: '1px solid', borderColor: 'divider' }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
-                    <Typography variant="body2" noWrap sx={{
-                        fontWeight: 600,
-                        color: 'text.primary',
-                    }}>Default Mode</Typography>
-                    <Tooltip placement="top" arrow title={`${selectedText.label}: ${selectedText.description}`}>
-                        <InfoOutlinedIcon sx={{ fontSize: 14, color: 'text.disabled', cursor: 'help' }} />
-                    </Tooltip>
-                </Box>
-                <Box sx={{ minWidth: 0 }}>
-                    <Box component="span" sx={CLAUDE_CONFIG_KEY_SX}>
-                        defaultMode
-                    </Box>
-                </Box>
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', minWidth: 0 }}>
-                    <FormControl size="small" sx={{ width: 360 }}>
-                        <Select
-                            value={defaultMode}
-                            onChange={(e) => setDefaultMode(e.target.value as ClaudeCodeDefaultMode)}
-                            renderValue={(value) => {
-                                const mode = value as ClaudeCodeDefaultMode;
-                                return (
+        <SettingsRowSection
+            title={meta.title}
+            hint={meta.hint}
+            label="Default Mode"
+            tooltip={`${selectedText.label}: ${selectedText.description}`}
+            settingsKey="defaultMode"
+            control={
+                <FormControl size="small" sx={{ width: 360 }}>
+                    <Select
+                        value={defaultMode}
+                        onChange={(e) => setDefaultMode(e.target.value as ClaudeCodeDefaultMode)}
+                        renderValue={(value) => {
+                            const mode = value as ClaudeCodeDefaultMode;
+                            return (
+                                <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 2, width: '100%' }}>
+                                    <Typography component="span" variant="body2">{text[mode].label}</Typography>
+                                    <Typography
+                                        component="span"
+                                        variant="caption"
+                                        sx={{
+                                            color: "text.secondary",
+                                            fontFamily: 'monospace'
+                                        }}>{mode}</Typography>
+                                </Box>
+                            );
+                        }}
+                        MenuProps={{
+                            slotProps: { paper: { sx: { maxHeight: 320, width: 360 } }, list: { sx: { py: 0.5 } } },
+                        }}
+                        sx={{
+                            height: 40,
+                            '& .MuiSelect-select': {
+                                display: 'flex',
+                                alignItems: 'center',
+                                py: 1,
+                            },
+                        }}
+                    >
+                        {CLAUDE_CODE_DEFAULT_MODE_OPTIONS.map((mode) => (
+                            <MenuItem key={mode} value={mode} sx={{ minHeight: 40, py: 1 }}>
+                                <Tooltip title={text[mode].description} arrow placement="left">
                                     <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 2, width: '100%' }}>
-                                        <Typography component="span" variant="body2">{text[mode].label}</Typography>
+                                        <Typography variant="body2">{text[mode].label}</Typography>
                                         <Typography
-                                            component="span"
                                             variant="caption"
                                             sx={{
                                                 color: "text.secondary",
                                                 fontFamily: 'monospace'
                                             }}>{mode}</Typography>
                                     </Box>
-                                );
-                            }}
-                            MenuProps={{
-                                slotProps: { paper: { sx: { maxHeight: 320, width: 360 } }, list: { sx: { py: 0.5 } } },
-                            }}
-                            sx={{
-                                height: 40,
-                                '& .MuiSelect-select': {
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    py: 1,
-                                },
-                            }}
-                        >
-                            {CLAUDE_CODE_DEFAULT_MODE_OPTIONS.map((mode) => (
-                                <MenuItem key={mode} value={mode} sx={{ minHeight: 40, py: 1 }}>
-                                    <Tooltip title={text[mode].description} arrow placement="left">
-                                        <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 2, width: '100%' }}>
-                                            <Typography variant="body2">{text[mode].label}</Typography>
-                                            <Typography
-                                                variant="caption"
-                                                sx={{
-                                                    color: "text.secondary",
-                                                    fontFamily: 'monospace'
-                                                }}>{mode}</Typography>
-                                        </Box>
-                                    </Tooltip>
-                                </MenuItem>
-                            ))}
-                        </Select>
-                    </FormControl>
-                </Box>
-            </Box>
-        </Box>
+                                </Tooltip>
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+            }
+        />
     );
 };
 
@@ -931,35 +956,20 @@ const ShowThinkingSummariesSection: React.FC<{
     const text = SHOW_THINKING_SUMMARIES_TEXT[lang];
 
     return (
-        <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1.5, overflow: 'hidden' }}>
-            <Box sx={{ px: 1.5, py: 1.15, bgcolor: 'action.hover' }}>
-                <Typography variant="subtitle1" sx={{ fontWeight: 700, color: 'text.primary', lineHeight: 1.35 }}>{text.title}</Typography>
-                <Typography variant="body2" sx={{ mt: 0.25, color: 'text.secondary', lineHeight: 1.45 }}>{text.hint}</Typography>
-            </Box>
-            <Box sx={{ display: 'grid', gridTemplateColumns: CLAUDE_CONFIG_ROW_COLUMNS, alignItems: 'center', columnGap: 2, rowGap: 1, px: 1.5, py: 1.1, minHeight: 56, borderTop: '1px solid', borderColor: 'divider' }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
-                    <Typography variant="body2" noWrap sx={{
-                        fontWeight: 600,
-                        color: 'text.primary',
-                    }}>{text.label}</Typography>
-                    <Tooltip placement="top" arrow title={text.tooltip}>
-                        <InfoOutlinedIcon sx={{ fontSize: 14, color: 'text.disabled', cursor: 'help' }} />
-                    </Tooltip>
-                </Box>
-                <Box sx={{ minWidth: 0 }}>
-                    <Box component="span" sx={CLAUDE_CONFIG_KEY_SX}>
-                        showThinkingSummaries
-                    </Box>
-                </Box>
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', minWidth: 0 }}>
-                    <Switch
-                        size="small"
-                        checked={checked}
-                        onChange={(_, c) => onChange(c)}
-                    />
-                </Box>
-            </Box>
-        </Box>
+        <SettingsRowSection
+            title={text.title}
+            hint={text.hint}
+            label={text.label}
+            tooltip={text.tooltip}
+            settingsKey="showThinkingSummaries"
+            control={
+                <Switch
+                    size="small"
+                    checked={checked}
+                    onChange={(_, c) => onChange(c)}
+                />
+            }
+        />
     );
 };
 

--- a/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
+++ b/frontend/src/pages/scenario/components/ClaudeCodeQuickConfig.tsx
@@ -422,6 +422,9 @@ interface DefaultModeOptionText {
 
 export const CLAUDE_CODE_DEFAULT_MODE_OPTIONS: ClaudeCodeDefaultMode[] = ['acceptEdits', 'default', 'manual', 'plan', 'auto', 'delegate', 'dontAsk', 'bypassPermissions'];
 
+// Mirrors agent.DefaultClaudeCodeShowThinkingSummaries in internal/agent/prefs.go.
+export const CLAUDE_CODE_DEFAULT_SHOW_THINKING_SUMMARIES = true;
+
 const DEFAULT_MODE_TEXT_ZH: Record<ClaudeCodeDefaultMode, DefaultModeOptionText> = {
     acceptEdits: { label: '接受编辑（推荐）', description: '自动接受文件编辑，其他高风险操作仍按 Claude Code 规则处理。' },
     default: { label: '默认', description: '使用 Claude Code 官方默认权限行为。' },
@@ -457,6 +460,28 @@ const DEFAULT_MODE_SECTION_TEXT: Record<Lang, SectionText> = {
     en: {
         title: 'Default permission mode',
         hint: 'Writes defaultMode in settings.json; tb recommends acceptEdits.',
+    },
+};
+
+interface ToggleSettingText {
+    title: string;
+    hint: string;
+    label: string;
+    tooltip: string;
+}
+
+const SHOW_THINKING_SUMMARIES_TEXT: Record<Lang, ToggleSettingText> = {
+    zh: {
+        title: '思考摘要',
+        hint: '写入 settings.json 的顶层 showThinkingSummaries；不是 env 变量。',
+        label: '显示思考摘要',
+        tooltip: '开启后 Claude Code 会在回复前展示模型的推理摘要（reasoning）。关闭仅隐藏摘要展示，不影响模型是否思考。',
+    },
+    en: {
+        title: 'Thinking summaries',
+        hint: 'Writes the top-level showThinkingSummaries in settings.json; not an env var.',
+        label: 'Show thinking summaries',
+        tooltip: "When on, Claude Code displays the model's reasoning summary before its reply. Turning it off only hides the summary — it doesn't affect whether the model thinks.",
     },
 };
 
@@ -898,17 +923,65 @@ const DefaultModeSection: React.FC<{
     );
 };
 
-const ClaudeCodeQuickConfig: React.FC<QuickConfigPanelProps> = ({
+const ShowThinkingSummariesSection: React.FC<{
+    lang: Lang;
+    checked: boolean;
+    onChange: (checked: boolean) => void;
+}> = ({ lang, checked, onChange }) => {
+    const text = SHOW_THINKING_SUMMARIES_TEXT[lang];
+
+    return (
+        <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1.5, overflow: 'hidden' }}>
+            <Box sx={{ px: 1.5, py: 1.15, bgcolor: 'action.hover' }}>
+                <Typography variant="subtitle1" sx={{ fontWeight: 700, color: 'text.primary', lineHeight: 1.35 }}>{text.title}</Typography>
+                <Typography variant="body2" sx={{ mt: 0.25, color: 'text.secondary', lineHeight: 1.45 }}>{text.hint}</Typography>
+            </Box>
+            <Box sx={{ display: 'grid', gridTemplateColumns: CLAUDE_CONFIG_ROW_COLUMNS, alignItems: 'center', columnGap: 2, rowGap: 1, px: 1.5, py: 1.1, minHeight: 56, borderTop: '1px solid', borderColor: 'divider' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                    <Typography variant="body2" noWrap sx={{
+                        fontWeight: 600,
+                        color: 'text.primary',
+                    }}>{text.label}</Typography>
+                    <Tooltip placement="top" arrow title={text.tooltip}>
+                        <InfoOutlinedIcon sx={{ fontSize: 14, color: 'text.disabled', cursor: 'help' }} />
+                    </Tooltip>
+                </Box>
+                <Box sx={{ minWidth: 0 }}>
+                    <Box component="span" sx={CLAUDE_CONFIG_KEY_SX}>
+                        showThinkingSummaries
+                    </Box>
+                </Box>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', minWidth: 0 }}>
+                    <Switch
+                        size="small"
+                        checked={checked}
+                        onChange={(_, c) => onChange(c)}
+                    />
+                </Box>
+            </Box>
+        </Box>
+    );
+};
+
+interface QuickConfigPanelWithBehaviorProps extends QuickConfigPanelProps {
+    showThinkingSummaries: boolean;
+    setShowThinkingSummaries: (show: boolean) => void;
+}
+
+const ClaudeCodeQuickConfig: React.FC<QuickConfigPanelWithBehaviorProps> = ({
     prefs,
     setPrefs,
     defaultMode,
     setDefaultMode,
+    showThinkingSummaries,
+    setShowThinkingSummaries,
 }) => {
     const lang = useLang();
 
     return (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
             <DefaultModeSection lang={lang} defaultMode={defaultMode} setDefaultMode={setDefaultMode} />
+            <ShowThinkingSummariesSection lang={lang} checked={showThinkingSummaries} onChange={setShowThinkingSummaries} />
             <Section group="model" lang={lang} prefs={prefs} setPrefs={setPrefs} />
             <Section group="limits" lang={lang} prefs={prefs} setPrefs={setPrefs} />
             <Section group="switches" lang={lang} prefs={prefs} setPrefs={setPrefs} />

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1100,10 +1100,10 @@ export const api = {
     // `preferences` is the source of truth: each key is a Claude Code env
     // var name (e.g. ANTHROPIC_MODEL), and the backend writes them straight
     // into ~/.claude/settings.json under "env".
-    applyClaudeConfig: async (preferences: Record<string, string>, installStatusLine?: boolean, defaultMode: string = 'acceptEdits'): Promise<any> => {
+    applyClaudeConfig: async (preferences: Record<string, string>, installStatusLine?: boolean, defaultMode: string = 'acceptEdits', showThinkingSummaries: boolean = true): Promise<any> => {
         return controlApi((client, headers) => client.POST('/api/v1/config/apply/claude', {
             headers,
-            body: {preferences, installStatusLine, defaultMode},
+            body: {preferences, installStatusLine, defaultMode, showThinkingSummaries},
         }));
     },
 

--- a/internal/agent/cc_settings.go
+++ b/internal/agent/cc_settings.go
@@ -143,10 +143,11 @@ func GenerateCCEnv(cfg *serverconfig.Config, baseURL, apiKey, scenarioPath strin
 // file. Env may contain keys outside the typed preference surface; callers that
 // expose data through the API must convert it with ClaudeCodePrefsFromEnv.
 type ClaudeCodeSettingsSnapshot struct {
-	Exists      bool
-	Env         map[string]string
-	DefaultMode string
-	StatusLine  bool
+	Exists                bool
+	Env                   map[string]string
+	DefaultMode           string
+	StatusLine            bool
+	ShowThinkingSummaries *bool
 }
 
 // ReadMainClaudeCodeSettings reads the user's source-of-truth settings file.
@@ -169,9 +170,10 @@ func readClaudeCodeSettings(path string) (ClaudeCodeSettingsSnapshot, error) {
 	}
 	snapshot.Exists = true
 	var raw struct {
-		Env         map[string]any  `json:"env"`
-		DefaultMode string          `json:"defaultMode"`
-		StatusLine  json.RawMessage `json:"statusLine"`
+		Env                   map[string]any  `json:"env"`
+		DefaultMode           string          `json:"defaultMode"`
+		StatusLine            json.RawMessage `json:"statusLine"`
+		ShowThinkingSummaries *bool           `json:"showThinkingSummaries"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return snapshot, fmt.Errorf("failed to parse Claude Code settings: %w", err)
@@ -183,6 +185,7 @@ func readClaudeCodeSettings(path string) (ClaudeCodeSettingsSnapshot, error) {
 	}
 	snapshot.DefaultMode = raw.DefaultMode
 	snapshot.StatusLine = len(raw.StatusLine) > 0 && string(raw.StatusLine) != "null"
+	snapshot.ShowThinkingSummaries = raw.ShowThinkingSummaries
 	return snapshot, nil
 }
 

--- a/internal/agent/prefs.go
+++ b/internal/agent/prefs.go
@@ -7,6 +7,10 @@ import (
 
 const DefaultClaudeCodeDefaultMode = "acceptEdits"
 
+// DefaultClaudeCodeShowThinkingSummaries mirrors Claude Code's own built-in
+// default for the top-level showThinkingSummaries setting.
+const DefaultClaudeCodeShowThinkingSummaries = true
+
 var validClaudeCodeDefaultModes = map[string]struct{}{
 	"acceptEdits":       {},
 	"bypassPermissions": {},
@@ -26,6 +30,16 @@ func NormalizeClaudeCodeDefaultMode(mode string) (string, bool) {
 	}
 	_, ok := validClaudeCodeDefaultModes[mode]
 	return mode, ok
+}
+
+// NormalizeClaudeCodeShowThinkingSummaries applies the Tingly default when the
+// setting has never been written (nil), and passes an explicit value through
+// unchanged.
+func NormalizeClaudeCodeShowThinkingSummaries(v *bool) bool {
+	if v == nil {
+		return DefaultClaudeCodeShowThinkingSummaries
+	}
+	return *v
 }
 
 // ClaudeCodePrefs is the user-tunable surface of Claude Code's env config.

--- a/internal/agent/prefs_test.go
+++ b/internal/agent/prefs_test.go
@@ -14,6 +14,26 @@ func TestNormalizeClaudeCodeDefaultModeAcceptsManual(t *testing.T) {
 	}
 }
 
+func TestNormalizeClaudeCodeShowThinkingSummaries(t *testing.T) {
+	trueVal, falseVal := true, false
+	cases := []struct {
+		name string
+		in   *bool
+		want bool
+	}{
+		{"nil falls back to the tb default", nil, DefaultClaudeCodeShowThinkingSummaries},
+		{"explicit true passes through", &trueVal, true},
+		{"explicit false passes through", &falseVal, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeClaudeCodeShowThinkingSummaries(tc.in); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestClaudeCodePrefs_ToEnv_OmitsEmpty(t *testing.T) {
 	// Sparse prefs: only one model + one limit, everything else empty.
 	p := ClaudeCodePrefs{

--- a/internal/server/config/apply_config.go
+++ b/internal/server/config/apply_config.go
@@ -249,10 +249,11 @@ func ensureDir(path string) error {
 type ApplyOption func(*applyOptions)
 
 type applyOptions struct {
-	backup      bool
-	retention   int
-	extras      map[string]any
-	defaultMode string
+	backup                bool
+	retention             int
+	extras                map[string]any
+	defaultMode           string
+	showThinkingSummaries *bool
 }
 
 // WithBackup enables or disables backup when applying settings.
@@ -275,6 +276,14 @@ func WithBackupRetention(n int) ApplyOption {
 func WithDefaultMode(mode string) ApplyOption {
 	return func(opts *applyOptions) {
 		opts.defaultMode = mode
+	}
+}
+
+// WithShowThinkingSummaries sets the Claude Code top-level showThinkingSummaries
+// value in settings.json.
+func WithShowThinkingSummaries(show bool) ApplyOption {
+	return func(opts *applyOptions) {
+		opts.showThinkingSummaries = &show
 	}
 }
 

--- a/internal/server/config/apply_config_claude.go
+++ b/internal/server/config/apply_config_claude.go
@@ -46,6 +46,9 @@ func buildClaudeSettings(base []byte, env map[string]string, applyOpts *applyOpt
 	if applyOpts.defaultMode != "" {
 		existingConfig["defaultMode"] = applyOpts.defaultMode
 	}
+	if applyOpts.showThinkingSummaries != nil {
+		existingConfig["showThinkingSummaries"] = *applyOpts.showThinkingSummaries
+	}
 	for k, v := range applyOpts.extras {
 		existingConfig[k] = v
 	}

--- a/internal/server/config/apply_config_claude_test.go
+++ b/internal/server/config/apply_config_claude_test.go
@@ -33,6 +33,58 @@ func TestApplyClaudeSettings_DefaultMode(t *testing.T) {
 	}
 }
 
+func TestApplyClaudeSettings_ShowThinkingSummaries(t *testing.T) {
+	targetPath := filepath.Join(t.TempDir(), "settings.json")
+
+	result, err := ApplyClaudeSettingsToPath(targetPath, map[string]string{
+		"ANTHROPIC_MODEL": "test-model",
+	}, WithShowThinkingSummaries(false), WithBackup(false))
+	if err != nil {
+		t.Fatalf("ApplyClaudeSettingsToPath failed: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got: %s", result.Message)
+	}
+
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal settings: %v", err)
+	}
+	if settings["showThinkingSummaries"] != false {
+		t.Fatalf("showThinkingSummaries = %v, want false", settings["showThinkingSummaries"])
+	}
+}
+
+func TestApplyClaudeSettings_ShowThinkingSummariesOmittedWhenUnset(t *testing.T) {
+	targetPath := filepath.Join(t.TempDir(), "settings.json")
+
+	result, err := ApplyClaudeSettingsToPath(targetPath, map[string]string{
+		"ANTHROPIC_MODEL": "test-model",
+	}, WithBackup(false))
+	if err != nil {
+		t.Fatalf("ApplyClaudeSettingsToPath failed: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got: %s", result.Message)
+	}
+
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal settings: %v", err)
+	}
+	if _, present := settings["showThinkingSummaries"]; present {
+		t.Fatalf("showThinkingSummaries should be omitted when WithShowThinkingSummaries is not used, got: %v", settings["showThinkingSummaries"])
+	}
+}
+
 func TestApplyClaudeSettings_NewFile(t *testing.T) {
 	// Create a temporary directory
 	tempDir, err := os.MkdirTemp("", "tingly-test")

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -55,11 +55,12 @@ func (h *Handler) GetClaudeConfig(c *gin.Context) {
 		defaultMode = agent.DefaultClaudeCodeDefaultMode
 	}
 	c.JSON(http.StatusOK, ClaudeConfigResponse{
-		Success:           true,
-		Exists:            snapshot.Exists,
-		Preferences:       prefs,
-		DefaultMode:       defaultMode,
-		InstallStatusLine: snapshot.StatusLine,
+		Success:               true,
+		Exists:                snapshot.Exists,
+		Preferences:           prefs,
+		DefaultMode:           defaultMode,
+		InstallStatusLine:     snapshot.StatusLine,
+		ShowThinkingSummaries: agent.NormalizeClaudeCodeShowThinkingSummaries(snapshot.ShowThinkingSummaries),
 	})
 }
 
@@ -234,6 +235,7 @@ func (h *Handler) ApplyClaudeConfig(c *gin.Context) {
 
 	var opts []config.ApplyOption
 	opts = append(opts, config.WithDefaultMode(defaultMode))
+	opts = append(opts, config.WithShowThinkingSummaries(agent.NormalizeClaudeCodeShowThinkingSummaries(req.ShowThinkingSummaries)))
 	if req.InstallStatusLine {
 		var scriptCreated bool
 		statusLinePath, scriptCreated, err = config.InstallStatusLineScript()

--- a/internal/server/module/configapply/handler_test.go
+++ b/internal/server/module/configapply/handler_test.go
@@ -48,6 +48,7 @@ func TestGetClaudeConfig_RestoresAppliedPreferences(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(settingsDir, "settings.json"), []byte(`{
 		"env":{"CLAUDE_CODE_MAX_OUTPUT_TOKENS":"64000"},
 		"defaultMode":"plan",
+		"showThinkingSummaries":false,
 		"statusLine":{"type":"command","command":"status.sh"}
 	}`), 0644))
 
@@ -66,66 +67,7 @@ func TestGetClaudeConfig_RestoresAppliedPreferences(t *testing.T) {
 	assert.True(t, response.InstallStatusLine)
 	assert.Equal(t, "plan", response.DefaultMode)
 	assert.Equal(t, "64000", response.Preferences.ClaudeCodeMaxOutputTokens)
-	// showThinkingSummaries absent from the file → falls back to the tb default.
-	assert.Equal(t, agent.DefaultClaudeCodeShowThinkingSummaries, response.ShowThinkingSummaries)
-}
-
-func TestGetClaudeConfig_RestoresShowThinkingSummaries(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-	settingsDir := filepath.Join(home, ".claude")
-	require.NoError(t, os.MkdirAll(settingsDir, 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(settingsDir, "settings.json"), []byte(`{
-		"env":{},
-		"showThinkingSummaries": false
-	}`), 0644))
-
-	handler := NewHandler(nil, "localhost")
-	router := gin.New()
-	router.GET("/config/claude", handler.GetClaudeConfig)
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/config/claude", nil)
-	router.ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
-	var response ClaudeConfigResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 	assert.False(t, response.ShowThinkingSummaries)
-}
-
-// A request that explicitly turns the toggle off must land in settings.json.
-func TestApplyClaudeConfig_WritesShowThinkingSummaries(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-
-	tmpDir := t.TempDir()
-	cfg, err := config.NewConfig(config.WithConfigDir(tmpDir))
-	require.NoError(t, err)
-	handler := NewHandler(cfg, "localhost")
-
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	router.POST("/apply/claude", handler.ApplyClaudeConfig)
-
-	show := false
-	body, _ := json.Marshal(ApplyClaudeConfigRequest{
-		Preferences:           &agent.ClaudeCodePrefs{AnthropicModel: "tingly/cc"},
-		ShowThinkingSummaries: &show,
-	})
-	req, _ := http.NewRequest("POST", "/apply/claude", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
-
-	data, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
-	require.NoError(t, err)
-	var settings map[string]interface{}
-	require.NoError(t, json.Unmarshal(data, &settings))
-	assert.Equal(t, false, settings["showThinkingSummaries"])
 }
 
 func TestGetCodexConfig_RestoresAppliedPreferences(t *testing.T) {
@@ -299,6 +241,7 @@ func TestApplyClaudeConfigRequest_JSONShape(t *testing.T) {
 	wire := []byte(`{
 			"installStatusLine": true,
 			"defaultMode": "delegate",
+			"showThinkingSummaries": false,
 			"preferences": {
 			"ANTHROPIC_MODEL": "tingly/cc-default",
 			"ANTHROPIC_DEFAULT_SONNET_MODEL": "tingly/cc-sonnet[1m]",
@@ -316,6 +259,9 @@ func TestApplyClaudeConfigRequest_JSONShape(t *testing.T) {
 	}
 	if req.DefaultMode != "delegate" {
 		t.Errorf("DefaultMode = %q", req.DefaultMode)
+	}
+	if req.ShowThinkingSummaries == nil || *req.ShowThinkingSummaries != false {
+		t.Errorf("ShowThinkingSummaries = %v, want false", req.ShowThinkingSummaries)
 	}
 	if req.Preferences == nil {
 		t.Fatal("Preferences = nil, want populated")

--- a/internal/server/module/configapply/handler_test.go
+++ b/internal/server/module/configapply/handler_test.go
@@ -66,6 +66,66 @@ func TestGetClaudeConfig_RestoresAppliedPreferences(t *testing.T) {
 	assert.True(t, response.InstallStatusLine)
 	assert.Equal(t, "plan", response.DefaultMode)
 	assert.Equal(t, "64000", response.Preferences.ClaudeCodeMaxOutputTokens)
+	// showThinkingSummaries absent from the file → falls back to the tb default.
+	assert.Equal(t, agent.DefaultClaudeCodeShowThinkingSummaries, response.ShowThinkingSummaries)
+}
+
+func TestGetClaudeConfig_RestoresShowThinkingSummaries(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	settingsDir := filepath.Join(home, ".claude")
+	require.NoError(t, os.MkdirAll(settingsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(settingsDir, "settings.json"), []byte(`{
+		"env":{},
+		"showThinkingSummaries": false
+	}`), 0644))
+
+	handler := NewHandler(nil, "localhost")
+	router := gin.New()
+	router.GET("/config/claude", handler.GetClaudeConfig)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/config/claude", nil)
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var response ClaudeConfigResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.False(t, response.ShowThinkingSummaries)
+}
+
+// A request that explicitly turns the toggle off must land in settings.json.
+func TestApplyClaudeConfig_WritesShowThinkingSummaries(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(config.WithConfigDir(tmpDir))
+	require.NoError(t, err)
+	handler := NewHandler(cfg, "localhost")
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/apply/claude", handler.ApplyClaudeConfig)
+
+	show := false
+	body, _ := json.Marshal(ApplyClaudeConfigRequest{
+		Preferences:           &agent.ClaudeCodePrefs{AnthropicModel: "tingly/cc"},
+		ShowThinkingSummaries: &show,
+	})
+	req, _ := http.NewRequest("POST", "/apply/claude", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	require.NoError(t, err)
+	var settings map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &settings))
+	assert.Equal(t, false, settings["showThinkingSummaries"])
 }
 
 func TestGetCodexConfig_RestoresAppliedPreferences(t *testing.T) {

--- a/internal/server/module/configapply/types.go
+++ b/internal/server/module/configapply/types.go
@@ -15,6 +15,9 @@ type ApplyClaudeConfigRequest struct {
 	InstallStatusLine bool                   `json:"installStatusLine,omitempty"`
 	Preferences       *agent.ClaudeCodePrefs `json:"preferences"`
 	DefaultMode       string                 `json:"defaultMode,omitempty"`
+	// ShowThinkingSummaries controls the top-level showThinkingSummaries key in
+	// settings.json. nil falls back to agent.DefaultClaudeCodeShowThinkingSummaries.
+	ShowThinkingSummaries *bool `json:"showThinkingSummaries,omitempty"`
 }
 
 const DefaultClaudeCodeDefaultMode = agent.DefaultClaudeCodeDefaultMode
@@ -32,11 +35,12 @@ type ApplyConfigResponse struct {
 // ClaudeConfigResponse returns the typed values currently persisted in the
 // user's main ~/.claude/settings.json so the frontend can restore Apply state.
 type ClaudeConfigResponse struct {
-	Success           bool                  `json:"success"`
-	Exists            bool                  `json:"exists"`
-	Preferences       agent.ClaudeCodePrefs `json:"preferences"`
-	DefaultMode       string                `json:"defaultMode"`
-	InstallStatusLine bool                  `json:"installStatusLine"`
+	Success               bool                  `json:"success"`
+	Exists                bool                  `json:"exists"`
+	Preferences           agent.ClaudeCodePrefs `json:"preferences"`
+	DefaultMode           string                `json:"defaultMode"`
+	InstallStatusLine     bool                  `json:"installStatusLine"`
+	ShowThinkingSummaries bool                  `json:"showThinkingSummaries"`
 }
 
 // CodexConfigResponse returns the typed values currently persisted in the

--- a/openapi.json
+++ b/openapi.json
@@ -7634,6 +7634,10 @@
           },
           "preferences": {
             "$ref": "#/components/schemas/ClaudeCodePrefs"
+          },
+          "showThinkingSummaries": {
+            "type": "boolean",
+            "description": "Field showThinkingSummaries"
           }
         },
         "required": [
@@ -8263,6 +8267,10 @@
           "preferences": {
             "$ref": "#/components/schemas/ClaudeCodePrefs"
           },
+          "showThinkingSummaries": {
+            "type": "boolean",
+            "description": "Field showThinkingSummaries"
+          },
           "success": {
             "type": "boolean",
             "description": "Field success"
@@ -8273,7 +8281,8 @@
           "exists",
           "preferences",
           "defaultMode",
-          "installStatusLine"
+          "installStatusLine",
+          "showThinkingSummaries"
         ]
       },
       "ClientListResponse": {


### PR DESCRIPTION
## Summary
Claude Code's top-level `showThinkingSummaries` setting (controls whether reasoning summaries are shown) had no UI or API surface in tb; this adds it end to end, mirroring the existing `defaultMode` top-level setting.

## Key Changes

- **Quick Config toggle**: New "Thinking summaries" row in the Auto Config modal, next to Default Mode, backed by `showThinkingSummaries` in `~/.claude/settings.json` — writable, restorable on reopen, and reflected in the Manual tab's JSON preview.
- **Backend wire-shape**: Since it's a top-level settings.json key (not an env var), it's threaded through the same mechanism as `defaultMode` — a new `WithShowThinkingSummaries` `ApplyOption`, a tri-state `*bool` snapshot field so "never set" correctly falls back to tb's default (`true`), and request/response fields on the `/config/claude` apply/get endpoints.
- **Codegen**: Regenerated `openapi.json` and the frontend client SDK for the new request/response fields.

## Minor
- Extracted a shared `SettingsRowSection` wrapper for the two top-level-setting rows (`DefaultModeSection`, `ShowThinkingSummariesSection`) to avoid duplicated layout markup.
- Consolidated test coverage to match the existing `defaultMode` convention: a unit test for the normalize-default logic, the new field folded into the existing wire-shape and GET-restore tests, instead of separate handler-level round-trip tests.

## Notes
- Scoped to the main Quick Config only; not added to per-profile overrides (`ClaudeCodeProfileConfig`) — `defaultMode` has profile-override support today and this doesn't, which is a deliberate scope cut, not an oversight. Happy to extend if profile-level parity is wanted.

## Testing
- `go build ./...`, `go test ./internal/server/config/... ./internal/agent/... ./internal/server/module/configapply/...` — all pass.
- `pnpm typecheck` / `pnpm lint` / `pnpm build` / `pnpm test` — clean, no new failures (pre-existing unrelated `usageMetricColumns.test.ts` failures reproduce on `main` too).
- Verified visually in the mock UI (headless Chromium): toggle renders, flips state, and the Manual tab's JSON preview reflects the change.