### PR TITLE
fix(opencode): declare vision support and collect real models in generated opencode.json

### DIFF
--- a/internal/agent/apply_test.go
+++ b/internal/agent/apply_test.go
@@ -83,3 +83,49 @@ func TestBuildOpenCodeConfig_CustomModels(t *testing.T) {
 		t.Error("tingly/cc-haiku not found")
 	}
 }
+
+func TestBuildOpenCodeModels_DeclaresAttachmentAndModalities(t *testing.T) {
+	models := BuildOpenCodeModels([]string{"tingly-opencode-a", "tingly-opencode-b"})
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+
+	for name, raw := range models {
+		entry, ok := raw.(map[string]interface{})
+		if !ok {
+			t.Fatalf("model %q entry is not a map: %v", name, raw)
+		}
+		if entry["name"] != name {
+			t.Errorf("model %q: name = %v, want %q", name, entry["name"], name)
+		}
+		if entry["attachment"] != true {
+			t.Errorf("model %q: attachment = %v, want true", name, entry["attachment"])
+		}
+		modalities, ok := entry["modalities"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("model %q: modalities is not a map: %v", name, entry["modalities"])
+		}
+		input, ok := modalities["input"].([]string)
+		if !ok || len(input) != 2 || input[0] != "text" || input[1] != "image" {
+			t.Errorf("model %q: modalities.input = %v, want [text image]", name, modalities["input"])
+		}
+		output, ok := modalities["output"].([]string)
+		if !ok || len(output) != 1 || output[0] != "text" {
+			t.Errorf("model %q: modalities.output = %v, want [text]", name, modalities["output"])
+		}
+	}
+}
+
+func TestBuildOpenCodeModels_EmptyFallsBackToDefault(t *testing.T) {
+	models := BuildOpenCodeModels(nil)
+	if len(models) != 1 {
+		t.Fatalf("expected 1 default model, got %d", len(models))
+	}
+	entry, ok := models["tingly-opencode"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("missing default model 'tingly-opencode': %v", models)
+	}
+	if entry["attachment"] != true {
+		t.Errorf("default model attachment = %v, want true", entry["attachment"])
+	}
+}

--- a/internal/agent/builder.go
+++ b/internal/agent/builder.go
@@ -27,14 +27,53 @@ func BuildClaudeCodeModelConfig(unified bool) aiagent.ClaudeCodeModelConfig {
 	}
 }
 
+// openCodeModelEntry builds a single OpenCode provider model entry.
+//
+// OpenCode only shows the image-attachment affordance and forwards image
+// content for a custom (non-catalog) provider model when the model entry
+// explicitly declares attachment/modalities support — otherwise it defaults
+// both to false/text-only (see sst/opencode's provider.ts: capabilities are
+// derived from `model.attachment ?? false` and
+// `model.modalities?.input?.includes("image") ?? false`). tingly-box has no
+// per-model vision-capability data of its own yet, so — mirroring the same
+// conservative-but-permissive stance ApplyCodexConfig's RenderCodexModelCatalog
+// already takes for Codex (input_modalities always ["text", "image"]) — every
+// model tingly-box writes into opencode.json is declared attachment-capable.
+func openCodeModelEntry(name string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":       name,
+		"attachment": true,
+		"modalities": map[string]interface{}{
+			"input":  []string{"text", "image"},
+			"output": []string{"text"},
+		},
+	}
+}
+
+// BuildOpenCodeModels builds the OpenCode provider "models" map from a list
+// of request-model names, declaring each as attachment/vision-capable (see
+// openCodeModelEntry). An empty list falls back to the single default model
+// "tingly-opencode" so a fresh setup with no routing rules yet still gets a
+// usable config.
+func BuildOpenCodeModels(names []string) map[string]interface{} {
+	if len(names) == 0 {
+		return map[string]interface{}{
+			"tingly-opencode": openCodeModelEntry("tingly-opencode"),
+		}
+	}
+	models := make(map[string]interface{}, len(names))
+	for _, name := range names {
+		models[name] = openCodeModelEntry(name)
+	}
+	return models
+}
+
 // BuildOpenCodeConfig constructs the OpenCode configuration object.
 // This function contains the business logic for OpenCode config structure.
 func BuildOpenCodeConfig(configBaseURL, apiKey string, models map[string]interface{}) map[string]interface{} {
 	if len(models) == 0 {
 		// Default single-model layout
-		models = map[string]interface{}{
-			"tingly-opencode": map[string]interface{}{"name": "tingly-opencode"},
-		}
+		models = BuildOpenCodeModels(nil)
 	}
 
 	providerConfig := map[string]interface{}{

--- a/internal/agent/rule_bridge.go
+++ b/internal/agent/rule_bridge.go
@@ -118,7 +118,8 @@ func (aa *AgentApply) ApplyAgent(req *ApplyAgentRequest) (*ApplyAgentResult, err
 		}
 		configBaseURL := baseURL + "/tingly/opencode"
 		// Build config object with business logic
-		openCodeConfig := BuildOpenCodeConfig(configBaseURL, apiKey, nil)
+		openCodeModels := BuildOpenCodeModels(aa.collectOpenCodeRuleModels())
+		openCodeConfig := BuildOpenCodeConfig(configBaseURL, apiKey, openCodeModels)
 		fileResult, err = config.Apply(&aiagent.OpenCodeParams{
 			Config: openCodeConfig,
 		})
@@ -216,6 +217,19 @@ func (aa *AgentApply) collectCodexRuleModels() []string {
 	var models []string
 	for _, rule := range aa.config.GetRequestConfigs() {
 		if rule.GetScenario() != typ.ScenarioCodex || !rule.Active {
+			continue
+		}
+		models = append(models, rule.RequestModel)
+	}
+	return CollectCodexModels(models)
+}
+
+// collectOpenCodeRuleModels returns the request_models of every active rule
+// under the OpenCode scenario, deduplicated and in declaration order.
+func (aa *AgentApply) collectOpenCodeRuleModels() []string {
+	var models []string
+	for _, rule := range aa.config.GetRequestConfigs() {
+		if rule.GetScenario() != typ.ScenarioOpenCode || !rule.Active {
 			continue
 		}
 		models = append(models, rule.RequestModel)

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -346,9 +346,9 @@ func (h *Handler) ApplyOpenCodeConfigFromState(c *gin.Context) {
 	// Use the model token from config (tingly-box- prefixed JWT)
 	apiKey := h.config.GetModelToken()
 
-	// Models are collected from active rules when available; an empty map
-	// is fine — BuildOpenCodeConfig fills in a sensible default.
-	models := make(map[string]interface{})
+	// Models are collected from active OpenCode-scenario rules; an empty
+	// list is fine — BuildOpenCodeModels fills in a sensible default.
+	models := agent.BuildOpenCodeModels(collectOpenCodeRuleModels(cfg))
 
 	// Generate OpenCode config with collected models
 	payload := agent.BuildOpenCodeConfig(configBaseURL, apiKey, models)
@@ -446,9 +446,9 @@ func (h *Handler) GetOpenCodeConfigPreview(c *gin.Context) {
 	// Use the model token from config (tingly-box- prefixed JWT)
 	apiKey := h.config.GetModelToken()
 
-	// Models are collected from active rules when available; an empty map
-	// is fine — BuildOpenCodeConfig fills in a sensible default.
-	models := make(map[string]interface{})
+	// Models are collected from active OpenCode-scenario rules; an empty
+	// list is fine — BuildOpenCodeModels fills in a sensible default.
+	models := agent.BuildOpenCodeModels(collectOpenCodeRuleModels(cfg))
 
 	// Generate OpenCode config JSON
 	configPayload := agent.BuildOpenCodeConfig(configBaseURL, apiKey, models)
@@ -546,10 +546,22 @@ console.log("OpenCode config written to", configPath);`, modelsJSON, configBaseU
 // collectCodexRuleModels returns the request_models of every active rule in
 // the Codex scenario, deduplicated and in declaration order.
 func collectCodexRuleModels(cfg *config.Config) []string {
+	return collectScenarioRuleModels(cfg, typ.ScenarioCodex)
+}
+
+// collectOpenCodeRuleModels returns the request_models of every active rule
+// in the OpenCode scenario, deduplicated and in declaration order.
+func collectOpenCodeRuleModels(cfg *config.Config) []string {
+	return collectScenarioRuleModels(cfg, typ.ScenarioOpenCode)
+}
+
+// collectScenarioRuleModels returns the request_models of every active rule
+// under the given scenario, deduplicated and in declaration order.
+func collectScenarioRuleModels(cfg *config.Config, scenario typ.RuleScenario) []string {
 	seen := map[string]struct{}{}
 	var out []string
 	for _, rule := range cfg.GetRequestConfigs() {
-		if rule.GetScenario() != typ.ScenarioCodex || !rule.Active {
+		if rule.GetScenario() != scenario || !rule.Active {
 			continue
 		}
 		model := strings.TrimSpace(rule.RequestModel)

--- a/internal/server/module/configapply/handler_test.go
+++ b/internal/server/module/configapply/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tingly-dev/tingly-box/internal/agent"
 	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
 func setupTestRouter(cfg *config.Config) *gin.Engine {
@@ -321,6 +322,54 @@ func TestApplyOpenCodeConfig_SucceedsWithoutRules(t *testing.T) {
 
 	body := w.Body.String()
 	assert.Contains(t, body, `"success":true`)
+}
+
+func TestGetOpenCodeConfigPreview_IncludesRuleModelsAndModalities(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(config.WithConfigDir(tmpDir))
+	require.NoError(t, err)
+	cfg.Rules = []typ.Rule{
+		{UUID: "oc1", Scenario: typ.ScenarioOpenCode, RequestModel: "tingly-opencode-vision", Active: true},
+		{UUID: "oc2", Scenario: typ.ScenarioOpenCode, RequestModel: "inactive-model", Active: false},
+		{UUID: "cc1", Scenario: typ.ScenarioClaudeCode, RequestModel: "other-scenario-model", Active: true},
+	}
+	handler := NewHandler(cfg, "localhost")
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/preview/opencode", handler.GetOpenCodeConfigPreview)
+
+	req, _ := http.NewRequest("GET", "/preview/opencode", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp OpenCodeConfigPreviewResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(resp.ConfigJSON), &payload))
+
+	providers := payload["provider"].(map[string]interface{})
+	tb := providers["tingly-box"].(map[string]interface{})
+	models := tb["models"].(map[string]interface{})
+
+	// Only the active OpenCode-scenario rule's model should be present.
+	assert.Len(t, models, 1)
+	entry, ok := models["tingly-opencode-vision"].(map[string]interface{})
+	require.True(t, ok, "expected model entry for the active OpenCode rule, got %v", models)
+	assert.NotContains(t, models, "inactive-model")
+	assert.NotContains(t, models, "other-scenario-model")
+
+	// The model must declare attachment/modalities support so opencode
+	// doesn't default image input to unavailable (see openCodeModelEntry).
+	assert.Equal(t, true, entry["attachment"])
+	modalities, ok := entry["modalities"].(map[string]interface{})
+	require.True(t, ok, "expected modalities object, got %v", entry["modalities"])
+	assert.ElementsMatch(t, []interface{}{"text", "image"}, modalities["input"])
+	assert.ElementsMatch(t, []interface{}{"text"}, modalities["output"])
 }
 
 func TestGetOpenCodeConfigPreview_NilConfig(t *testing.T) {


### PR DESCRIPTION
## Summary
OpenCode only enables image input for a custom-provider model when its config entry explicitly declares `attachment`/`modalities` (verified against `sst/opencode`'s `provider.ts`); tingly-box's generated `opencode.json` never set either, and never even populated real per-rule models, so vision silently defaulted to unavailable.

## Key Changes

- **Vision declaration**: every model tingly-box writes into `opencode.json` now sets `attachment: true` and `modalities: {input:[text,image], output:[text]}` (`openCodeModelEntry`/`BuildOpenCodeModels` in `internal/agent/builder.go`).
- **Real model collection**: the OpenCode preview/apply endpoints and the CLI apply path always fell back to a single placeholder `tingly-opencode` model — they now collect the active OpenCode-scenario rules' request models (`collectOpenCodeRuleModels`), mirroring the existing Codex helper.

## Notes
tingly-box has no per-model vision-capability data yet, so a genuinely text-only/fast-tier model is still declared vision-capable here; sending it an image will still fail upstream. Scoping this fix to declaration + real model collection was a deliberate call — see PR discussion for the accurate-per-model-capability follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3zD5QbiiYhw3CqismGeQF)_