### PR TITLE
fix(protocol): collapse extended reasoning_effort ladder for unverified vendors

### DIFF
--- a/.design/model-data.md
+++ b/.design/model-data.md
@@ -53,6 +53,11 @@
   (adaptive / enabled+budget / output_config.effort)做 vendor 阶段互转与钳制。
 - effort↔budget 的统一阶梯在 `internal/protocol/thinking`(见 `.design/rule-flags.md`
   的 `thinking_effort` 行),catalog 只负责"模型支持哪些方言/档位"。
+- OpenAI 兼容出口没有按模型的 catalog,粒度是按 provider host 白名单
+  (`ops.supportsExplicitPromptCache`)。不在白名单上的 host 一律保守收窄:
+  reasoning_effort 收窄到 low/medium/high(`ops.genericEffortTiers`),
+  prompt-cache 字段整体剥离。与上面 Claude 兜底同一条原则的另一份实现——
+  "未验证的能力,一律折叠回已验证的公共子集",不是两套设计。
 
 ## 注意
 

--- a/internal/protocol/ops/request_openai_extensions.go
+++ b/internal/protocol/ops/request_openai_extensions.go
@@ -22,7 +22,8 @@ func ApplyProviderTransforms(req *openai.ChatCompletionNewParams, providerURL, m
 
 	// See stripOpenAIPromptCacheFields for why: most OpenAI-compatible
 	// vendors reject these fields outright (#1548), so default to stripping.
-	if !supportsExplicitPromptCache(host) {
+	nativeOpenAI := supportsExplicitPromptCache(host)
+	if !nativeOpenAI {
 		stripOpenAIPromptCacheFields(req)
 	}
 
@@ -50,7 +51,7 @@ func ApplyProviderTransforms(req *openai.ChatCompletionNewParams, providerURL, m
 
 	// api.openai.com falls through to here too — no vendor-specific shaping
 	// needed beyond applyDefaultTransform's thinking fallback.
-	return applyDefaultTransform(req, config)
+	return applyDefaultTransform(req, config, nativeOpenAI)
 }
 
 // supportsExplicitPromptCache reports whether the provider host is confirmed
@@ -205,9 +206,21 @@ func flattenRichContent(parts []interface{}) (string, bool) {
 // fallback when no vendor-specific transform matched. Sets reasoning_effort
 // from config, or falls back to a `thinking.type=enabled` extra field for
 // providers that accept the Anthropic-style extension.
-func applyDefaultTransform(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig) *openai.ChatCompletionNewParams {
+//
+// nativeReasoningEffort mirrors supportsExplicitPromptCache: only a
+// confirmed-OpenAI host gets the full six-level ladder verbatim. Every other
+// OpenAI-compatible vendor reached through here — including relays like
+// opencode.ai/zen/go whose model name doesn't hint at a specific
+// vendor-transform case above — gets the effort collapsed through
+// genericEffortTiers instead of "minimal"/"xhigh" sent raw to a vendor that
+// has never seen those enum members.
+func applyDefaultTransform(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig, nativeReasoningEffort bool) *openai.ChatCompletionNewParams {
 	if config.HasThinking && config.ReasoningEffort != "" {
-		req.ReasoningEffort = config.ReasoningEffort
+		if nativeReasoningEffort {
+			req.ReasoningEffort = config.ReasoningEffort
+		} else {
+			applyReasoningEffortTier(req, config, genericEffortTiers())
+		}
 	} else if config.HasThinking {
 		extra := req.ExtraFields()
 		if extra == nil {

--- a/internal/protocol/ops/request_openai_extensions.go
+++ b/internal/protocol/ops/request_openai_extensions.go
@@ -208,12 +208,8 @@ func flattenRichContent(parts []interface{}) (string, bool) {
 // providers that accept the Anthropic-style extension.
 //
 // nativeReasoningEffort mirrors supportsExplicitPromptCache: only a
-// confirmed-OpenAI host gets the full six-level ladder verbatim. Every other
-// OpenAI-compatible vendor reached through here — including relays like
-// opencode.ai/zen/go whose model name doesn't hint at a specific
-// vendor-transform case above — gets the effort collapsed through
-// genericEffortTiers instead of "minimal"/"xhigh" sent raw to a vendor that
-// has never seen those enum members.
+// confirmed-OpenAI host gets the six-level ladder verbatim; everything else
+// collapses through genericEffortTiers (see .design/model-data.md).
 func applyDefaultTransform(req *openai.ChatCompletionNewParams, config *protocol.OpenAIConfig, nativeReasoningEffort bool) *openai.ChatCompletionNewParams {
 	if config.HasThinking && config.ReasoningEffort != "" {
 		if nativeReasoningEffort {

--- a/internal/protocol/ops/request_openai_extensions_test.go
+++ b/internal/protocol/ops/request_openai_extensions_test.go
@@ -47,13 +47,9 @@ func TestProviderDispatchMatchesBareHostnameWithoutScheme(t *testing.T) {
 	assert.Equal(t, "high", string(req.ReasoningEffort))
 }
 
-// TestDefaultTransformCollapsesExtendedEffortForUnverifiedVendor proves the
-// fix for a regression introduced when the ladder was extended to six levels
-// (#1524/#1528): a relay like opencode.ai/zen/go whose model name gives no
-// vendor hint (e.g. a codenamed model that isn't literally "deepseek") falls
-// through to applyDefaultTransform, which used to forward "minimal"/"xhigh"
-// verbatim — values only api.openai.com is confirmed to accept — causing the
-// downstream vendor to 400 on the unrecognized reasoning_effort enum member.
+// TestDefaultTransformCollapsesExtendedEffortForUnverifiedVendor proves an
+// unverified relay (e.g. opencode.ai/zen/go with a codenamed model that
+// doesn't hint "deepseek") never receives "minimal"/"xhigh"/"max" verbatim.
 func TestDefaultTransformCollapsesExtendedEffortForUnverifiedVendor(t *testing.T) {
 	tests := []struct {
 		ladderEffort string
@@ -83,10 +79,8 @@ func TestDefaultTransformCollapsesExtendedEffortForUnverifiedVendor(t *testing.T
 	}
 }
 
-// TestDefaultTransformKeepsExtendedEffortForVerifiedOpenAI proves that
-// api.openai.com — the one host confirmed to accept the full six-level
-// ladder — still gets "minimal"/"xhigh" verbatim, unaffected by the
-// unverified-vendor collapse above.
+// TestDefaultTransformKeepsExtendedEffortForVerifiedOpenAI proves
+// api.openai.com is unaffected by the unverified-vendor collapse above.
 func TestDefaultTransformKeepsExtendedEffortForVerifiedOpenAI(t *testing.T) {
 	req := &openai.ChatCompletionNewParams{
 		Model: openai.ChatModel("gpt-5.6"),

--- a/internal/protocol/ops/request_openai_extensions_test.go
+++ b/internal/protocol/ops/request_openai_extensions_test.go
@@ -46,3 +46,56 @@ func TestProviderDispatchMatchesBareHostnameWithoutScheme(t *testing.T) {
 
 	assert.Equal(t, "high", string(req.ReasoningEffort))
 }
+
+// TestDefaultTransformCollapsesExtendedEffortForUnverifiedVendor proves the
+// fix for a regression introduced when the ladder was extended to six levels
+// (#1524/#1528): a relay like opencode.ai/zen/go whose model name gives no
+// vendor hint (e.g. a codenamed model that isn't literally "deepseek") falls
+// through to applyDefaultTransform, which used to forward "minimal"/"xhigh"
+// verbatim — values only api.openai.com is confirmed to accept — causing the
+// downstream vendor to 400 on the unrecognized reasoning_effort enum member.
+func TestDefaultTransformCollapsesExtendedEffortForUnverifiedVendor(t *testing.T) {
+	tests := []struct {
+		ladderEffort string
+		want         string
+	}{
+		{"minimal", "low"},
+		{"low", "low"},
+		{"medium", "medium"},
+		{"high", "high"},
+		{"xhigh", "high"},
+		{"max", "high"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ladderEffort, func(t *testing.T) {
+			req := &openai.ChatCompletionNewParams{
+				Model: openai.ChatModel("gpt-5.6-luna"),
+			}
+
+			ApplyProviderTransforms(req, "https://opencode.ai/zen/go/v1", string(req.Model), &protocol.OpenAIConfig{
+				HasThinking:     true,
+				ReasoningEffort: openai.ReasoningEffort(tt.ladderEffort),
+			})
+
+			assert.Equal(t, tt.want, string(req.ReasoningEffort))
+		})
+	}
+}
+
+// TestDefaultTransformKeepsExtendedEffortForVerifiedOpenAI proves that
+// api.openai.com — the one host confirmed to accept the full six-level
+// ladder — still gets "minimal"/"xhigh" verbatim, unaffected by the
+// unverified-vendor collapse above.
+func TestDefaultTransformKeepsExtendedEffortForVerifiedOpenAI(t *testing.T) {
+	req := &openai.ChatCompletionNewParams{
+		Model: openai.ChatModel("gpt-5.6"),
+	}
+
+	ApplyProviderTransforms(req, "https://api.openai.com/v1", string(req.Model), &protocol.OpenAIConfig{
+		HasThinking:     true,
+		ReasoningEffort: "xhigh",
+	})
+
+	assert.Equal(t, "xhigh", string(req.ReasoningEffort))
+}

--- a/internal/protocol/ops/request_openai_reasoning_tier.go
+++ b/internal/protocol/ops/request_openai_reasoning_tier.go
@@ -32,6 +32,23 @@ func lowHighMaxEffortTiers() reasoningEffortTierMap {
 	}
 }
 
+// genericEffortTiers is the safe fallback for any OpenAI-compatible vendor
+// not confirmed to accept the full six-level ladder (see
+// supportsExplicitPromptCache — the same allowlist gates both concerns,
+// since both are OpenAI's own gpt-5.6+ extensions). It restores the
+// low/medium/high range every OpenAI-compatible clone has historically
+// documented — the range this gateway sent exclusively before the ladder
+// was extended to six levels (#1524) — rather than forwarding "minimal" or
+// "xhigh" verbatim to a vendor that has never seen those values and may
+// 400 on the unrecognized enum member.
+func genericEffortTiers() reasoningEffortTierMap {
+	return reasoningEffortTierMap{
+		thinking.LevelMinimal: "low",
+		thinking.LevelXHigh:   "high",
+		thinking.LevelMax:     "high",
+	}
+}
+
 // applyReasoningEffortTier forwards the resolved thinking-effort signal as
 // reasoning_effort, collapsed through the given tier map. Earlier models in
 // the DeepSeek/Kimi family had no effort dial at all (thinking was an on/off

--- a/internal/protocol/ops/request_openai_reasoning_tier.go
+++ b/internal/protocol/ops/request_openai_reasoning_tier.go
@@ -33,14 +33,11 @@ func lowHighMaxEffortTiers() reasoningEffortTierMap {
 }
 
 // genericEffortTiers is the safe fallback for any OpenAI-compatible vendor
-// not confirmed to accept the full six-level ladder (see
-// supportsExplicitPromptCache — the same allowlist gates both concerns,
-// since both are OpenAI's own gpt-5.6+ extensions). It restores the
-// low/medium/high range every OpenAI-compatible clone has historically
-// documented — the range this gateway sent exclusively before the ladder
-// was extended to six levels (#1524) — rather than forwarding "minimal" or
-// "xhigh" verbatim to a vendor that has never seen those values and may
-// 400 on the unrecognized enum member.
+// not confirmed (via supportsExplicitPromptCache) to accept the full
+// six-level ladder: collapses onto the low/medium/high range every
+// OpenAI-compatible clone has historically documented, rather than
+// forwarding "minimal"/"xhigh"/"max" verbatim to a vendor that may 400 on
+// the unrecognized enum member. See .design/model-data.md.
 func genericEffortTiers() reasoningEffortTierMap {
 	return reasoningEffortTierMap{
 		thinking.LevelMinimal: "low",

--- a/internal/protocol/ops/request_openai_reasoning_tier.go
+++ b/internal/protocol/ops/request_openai_reasoning_tier.go
@@ -37,10 +37,16 @@ func lowHighMaxEffortTiers() reasoningEffortTierMap {
 // six-level ladder: collapses onto the low/medium/high range every
 // OpenAI-compatible clone has historically documented, rather than
 // forwarding "minimal"/"xhigh"/"max" verbatim to a vendor that may 400 on
-// the unrecognized enum member. See .design/model-data.md.
+// the unrecognized enum member. All six levels are listed explicitly, even
+// where the value is unchanged, so the map doesn't rely on
+// applyReasoningEffortTier's passthrough-on-miss behavior to be complete.
+// See .design/model-data.md.
 func genericEffortTiers() reasoningEffortTierMap {
 	return reasoningEffortTierMap{
 		thinking.LevelMinimal: "low",
+		thinking.LevelLow:     "low",
+		thinking.LevelMedium:  "medium",
+		thinking.LevelHigh:    "high",
 		thinking.LevelXHigh:   "high",
 		thinking.LevelMax:     "high",
 	}


### PR DESCRIPTION
## Summary
The six-level `thinking_effort` ladder (#1524/#1528) sends `minimal`/`xhigh`/`max` as raw OpenAI `reasoning_effort`, but the vendor-dispatch fallback (`applyDefaultTransform`) forwarded it to every OpenAI-compatible host unconditionally — breaking relays like opencode.ai/zen/go whose model name gives no vendor hint (e.g. `gpt-5.6-luna`), which 400 on the unrecognized enum member.

## Key Changes
- **Vendor-aware reasoning_effort**: only a host confirmed to accept the full ladder (`api.openai.com`, via the existing `supportsExplicitPromptCache` allowlist) gets `minimal`/`xhigh`/`max` verbatim; every other host collapses through `genericEffortTiers` back onto the low/medium/high range sent before the ladder was extended.

## Minor
- Documents the same "unverified capability → collapse to verified common subset" principle already used for the Claude catalog fallback, now applied on the OpenAI host-dispatch side (`.design/model-data.md`).
- Adds regression coverage for the opencode.ai/zen/go collapse and the api.openai.com pass-through.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VkaZMSJX7FaDEWSZeC8hKg)_