### PR TITLE
feat(routing-graph): inline provider edit, service-identity fixes

### DIFF
--- a/frontend/src/components/ModelSelectDialog.tsx
+++ b/frontend/src/components/ModelSelectDialog.tsx
@@ -97,11 +97,16 @@ function ModelSelectTabInner({
     //   3. selectedProvider — lock onto the selected provider if a model is chosen
     //   4. lastProvider — remember the last chosen provider when nothing is selected
     //   5. first available provider — final default
-    const currentTab = externalActiveTab
+    // The winner must resolve to an existing provider: an absent (empty-string)
+    // or stale (deleted provider) reference would otherwise leave the right
+    // panel blank, so fall through to the first provider instead.
+    const requestedTab = externalActiveTab
         ?? internalCurrentTab
         ?? (selectedProvider && selectedModel ? selectedProvider : undefined)
-        ?? lastProvider
-        ?? flattenedProviders[0]?.uuid;
+        ?? (lastProvider || undefined);
+    const currentTab = flattenedProviders.some(p => p.uuid === requestedTab)
+        ? requestedTab
+        : flattenedProviders[0]?.uuid;
 
     const handleTabChange = useCallback(async (providerUuid: string) => {
         if (externalActiveTab === undefined) {

--- a/frontend/src/components/ModelSelectDialog.tsx
+++ b/frontend/src/components/ModelSelectDialog.tsx
@@ -1,11 +1,13 @@
 import { Box } from '@mui/material';
-import React, { useEffect, useCallback, useRef } from 'react';
+import React, { useEffect, useCallback, useMemo, useRef, useState } from 'react';
+import { api } from '@/services/api';
 import { useCustomModels } from '@/hooks/useCustomModels';
 import { useProviderModels } from '@/hooks/useProviderModels';
 import { useGridLayout } from '@/hooks/useGridLayout';
 import { useProviderGroups } from '@/hooks/useProviderGroups';
 import { useModelSelection } from '@/hooks/useModelSelection';
 import { useRecentModels } from '@/hooks/useRecentModels';
+import { useProviderEditDialog } from '@/hooks/useProviderEditDialog';
 import { ModelSelectProvider, useModelSelectContext } from '@/contexts/ModelSelectContext';
 import type { Provider } from '@/types/provider';
 import { getModelTypeInfo } from '@/utils/modelUtils';
@@ -52,15 +54,41 @@ function ModelSelectTabInner({
         closeCustomModelDialog,
         customModelDialog,
         triggerRefresh,
+        showSnackbar,
     } = useModelSelectContext();
 
     const { handleModelSelect } = useModelSelection({ onSelected });
     const { recentModels, lastProvider } = useRecentModels();
 
+    // Providers edited through the in-dialog "Edit Provider" button. Callers
+    // own the providers prop and only refetch it on their own surfaces, so an
+    // edit (e.g. a rename) wouldn't show up here until the dialog reopens.
+    // Overlay the freshly-fetched record on the prop until the next refresh.
+    const [providerOverrides, setProviderOverrides] = useState<Record<string, Provider>>({});
+    const effectiveProviders = useMemo(
+        () => providers.map(p => providerOverrides[p.uuid] ?? p),
+        [providers, providerOverrides]
+    );
+
+    const handleProviderUpdated = useCallback(async (providerUuid: string) => {
+        const result = await api.getProvider(providerUuid);
+        if (result.success) {
+            setProviderOverrides(prev => ({ ...prev, [providerUuid]: result.data as Provider }));
+        }
+        // The edit may change api style/endpoint — refetch models for the tab.
+        fetchModels(providerUuid);
+        triggerRefresh();
+    }, [fetchModels, triggerRefresh]);
+
+    const { editProvider, providerEditDialogs } = useProviderEditDialog({
+        onUpdated: handleProviderUpdated,
+        showNotification: showSnackbar,
+    });
+
     const {
         groupedProviders,
         flattenedProviders,
-    } = useProviderGroups(providers, singleProvider);
+    } = useProviderGroups(effectiveProviders, singleProvider);
 
     // Use external activeTab if provided, otherwise use internal state.
     // Fallback chain to prevent flickering:
@@ -200,12 +228,16 @@ function ModelSelectTabInner({
                         onModelSelect={handleModelSelect}
                         onCustomModelEdit={handleCustomModelEdit}
                         onCustomModelDelete={handleDeleteCustomModel}
+                        onProviderEdit={(provider) => editProvider(provider.uuid)}
                     />
                 );
             })()}
 
             {/* Custom Model Dialog */}
             <CustomModelDialog onSave={handleCustomModelSave} />
+
+            {/* Provider edit dialogs (API-key form / OAuth detail) */}
+            {providerEditDialogs}
         </Box>
     );
 }

--- a/frontend/src/components/RuleCard.tsx
+++ b/frontend/src/components/RuleCard.tsx
@@ -56,7 +56,7 @@ export interface RuleCardProps {
     onProviderModelsChange?: (providerUuid: string, models: ProviderModelData) => void;
     onRefreshProvider?: (providerUuid: string) => void;
     onProviderUpdated?: (providerUuid: string) => void | Promise<void>;
-    onModelSelectOpen: (ruleUuid: string, configRecord: ConfigRecord, mode: 'edit' | 'add', providerUuid?: string, addTier?: number) => void;
+    onModelSelectOpen: (ruleUuid: string, configRecord: ConfigRecord, mode: 'edit' | 'add', serviceUuid?: string, addTier?: number) => void;
     collapsible?: boolean;
     initiallyExpanded?: boolean;
     allowDeleteRule?: boolean;
@@ -179,11 +179,13 @@ export const RuleCard: React.FC<RuleCardProps> = ({
         [configRecord, updateField]
     );
 
-    // Handler: Provider node click
-    const handleProviderNodeClick = useCallback(
-        (providerUuid: string) => {
+    // Handler: service node click — open the model-select dialog on that
+    // service's provider + model. The service uuid locates the entry being
+    // edited (the same provider may appear in multiple services).
+    const handleServiceNodeClick = useCallback(
+        (serviceUuid: string) => {
             if (configRecord) {
-                onModelSelectOpen(rule.uuid, configRecord, 'edit', providerUuid);
+                onModelSelectOpen(rule.uuid, configRecord, 'edit', serviceUuid);
             }
         },
         [configRecord, rule.uuid, onModelSelectOpen]
@@ -201,10 +203,10 @@ export const RuleCard: React.FC<RuleCardProps> = ({
     // updateField re-compacts tiers on commit, so moving the last T0 service
     // down promotes the tiers below and moving past the bottom is a no-op.
     const handleProviderTierChange = useCallback(
-        async (providerUuid: string, tier: number) => {
+        async (serviceUuid: string, tier: number) => {
             if (!configRecord) return;
             const updated = configRecord.providers.map((p) =>
-                p.uuid === providerUuid ? { ...p, tier } : p,
+                p.uuid === serviceUuid ? { ...p, tier } : p,
             );
             await updateField(configRecord, setConfigRecord, 'providers', updated);
         },
@@ -345,10 +347,10 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                 extraActions={extraActions}
                 extensionsCard={extensionsCard}
                 onUpdateRecord={(field, value) => updateField(configRecord, setConfigRecord, field, value)}
-                onProviderNodeClick={handleProviderNodeClick}
+                onServiceNodeClick={handleServiceNodeClick}
                 onEditProvider={editProvider}
                 onTierChange={handleProviderTierChange}
-                onDeleteProvider={(providerUuid) => handleDeleteProvider(configRecord.uuid, providerUuid)}
+                onDeleteService={(serviceUuid) => handleDeleteProvider(configRecord.uuid, serviceUuid)}
                 onAddService={handleAddServiceButtonClick}
                 onAddSmartRule={smartHandlers.handleAddSmartRule}
                 onEditSmartRule={smartHandlers.handleEditSmartRule}

--- a/frontend/src/components/SearchField.tsx
+++ b/frontend/src/components/SearchField.tsx
@@ -1,0 +1,33 @@
+import { Search } from '@/components/icons';
+import { InputAdornment, TextField, type TextFieldProps } from '@mui/material';
+
+// Unified compact search input: 32px tall with a small search icon.
+// The theme owns colors/borders, but "is a search box" is a semantic the
+// theme can't express (CSS can't select by purpose), so this component is
+// the size contract — every search field in the app should render through
+// it so search sizing stays consistent across surfaces.
+export function SearchField({ slotProps, sx, ...rest }: TextFieldProps) {
+    const inputSlot = (slotProps as Record<string, any> | undefined)?.input ?? {};
+    return (
+        <TextField
+            size="small"
+            hiddenLabel
+            {...rest}
+            slotProps={{
+                ...slotProps,
+                input: {
+                    startAdornment: (
+                        <InputAdornment position="start">
+                            <Search fontSize="small" />
+                        </InputAdornment>
+                    ),
+                    ...inputSlot,
+                    sx: { height: 32, ...inputSlot.sx },
+                },
+            }}
+            sx={sx}
+        />
+    );
+}
+
+export default SearchField;

--- a/frontend/src/components/UnifiedRoutingGraph.tsx
+++ b/frontend/src/components/UnifiedRoutingGraph.tsx
@@ -85,10 +85,10 @@ export interface UnifiedRoutingGraphProps {
 
     // Callbacks
     onUpdateRecord?: (field: keyof ConfigRecord, value: any) => void;
-    onProviderNodeClick?: (providerUuid: string) => void;
+    onServiceNodeClick?: (serviceUuid: string) => void;
     onEditProvider?: (providerUuid: string) => void;
-    onTierChange?: (providerUuid: string, tier: number) => void;
-    onDeleteProvider?: (providerUuid: string) => void;
+    onTierChange?: (serviceUuid: string, tier: number) => void;
+    onDeleteService?: (serviceUuid: string) => void;
     onAddService?: (tier?: number) => void;
     onToggleExpanded?: () => void;
 
@@ -176,10 +176,10 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                                                                             collapsible = false,
                                                                             guideMode = false,
                                                                             onUpdateRecord,
-                                                                            onProviderNodeClick,
+                                                                            onServiceNodeClick,
                                                                             onEditProvider,
                                                                             onTierChange,
-                                                                            onDeleteProvider,
+                                                                            onDeleteService,
                                                                             onAddService,
                                                                             onToggleExpanded,
                                                                             onAddSmartRule,
@@ -341,8 +341,8 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                                 scenario={record.scenario}
                                 providersData={providers}
                                 active={active && p.active !== false}
-                                onDelete={() => onDeleteProvider?.(p.uuid)}
-                                onNodeClick={() => onProviderNodeClick?.(p.uuid)}
+                                onDelete={() => onDeleteService?.(p.uuid)}
+                                onNodeClick={() => onServiceNodeClick?.(p.uuid)}
                                 onEditProvider={onEditProvider}
                                 showTier={false}
                                 forceShowActions={shouldShowActions ?? (hoveredTier === group.tier)}
@@ -365,7 +365,7 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                 })}
             </Box>
         );
-    }, [t, tierGroups, active, saving, record.providers.length, getApiStyle, providers, onDeleteProvider, onProviderNodeClick, onEditProvider, onTierChange, onAddService, hoveredTier, guideMode, handleShowGuide]);
+    }, [t, tierGroups, active, saving, record.providers.length, getApiStyle, providers, onDeleteService, onServiceNodeClick, onEditProvider, onTierChange, onAddService, hoveredTier, guideMode, handleShowGuide]);
 
     // Render smart rules section
     const renderSmartRules = () => {
@@ -409,7 +409,7 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                                                 providersData={providers}
                                                 active={active && service.active !== false}
                                                 onDelete={() => onDeleteServiceFromSmartRule?.(rule.uuid, service.uuid)}
-                                                onNodeClick={() => onProviderNodeClick?.(service.uuid)}
+                                                onNodeClick={() => onServiceNodeClick?.(service.uuid)}
                                                 onEditProvider={onEditProvider}
                                             />
                                         ))}

--- a/frontend/src/components/UnifiedRoutingGraph.tsx
+++ b/frontend/src/components/UnifiedRoutingGraph.tsx
@@ -409,7 +409,7 @@ export const UnifiedRoutingGraph: React.FC<UnifiedRoutingGraphProps> = ({
                                                 providersData={providers}
                                                 active={active && service.active !== false}
                                                 onDelete={() => onDeleteServiceFromSmartRule?.(rule.uuid, service.uuid)}
-                                                onNodeClick={() => onProviderNodeClick?.(service.provider)}
+                                                onNodeClick={() => onProviderNodeClick?.(service.uuid)}
                                                 onEditProvider={onEditProvider}
                                             />
                                         ))}

--- a/frontend/src/components/model-select/ModelsPanel.tsx
+++ b/frontend/src/components/model-select/ModelsPanel.tsx
@@ -9,9 +9,7 @@ import {
     Button,
     CircularProgress,
     IconButton,
-    InputAdornment,
     Stack,
-    TextField,
     Typography,
     Divider,
 } from '@mui/material';
@@ -20,7 +18,7 @@ import type { Provider } from '@/types/provider';
 import type { ProviderQuota } from '@/types/quota';
 import { QuotaBarItem } from '@/components/credential/QuotaBarItem';
 import { useQuotaBars } from '@/components/credential/QuotaBarRow';
-import { Search as SearchIcon } from '@/components/icons';
+import SearchField from '@/components/SearchField';
 import { getModelTypeInfo } from '@/utils/modelUtils';
 import { useCustomModels } from '@/hooks/useCustomModels';
 import { useProviderModels } from '@/hooks/useProviderModels';
@@ -292,20 +290,10 @@ export function ModelsPanel({
                     </Stack>
 
                     {/* Search box */}
-                    <TextField
-                        size="small"
+                    <SearchField
                         placeholder="Search models..."
                         value={searchTerms[provider.uuid] || ''}
                         onChange={(e) => handleSearchChange(provider.uuid, e.target.value)}
-                        slotProps={{
-                            input: {
-                                startAdornment: (
-                                    <InputAdornment position="start">
-                                        <SearchIcon fontSize="small" />
-                                    </InputAdornment>
-                                ),
-                            },
-                        }}
                         sx={{ width: 200 }}
                     />
                 </Stack>

--- a/frontend/src/components/model-select/ModelsPanel.tsx
+++ b/frontend/src/components/model-select/ModelsPanel.tsx
@@ -2,8 +2,8 @@ import { AddCircleOutline as AddCircleOutlineIcon } from '@/components/icons';
 import { NavigateBefore as NavigateBeforeIcon } from '@/components/icons';
 import { NavigateNext as NavigateNextIcon } from '@/components/icons';
 import { Refresh as RefreshIcon } from '@/components/icons';
-import { Search as SearchIcon } from '@/components/icons';
 import { BugReport as BugReportIcon } from '@/components/icons';
+import { Edit as EditIcon } from '@/components/icons';
 import {
     Box,
     Button,
@@ -20,6 +20,7 @@ import type { Provider } from '@/types/provider';
 import type { ProviderQuota } from '@/types/quota';
 import { QuotaBarItem } from '@/components/credential/QuotaBarItem';
 import { useQuotaBars } from '@/components/credential/QuotaBarRow';
+import { Search as SearchIcon } from '@/components/icons';
 import { getModelTypeInfo } from '@/utils/modelUtils';
 import { useCustomModels } from '@/hooks/useCustomModels';
 import { useProviderModels } from '@/hooks/useProviderModels';
@@ -83,6 +84,9 @@ export interface ModelsPanelProps {
     onModelSelect: (provider: Provider, model: string) => void;
     onCustomModelEdit: (provider: Provider, value?: string) => void;
     onCustomModelDelete: (provider: Provider, customModel: string) => void;
+    // Open the provider edit dialog for this provider. Omitted on surfaces
+    // that don't support credential editing — the button is hidden then.
+    onProviderEdit?: (provider: Provider) => void;
 }
 
 export function ModelsPanel({
@@ -94,6 +98,7 @@ export function ModelsPanel({
     onModelSelect,
     onCustomModelEdit,
     onCustomModelDelete,
+    onProviderEdit,
 }: ModelsPanelProps) {
     const { customModels } = useCustomModels();
     const { providerModels, refreshingProviders, refreshModels, fetchModels } = useProviderModels();
@@ -243,28 +248,42 @@ export function ModelsPanel({
                     }}>
                         <Button
                             variant="outlined"
+                            size="small"
                             startIcon={<AddCircleOutlineIcon />}
                             onClick={() => onCustomModelEdit(provider)}
-                            sx={{ height: 40, minWidth: 100 }}
+                            sx={{ minWidth: 100 }}
                         >
                             Custom Model
                         </Button>
                         <Button
                             variant="outlined"
+                            size="small"
                             startIcon={isRefreshing ? <CircularProgress size={16} /> : <RefreshIcon />}
                             onClick={() => refreshModels(provider.uuid)}
                             disabled={isRefreshing}
-                            sx={{ height: 40, minWidth: 100 }}
+                            sx={{ minWidth: 100 }}
                         >
                             {isRefreshing ? 'Fetching...' : 'Refresh'}
                         </Button>
+                        {onProviderEdit && (
+                            <Button
+                                variant="outlined"
+                                size="small"
+                                startIcon={<EditIcon />}
+                                onClick={() => onProviderEdit(provider)}
+                                sx={{ minWidth: 100 }}
+                            >
+                                Edit Provider
+                            </Button>
+                        )}
                         {import.meta.env.DEV && (
                             <Button
                                 variant="outlined"
+                                size="small"
                                 color="warning"
                                 startIcon={<BugReportIcon />}
                                 onClick={handleDevTestRemoveModels}
-                                sx={{ height: 40, minWidth: 100 }}
+                                sx={{ minWidth: 100 }}
                                 title="Dev: Randomly mark some models as 'new' for testing"
                             >
                                 Test New
@@ -282,7 +301,7 @@ export function ModelsPanel({
                             input: {
                                 startAdornment: (
                                     <InputAdornment position="start">
-                                        <SearchIcon />
+                                        <SearchIcon fontSize="small" />
                                     </InputAdornment>
                                 ),
                             },

--- a/frontend/src/components/model-select/ProviderSidebar.tsx
+++ b/frontend/src/components/model-select/ProviderSidebar.tsx
@@ -1,9 +1,10 @@
-import { CheckCircle, Search } from '@/components/icons';
-import { Box, Stack, Typography, TextField, InputAdornment } from '@mui/material';
+import { CheckCircle } from '@/components/icons';
+import { Box, Stack, Typography } from '@mui/material';
 import React, { useState, useMemo } from 'react';
 import type { Provider } from '../../types/provider';
 import { AuthTypeBadge } from '../AuthTypeBadge';
 import { ApiStyleBadge } from '../ApiStyleBadge';
+import SearchField from '../SearchField';
 
 export interface ProviderSidebarProps {
     groupedProviders: Array<{ authType: string; providers: Provider[] }>;
@@ -48,20 +49,10 @@ export function ProviderSidebar({
         }}>
             {/* Header */}
             <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>
-                <TextField
-                    size="small"
+                <SearchField
                     placeholder="Search credentials..."
                     value={providerSearchTerm}
                     onChange={(e) => setProviderSearchTerm(e.target.value)}
-                    slotProps={{
-                        input: {
-                            startAdornment: (
-                                <InputAdornment position="start">
-                                    <Search />
-                                </InputAdornment>
-                            ),
-                        },
-                    }}
                     sx={{ width: 200 }}
                 />
             </Box>

--- a/frontend/src/components/tier/StaticGraphViewer.tsx
+++ b/frontend/src/components/tier/StaticGraphViewer.tsx
@@ -60,9 +60,9 @@ export const StaticGraphViewer: React.FC<StaticGraphViewerProps> = ({
 
     // Create demo callbacks that do nothing
     const handleUpdateRecord = () => {};
-    const handleProviderNodeClick = () => {};
+    const handleServiceNodeClick = () => {};
     const handleTierChange = () => {};
-    const handleDeleteProvider = () => {};
+    const handleDeleteService = () => {};
     const handleAddService = () => {};
     const handleAddSmartRule = () => {};
     const handleEditSmartRule = () => {};
@@ -93,9 +93,9 @@ export const StaticGraphViewer: React.FC<StaticGraphViewerProps> = ({
                 guideMode={true}
                 autoScroll={true}
                 onUpdateRecord={handleUpdateRecord}
-                onProviderNodeClick={handleProviderNodeClick}
+                onServiceNodeClick={handleServiceNodeClick}
                 onTierChange={handleTierChange}
-                onDeleteProvider={handleDeleteProvider}
+                onDeleteService={handleDeleteService}
                 onAddService={handleAddService}
                 onAddSmartRule={handleAddSmartRule}
                 onEditSmartRule={handleEditSmartRule}

--- a/frontend/src/hooks/useModelSelectDialog.tsx
+++ b/frontend/src/hooks/useModelSelectDialog.tsx
@@ -10,7 +10,7 @@ import { buildRuleUpdatePayload } from '@/components/rule-card/ruleUpdatePayload
 export interface ModelSelectOptions {
     ruleUuid: string;
     configRecord: ConfigRecord;
-    providerUuid?: string; // The uuid of the service to edit, or "smart:${index}" for adding to smart rule
+    serviceUuid?: string; // The uuid of the service to edit, or "smart:${index}" for adding to smart rule
     mode?: 'edit' | 'add';
     addTier?: number; // Tier to assign when mode='add' (for tier-based adds)
 }
@@ -45,7 +45,7 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
     // Dialog state
     const [open, setOpen] = useState(false);
     const [mode, setMode] = useState<'edit' | 'add' | 'create-rule'>('add');
-    const [editingProviderUuid, setEditingProviderUuid] = useState<string | null>(null);
+    const [editingServiceUuid, setEditingServiceUuid] = useState<string | null>(null);
     const [currentRuleUuid, setCurrentRuleUuid] = useState<string | null>(null);
     const [currentConfigRecord, setCurrentConfigRecord] = useState<ConfigRecord | null>(null);
     const [modelSelectionCleared, setModelSelectionCleared] = useState(false);
@@ -81,7 +81,7 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
 
     // Open the dialog
     const openModelSelect = useCallback((options: ModelSelectOptions) => {
-        const { ruleUuid, configRecord, providerUuid, mode: newMode = 'edit', addTier } = options;
+        const { ruleUuid, configRecord, serviceUuid, mode: newMode = 'edit', addTier } = options;
 
         setCurrentRuleUuid(ruleUuid);
         setCurrentConfigRecord(configRecord);
@@ -89,19 +89,19 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
         setModelSelectionCleared(false);
         setCurrentAddTier(addTier);
 
-        // Check if providerUuid is a smart rule reference (format: "smart:${index}")
-        if (providerUuid?.startsWith('smart:')) {
-            const index = parseInt(providerUuid.substring(6), 10);
+        // Check if serviceUuid is a smart rule reference (format: "smart:${index}")
+        if (serviceUuid?.startsWith('smart:')) {
+            const index = parseInt(serviceUuid.substring(6), 10);
             currentSmartRuleIndexRef.current = index;
-            setEditingProviderUuid(null);
+            setEditingServiceUuid(null);
             editingServiceContextRef.current = null;
         } else {
             currentSmartRuleIndexRef.current = null;
-            setEditingProviderUuid(providerUuid || null);
+            setEditingServiceUuid(serviceUuid || null);
 
-            // In edit mode, determine if providerUuid refers to a service in smartRouting or providers
-            if (newMode === 'edit' && providerUuid) {
-                const found = findService(configRecord, providerUuid);
+            // In edit mode, determine if serviceUuid refers to a service in smartRouting or providers
+            if (newMode === 'edit' && serviceUuid) {
+                const found = findService(configRecord, serviceUuid);
                 if (found) {
                     editingServiceContextRef.current = {
                         isSmartRouting: found.isSmartRouting,
@@ -122,7 +122,7 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
         setMode('create-rule');
         setCurrentRuleUuid(null);
         setCurrentConfigRecord(null);
-        setEditingProviderUuid(null);
+        setEditingServiceUuid(null);
         setModelSelectionCleared(false);
         setCurrentAddTier(undefined);
         currentSmartRuleIndexRef.current = null;
@@ -172,7 +172,7 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
                     { uuid: uuidv4(), provider: option.provider.uuid, model: option.model || '', isManualInput: false, tier: currentAddTier ?? 0 },
                 ],
             };
-        } else if (mode === 'edit' && editingProviderUuid) {
+        } else if (mode === 'edit' && editingServiceUuid) {
             // Edit existing provider or smart routing service
             if (editingContext?.isSmartRouting && editingContext.smartRuleIndex !== undefined) {
                 // Edit service in smart routing
@@ -183,7 +183,7 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
                             return {
                                 ...rule,
                                 services: (rule.services || []).map(service => {
-                                    if (service.uuid === editingProviderUuid) {
+                                    if (service.uuid === editingServiceUuid) {
                                         return { ...service, provider: option.provider.uuid, model: option.model || '' };
                                     }
                                     return service;
@@ -198,7 +198,7 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
                 updated = {
                     ...currentConfigRecord,
                     providers: currentConfigRecord.providers.map(p => {
-                        if (p.uuid === editingProviderUuid) {
+                        if (p.uuid === editingServiceUuid) {
                             return { ...p, provider: option.provider.uuid, model: option.model || '' };
                         }
                         return p;
@@ -241,32 +241,32 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
         setOpen(false);
         setCurrentRuleUuid(null);
         setCurrentConfigRecord(null);
-        setEditingProviderUuid(null);
+        setEditingServiceUuid(null);
         setCurrentAddTier(undefined);
         currentSmartRuleIndexRef.current = null;
         editingServiceContextRef.current = null;
-    }, [currentConfigRecord, currentAddTier, currentRuleUuid, mode, editingProviderUuid, rules, onRuleChange, showNotification, onCreateFromModel]);
+    }, [currentConfigRecord, currentAddTier, currentRuleUuid, mode, editingServiceUuid, rules, onRuleChange, showNotification, onCreateFromModel]);
 
     // Get selected provider and model for pre-selection
     const getSelectedProvider = useCallback(() => {
-        if (mode === 'edit' && editingProviderUuid && currentConfigRecord) {
-            const found = findService(currentConfigRecord, editingProviderUuid);
+        if (mode === 'edit' && editingServiceUuid && currentConfigRecord) {
+            const found = findService(currentConfigRecord, editingServiceUuid);
             return found?.service.provider;
         }
         return undefined;
-    }, [mode, editingProviderUuid, currentConfigRecord, findService]);
+    }, [mode, editingServiceUuid, currentConfigRecord, findService]);
 
     const getSelectedModel = useCallback(() => {
         // If model selection was cleared (e.g., after deleting a custom model), return undefined
         if (modelSelectionCleared) {
             return undefined;
         }
-        if (mode === 'edit' && editingProviderUuid && currentConfigRecord) {
-            const found = findService(currentConfigRecord, editingProviderUuid);
+        if (mode === 'edit' && editingServiceUuid && currentConfigRecord) {
+            const found = findService(currentConfigRecord, editingServiceUuid);
             return found?.service.model;
         }
         return undefined;
-    }, [mode, editingProviderUuid, currentConfigRecord, findService, modelSelectionCleared]);
+    }, [mode, editingServiceUuid, currentConfigRecord, findService, modelSelectionCleared]);
 
     // Get a unique key for ModelSelectTab to force remount when selection changes
     const dialogKey = open ? `${getSelectedProvider() || ''}-${getSelectedModel() || ''}` : 'closed';
@@ -276,7 +276,7 @@ export const useModelSelectDialog = (options: UseModelSelectDialogOptions) => {
         setOpen(false);
         setCurrentRuleUuid(null);
         setCurrentConfigRecord(null);
-        setEditingProviderUuid(null);
+        setEditingServiceUuid(null);
         setCurrentAddTier(undefined);
         currentSmartRuleIndexRef.current = null;
         editingServiceContextRef.current = null;

--- a/frontend/src/pages/UserUsagePage.tsx
+++ b/frontend/src/pages/UserUsagePage.tsx
@@ -8,7 +8,6 @@ import {
     CircularProgress,
     Grid,
     IconButton,
-    InputAdornment,
     Paper,
     Skeleton,
     Stack,
@@ -20,7 +19,6 @@ import {
     TablePagination,
     TableRow,
     TableSortLabel,
-    TextField,
     ToggleButton,
     ToggleButtonGroup,
     Tooltip,
@@ -37,11 +35,11 @@ import {
     CheckCircle,
     ErrorOutline,
     Refresh,
-    Search,
     Token,
     Users,
 } from '@/components/icons';
 import PageHeader from '@/components/PageHeader';
+import SearchField from '@/components/SearchField';
 import {
     formatNumber,
     StatCard,
@@ -538,18 +536,10 @@ export default function UserUsagePage() {
                                 </Typography>
                                 <Chip size="small" label={visibleRows.length} sx={{ height: 22 }} />
                             </Stack>
-                            <TextField
-                                size="small"
+                            <SearchField
                                 value={search}
                                 onChange={(event) => setSearch(event.target.value)}
                                 placeholder={t('dashboard.userUsage.search', { defaultValue: 'Search users' })}
-                                slotProps={{
-                                    input: {
-                                        startAdornment: (
-                                            <InputAdornment position="start"><Search fontSize="small" /></InputAdornment>
-                                        ),
-                                    },
-                                }}
                                 sx={{ width: { xs: '100%', sm: 220 } }}
                             />
                         </Box>

--- a/frontend/src/pages/scenario/components/TemplatePage.tsx
+++ b/frontend/src/pages/scenario/components/TemplatePage.tsx
@@ -175,10 +175,10 @@ const TemplatePage: React.FC<TemplatePageProps> = (props) => {
         ruleUuid: string,
         configRecord: any,
         mode: 'edit' | 'add',
-        providerUuid?: string,
+        serviceUuid?: string,
         addTier?: number
     ) => {
-        openModelSelect({ruleUuid, configRecord, providerUuid, mode, addTier});
+        openModelSelect({ruleUuid, configRecord, serviceUuid, mode, addTier});
     }, [openModelSelect]);
 
     // Add-provider flow opened in place (rather than navigating away).

--- a/frontend/src/theme/components/claude.ts
+++ b/frontend/src/theme/components/claude.ts
@@ -62,6 +62,11 @@ export const claudeComponents: ThemeOptions['components'] = {
         borderRadius: 6,
         backgroundColor: 'transparent',
         transition: 'background-color 120ms ease, border-color 120ms ease',
+        // MUI keeps adornment icons at 24px inside size="small" inputs, which
+        // visually inflates the field — shrink them app-wide at the theme level.
+        '&.MuiInputBase-sizeSmall .MuiInputAdornment-root .MuiSvgIcon-root': {
+          fontSize: 20,
+        },
         '& .MuiOutlinedInput-notchedOutline': { borderColor: '#D6D3C7' },
         '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#B0AEA5' },
         '&.Mui-focused .MuiOutlinedInput-notchedOutline': {

--- a/frontend/src/theme/components/dark.ts
+++ b/frontend/src/theme/components/dark.ts
@@ -69,6 +69,11 @@ export const darkComponents: ThemeOptions['components'] = {
         borderRadius: 6,
         backgroundColor: darkInputBg,
         transition: 'background-color 120ms ease, border-color 120ms ease',
+        // MUI keeps adornment icons at 24px inside size="small" inputs, which
+        // visually inflates the field — shrink them app-wide at the theme level.
+        '&.MuiInputBase-sizeSmall .MuiInputAdornment-root .MuiSvgIcon-root': {
+          fontSize: 20,
+        },
         '& .MuiOutlinedInput-notchedOutline': { borderColor: darkInputBorder },
         '&:hover': { backgroundColor: darkInputBgHover },
         '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: darkInputBorderHover },

--- a/frontend/src/theme/components/light.ts
+++ b/frontend/src/theme/components/light.ts
@@ -61,6 +61,11 @@ export const lightComponents: ThemeOptions['components'] = {
         borderRadius: 6,
         backgroundColor: 'transparent',
         transition: 'background-color 120ms ease, border-color 120ms ease',
+        // MUI keeps adornment icons at 24px inside size="small" inputs, which
+        // visually inflates the field — shrink them app-wide at the theme level.
+        '&.MuiInputBase-sizeSmall .MuiInputAdornment-root .MuiSvgIcon-root': {
+          fontSize: 20,
+        },
         '& .MuiOutlinedInput-notchedOutline': { borderColor: '#d1d5db' },
         '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#9ca3af' },
         '&.Mui-focused .MuiOutlinedInput-notchedOutline': {

--- a/frontend/src/theme/components/sunlit.ts
+++ b/frontend/src/theme/components/sunlit.ts
@@ -93,6 +93,11 @@ export const sunlitComponents: ThemeOptions['components'] = {
         borderRadius: 6,
         backgroundColor: sunlitTokens.inputBg,
         transition: 'background-color 120ms ease, border-color 120ms ease',
+        // MUI keeps adornment icons at 24px inside size="small" inputs, which
+        // visually inflates the field — shrink them app-wide at the theme level.
+        '&.MuiInputBase-sizeSmall .MuiInputAdornment-root .MuiSvgIcon-root': {
+          fontSize: 20,
+        },
         '& .MuiOutlinedInput-notchedOutline': { borderColor: sunlitTokens.borderInput },
         '&:hover': { backgroundColor: sunlitTokens.inputBgHover },
         '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: sunlitTokens.borderInputHover },


### PR DESCRIPTION
## Summary
Routing-graph node clicks conflated provider and service identity, so smart-rule clicks and tier/delete actions could target the wrong entry, and the models dialog lacked in-place credential editing or consistent search styling. 

This batch fixes the identity bugs and adds inline provider editing plus a unified search field.

<img width="1594" height="198" alt="image" src="https://github.com/user-attachments/assets/a91b9553-4122-4a0f-b0c6-2a4968ec5039" />

## Key Changes

- **Service vs provider identity**: Routing-graph callbacks (`onProviderNodeClick`/`onDeleteProvider`/tier params) now consistently pass service uuid, fixing smart-rule node clicks and deletes hitting the wrong entry.
- **Inline provider editing**: Models panel toolbar gets an "Edit Provider" button that opens the edit dialog and refreshes that tab without leaving model selection.
- **Model-select tab fallback**: Stale or empty provider tab refs now fall through to the first available provider instead of leaving the panel blank.
- **Unified search field**: New `SearchField` component consolidates model/credential/usage search boxes to one consistent compact size.
- **Adornment icon sizing**: Theme-level fix shrinks oversized 24px adornment icons to 20px in small inputs across all four themes.
