### PR TITLE
feat(ai/quota): read OpenCode Zen / Go quota

### DIFF
--- a/.design/opencode-quota.md
+++ b/.design/opencode-quota.md
@@ -1,0 +1,146 @@
+# OpenCode（Zen / Go）配额方案
+
+> 适用对象：改 `ai/quota/fetcher/opencode.go` 或排查 OpenCode provider 额度显示的贡献者。
+> 结构：调研（§1–§3）→ 我们能读到什么（§4）→ 归一实现（§5）→ 验证（§6）→ 待定（§7）。
+> 调研来源：`sst/opencode`（现 `anomalyco/opencode`）`dev` 分支源码 —— 网关实现在
+> `packages/console/app/src/routes/zen/**`，客户端错误处理在
+> `packages/opencode/src/session/retry.ts`；文档 `opencode.ai/docs/zen`、`/docs/go`。
+
+---
+
+## 1. 一个 host、一把 key、两个产品
+
+OpenCode 的网关（`packages/console/app/src/routes/zen/`）在同一个域名下开两组路由：
+
+| 路由 | 产品 | 计费 |
+|---|---|---|
+| `/zen/v1/{chat/completions,messages,responses,models}` | Zen（按量付费） | 预充余额 balance |
+| `/zen/go/v1/{...,usage}` | Go 订阅（内部代号 `lite`） | 订阅额度，超限拒绝 |
+
+两组路由认的是**同一把 Zen API key**（`Authorization: Bearer <key>`），
+key 背后是 workspace + user。所以「这把 key 属于哪个产品」不是配置出来的，
+而是**看这个 workspace 有没有订阅**——这一点决定了 §5 的读取策略。
+
+## 2. 四种计费源，网关按固定优先级判定
+
+`validateBilling()`（`zen/util/handler.go` 对应的 `handler.ts`）返回
+`anonymous | free | byok | subscription | lite | balance`，判定顺序即优先级：
+
+1. **匿名 / free**：未带 key 或只用免费模型。限额是**按 IP 的每日请求数**
+   （`zen/util/ipRateLimiter.ts`：UTC 日切，新 IP 在终身前 `dailyLimit*7` 次内享双倍日限），
+   超限抛 `FreeUsageLimitError`。另有按 IP 的试用 token 池（`trialLimiter.ts`，`promoTokens`）。
+2. **byok**：workspace 自带上游 key，网关不计费。
+3. **subscription（Black，$20/$100/$200 档）**：一个滚动窗口 + 一个固定（周）窗口，
+   超限抛 `BlackUsageLimitError`。
+4. **lite（即 Go 订阅）**：**周 → 月 → 5 小时滚动**三个窗口依次校验，
+   任一打满即抛 `GoUsageLimitError`。
+5. **balance（按量付费）**：`balance <= 0` → `CreditsError`；
+   workspace 月度上限 → `MonthlyLimitError`；成员个人月度上限 → `UserLimitError`。
+   余额低于 `reloadTrigger`（默认 $5）自动充值（默认 $20），可关。
+
+订阅档位开启 `useBalance` 时，订阅超限会**回落到余额**继续跑而不是拒绝
+（`catch (e) { if (!...useBalance) throw e }`）。
+
+### 2.1 限额是钱，不是 token
+
+`Subscription.analyze{Rolling,Weekly,Monthly}Usage()`（`console/core/src/subscription.ts`）
+把用量和限额都换算成 **microcents** 比较，返回 `{status, resetInSec, usagePercent}`：
+
+- 滚动窗口：窗口长度 `rollingWindow`（小时）；`timeUpdated` 早于窗口起点即视为归零；
+  窗口末端 = 最后一次计费时间 + 窗口长度（**不是自然滑动**，是"最后一次用之后再等一个窗口"）。
+- 周窗口：自然周边界。
+- 月窗口：**从订阅日起算**的账期（`getMonthlyBounds(now, timeSubscribed)`），不是自然月。
+- `usagePercent` 向下取整；打满返回 `status: "rate-limited"`。
+
+具体限额数值来自部署期资源 `ZEN_LIMITS`（`free.dailyRequests` / `lite.rollingLimit` /
+`lite.rollingWindow` / `lite.weeklyLimit` / `lite.monthlyLimit` / `black.*`），
+**源码里没有硬编码值，API 也不返回**——这是 §4 的关键约束。
+
+## 3. 超限时客户端拿到什么
+
+网关统一返回 **429**，body：
+
+```json
+{"type":"error","error":{"type":"GoUsageLimitError","message":"..."},
+ "metadata":{"workspace":"wrk_...","limitName":"5 hour"}}
+```
+
+`retry-after`（秒）来自 `resetInSec`。`limitName` ∈ `"5 hour" | "weekly" | "monthly"`。
+`FreeUsageLimitError` / `BlackUsageLimitError` 不带 metadata。
+认证与计费类错误（`AuthError` / `CreditsError` / `MonthlyLimitError` / `UserLimitError` /
+`ModelError`）走 **401**，`RegionError` / `DataPolicyError` 走 403。
+
+客户端 `session/retry.ts` 据此渲染：`FreeUsageLimitError` → 引导订阅 Go；
+`GoUsageLimitError` → "X usage limit reached, resets in ..."，链接到
+`opencode.ai/workspace/<id>/go`。
+
+## 4. 我们能主动读到的只有一个端点
+
+```
+GET https://opencode.ai/zen/go/v1/usage
+Authorization: Bearer <zen api key>
+
+{"usage":{
+  "rolling": {"status":"ok","percent":12,"resetsAt":"..."},
+  "weekly":  {"status":"ok","percent":40,"resetsAt":"..."},
+  "monthly": {"status":"ok","percent":31,"resetsAt":"..."}}}
+```
+
+三条约束，直接决定了归一方式：
+
+1. **只有百分比。** 限额（美元）与已用量都不返回，只给 `percent` + `resetsAt`。
+   所以窗口只能落在 0-100 标度上（`Unit=percent`，`Limit=100`），
+   跟 codex / anthropic 同一路数。
+2. **窗口长度不返回。** `resetsAt` 是"这次什么时候回来"，不是周期长度
+   （未用过时才等于整窗）。滚动窗口按网关自己在超限文案里给的名字取 **5 小时**；
+   月窗口按 30 天记（真实边界以 `resetsAt` 为准）。
+3. **余额没有公开端点。** 只有订阅有 `usage`；按量付费的 balance 至今只能看 web 控制台
+   （上游 issue #10448 仍开着）。因此**没有 Go 订阅的 key** 会拿到
+   `403 EntitlementError: OpenCode Go subscription required.`——
+   这是一把好 key，不是错误。
+
+## 5. 归一到 `ai/quota`
+
+`ai/quota/fetcher/opencode.go`（`ProviderTypeOpenCode = "opencode"`，`api_key` 认证）：
+
+| 上游 | 窗口 | 说明 |
+|---|---|---|
+| `usage.rolling` | `rolling`，`session`，300min | `Kind=limit`；`ResetsAt` 来自上游 |
+| `usage.weekly` | `weekly`，`weekly`，7d | 同上 |
+| `usage.monthly` | `monthly`，`monthly`，30d | 账期从订阅日起算，长度只是名义值 |
+
+- 三个窗口都是**账户级 gate**（网关任一打满即拒），所以都进 `Windows`，
+  由 `Tightest()` 选出真正卡住的那个——不是"取周窗口"或"取最先重置的"。
+- `status: "rate-limited"` → `LimitReached=true` / `Allowed=false`。
+  百分比是向下取整的，100% 分不出"刚好用尽"和"正在被拒"，只有 `status` 分得出。
+- **403 EntitlementError → `unreadableUsage`**（记 `LastError`，不产出窗口）。
+  报错会让用户去修一把没坏的 key；报 0% 则是撒谎——按 §5.3 的不变量，
+  读不到就得说读不到。其余非 200 才是真错误，并把上游 message 带进错误文本。
+- provider 的 `APIBase` 配的是推理端点（`…/zen/v1` 或 `…/zen/go/v1`），
+  usage 挂在 host 根上，用 `apiRoot()` 先削前缀（长后缀优先，`/zen/go/v1` 也以 `/v1` 结尾）。
+- `manager.go` 的 host 推断：`opencode.ai` → `ProviderTypeOpenCode`，两个产品不按 path 分——
+  fetcher 本身就能回答"这把 key 有没有订阅"。
+
+免费额度（按 IP 日限）与按量付费余额**不产出窗口**：前者的口径是 IP 不是 key，
+我们无从查询；后者上游没端点。两者都只会以 429 / 401 的形式在推理链路上出现。
+
+## 6. 验证
+
+- `ai/quota/fetcher/opencode_test.go`：三窗口归一（周为最紧）、`rate-limited` 落到
+  `LimitReached/Allowed`、403 走 unreadable、401 报错、`/zen/v1` 前缀削除后打到
+  `/zen/go/v1/usage`、Bearer 头。
+- `taskfile_samples_test.go` + `build/Taskfile.quota.yml`（`task -t build/Taskfile.quota.yml opencode`）
+  钉住样本归一结果，并记录真实抓取命令。
+- 每个用例都过 `checkInvariants`（`.design/quota-semantics.md` §5.3）。
+
+## 7. 待定
+
+1. **滚动窗口长度是配置项**（`ZEN_LIMITS.lite.rollingWindow`），我们写死 300min。
+   若上游改档位，窗口排序会偏——真出问题前不值得为它加配置项。
+2. **Black 档（$20/$100/$200）没有 usage 端点**，只有 429 才知道。
+   若上游补上 `/zen/black/v1/usage` 之类，按 §5 同款接入即可。
+3. **余额**：等上游 issue #10448 落地 `GET /zen/v1/balance` 后，
+   按 `WindowTypeBalance` + `WindowKindResource` 补一个资源窗口（对齐 openrouter 的做法）。
+4. **`useBalance` 回落**：订阅打满但开了回落时，请求其实仍能跑。
+   `usage` 端点不返回这个开关，所以 100% 的窗口可能"看着卡住实际能用"。
+   要修得等上游给出该字段。

--- a/.design/quota-semantics.md
+++ b/.design/quota-semantics.md
@@ -38,6 +38,7 @@
 | Kimi Code | 周额度 + N 个 limit（**部分不给时长**）；booster 钱包 | — |
 | Kimi K2 | `consumed` / `remaining` | 原始总额（只能合成） |
 | OpenRouter | key 终身限额（可为 null）；日/周/月花费（**月花费永远无上限**——key limit 管终身不管当月） | — |
+| OpenCode | Go 订阅三个窗口（5h 滚动 / 周 / 月）的百分比 + 重置时间 + `status` | 限额绝对值、窗口长度、**按量付费余额（无公开端点）**、免费额度（按 IP 计） |
 | OpenAI | 花费时序（`/v1/usage` 常 404） | 上限 |
 | Copilot / Cursor / VertexAI | 无配额 API | 一切 |
 
@@ -184,7 +185,7 @@ return w != nil && !w.Unknown && !w.Unlimited && w.Limit > 0
 |---|---|
 | 判定 API、排序、`Unreadable` | `ai/quota/semantic.go` |
 | 字段定义、`AddWindow` / `AddBreakdown`、语义推导 | `ai/quota/types.go` |
-| 14 个 fetcher | `ai/quota/fetcher/*.go` |
+| 15 个 fetcher | `ai/quota/fetcher/*.go` |
 | 共享助手（`endpoint` / `calcPercent` / `windowTypeForMinutes` / `unreadableUsage`） | `ai/quota/fetcher/helpers.go` |
 | 不变量断言（每个 provider 测试调用） | `ai/quota/fetcher/invariants_test.go` |
 | 真实样本固化 | `ai/quota/fetcher/taskfile_samples_test.go` + `build/Taskfile.quota.yml` |
@@ -202,6 +203,7 @@ return w != nil && !w.Unknown && !w.Unlimited && w.Limit > 0
 | kimi_code | booster → `resource`；weekly 补 7d；无时长 limit 保持 `custom` |
 | kimik2 | credits → `resource` |
 | openrouter | key 余额 → `resource`；月度花费两个分支都标 `Unlimited`（key limit 管终身不管当月）；去掉重复的第二个 monthly 窗口 |
+| opencode | 三个窗口都是账户级 gate（网关任一打满即拒），交给 `Tightest()`；只有百分比 → 0-100 标度；滚动窗口长度上游不给，按其超限文案的 "5 hour" 取 300min；无 Go 订阅的 403 `EntitlementError` → `MarkUnreadable`（好 key，不是错误，更不是 0%）。详见 `.design/opencode-quota.md` |
 | openai | 有花费无上限 → `Unknown` 窗口（数值可见）；404 → 只记 `LastError` |
 | copilot / cursor / vertex_ai | 只记 `LastError`，不产出窗口 |
 

--- a/ai/quota/fetcher/opencode.go
+++ b/ai/quota/fetcher/opencode.go
@@ -1,0 +1,202 @@
+package fetcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/ai/quota"
+)
+
+// OpenCode's gateway serves two products off one host and one API key:
+// pay-as-you-go Zen (a prepaid balance) under /zen/v1, and the Go
+// subscription under /zen/go/v1. Only the subscription publishes usage —
+// GET /zen/go/v1/usage — and it answers in percentages, one per limit the
+// plan enforces: a rolling window, the calendar week, and the billing month.
+// The Zen balance has no public endpoint (opencode issue #10448), so a
+// balance-only key reads as unreadable rather than as an error.
+// See .design/opencode-quota.md.
+const (
+	opencodeAPIHost   = "https://opencode.ai"
+	opencodeUsagePath = "/zen/go/v1/usage"
+
+	// Upstream reports the rolling window's percentage and reset time but not
+	// its length, and the length is what orders windows against other
+	// providers'. Five hours is the figure the gateway itself names when the
+	// window is spent (GoUsageLimitError carries limitName "5 hour"), so it is
+	// the plan's documented period rather than a number invented here.
+	opencodeRollingWindowMinutes = 5 * 60
+	// The billing month runs from the subscription date, not the 1st, so its
+	// length varies; 30 days is the nominal period, and ResetsAt carries the
+	// real boundary.
+	opencodeMonthlyWindowMinutes = 30 * 24 * 60
+)
+
+// OpenCodeFetcher retrieves OpenCode Zen / Go quota data.
+// Uses: GET https://opencode.ai/zen/go/v1/usage (Zen API key as Bearer).
+type OpenCodeFetcher struct{}
+
+func NewOpenCodeFetcher() *OpenCodeFetcher {
+	return &OpenCodeFetcher{}
+}
+
+func (f *OpenCodeFetcher) Name() string                     { return "opencode" }
+func (f *OpenCodeFetcher) ProviderType() quota.ProviderType { return quota.ProviderTypeOpenCode }
+func (f *OpenCodeFetcher) RequiresAuth() ai.AuthType        { return ai.AuthTypeAPIKey }
+
+func (f *OpenCodeFetcher) Validate(provider *ai.Provider) error {
+	if provider == nil {
+		return fmt.Errorf("provider is nil")
+	}
+	if provider.GetAccessToken() == "" {
+		return fmt.Errorf("no API key available")
+	}
+	return nil
+}
+
+// opencodeUsageResponse from GET /zen/go/v1/usage.
+//
+// Each entry is a percentage and a reset time; upstream never reports the
+// dollar amounts behind them, so the plan's limits stay invisible to us.
+type opencodeUsageResponse struct {
+	Usage struct {
+		Rolling *opencodeUsageWindow `json:"rolling"`
+		Weekly  *opencodeUsageWindow `json:"weekly"`
+		Monthly *opencodeUsageWindow `json:"monthly"`
+	} `json:"usage"`
+}
+
+type opencodeUsageWindow struct {
+	Status   string  `json:"status"`   // "ok" | "rate-limited"
+	Percent  float64 `json:"percent"`  // 0-100, floored upstream
+	ResetsAt string  `json:"resetsAt"` // RFC3339
+}
+
+// opencodeError is the gateway's error envelope, shared by the inference and
+// usage endpoints. The type field is what separates a rejected key from a key
+// that is simply not on the Go plan.
+type opencodeError struct {
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func (f *OpenCodeFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.ProviderUsage, error) {
+	// A provider is configured with an inference base — "…/zen/v1" for
+	// pay-as-you-go, "…/zen/go/v1" for the subscription — while the usage
+	// endpoint is addressed from the host root. Longest suffix first, since
+	// "/zen/go/v1" also ends with "/v1".
+	url := apiRoot(provider.APIBase, opencodeAPIHost, "/zen/go/v1", "/zen/v1", "/v1") + opencodeUsagePath
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+provider.GetAccessToken())
+	req.Header.Set("Accept", "application/json")
+
+	client := quota.NewHTTPClient(provider.ProxyURL, 30*time.Second)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// 403 EntitlementError is not a failure: it is a working key that
+		// happens to bill against the Zen balance, and the balance has no
+		// public endpoint. Saying so beats reporting an error the user cannot
+		// act on — and beats reporting 0% usage, which would be a lie.
+		if resp.StatusCode == http.StatusForbidden && opencodeErrorType(body) == "EntitlementError" {
+			return unreadableUsage(provider, quota.ProviderTypeOpenCode,
+				"no OpenCode Go subscription; the Zen balance has no usage API"), nil
+		}
+		return nil, fmt.Errorf("unexpected status code: %d%s", resp.StatusCode, errorDetail(body))
+	}
+
+	var apiResp opencodeUsageResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	now := time.Now()
+	usage := &quota.ProviderUsage{
+		ProviderUUID: provider.UUID,
+		ProviderName: provider.Name,
+		ProviderType: quota.ProviderTypeOpenCode,
+		FetchedAt:    now,
+		ExpiresAt:    now.Add(5 * time.Minute),
+		RawResponse:  json.RawMessage(body),
+	}
+
+	// The gateway checks weekly, then monthly, then rolling, and the first one
+	// that is spent rejects the request; all three are therefore account-level
+	// gates, and the tightest of them is what binds.
+	addOpenCodeWindow(usage, "rolling", apiResp.Usage.Rolling,
+		quota.WindowTypeSession, opencodeRollingWindowMinutes, "5h limit")
+	addOpenCodeWindow(usage, "weekly", apiResp.Usage.Weekly,
+		quota.WindowTypeWeekly, 7*24*60, "Weekly limit")
+	addOpenCodeWindow(usage, "monthly", apiResp.Usage.Monthly,
+		quota.WindowTypeMonthly, opencodeMonthlyWindowMinutes, "Monthly limit")
+
+	if len(usage.Windows) == 0 {
+		usage.MarkUnreadable("usage response carried no windows", now)
+	}
+	return usage, nil
+}
+
+// addOpenCodeWindow appends one plan limit. Upstream gives a percentage and
+// nothing else, so the window is expressed on the 0-100 scale rather than
+// pretending to know the dollar cap behind it.
+func addOpenCodeWindow(usage *quota.ProviderUsage, key string, w *opencodeUsageWindow,
+	windowType quota.WindowType, windowMinutes int, label string) {
+	if w == nil {
+		return
+	}
+
+	window := &quota.UsageWindow{
+		Type:          windowType,
+		Kind:          quota.WindowKindLimit, // recovers on its own; see Pct(WindowKindLimit)
+		Used:          w.Percent,
+		Limit:         100,
+		UsedPercent:   w.Percent,
+		Unit:          quota.UsageUnitPercent,
+		WindowMinutes: windowMinutes,
+		Label:         label,
+		Description:   fmt.Sprintf("%.0f%% of the Go %s used", w.Percent, strings.ToLower(label)),
+	}
+	if resetsAt, err := time.Parse(time.RFC3339, w.ResetsAt); err == nil {
+		window.ResetsAt = &resetsAt
+	}
+	// "rate-limited" is the gateway's own verdict on this window; it is the
+	// only signal that says requests are being refused right now, since a
+	// floored 100% can also mean "very nearly spent".
+	if w.Status != "" {
+		limitReached := w.Status == "rate-limited"
+		allowed := !limitReached
+		window.LimitReached = &limitReached
+		window.Allowed = &allowed
+	}
+
+	usage.AddWindow(key, window)
+}
+
+// opencodeErrorType reads the error type out of the gateway's envelope.
+func opencodeErrorType(body []byte) string {
+	var envelope opencodeError
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return ""
+	}
+	return envelope.Error.Type
+}

--- a/ai/quota/fetcher/opencode_test.go
+++ b/ai/quota/fetcher/opencode_test.go
@@ -1,0 +1,131 @@
+package fetcher
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/ai/quota"
+)
+
+func opencodeProvider(base string) *ai.Provider {
+	return &ai.Provider{UUID: "u-opencode", Name: "OpenCode", Token: "oc-key", APIBase: base}
+}
+
+func TestOpenCodeFetcher_Fetch(t *testing.T) {
+	var gotPath, gotAuth string
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotAuth = r.URL.Path, r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"usage":{
+		 "rolling":{"status":"ok","percent":12,"resetsAt":"2026-08-19T13:00:00.000Z"},
+		 "weekly":{"status":"ok","percent":40,"resetsAt":"2026-08-24T00:00:00.000Z"},
+		 "monthly":{"status":"ok","percent":31,"resetsAt":"2026-09-03T00:00:00.000Z"}}}`))
+	}))
+	defer s.Close()
+
+	// The provider is configured with the inference base; the usage endpoint
+	// hangs off the host root, so the "/zen/v1" prefix has to come off first.
+	u, err := (&OpenCodeFetcher{}).Fetch(context.Background(), opencodeProvider(s.URL+"/zen/v1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/zen/go/v1/usage" {
+		t.Errorf("path = %q; want /zen/go/v1/usage", gotPath)
+	}
+	if gotAuth != "Bearer oc-key" {
+		t.Errorf("authorization = %q; want the Zen API key as a bearer token", gotAuth)
+	}
+
+	// The week is the binding limit even though the 5h window resets sooner:
+	// the gateway refuses on whichever is spent first.
+	check(t, "opencode", u, want{pct: 40, ok: true, tightest: "weekly", windows: 3})
+
+	rolling := findWindow(t, u, "rolling")
+	if rolling.WindowMinutes != 5*60 {
+		t.Errorf("rolling = %d min; want 300, the window the gateway names", rolling.WindowMinutes)
+	}
+	if rolling.Unit != quota.UsageUnitPercent {
+		t.Errorf("rolling unit = %q; upstream reports percentages only", rolling.Unit)
+	}
+	if rolling.ResetsAt == nil || !rolling.ResetsAt.Equal(time.Date(2026, 8, 19, 13, 0, 0, 0, time.UTC)) {
+		t.Errorf("rolling ResetsAt = %v; want the upstream timestamp", rolling.ResetsAt)
+	}
+	if u.RecoversAt() == nil {
+		t.Error("a Go plan limit refills on its own; RecoversAt should say when")
+	}
+}
+
+// A spent window is reported as rate-limited, and that verdict has to survive
+// into the window — a floored 100% alone cannot tell "just barely spent" from
+// "requests are being refused".
+func TestOpenCodeFetcher_RateLimited(t *testing.T) {
+	s := serve(t, `{"usage":{
+	 "rolling":{"status":"rate-limited","percent":100,"resetsAt":"2026-08-19T15:00:00.000Z"},
+	 "weekly":{"status":"ok","percent":70,"resetsAt":"2026-08-24T00:00:00.000Z"},
+	 "monthly":{"status":"ok","percent":55,"resetsAt":"2026-09-03T00:00:00.000Z"}}}`)
+
+	u, err := (&OpenCodeFetcher{}).Fetch(context.Background(), opencodeProvider(s.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	check(t, "opencode limited", u, want{pct: 100, ok: true, tightest: "rolling", windows: 3})
+
+	rolling := findWindow(t, u, "rolling")
+	if rolling.LimitReached == nil || !*rolling.LimitReached {
+		t.Error("rolling: LimitReached should be true when upstream says rate-limited")
+	}
+	if rolling.Allowed == nil || *rolling.Allowed {
+		t.Error("rolling: Allowed should be false when upstream says rate-limited")
+	}
+}
+
+// A pay-as-you-go Zen key is a working key with no Go plan behind it. Its
+// balance has no public endpoint, so the honest answer is "unknown" — not an
+// error the user can act on, and emphatically not 0% used.
+func TestOpenCodeFetcher_NoSubscription(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"EntitlementError",
+		 "message":"OpenCode Go subscription required."}}`))
+	}))
+	defer s.Close()
+
+	u, err := (&OpenCodeFetcher{}).Fetch(context.Background(), opencodeProvider(s.URL))
+	if err != nil {
+		t.Fatalf("a balance-only key is not a fetch failure: %v", err)
+	}
+	check(t, "opencode balance-only", u, want{ok: false, windows: 0})
+	if u.LastError == "" {
+		t.Error("the reason the quota is unreadable should be recorded")
+	}
+}
+
+// A rejected key is a real failure, and the upstream message is what tells the
+// user whether the key is wrong or revoked.
+func TestOpenCodeFetcher_Unauthorized(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"AuthError","message":"Unauthorized"}}`))
+	}))
+	defer s.Close()
+
+	if _, err := (&OpenCodeFetcher{}).Fetch(context.Background(), opencodeProvider(s.URL)); err == nil {
+		t.Fatal("expected an error for a rejected key")
+	}
+}
+
+func TestOpenCodeFetcher_Validate(t *testing.T) {
+	f := NewOpenCodeFetcher()
+	if err := f.Validate(nil); err == nil {
+		t.Error("nil provider should not validate")
+	}
+	if err := f.Validate(&ai.Provider{UUID: "u", Name: "OpenCode"}); err == nil {
+		t.Error("a provider with no API key should not validate")
+	}
+	if err := f.Validate(opencodeProvider("")); err != nil {
+		t.Errorf("a key-bearing provider should validate: %v", err)
+	}
+}

--- a/ai/quota/fetcher/register.go
+++ b/ai/quota/fetcher/register.go
@@ -22,6 +22,7 @@ func RegisterAll(r quota.FetcherRegistrar, logger *logrus.Logger) {
 		NewMiniMaxFetcher(),
 		NewMiniMaxCNFetcher(),
 		NewCodexFetcher(),
+		NewOpenCodeFetcher(),
 	}
 	for _, f := range fetchers {
 		if err := r.RegisterFetcher(f); err != nil {

--- a/ai/quota/fetcher/taskfile_samples_test.go
+++ b/ai/quota/fetcher/taskfile_samples_test.go
@@ -218,6 +218,20 @@ func TestTaskfileSamples(t *testing.T) {
 	findBreakdown(t, glmU, "mcp")
 	findBreakdown(t, glmU, "search-prime")
 
+	// ── opencode go (build/Taskfile.quota.yml) ──
+	// Percentages are all upstream gives; the plan's dollar limits never
+	// appear, so the windows live on the 0-100 scale.
+	s = serve(t, `{"usage":{
+	 "rolling":{"status":"ok","percent":12,"resetsAt":"2026-08-19T13:00:00.000Z"},
+	 "weekly":{"status":"ok","percent":40,"resetsAt":"2026-08-24T00:00:00.000Z"},
+	 "monthly":{"status":"ok","percent":31,"resetsAt":"2026-09-03T00:00:00.000Z"}}}`)
+	u, err = (&OpenCodeFetcher{}).Fetch(context.Background(),
+		&ai.Provider{UUID: "u", Name: "OpenCode", Token: "k", APIBase: s.URL + "/zen/v1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	check(t, "opencode", u, want{pct: 40, ok: true, tightest: "weekly", windows: 3})
+
 	// ── openai 404 / copilot ──
 	s = serve(t, "")
 	srv404 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/ai/quota/manager.go
+++ b/ai/quota/manager.go
@@ -391,6 +391,12 @@ func inferProviderType(provider *typ.Provider) ProviderType {
 		return ProviderTypeMiniMax
 	case hostIs(host, "chatgpt.com"), strings.Contains(host, "codex"):
 		return ProviderTypeCodex
+	// One host serves both OpenCode products: /zen/v1 bills the prepaid
+	// balance, /zen/go/v1 the Go subscription. The fetcher reads the
+	// subscription either way and says so when the key has no plan, so the
+	// path does not need to split them here.
+	case hostIs(host, "opencode.ai"):
+		return ProviderTypeOpenCode
 	}
 	return ""
 }

--- a/ai/quota/types.go
+++ b/ai/quota/types.go
@@ -26,6 +26,7 @@ const (
 	ProviderTypeMiniMaxCN  ProviderType = "minimaxi"
 	ProviderTypeCursor     ProviderType = "cursor"
 	ProviderTypeCodex      ProviderType = "codex"
+	ProviderTypeOpenCode   ProviderType = "opencode"
 )
 
 // WindowType window type enumeration

--- a/build/Taskfile.quota.yml
+++ b/build/Taskfile.quota.yml
@@ -617,6 +617,55 @@ tasks:
         {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }} | jq
 
 
+  # opencode (zen / go)
+  #
+  # One host, two products, one key: /zen/v1 bills the prepaid Zen balance,
+  # /zen/go/v1 the Go subscription. Only the subscription publishes usage, and
+  # only as percentages — the dollar limits behind them are never returned.
+  # A key with no Go plan gets 403 EntitlementError; the Zen balance itself has
+  # no public endpoint (opencode issue #10448).
+  opencode:
+    cmds:
+      - |
+        echo "example"
+        cat << EOF
+        {
+          "usage": {
+            "rolling": {
+              "status": "ok",
+              "percent": 12,
+              "resetsAt": "2026-08-19T13:00:00.000Z"
+            },
+            "weekly": {
+              "status": "ok",
+              "percent": 40,
+              "resetsAt": "2026-08-24T00:00:00.000Z"
+            },
+            "monthly": {
+              "status": "ok",
+              "percent": 31,
+              "resetsAt": "2026-09-03T00:00:00.000Z"
+            }
+          }
+        }
+        EOF
+      - |
+        echo "no subscription"
+        cat << EOF
+        {
+          "type": "error",
+          "error": {
+            "type": "EntitlementError",
+            "message": "OpenCode Go subscription required."
+          }
+        }
+        EOF
+      - |
+        curl https://opencode.ai/zen/go/v1/usage \
+        -H "Authorization: Bearer {{.OPENCODE_KEY}}" \
+        -H "Accept: application/json" \
+        {{ if .PROXY }}--proxy "{{.PROXY}}"{{ end }} | jq
+
   # copilot, cursor, vertex_ai: no public quota API
   copilot:
     cmds:


### PR DESCRIPTION
## Summary

OpenCode quota was unreadable: it serves pay-as-you-go Zen (`/zen/v1`, prepaid balance) and the Go subscription (`/zen/go/v1`) off one host and one API key, and only the subscription publishes usage at `GET /zen/go/v1/usage`.

## Key Changes

- **Account quota becomes readable**: new `opencode` fetcher normalizes the 5h rolling / weekly / monthly windows onto the 0-100 scale, since upstream reports percentages only.
- **Tightest window binds**: all three windows are gateway refusal gates (whichever is spent returns 429), so all three go into `Windows` for `Tightest()` instead of fixing on the weekly one.
- **No subscription is not an error**: 403 `EntitlementError` is a working balance-billed key whose balance has no public endpoint (upstream issue #10448), so it reads as unreadable — neither an error nor 0% used.
- **Window lengths filled in**: upstream gives `resetsAt` but no period, so the rolling window takes the 5 hours the gateway itself names when rejecting, satisfying the cross-provider ordering invariant.
- **Research recorded**: `.design/opencode-quota.md` captures the gateway's billing precedence (free per-IP daily limits / Black / Go / balance) and its error taxonomy.

## Notes

- Black tiers ($20/$100/$200) and the Zen balance have no query endpoint; they surface only as 429/401 on the inference path, and can be wired the same way once upstream adds one.
- With `useBalance` enabled, a spent window still serves requests — `usage` does not return that flag, so the two are indistinguishable for now.