### PR TITLE
feat(provider-import): show result after import instead of a dead-end toast

### DIFF
--- a/.design/connect-ai-flow.md
+++ b/.design/connect-ai-flow.md
@@ -36,7 +36,8 @@ configuration is no longer a separate picker card or mode. See [dual-provider.md
 
 **Routing on card click:**
 - **Custom / Key provider / Self-hosted** → opens the form dialog (pre-filled when a template was chosen)
-- **Import** → opens the import modal
+- **Import** → opens the import modal; on success, stays open showing a
+  result list (see "Import" below) instead of closing
 - **OAuth** → opens OAuthDialog in direct mode (skips the provider grid, shows provider + proxy config, then starts auth)
 
 ### Flow at a glance
@@ -56,21 +57,31 @@ configuration is no longer a separate picker card or mode. See [dual-provider.md
   │ slots     │  │ file import │ │ from     │ │ localhost  │ │ provider +   │
   │           │  │             │ │ template │ │ :port +    │ │ proxy config │
   │           │  │             │ │          │ │ key conv.  │ │ ▸ sign in    │
-  └─────┬─────┘  └─────────────┘ └────┬─────┘ └─────┬──────┘ └──────┬───────┘
-        │                              │             │               │
-        └──────────────────────────────┴─────────────┘               │
-                               ▼                                     ▼
-                    ┌─────────────────────┐                ┌──────────────────┐
-                    │  ProviderFormDialog  │                │  token stored on │
-                    │  (← Back re-opens    │                │  callback; new   │
-                    │   the picker)        │                │  provider record │
-                    └──────────┬───────────┘                └──────────────────┘
-                               │ submit
-                               ▼
-                    ┌─────────────────────┐
-                    │  api.addProvider     │  one record; optional
-                    │                     │  api_base_openai + api_base_anthropic
-                    └─────────────────────┘
+  └─────┬─────┘  └──────┬──────┘ └────┬─────┘ └─────┬──────┘ └──────┬───────┘
+        │                │             │             │               │
+        └────────────────┘             └─────────────┘               │
+                 │                            ▼                      ▼
+                 │              ┌─────────────────────┐    ┌──────────────────┐
+                 │              │  ProviderFormDialog  │    │  token stored on │
+                 │              │  (← Back re-opens    │    │  callback; new   │
+                 │              │   the picker)        │    │  provider record │
+                 │              └──────────┬───────────┘    └──────────────────┘
+                 │                         │ submit
+                 │                         ▼
+                 │              ┌─────────────────────┐
+                 │              │  api.addProvider     │  one record; optional
+                 │              │                     │  api_base_openai + api_base_anthropic
+                 │              └─────────────────────┘
+                 ▼
+      ┌────────────────────────┐
+      │  api.importProvider     │  persists immediately — always mints a
+      │  (POST /provider-import)│  fresh UUID per provider, no confirm step
+      └──────────┬──────────────┘
+                 ▼
+      ┌────────────────────────┐
+      │  ImportModal result list │  every created provider, each with an
+      │  (replaces close+toast) │  inline Edit → useProviderEditDialog
+      └────────────────────────┘
 ```
 
 Every surface renders this picker → route sequence through the same pair:
@@ -88,6 +99,18 @@ individual kinds themselves, so no entry point can drift to a subset:
   passes `inline` to `ConnectAIDialogs` (no picker dialog, no "← Back to
   picker" in the form). The old separate "Paste & detect" tab is gone; paste
   is a picker card here like everywhere else.
+
+### Import — no confirm step, edit-after instead
+
+Import intentionally does **not** route through `ProviderFormDialog` before
+persisting — see `.sdlc/docs/provider-import-confirm-flow-20260819.spec.md`
+for why a parse-then-confirm step was considered and dropped: every imported
+provider always gets a freshly minted UUID (no reuse-on-conflict branch), so
+there's no ambiguous default left to gate behind a preview. Instead,
+`ImportModal` stays open after a successful import and shows the created
+providers as a list; each row's Edit button opens the same
+`useProviderEditDialog` flow `CredentialPage` uses for any other provider —
+reusing the existing edit path instead of inventing a pre-create draft state.
 
 ---
 
@@ -164,6 +187,8 @@ enter their key without unchecking a separate toggle.
 | `frontend/src/pages/CredentialPage.tsx` | Credential-management surface; standard add flow uses `useProviderDialog`, edit flow uses `useProviderEditDialog` |
 | `frontend/src/hooks/useProviderDialog.tsx` | Single source of truth for the add flow: picker state + routing for every `ConnectSelection` kind, form submit, OAuth / paste / import dialog state |
 | `frontend/src/components/ConnectAIDialogs.tsx` | Renders the full downstream dialog stack (picker, form, OAuth, paste & detect, import) from the hook's return; `inline` variant for onboarding |
+| `frontend/src/components/ImportModal.tsx` | Paste/upload import UI; after a successful import, switches into a result-list view (no separate confirm dialog) |
+| `frontend/src/hooks/useProviderEditDialog.tsx` | Provider-edit dialog + submit logic; reused both by `CredentialPage` row-edit and `ImportModal`'s per-row Edit |
 | `frontend/src/components/provider-form-dialog/ApiKeyField.tsx` | Key field; optional editable token state for self-hosted providers |
 | `frontend/src/components/provider-form-dialog/ProtocolSlot.tsx` | OpenAI / Anthropic URL slot UI |
 | `frontend/src/components/provider-form-dialog/ProxyUrlField.tsx` | Proxy URL and global quick-proxy selector |

--- a/frontend/src/components/ConnectAIDialogs.tsx
+++ b/frontend/src/components/ConnectAIDialogs.tsx
@@ -62,7 +62,11 @@ const ConnectAIDialogs: React.FC<ConnectAIDialogsProps> = ({ flow, inline = fals
                 onClose={flow.handleCloseImport}
                 onImport={flow.handleImportData}
                 loading={flow.importing}
+                result={flow.importResult}
+                onEditProvider={flow.handleEditImportedProvider}
+                onDone={flow.handleImportDone}
             />
+            {flow.importEditDialogs}
             <CloudProviderDialog
                 open={flow.cloudPresetId !== null}
                 presetId={flow.cloudPresetId}

--- a/frontend/src/components/ImportModal.tsx
+++ b/frontend/src/components/ImportModal.tsx
@@ -1,4 +1,4 @@
-import { ContentPaste as PasteIcon, Upload as UploadIcon, Code as CodeIcon } from '@/components/icons';
+import { ContentPaste as PasteIcon, Upload as UploadIcon, Code as CodeIcon, CheckCircle as CheckIcon, Edit as EditIcon } from '@/components/icons';
 import {
     Box,
     Button,
@@ -11,14 +11,33 @@ import {
     Tabs,
     Tab,
     styled,
+    List,
+    ListItem,
+    ListItemIcon,
+    ListItemText,
+    IconButton,
 } from '@mui/material';
 import { useState } from 'react';
+
+export interface ImportResultItem {
+    uuid: string;
+    name: string;
+    action: string;
+    /** True when the imported name collided with an existing one and was auto-suffixed. */
+    renamed?: boolean;
+}
 
 interface ImportModalProps {
     open: boolean;
     onClose: () => void;
     onImport: (data: string) => void;
     loading?: boolean;
+    /** Set once import succeeds; switches the dialog into the result-list view. */
+    result?: ImportResultItem[] | null;
+    /** Opens the provider-edit dialog for one imported row. */
+    onEditProvider?: (uuid: string) => void;
+    /** Dismisses the result view and closes the dialog. */
+    onDone?: () => void;
 }
 
 const TabPanel = styled(Box)<{ value: number; index: number }>(
@@ -28,7 +47,15 @@ const TabPanel = styled(Box)<{ value: number; index: number }>(
     })
 );
 
-export const ImportModal = ({ open, onClose, onImport, loading = false }: ImportModalProps) => {
+export const ImportModal = ({
+    open,
+    onClose,
+    onImport,
+    loading = false,
+    result = null,
+    onEditProvider,
+    onDone,
+}: ImportModalProps) => {
     const [tabValue, setTabValue] = useState(0);
     const [base64Data, setBase64Data] = useState('');
     const [jsonlData, setJsonlData] = useState('');
@@ -65,122 +92,172 @@ export const ImportModal = ({ open, onClose, onImport, loading = false }: Import
         reader.readAsText(file);
     };
 
+    const handleDone = () => {
+        setBase64Data('');
+        setJsonlData('');
+        setFileName('');
+        setTabValue(0);
+        onDone?.();
+    };
+
     return (
         <Dialog
             open={open}
-            onClose={handleClose}
+            onClose={result ? handleDone : handleClose}
             maxWidth="sm"
             fullWidth
             slotProps={{
                 paper: {sx: {maxHeight: '82vh', display: 'flex', flexDirection: 'column'}}
             }}
         >
-            <DialogTitle>Import</DialogTitle>
-            <DialogContent>
-                <Tabs
-                    value={tabValue}
-                    onChange={(_, newValue) => setTabValue(newValue)}
-                    sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}
-                >
-                    <Tab label="Base64" icon={<PasteIcon />} disabled={loading} />
-                    <Tab label="JSONL" icon={<CodeIcon />} disabled={loading} />
-                    <Tab label="Upload File" icon={<UploadIcon />} disabled={loading} />
-                </Tabs>
-
-                <TabPanel value={tabValue} index={0}>
-                    <Typography
-                        variant="body2"
-                        sx={{
-                            color: "text.secondary",
-                            mb: 2
-                        }}>
-                        Paste exported data in Base64 format below.
+            <DialogTitle>{result ? 'Import Complete' : 'Import'}</DialogTitle>
+            {result ? (
+                <DialogContent>
+                    <Typography variant="body2" sx={{ color: 'text.secondary', mb: 1 }}>
+                        {result.length} provider{result.length === 1 ? '' : 's'} created.
+                        Edit any of them below if you'd like to adjust the name or settings.
                     </Typography>
-                    <TextField
-                        fullWidth
-                        multiline
-                        rows={8}
-                        placeholder="TGB64:1.0:..."
-                        value={base64Data}
-                        onChange={(e) => setBase64Data(e.target.value)}
-                        disabled={loading}
-                        sx={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
-                    />
-                </TabPanel>
-
-                <TabPanel value={tabValue} index={1}>
-                    <Typography
-                        variant="body2"
-                        sx={{
-                            color: "text.secondary",
-                            mb: 2
-                        }}>
-                        Paste exported data in JSONL format below.
-                    </Typography>
-                    <TextField
-                        fullWidth
-                        multiline
-                        rows={8}
-                        placeholder='{"type":"metadata","version":"1.0",...}\n{"type":"rule",...}'
-                        value={jsonlData}
-                        onChange={(e) => setJsonlData(e.target.value)}
-                        disabled={loading}
-                        sx={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
-                    />
-                </TabPanel>
-
-                <TabPanel value={tabValue} index={2}>
-                    <Typography
-                        variant="body2"
-                        sx={{
-                            color: "text.secondary",
-                            mb: 2
-                        }}>
-                        Upload a file containing exported data (JSONL or Base64 format).
-                    </Typography>
-                    <Button
-                        variant="outlined"
-                        component="label"
-                        startIcon={<UploadIcon />}
-                        disabled={loading}
-                        sx={{ mb: 2 }}
+                    <List dense>
+                        {result.map((item) => (
+                            <ListItem
+                                key={item.uuid}
+                                secondaryAction={
+                                    <IconButton
+                                        edge="end"
+                                        size="small"
+                                        aria-label={`Edit ${item.name}`}
+                                        onClick={() => onEditProvider?.(item.uuid)}
+                                    >
+                                        <EditIcon fontSize="small" />
+                                    </IconButton>
+                                }
+                            >
+                                <ListItemIcon sx={{ minWidth: 36 }}>
+                                    <CheckIcon fontSize="small" color="success" />
+                                </ListItemIcon>
+                                <ListItemText
+                                    primary={item.name}
+                                    secondary={item.renamed ? 'Renamed to avoid a duplicate name' : undefined}
+                                />
+                            </ListItem>
+                        ))}
+                    </List>
+                </DialogContent>
+            ) : (
+                <DialogContent>
+                    <Tabs
+                        value={tabValue}
+                        onChange={(_, newValue) => setTabValue(newValue)}
+                        sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}
                     >
-                        Select File
-                        <input
-                            type="file"
-                            accept=".txt,.jsonl,.json"
-                            onChange={handleFileChange}
-                            style={{ display: 'none' }}
-                        />
-                    </Button>
-                    {fileName && (
-                        <Typography variant="body2" sx={{ color: 'text.primary' }}>
-                            Selected: {fileName}
+                        <Tab label="Base64" icon={<PasteIcon />} disabled={loading} />
+                        <Tab label="JSONL" icon={<CodeIcon />} disabled={loading} />
+                        <Tab label="Upload File" icon={<UploadIcon />} disabled={loading} />
+                    </Tabs>
+
+                    <TabPanel value={tabValue} index={0}>
+                        <Typography
+                            variant="body2"
+                            sx={{
+                                color: "text.secondary",
+                                mb: 2
+                            }}>
+                            Paste exported data in Base64 format below.
                         </Typography>
-                    )}
-                </TabPanel>
-            </DialogContent>
+                        <TextField
+                            fullWidth
+                            multiline
+                            rows={8}
+                            placeholder="TGB64:1.0:..."
+                            value={base64Data}
+                            onChange={(e) => setBase64Data(e.target.value)}
+                            disabled={loading}
+                            sx={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
+                        />
+                    </TabPanel>
+
+                    <TabPanel value={tabValue} index={1}>
+                        <Typography
+                            variant="body2"
+                            sx={{
+                                color: "text.secondary",
+                                mb: 2
+                            }}>
+                            Paste exported data in JSONL format below.
+                        </Typography>
+                        <TextField
+                            fullWidth
+                            multiline
+                            rows={8}
+                            placeholder='{"type":"metadata","version":"1.0",...}\n{"type":"rule",...}'
+                            value={jsonlData}
+                            onChange={(e) => setJsonlData(e.target.value)}
+                            disabled={loading}
+                            sx={{ fontFamily: 'monospace', fontSize: '0.85rem' }}
+                        />
+                    </TabPanel>
+
+                    <TabPanel value={tabValue} index={2}>
+                        <Typography
+                            variant="body2"
+                            sx={{
+                                color: "text.secondary",
+                                mb: 2
+                            }}>
+                            Upload a file containing exported data (JSONL or Base64 format).
+                        </Typography>
+                        <Button
+                            variant="outlined"
+                            component="label"
+                            startIcon={<UploadIcon />}
+                            disabled={loading}
+                            sx={{ mb: 2 }}
+                        >
+                            Select File
+                            <input
+                                type="file"
+                                accept=".txt,.jsonl,.json"
+                                onChange={handleFileChange}
+                                style={{ display: 'none' }}
+                            />
+                        </Button>
+                        {fileName && (
+                            <Typography variant="body2" sx={{ color: 'text.primary' }}>
+                                Selected: {fileName}
+                            </Typography>
+                        )}
+                    </TabPanel>
+                </DialogContent>
+            )}
             <DialogActions>
-                <Button onClick={handleClose} disabled={loading}>
-                    Cancel
-                </Button>
-                {tabValue === 0 && (
-                    <Button
-                        onClick={handleBase64Import}
-                        variant="contained"
-                        disabled={!base64Data.trim() || loading}
-                    >
-                        {loading ? 'Importing...' : 'Import'}
+                {result ? (
+                    <Button onClick={handleDone} variant="contained">
+                        Done
                     </Button>
-                )}
-                {tabValue === 1 && (
-                    <Button
-                        onClick={handleJsonlImport}
-                        variant="contained"
-                        disabled={!jsonlData.trim() || loading}
-                    >
-                        {loading ? 'Importing...' : 'Import'}
-                    </Button>
+                ) : (
+                    <>
+                        <Button onClick={handleClose} disabled={loading}>
+                            Cancel
+                        </Button>
+                        {tabValue === 0 && (
+                            <Button
+                                onClick={handleBase64Import}
+                                variant="contained"
+                                disabled={!base64Data.trim() || loading}
+                            >
+                                {loading ? 'Importing...' : 'Import'}
+                            </Button>
+                        )}
+                        {tabValue === 1 && (
+                            <Button
+                                onClick={handleJsonlImport}
+                                variant="contained"
+                                disabled={!jsonlData.trim() || loading}
+                            >
+                                {loading ? 'Importing...' : 'Import'}
+                            </Button>
+                        )}
+                    </>
                 )}
             </DialogActions>
         </Dialog>

--- a/frontend/src/hooks/useProviderDialog.tsx
+++ b/frontend/src/hooks/useProviderDialog.tsx
@@ -2,6 +2,8 @@ import { useState, useCallback } from 'react';
 import { api } from '../services/api';
 import type { EnhancedProviderFormData } from '@/components/ProviderFormDialog';
 import type { ConnectSelection } from '@/components/ConnectProviderDialog';
+import type { ImportResultItem } from '@/components/ImportModal';
+import { useProviderEditDialog } from './useProviderEditDialog';
 
 interface UseProviderDialogOptions {
     defaultApiStyle?: 'openai' | 'anthropic' | undefined;
@@ -82,9 +84,17 @@ export interface UseProviderDialogReturn {
     /** Open state for the built-in ImportModal (owned by this hook). */
     importModalOpen: boolean;
     importing: boolean;
+    /** Populated after a successful import; switches ImportModal into the result-list view. */
+    importResult: ImportResultItem[] | null;
     handleImportClick: () => void;
     handleCloseImport: () => void;
     handleImportData: (data: string) => Promise<void>;
+    /** Opens the edit dialog for one just-imported provider. */
+    handleEditImportedProvider: (uuid: string) => void;
+    /** Dismisses the import result view and closes the modal. */
+    handleImportDone: () => void;
+    /** Renders the provider-edit dialog opened via handleEditImportedProvider. */
+    importEditDialogs: React.ReactNode;
     /** Open state for the built-in add-flow OAuthDialog (owned by this hook). */
     oauthDialogOpen: boolean;
     oauthAutoStartId: string | null;
@@ -116,6 +126,7 @@ export const useProviderDialog = (
     const [pasteDialogOpen, setPasteDialogOpen] = useState(false);
     const [importModalOpen, setImportModalOpen] = useState(false);
     const [importing, setImporting] = useState(false);
+    const [importResult, setImportResult] = useState<ImportResultItem[] | null>(null);
     const [oauthDialogOpen, setOAuthDialogOpen] = useState(false);
     const [oauthAutoStartId, setOAuthAutoStartId] = useState<string | null>(null);
     const [cloudPresetId, setCloudPresetId] = useState<string | null>(null);
@@ -173,7 +184,19 @@ export const useProviderDialog = (
 
     const handleCloseImport = useCallback(() => {
         setImportModalOpen(false);
+        setImportResult(null);
     }, []);
+
+    const handleImportDone = useCallback(() => {
+        setImportModalOpen(false);
+        setImportResult(null);
+    }, []);
+
+    // Edit dialog for a just-imported provider — a separate instance from the
+    // main add-flow ProviderFormDialog so opening it doesn't disturb import
+    // state; onUpdated just triggers the same refresh as any other edit.
+    const { editProvider: handleEditImportedProvider, providerEditDialogs: importEditDialogs } =
+        useProviderEditDialog({ onUpdated: () => onProviderAdded?.(), showNotification });
 
     const handleImportData = useCallback(async (data: string) => {
         setImporting(true);
@@ -181,13 +204,19 @@ export const useProviderDialog = (
             const result = await api.importProvider(data);
             if (result.success) {
                 const created = result.data?.providers_created || 0;
-                const used = result.data?.providers_used || 0;
-                let message = 'Provider import completed';
-                if (created > 0) message += `. ${created} new provider${created > 1 ? 's' : ''} created`;
-                if (used > 0) message += `. ${used} existing provider${used > 1 ? 's' : ''} referenced`;
-                if (created === 0 && used === 0) message = 'No providers found in import data';
-                showNotification(message, 'success');
-                setImportModalOpen(false);
+                const providers: ImportResultItem[] = (result.data?.providers || []).map((p: any) => ({
+                    uuid: p.uuid,
+                    name: p.name,
+                    action: p.action,
+                    renamed: p.renamed,
+                }));
+                showNotification(
+                    created > 0
+                        ? `${created} new provider${created > 1 ? 's' : ''} created`
+                        : 'No providers found in import data',
+                    'success'
+                );
+                setImportResult(providers);
                 onProviderAdded?.();
             } else {
                 showNotification(`Import failed: ${result.error || 'Unknown error'}`, 'error');
@@ -289,9 +318,13 @@ export const useProviderDialog = (
         handleClosePasteDialog,
         importModalOpen,
         importing,
+        importResult,
         handleImportClick,
         handleCloseImport,
         handleImportData,
+        handleEditImportedProvider,
+        handleImportDone,
+        importEditDialogs,
         oauthDialogOpen,
         oauthAutoStartId,
         handleCloseOAuth,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -416,8 +416,9 @@ export const api = {
         return controlApi((client, headers) => client.GET('/api/v1/rule/flags/registry', {headers}));
     },
 
-    // Imports providers from a base64/JSONL export bundle.
-    importProvider: async (data: string, onProviderConflict: string = 'use'): Promise<any> => {
+    // Imports providers from a base64/JSONL export bundle. Every imported
+    // provider is always created with a freshly minted UUID.
+    importProvider: async (data: string): Promise<any> => {
         try {
             const client = await getClient();
             const headers = await getAuthHeaders();
@@ -425,7 +426,6 @@ export const api = {
                 headers,
                 body: {
                     data,
-                    on_provider_conflict: onProviderConflict,
                 },
             });
             return unwrap(response);

--- a/gui/wails3/services/tingly_service.go
+++ b/gui/wails3/services/tingly_service.go
@@ -165,7 +165,6 @@ func (s *TinglyService) ListRules() []typ.Rule {
 // dataio export/import no longer carries rule data.
 func (s *TinglyService) ImportRule(data string) (*command.ImportResult, error) {
 	return command.ImportProviders(s.appManager.GetGlobalConfig(), data, exportpkg.FormatAuto, command.ImportOptions{
-		OnProviderConflict: "use",
-		Quiet:              true,
+		Quiet: true,
 	})
 }

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -48,8 +48,7 @@ func runImport(appManager *AppManager, formatStr string, args []string) error {
 	}
 
 	result, err := ImportProviders(appManager.GetGlobalConfig(), data, format, ImportOptions{
-		OnProviderConflict: "use", // Use existing provider by default
-		Quiet:              false,
+		Quiet: false,
 	})
 
 	if err != nil {
@@ -59,11 +58,7 @@ func runImport(appManager *AppManager, formatStr string, args []string) error {
 	fmt.Printf("\nImport completed!\n")
 	if result.ProvidersCreated > 0 {
 		fmt.Printf("✓ Providers created: %d\n", result.ProvidersCreated)
-	}
-	if result.ProvidersUsed > 0 {
-		fmt.Printf("ℹ Providers reused: %d\n", result.ProvidersUsed)
-	}
-	if result.ProvidersCreated == 0 && result.ProvidersUsed == 0 {
+	} else {
 		fmt.Println("ℹ No providers were imported")
 	}
 

--- a/internal/command/provider_transfer.go
+++ b/internal/command/provider_transfer.go
@@ -8,25 +8,23 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// ImportOptions controls how provider conflicts are handled during import.
+// ImportOptions controls provider import behavior.
 type ImportOptions struct {
-	// OnProviderConflict is one of "use", "skip", or "suffix".
-	OnProviderConflict string
 	// Quiet suppresses progress output.
 	Quiet bool
 }
 
-// ProviderImportInfo describes one imported, reused, or skipped provider.
+// ProviderImportInfo describes one imported provider.
 type ProviderImportInfo struct {
-	UUID   string
-	Name   string
-	Action string
+	UUID    string
+	Name    string
+	Action  string
+	Renamed bool
 }
 
 // ImportResult contains the results of a provider import.
 type ImportResult struct {
 	ProvidersCreated int
-	ProvidersUsed    int
 	Providers        []ProviderImportInfo
 	ProviderMap      map[string]string
 }
@@ -76,8 +74,7 @@ func providerUUIDsFromRule(rule *typ.Rule) []string {
 // ImportProviders imports provider data without requiring an AppManager.
 func ImportProviders(cfg *serverconfig.Config, data string, format dataio.Format, opts ImportOptions) (*ImportResult, error) {
 	result, err := dataio.Import(data, cfg, format, dataio.ImportOptions{
-		OnProviderConflict: opts.OnProviderConflict,
-		Quiet:              opts.Quiet,
+		Quiet: opts.Quiet,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to import providers: %w", err)
@@ -86,12 +83,11 @@ func ImportProviders(cfg *serverconfig.Config, data string, format dataio.Format
 	providers := make([]ProviderImportInfo, len(result.Providers))
 	for i, provider := range result.Providers {
 		providers[i] = ProviderImportInfo{
-			UUID: provider.UUID, Name: provider.Name, Action: provider.Action,
+			UUID: provider.UUID, Name: provider.Name, Action: provider.Action, Renamed: provider.Renamed,
 		}
 	}
 	return &ImportResult{
 		ProvidersCreated: result.ProvidersCreated,
-		ProvidersUsed:    result.ProvidersUsed,
 		Providers:        providers,
 		ProviderMap:      result.ProviderMap,
 	}, nil

--- a/internal/dataio/jsonl_import.go
+++ b/internal/dataio/jsonl_import.go
@@ -11,26 +11,25 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// ImportOptions controls how imports are handled when conflicts occur
+// ImportOptions controls import behavior.
 type ImportOptions struct {
-	// OnProviderConflict specifies what to do when a provider already exists.
-	// "use" - use existing provider, "skip" - skip this provider, "suffix" - create with suffixed name
-	OnProviderConflict string
 	// Quiet suppresses progress output
 	Quiet bool
 }
 
-// ProviderImportInfo contains information about an imported or used provider
+// ProviderImportInfo contains information about an imported provider
 type ProviderImportInfo struct {
 	UUID   string
 	Name   string
-	Action string // "created", "used", "skipped"
+	Action string // "created"
+	// Renamed is true when Name was auto-suffixed because it collided with
+	// an already-existing provider name.
+	Renamed bool
 }
 
 // ImportResult contains the results of an import operation
 type ImportResult struct {
 	ProvidersCreated int
-	ProvidersUsed    int
 	Providers        []ProviderImportInfo
 	ProviderMap      map[string]string // old UUID -> new UUID
 }
@@ -58,11 +57,6 @@ func (i *JSONLImporter) Format() Format {
 func (i *JSONLImporter) Import(data string, globalConfig *config.Config, opts ImportOptions) (*ImportResult, error) {
 	result := &ImportResult{
 		ProviderMap: make(map[string]string),
-	}
-
-	// Set defaults
-	if opts.OnProviderConflict == "" {
-		opts.OnProviderConflict = "use"
 	}
 
 	// Parse lines
@@ -115,71 +109,20 @@ func (i *JSONLImporter) Import(data string, globalConfig *config.Config, opts Im
 
 	// Import providers
 	for _, p := range providersData {
-		providerResult, err := i.importProvider(globalConfig, p, opts.OnProviderConflict, result.ProviderMap)
+		info, err := i.importProvider(globalConfig, p, result.ProviderMap)
 		if err != nil {
 			return nil, fmt.Errorf("failed to import provider '%s': %w", p.Name, err)
 		}
-		if providerResult.created {
-			result.ProvidersCreated++
-		}
-		if providerResult.used {
-			result.ProvidersUsed++
-		}
-		// Add provider info to result
-		if providerResult.info != nil {
-			result.Providers = append(result.Providers, *providerResult.info)
-		}
+		result.ProvidersCreated++
+		result.Providers = append(result.Providers, *info)
 	}
 
 	return result, nil
 }
 
-type providerImportResult struct {
-	created bool
-	used    bool
-	info    *ProviderImportInfo
-}
-
-func (i *JSONLImporter) importProvider(globalConfig *config.Config, p *ProviderData, onConflict string, providerMap map[string]string) (*providerImportResult, error) {
-	result := &providerImportResult{}
-
-	// Check if provider with same UUID already exists (real conflict)
-	existingProvider, err := globalConfig.GetProviderByUUID(p.UUID)
-	if err == nil && existingProvider != nil {
-		// Real UUID conflict - provider was already imported before
-		switch onConflict {
-		case "skip":
-			result.info = &ProviderImportInfo{
-				UUID:   p.UUID,
-				Name:   p.Name,
-				Action: "skipped",
-			}
-			return result, nil
-		case "use":
-			// Use the existing provider
-			providerMap[p.UUID] = existingProvider.UUID
-			result.used = true
-			result.info = &ProviderImportInfo{
-				UUID:   existingProvider.UUID,
-				Name:   existingProvider.Name,
-				Action: "used",
-			}
-			return result, nil
-		default:
-			// Default to using existing provider for UUID conflicts
-			providerMap[p.UUID] = existingProvider.UUID
-			result.used = true
-			result.info = &ProviderImportInfo{
-				UUID:   existingProvider.UUID,
-				Name:   existingProvider.Name,
-				Action: "used",
-			}
-			return result, nil
-		}
-	}
-
+func (i *JSONLImporter) importProvider(globalConfig *config.Config, p *ProviderData, providerMap map[string]string) (*ProviderImportInfo, error) {
 	// Check if provider name already exists (need to avoid duplicate names)
-	_, err = globalConfig.GetProviderByName(p.Name)
+	_, err := globalConfig.GetProviderByName(p.Name)
 	nameExists := err == nil
 
 	// Always create a new UUID for imported providers
@@ -187,6 +130,7 @@ func (i *JSONLImporter) importProvider(globalConfig *config.Config, p *ProviderD
 	providerUUID := uuid.New().String()
 
 	// If name exists, add suffix to avoid conflicts
+	renamed := nameExists
 	if nameExists {
 		suffix := 2
 		newName := fmt.Sprintf("%s-%d", p.Name, suffix)
@@ -226,11 +170,10 @@ func (i *JSONLImporter) importProvider(globalConfig *config.Config, p *ProviderD
 
 	// Map old UUID to new UUID
 	providerMap[p.UUID] = newProvider.UUID
-	result.created = true
-	result.info = &ProviderImportInfo{
-		UUID:   newProvider.UUID,
-		Name:   newProvider.Name,
-		Action: "created",
-	}
-	return result, nil
+	return &ProviderImportInfo{
+		UUID:    newProvider.UUID,
+		Name:    newProvider.Name,
+		Action:  "created",
+		Renamed: renamed,
+	}, nil
 }

--- a/internal/server/module/provider/handler.go
+++ b/internal/server/module/provider/handler.go
@@ -592,18 +592,8 @@ func (h *Handler) ImportProviders(c *gin.Context) {
 		return
 	}
 
-	// Set default conflict handling
-	// OnProviderConflict: Only matters when the same provider UUID already exists
-	//   - "use": use the existing provider with the same UUID
-	//   - "skip": skip importing this provider
-	// Note: Provider names can be duplicated; if name exists, a suffix is added automatically
-	if req.OnProviderConflict == "" {
-		req.OnProviderConflict = "use" // Use existing if same UUID found
-	}
-
 	opts := dataio.ImportOptions{
-		OnProviderConflict: req.OnProviderConflict,
-		Quiet:              true,
+		Quiet: true,
 	}
 
 	result, err := dataio.Import(req.Data, cfg, dataio.FormatAuto, opts)
@@ -620,14 +610,14 @@ func (h *Handler) ImportProviders(c *gin.Context) {
 		Message: "Providers imported successfully",
 	}
 	response.Data.ProvidersCreated = result.ProvidersCreated
-	response.Data.ProvidersUsed = result.ProvidersUsed
 
 	// Convert provider import info to response format
 	for _, providerInfo := range result.Providers {
 		response.Data.Providers = append(response.Data.Providers, ProviderImportInfo{
-			UUID:   providerInfo.UUID,
-			Name:   providerInfo.Name,
-			Action: providerInfo.Action,
+			UUID:    providerInfo.UUID,
+			Name:    providerInfo.Name,
+			Action:  providerInfo.Action,
+			Renamed: providerInfo.Renamed,
 		})
 	}
 
@@ -637,8 +627,8 @@ func (h *Handler) ImportProviders(c *gin.Context) {
 		"providers_created": result.ProvidersCreated,
 	}).Info(
 		fmt.Sprintf(
-			"Provider import completed: created=%d, used=%d",
-			result.ProvidersCreated, result.ProvidersUsed,
+			"Provider import completed: created=%d",
+			result.ProvidersCreated,
 		),
 	)
 

--- a/internal/server/module/provider/handler_test.go
+++ b/internal/server/module/provider/handler_test.go
@@ -113,8 +113,7 @@ func TestImportProviders_JSONL(t *testing.T) {
 {"type":"provider","uuid":"prov-1","name":"TestProvider","api_base":"https://api.test.com","api_style":"openai","auth_type":"api_key","token":"sk-test","enabled":true,"timeout":30}`
 
 	importReq := ImportProvidersRequest{
-		Data:               jsonlData,
-		OnProviderConflict: "use",
+		Data: jsonlData,
 	}
 	body, _ := json.Marshal(importReq)
 	req, _ := http.NewRequest("POST", "/provider-import", bytes.NewBuffer(body))
@@ -148,8 +147,7 @@ func TestImportProviders_Base64(t *testing.T) {
 	base64Data := dataio.Base64Prefix + ":1.0:" + base64Payload
 
 	importReq := ImportProvidersRequest{
-		Data:               base64Data,
-		OnProviderConflict: "use",
+		Data: base64Data,
 	}
 	body, _ := json.Marshal(importReq)
 	req, _ := http.NewRequest("POST", "/provider-import", bytes.NewBuffer(body))
@@ -165,10 +163,12 @@ func TestImportProviders_Base64(t *testing.T) {
 	assert.Contains(t, bodyResp, `"success":true`)
 }
 
-// TestImportProviders_ProviderConflictUse tests using existing provider on conflict.
-// This test verifies that when a provider with the same UUID is imported,
-// the existing provider is used instead of creating a new one.
-func TestImportProviders_ProviderConflictUse(t *testing.T) {
+// TestImportProviders_AlwaysMintsNewUUID verifies that importing a bundle
+// whose provider UUID collides with an already-existing local provider does
+// not reuse that provider — it always creates a new one with a fresh UUID
+// (identity mapping is tracked separately via ProviderMap for future
+// rule-remap consumers; see internal/dataio/jsonl_import.go).
+func TestImportProviders_AlwaysMintsNewUUID(t *testing.T) {
 	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
@@ -193,8 +193,7 @@ func TestImportProviders_ProviderConflictUse(t *testing.T) {
 {"type":"provider","uuid":"prov-1","name":"TestProvider","api_base":"https://api.test.com","api_style":"openai","auth_type":"api_key","token":"sk-test","enabled":true}`
 
 	importReq := ImportProvidersRequest{
-		Data:               jsonlData,
-		OnProviderConflict: "use", // Use existing provider
+		Data: jsonlData,
 	}
 	body, _ := json.Marshal(importReq)
 	req, _ := http.NewRequest("POST", "/provider-import", bytes.NewBuffer(body))
@@ -215,12 +214,29 @@ func TestImportProviders_ProviderConflictUse(t *testing.T) {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
 
-	// Should have 0 providers created (used existing), 1 used
-	if resp.Data.ProvidersCreated != 0 {
-		t.Errorf("Expected 0 providers created, got %d", resp.Data.ProvidersCreated)
+	// A brand new provider is always created, with a fresh UUID distinct
+	// from both the bundle's original UUID and the pre-existing provider's.
+	if resp.Data.ProvidersCreated != 1 {
+		t.Errorf("Expected 1 provider created, got %d", resp.Data.ProvidersCreated)
 	}
-	if resp.Data.ProvidersUsed != 1 {
-		t.Errorf("Expected 1 provider used, got %d", resp.Data.ProvidersUsed)
+	if len(resp.Data.Providers) != 1 {
+		t.Fatalf("Expected 1 provider in response, got %d", len(resp.Data.Providers))
+	}
+	created := resp.Data.Providers[0]
+	if created.Action != "created" {
+		t.Errorf("Expected action 'created', got %q", created.Action)
+	}
+	if created.UUID == "prov-1" {
+		t.Error("Expected a freshly minted UUID, got the colliding source UUID")
+	}
+
+	// The pre-existing provider is left untouched.
+	stillExisting, err := cfg.GetProviderByUUID("prov-1")
+	if err != nil || stillExisting == nil {
+		t.Fatal("Expected the pre-existing provider to still be present")
+	}
+	if stillExisting.Name != "ExistingProvider" {
+		t.Errorf("Expected existing provider to be unmodified, got name %q", stillExisting.Name)
 	}
 }
 
@@ -234,8 +250,7 @@ func TestImportProviders_InvalidData(t *testing.T) {
 	router.POST("/provider-import", handler.ImportProviders)
 
 	importReq := ImportProvidersRequest{
-		Data:               "invalid data",
-		OnProviderConflict: "use",
+		Data: "invalid data",
 	}
 	body, _ := json.Marshal(importReq)
 	req, _ := http.NewRequest("POST", "/provider-import", bytes.NewBuffer(body))
@@ -249,75 +264,6 @@ func TestImportProviders_InvalidData(t *testing.T) {
 
 	bodyResp := w.Body.String()
 	assert.Contains(t, bodyResp, `"success":false`)
-}
-
-// TestImportProviders_ProviderUUIDConflict tests real UUID conflict scenario
-func TestImportProviders_ProviderUUIDConflict(t *testing.T) {
-	cfg, _ := config.NewConfig(config.WithConfigDir(t.TempDir()))
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	handler := NewHandler(cfg, nil)
-
-	router.POST("/provider-import", handler.ImportProviders)
-
-	// First create an existing provider with the same UUID (simulating re-import)
-	existingProvider := &typ.Provider{
-		UUID:     "prov-1", // Same UUID as in the export
-		Name:     "ExistingProvider",
-		APIBase:  "https://api.existing.com",
-		APIStyle: protocol.APIStyleOpenAI,
-		AuthType: typ.AuthTypeAPIKey,
-		Token:    "sk-existing",
-		Enabled:  true,
-	}
-	cfg.AddProvider(existingProvider)
-
-	// Import a provider with the same UUID
-	jsonlData := `{"type":"metadata","version":"1.0","exported_at":"2024-01-01T00:00:00Z"}
-{"type":"provider","uuid":"prov-1","name":"TestProvider","api_base":"https://api.test.com","api_style":"openai","auth_type":"api_key","token":"sk-test","enabled":true}`
-
-	importReq := ImportProvidersRequest{
-		Data:               jsonlData,
-		OnProviderConflict: "use", // Use existing provider with same UUID
-	}
-	body, _ := json.Marshal(importReq)
-	req, _ := http.NewRequest("POST", "/provider-import", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
-	}
-
-	bodyResp := w.Body.String()
-	assert.Contains(t, bodyResp, `"success":true`)
-
-	// Parse response to check provider info
-	var resp ImportProvidersResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("Failed to parse response: %v", err)
-	}
-
-	// Should have 0 providers created (used existing), 1 used
-	if resp.Data.ProvidersCreated != 0 {
-		t.Errorf("Expected 0 providers created, got %d", resp.Data.ProvidersCreated)
-	}
-	if resp.Data.ProvidersUsed != 1 {
-		t.Errorf("Expected 1 provider used, got %d", resp.Data.ProvidersUsed)
-	}
-
-	// Verify the used provider is the existing one
-	found := false
-	for _, p := range resp.Data.Providers {
-		if p.UUID == "prov-1" && p.Name == "ExistingProvider" && p.Action == "used" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("Expected to find existing provider being used")
-	}
 }
 
 // TestImportProviders_MissingData tests importing with missing data field

--- a/internal/server/module/provider/types.go
+++ b/internal/server/module/provider/types.go
@@ -133,12 +133,10 @@ type FetchProviderModelsResponse struct {
 }
 
 // ImportProvidersRequest represents a request to import providers from a
-// base64/JSONL encoded export bundle (see internal/dataio).
+// base64/JSONL encoded export bundle (see internal/dataio). Every imported
+// provider is always created with a freshly minted UUID.
 type ImportProvidersRequest struct {
 	Data string `json:"data" binding:"required" description:"Base64 encoded provider export data" example:"TGB64:1.0:..."`
-	// OnProviderConflict specifies what to do when a provider already exists.
-	// "use" - use existing provider, "skip" - skip this provider, "suffix" - create with suffixed name
-	OnProviderConflict string `json:"on_provider_conflict" description:"How to handle provider conflicts" example:"use"`
 }
 
 // ImportProvidersResponse represents the response for importing providers.
@@ -147,16 +145,18 @@ type ImportProvidersResponse struct {
 	Message string `json:"message" example:"Providers imported successfully"`
 	Data    struct {
 		ProvidersCreated int                  `json:"providers_created" example:"1"`
-		ProvidersUsed    int                  `json:"providers_used" example:"0"`
 		Providers        []ProviderImportInfo `json:"providers,omitempty"`
 	} `json:"data"`
 }
 
-// ProviderImportInfo contains basic information about an imported or used provider.
+// ProviderImportInfo contains basic information about an imported provider.
 type ProviderImportInfo struct {
 	UUID   string `json:"uuid" example:"123e4567-e89b-12d3-a456-426614174000"`
 	Name   string `json:"name" example:"openai"`
-	Action string `json:"action" example:"created"` // "created", "used", "skipped"
+	Action string `json:"action" example:"created"`
+	// Renamed is true when Name was auto-suffixed because it collided with
+	// an already-existing provider name.
+	Renamed bool `json:"renamed" example:"false"`
 }
 
 // ExportProviderResponse represents the response for exporting a single provider.

--- a/openapi.json
+++ b/openapi.json
@@ -10174,16 +10174,10 @@
             "type": "string",
             "description": "Base64 encoded provider export data",
             "example": "TGB64:1.0:..."
-          },
-          "on_provider_conflict": {
-            "type": "string",
-            "description": "How to handle provider conflicts",
-            "example": "use"
           }
         },
         "required": [
-          "data",
-          "on_provider_conflict"
+          "data"
         ]
       },
       "ImportProvidersResponse": {
@@ -10205,17 +10199,10 @@
                 "format": "int64",
                 "description": "Field providers_created",
                 "example": 1
-              },
-              "providers_used": {
-                "type": "integer",
-                "format": "int64",
-                "description": "Field providers_used",
-                "example": 0
               }
             },
             "required": [
-              "providers_created",
-              "providers_used"
+              "providers_created"
             ]
           },
           "message": {
@@ -12297,6 +12284,11 @@
             "description": "Field name",
             "example": "openai"
           },
+          "renamed": {
+            "type": "boolean",
+            "description": "Field renamed",
+            "example": false
+          },
           "uuid": {
             "type": "string",
             "description": "Field uuid",
@@ -12306,7 +12298,8 @@
         "required": [
           "uuid",
           "name",
-          "action"
+          "action",
+          "renamed"
         ]
       },
       "ProviderModelInfo": {


### PR DESCRIPTION
## Summary
Provider import used to persist silently and close with a toast, with a hidden "reuse existing provider on UUID match" default the user never saw or chose. Import now always creates fresh providers and shows what it created, so the next action is one click away instead of a dead end.

## Key Changes

- **No more silent UUID reuse**: every imported provider always gets a freshly minted UUID (matching normal provider creation); the opaque conflict/reuse branch and its `on_provider_conflict` option are removed.
- **Result list instead of toast**: `ImportModal` switches into a list of created providers after a successful import, flagging any auto-suffixed (renamed) names.
- **Edit right after import**: each result row's Edit button opens the same provider-edit dialog used everywhere else (`useProviderEditDialog`), so a rename or tweak doesn't require leaving the flow.

## Minor

- Synced `.design/connect-ai-flow.md`'s flow diagram, which had drifted from actual import behavior.
