### PR TITLE
refactor(lint): replace hand-rolled loop patterns with stdlib helpers

### DIFF
--- a/afk/truncate_test.go
+++ b/afk/truncate_test.go
@@ -75,7 +75,7 @@ func TestTruncate_CutsOnLineBoundaries(t *testing.T) {
 	got := Truncate(in, TruncateOptions{MaxBytes: 55})
 
 	require.True(t, got.Truncated)
-	for _, line := range strings.Split(got.Text, "\n") {
+	for line := range strings.SplitSeq(got.Text, "\n") {
 		assert.Equal(t, "abcdefghij", line, "every retained line should be whole")
 	}
 }

--- a/agentboot/claude/accumulator.go
+++ b/agentboot/claude/accumulator.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"encoding/json"
+	"maps"
 	"sync"
 
 	"github.com/tingly-dev/tingly-box/agentboot/protocol"
@@ -170,9 +171,7 @@ func (a *MessageAccumulator) GetToolUses() map[string]*PendingToolUse {
 
 	// Return a copy
 	result := make(map[string]*PendingToolUse)
-	for k, v := range a.pendingToolUses {
-		result[k] = v
-	}
+	maps.Copy(result, a.pendingToolUses)
 	return result
 }
 

--- a/agentboot/claude/cli_builder.go
+++ b/agentboot/claude/cli_builder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"maps"
 	"strings"
 )
 
@@ -134,14 +135,10 @@ func buildMCPArgs(config Config, opts CommonOptions) []string {
 	// Merge MCP servers from config and opts
 	mcpServers := make(map[string]interface{})
 	if config.MCPServers != nil {
-		for k, v := range config.MCPServers {
-			mcpServers[k] = v
-		}
+		maps.Copy(mcpServers, config.MCPServers)
 	}
 	if opts.MCPServers != nil {
-		for k, v := range opts.MCPServers {
-			mcpServers[k] = v
-		}
+		maps.Copy(mcpServers, opts.MCPServers)
 	}
 
 	if len(mcpServers) > 0 {

--- a/agentboot/claude/discovery.go
+++ b/agentboot/claude/discovery.go
@@ -366,8 +366,8 @@ func parseVersion(output string) string {
 	firstLine := strings.TrimSpace(lines[0])
 
 	// Try to extract version number (e.g., "1.0.0" from "Claude CLI v1.0.0")
-	parts := strings.Fields(firstLine)
-	for _, part := range parts {
+	parts := strings.FieldsSeq(firstLine)
+	for part := range parts {
 		if strings.HasPrefix(part, "v") && len(part) > 1 && part[1] >= '0' && part[1] <= '9' {
 			return strings.TrimPrefix(part, "v")
 		}

--- a/agentboot/claude/session/store.go
+++ b/agentboot/claude/session/store.go
@@ -307,8 +307,8 @@ func (s *Store) getCwdFromSessionFile(sessionPath string) string {
 		return ""
 	}
 
-	lines := strings.Split(string(content), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(string(content), "\n")
+	for line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue

--- a/agentboot/claude/tool_renderer.go
+++ b/agentboot/claude/tool_renderer.go
@@ -586,8 +586,8 @@ func truncate(s string, n int) string {
 }
 
 func firstLine(s string) string {
-	if i := strings.IndexByte(s, '\n'); i >= 0 {
-		return s[:i]
+	if before, _, ok := strings.Cut(s, "\n"); ok {
+		return before
 	}
 	return s
 }

--- a/agentboot/claude/transport.go
+++ b/agentboot/claude/transport.go
@@ -1,6 +1,7 @@
 package claude
 
 import (
+	"maps"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -139,9 +140,7 @@ func (t *Transport) parseControlRequest(ev protocol.Event) (agentboot.StreamEven
 			stamped = make(map[string]any)
 		} else {
 			cp := make(map[string]any, len(stamped)+2)
-			for k, v := range stamped {
-				cp[k] = v
-			}
+			maps.Copy(cp, stamped)
 			stamped = cp
 		}
 		if t.execCtx.chatID != "" {

--- a/ai/agent/apply_support.go
+++ b/ai/agent/apply_support.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -314,9 +315,7 @@ func buildClaudeSettings(base []byte, env map[string]string, applyOpts *applyOpt
 	if applyOpts.defaultMode != "" {
 		existingConfig["defaultMode"] = applyOpts.defaultMode
 	}
-	for k, v := range applyOpts.extras {
-		existingConfig[k] = v
-	}
+	maps.Copy(existingConfig, applyOpts.extras)
 
 	output, err := json.MarshalIndent(existingConfig, "", "  ")
 	if err != nil {
@@ -537,9 +536,7 @@ func ApplyClaudeOnboarding(payload map[string]interface{}) (*ApplyResult, error)
 	}
 
 	// Merge top-level keys from payload
-	for k, v := range payload {
-		existingConfig[k] = v
-	}
+	maps.Copy(existingConfig, payload)
 
 	// Write the merged config
 	output, err := json.MarshalIndent(existingConfig, "", "  ")
@@ -631,9 +628,7 @@ func ApplyOpenCodeConfig(payload map[string]interface{}) (*ApplyResult, error) {
 
 	// Merge new providers from payload
 	if newProviders, ok := payload["provider"].(map[string]interface{}); ok {
-		for k, v := range newProviders {
-			existingProviders[k] = v
-		}
+		maps.Copy(existingProviders, newProviders)
 	}
 
 	existingConfig["provider"] = existingProviders
@@ -979,9 +974,7 @@ func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []strin
 	// default) and stamped into each generated profile so profiles are
 	// self-contained. Converted first so it can never carry a managed key.
 	coerced := prefs.toConfig()
-	for k, v := range coerced {
-		cfg[k] = v
-	}
+	maps.Copy(cfg, coerced)
 
 	// Managed fields — written after prefs so they always win, guaranteeing
 	// prefs cannot clobber them (defense in depth on top of the whitelist).
@@ -1027,9 +1020,7 @@ func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []strin
 			"model":          model,
 			"model_provider": codexGatewayProviderName,
 		}
-		for k, v := range coerced {
-			profile[k] = v
-		}
+		maps.Copy(profile, coerced)
 		profiles[sanitizeCodexProfileKey(model)] = profile
 	}
 	if len(profiles) > 0 {
@@ -1536,9 +1527,7 @@ func mergeDshSettings(cfg map[string]interface{}, baseURL string, models []strin
 	}
 	// prefs.toConfig() always emits "api" (defaulting when unset/invalid), so
 	// the stanza literal above no longer needs a hardcoded default.
-	for k, v := range prefs.toConfig() {
-		stanza[k] = v
-	}
+	maps.Copy(stanza, prefs.toConfig())
 
 	providers[dshGatewayProviderName] = stanza
 	root["providers"] = providers

--- a/ai/agent/apply_support.go
+++ b/ai/agent/apply_support.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -733,10 +734,8 @@ func codexEnumValue(key, val string) (string, bool) {
 	if val == "" {
 		return "", false
 	}
-	for _, allowed := range codexEnumValues[key] {
-		if val == allowed {
-			return val, true
-		}
+	if slices.Contains(codexEnumValues[key], val) {
+		return val, true
 	}
 	return "", false
 }
@@ -1311,10 +1310,8 @@ var dshProtocolValues = []string{"openai-completions", "openai-responses", "anth
 // (read) so the two stay in lockstep.
 func dshProtocolValue(val string) (string, bool) {
 	val = strings.TrimSpace(val)
-	for _, allowed := range dshProtocolValues {
-		if val == allowed {
-			return val, true
-		}
+	if slices.Contains(dshProtocolValues, val) {
+		return val, true
 	}
 	return "", false
 }

--- a/ai/agent/claude_code.go
+++ b/ai/agent/claude_code.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"cmp"
 	"fmt"
+	"maps"
 	"strings"
 )
 
@@ -78,9 +79,7 @@ func (p *ClaudeCodeParams) BuildEnv() map[string]string {
 	env["CLAUDE_CODE_SUBAGENT_MODEL"] = cmp.Or(p.ModelConfig.SubAgent, defaultModel)
 
 	// Add extra env vars
-	for k, v := range p.ExtraEnv {
-		env[k] = v
-	}
+	maps.Copy(env, p.ExtraEnv)
 
 	return env
 }

--- a/ai/credential.go
+++ b/ai/credential.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 )
 
@@ -173,10 +174,8 @@ func ValidateCredentialAPIStyle(a AuthType, apiStyle string) error {
 	if allowed == nil {
 		return nil
 	}
-	for _, s := range allowed {
-		if apiStyle == s {
-			return nil
-		}
+	if slices.Contains(allowed, apiStyle) {
+		return nil
 	}
 	return fmt.Errorf("%s providers require api_style %s, got %q", a, strings.Join(allowed, " or "), apiStyle)
 }

--- a/ai/oauth/manager.go
+++ b/ai/oauth/manager.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -276,13 +277,7 @@ func (m *Manager) buildAuthURL(config *ProviderConfig, state string, codeVerifie
 					return "", "", fmt.Errorf("invalid port in BaseURL: %w", err)
 				}
 			}
-			allowed := false
-			for _, allowedPort := range config.CallbackPorts {
-				if portInt == allowedPort {
-					allowed = true
-					break
-				}
-			}
+			allowed := slices.Contains(config.CallbackPorts, portInt)
 			if !allowed {
 				return "", "", fmt.Errorf("port %d is not allowed for provider %s (allowed ports: %v)", portInt, config.Type, config.CallbackPorts)
 			}

--- a/ai/oauth/sessionstore.go
+++ b/ai/oauth/sessionstore.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"maps"
 	"sync"
 	"time"
 )
@@ -125,8 +126,6 @@ func (s *MemorySessionStorage) GetSessions() map[string]*SessionState {
 	defer s.mu.RUnlock()
 
 	result := make(map[string]*SessionState, len(s.sessions))
-	for k, v := range s.sessions {
-		result[k] = v
-	}
+	maps.Copy(result, s.sessions)
 	return result
 }

--- a/ai/oauth/statestore.go
+++ b/ai/oauth/statestore.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"maps"
 	"sync"
 	"time"
 )
@@ -104,8 +105,6 @@ func (s *MemoryStateStorage) GetStates() map[string]*StateData {
 	defer s.mu.RUnlock()
 
 	result := make(map[string]*StateData, len(s.states))
-	for k, v := range s.states {
-		result[k] = v
-	}
+	maps.Copy(result, s.states)
 	return result
 }

--- a/ai/oauth/token.go
+++ b/ai/oauth/token.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"maps"
 	"time"
 
 	"github.com/tingly-dev/tingly-box/ai"
@@ -102,7 +103,5 @@ func (t *Token) mergeMetadata(src map[string]any) {
 	if t.Metadata == nil {
 		t.Metadata = make(map[string]any)
 	}
-	for k, v := range src {
-		t.Metadata[k] = v
-	}
+	maps.Copy(t.Metadata, src)
 }

--- a/ai/quota/fetcher.go
+++ b/ai/quota/fetcher.go
@@ -2,6 +2,7 @@ package quota
 
 import (
 	"context"
+	"maps"
 	"net/http"
 	"net/url"
 	"sync"
@@ -82,9 +83,7 @@ func (r *Registry) List() map[ProviderType]Fetcher {
 	defer r.mu.RUnlock()
 	// Return a copy so callers cannot mutate the registry.
 	result := make(map[ProviderType]Fetcher, len(r.fetchers))
-	for k, v := range r.fetchers {
-		result[k] = v
-	}
+	maps.Copy(result, r.fetchers)
 	return result
 }
 

--- a/ai/quota/fetcher/kimi_code_test.go
+++ b/ai/quota/fetcher/kimi_code_test.go
@@ -264,7 +264,6 @@ func TestKimiCodeFetcherValidate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			err := fetcher.Validate(test.provider)

--- a/ai/quota/manager_test.go
+++ b/ai/quota/manager_test.go
@@ -127,7 +127,6 @@ func TestInferProviderTypeAPIBaseCaseInsensitive(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.apiBase, func(t *testing.T) {
 			t.Parallel()
 			got := inferProviderType(&typ.Provider{APIBase: tt.apiBase})
@@ -266,7 +265,6 @@ func TestInferProviderTypeIgnoresPathAndLocalHosts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := inferProviderType(&typ.Provider{APIBase: tt.apiBase}); got != tt.want {

--- a/ai/quota/semantic.go
+++ b/ai/quota/semantic.go
@@ -3,6 +3,7 @@ package quota
 import (
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"time"
 )
@@ -89,12 +90,7 @@ func matchesKind(w *UsageWindow, kinds []WindowKind) bool {
 	if len(kinds) == 0 {
 		return true
 	}
-	for _, k := range kinds {
-		if w.Kind == k {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(kinds, w.Kind)
 }
 
 // RecoversAt returns when the binding window refills. It is nil when usage is

--- a/cli/harness/duo.go
+++ b/cli/harness/duo.go
@@ -46,7 +46,7 @@ func resolveRoutes(spec string) ([]protocoltest.DuoRoute, error) {
 		return protocoltest.AllDuoRoutes(), nil
 	}
 	var routes []protocoltest.DuoRoute
-	for _, name := range strings.Split(spec, ",") {
+	for name := range strings.SplitSeq(spec, ",") {
 		name = strings.TrimSpace(name)
 		if name == "" {
 			continue

--- a/cli/harness/lb.go
+++ b/cli/harness/lb.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"embed"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -362,11 +362,8 @@ func (c *LbCmd) checkExpect(scn *lbScenario, steps []lbStepOutput, finalBreakers
 	for _, wantID := range e.AttemptsContain {
 		found := false
 		if lastTrace != nil {
-			for _, gotID := range lastTrace.Attempts {
-				if gotID == wantID {
-					found = true
-					break
-				}
+			if slices.Contains(lastTrace.Attempts, wantID) {
+				found = true
 			}
 		}
 		if !found {
@@ -377,10 +374,8 @@ func (c *LbCmd) checkExpect(scn *lbScenario, steps []lbStepOutput, finalBreakers
 	// AttemptsExclude: last request must NOT include any serviceID.
 	for _, banID := range e.AttemptsExclude {
 		if lastTrace != nil {
-			for _, gotID := range lastTrace.Attempts {
-				if gotID == banID {
-					return fmt.Errorf("expect: attempts_exclude: service %q should not appear in attempts (got %v)", banID, lastTrace.Attempts)
-				}
+			if slices.Contains(lastTrace.Attempts, banID) {
+				return fmt.Errorf("expect: attempts_exclude: service %q should not appear in attempts (got %v)", banID, lastTrace.Attempts)
 			}
 		}
 	}

--- a/cli/harness/routing.go
+++ b/cli/harness/routing.go
@@ -50,7 +50,7 @@ func (cmd *RoutingCmd) Run() error {
 		scenarios, err = protocoltest.LoadRoutingScenarios(cmd.File)
 	} else {
 		var names []string
-		for _, n := range strings.Split(cmd.Scenarios, ",") {
+		for n := range strings.SplitSeq(cmd.Scenarios, ",") {
 			if n = strings.TrimSpace(n); n != "" {
 				names = append(names, n)
 			}

--- a/imbot/core/config.go
+++ b/imbot/core/config.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 )
@@ -179,9 +180,7 @@ func (c *Config) Clone() *Config {
 	// Clone options map
 	if c.Options != nil {
 		clone.Options = make(map[string]interface{})
-		for k, v := range c.Options {
-			clone.Options[k] = v
-		}
+		maps.Copy(clone.Options, c.Options)
 	}
 
 	// Clone logging config

--- a/imbot/core/message.go
+++ b/imbot/core/message.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"maps"
 	"strings"
 )
 
@@ -39,8 +40,8 @@ func (m *Message) IsCallback() bool {
 
 // TextContent represents text message content
 type TextContent struct {
-	Text     string    `json:"text"`
-	Entities []Entity  `json:"entities,omitempty"`
+	Text     string   `json:"text"`
+	Entities []Entity `json:"entities,omitempty"`
 	// Segments preserves an ordered multi-segment body (e.g. interleaved
 	// body + thinking) on inbound messages. Nil for ordinary single-text
 	// messages. See core.Segment.
@@ -369,9 +370,7 @@ func cloneStringAnyMap(m map[string]interface{}) map[string]interface{} {
 		return nil
 	}
 	out := make(map[string]interface{}, len(m))
-	for k, v := range m {
-		out[k] = v
-	}
+	maps.Copy(out, m)
 	return out
 }
 
@@ -380,8 +379,6 @@ func (m *Message) WithMetadata(metadata map[string]interface{}) *Message {
 	if m.Metadata == nil {
 		m.Metadata = make(map[string]interface{})
 	}
-	for k, v := range metadata {
-		m.Metadata[k] = v
-	}
+	maps.Copy(m.Metadata, metadata)
 	return m
 }

--- a/imbot/examples/dingtalk/main.go
+++ b/imbot/examples/dingtalk/main.go
@@ -240,11 +240,9 @@ func handleCommand(ctx context.Context, bot imbot.Bot, msg imbot.Message, text s
 			return
 		}
 		// Check aliases
-		for _, alias := range cmd.Aliases {
-			if alias == cmdName {
-				executeCommand(ctx, bot, msg, cmd, args)
-				return
-			}
+		if slices.Contains(cmd.Aliases, cmdName) {
+			executeCommand(ctx, bot, msg, cmd, args)
+			return
 		}
 	}
 

--- a/imbot/examples/telegram/telegram-bot.go
+++ b/imbot/examples/telegram/telegram-bot.go
@@ -234,11 +234,9 @@ func handleCommand(ctx context.Context, bot imbot.Bot, msg imbot.Message, text s
 			return
 		}
 		// Check aliases
-		for _, alias := range cmd.Aliases {
-			if alias == cmdName {
-				executeCommand(ctx, bot, msg, cmd, args)
-				return
-			}
+		if slices.Contains(cmd.Aliases, cmdName) {
+			executeCommand(ctx, bot, msg, cmd, args)
+			return
 		}
 	}
 

--- a/imbot/platform/slack/slack.go
+++ b/imbot/platform/slack/slack.go
@@ -164,8 +164,8 @@ func (b *Bot) EditMessage(ctx context.Context, messageID string, text string) er
 
 	// Parse thread ID if present (for threaded messages)
 	var threadTimestamp string
-	if threadIDIdx := strings.Index(messageID, ":thread:"); threadIDIdx != -1 {
-		threadTimestamp = messageID[threadIDIdx+8:]
+	if _, after, ok := strings.Cut(messageID, ":thread:"); ok {
+		threadTimestamp = after
 	}
 
 	options := []slack.MsgOption{}

--- a/imbot/platform_config_test.go
+++ b/imbot/platform_config_test.go
@@ -1,6 +1,7 @@
 package imbot
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/tingly-dev/tingly-box/imbot/core"
@@ -55,12 +56,7 @@ func TestPlatformFormFieldsAgreeWithCoreAuthType(t *testing.T) {
 }
 
 func contains(haystack []string, needle string) bool {
-	for _, h := range haystack {
-		if h == needle {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(haystack, needle)
 }
 
 // TestBuildAuthConfigLark is the regression test for the defect the table

--- a/internal/agent/cc_settings.go
+++ b/internal/agent/cc_settings.go
@@ -254,15 +254,11 @@ func ResolveCCProfileSettings(cfg *serverconfig.Config, baseURL, apiKey, scenari
 		if valuesErr != nil {
 			return CCProfileSettingsResolution{}, valuesErr
 		}
-		for key, value := range defaultValues {
-			baseEnv[key] = value
-		}
+		maps.Copy(baseEnv, defaultValues)
 	}
 
 	generated := GenerateCCEnv(cfg, baseURL, apiKey, scenarioPath, profile.Unified, true)
-	for key, value := range generated {
-		baseEnv[key] = value
-	}
+	maps.Copy(baseEnv, generated)
 	basePreferences, err := ClaudeCodePrefsFromEnv(baseEnv)
 	if err != nil {
 		return CCProfileSettingsResolution{}, err

--- a/internal/agent/prefs.go
+++ b/internal/agent/prefs.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"maps"
 	"strings"
 )
 
@@ -100,9 +101,7 @@ func (p ClaudeCodePrefs) Values() (map[string]string, error) {
 	if err := json.Unmarshal(b, &values); err != nil {
 		return nil, err
 	}
-	for key, value := range p.Extra {
-		values[key] = value
-	}
+	maps.Copy(values, p.Extra)
 	return values, nil
 }
 

--- a/internal/agent/prefs.go
+++ b/internal/agent/prefs.go
@@ -145,7 +145,7 @@ func (p ClaudeCodePrefs) ToEnv(baseURL, apiKey string) (map[string]string, error
 func appendNoProxy(current string, hosts ...string) string {
 	existing := make(map[string]bool)
 	if current != "" {
-		for _, h := range strings.Split(current, ",") {
+		for h := range strings.SplitSeq(current, ",") {
 			existing[strings.TrimSpace(h)] = true
 		}
 	}

--- a/internal/agent/prefs_test.go
+++ b/internal/agent/prefs_test.go
@@ -272,8 +272,8 @@ func TestClaudeCodePrefs_JSONRoundTripPreservesFields(t *testing.T) {
 // and ToEnv would write spurious blank envs into settings.json.
 func TestClaudeCodePrefs_AllTypedFieldsUseOmitempty(t *testing.T) {
 	rt := reflect.TypeOf(ClaudeCodePrefs{})
-	for i := 0; i < rt.NumField(); i++ {
-		f := rt.Field(i)
+	for f := range rt.Fields() {
+		f := f
 		tag := f.Tag.Get("json")
 		if tag == "" || tag == "-" {
 			continue // Extra map (json:"-") is excluded by design.

--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -172,10 +173,8 @@ func withContext1MBeta(ctx context.Context, betas []anthropic.AnthropicBeta) []a
 	if !typ.GetRuleFlags(ctx).Context1M {
 		return betas
 	}
-	for _, b := range betas {
-		if b == anthropic.AnthropicBetaContext1m2025_08_07 {
-			return betas
-		}
+	if slices.Contains(betas, anthropic.AnthropicBetaContext1m2025_08_07) {
+		return betas
 	}
 	return append(betas, anthropic.AnthropicBetaContext1m2025_08_07)
 }

--- a/internal/client/claude_e2e_test.go
+++ b/internal/client/claude_e2e_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"os"
 	"strings"
 	"testing"
@@ -200,9 +201,7 @@ func TestE2E_ClaudeRoundTripper(t *testing.T) {
 						input := lastTool["input"].(map[string]interface{})
 						var partialInput map[string]interface{}
 						json.Unmarshal([]byte(event.Delta.PartialJSON), &partialInput)
-						for k, v := range partialInput {
-							input[k] = v
-						}
+						maps.Copy(input, partialInput)
 					}
 				}
 

--- a/internal/client/kimi_client.go
+++ b/internal/client/kimi_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/openai/openai-go/v3"
@@ -194,12 +195,7 @@ func (c *KimiClient) isContentMeaningful(content openai.ChatCompletionAssistantM
 
 	// Handle array content (for multi-modal messages)
 	if len(content.OfArrayOfContentParts) > 0 {
-		for _, part := range content.OfArrayOfContentParts {
-			if c.isContentPartMeaningful(part) {
-				return true
-			}
-		}
-		return false
+		return slices.ContainsFunc(content.OfArrayOfContentParts, c.isContentPartMeaningful)
 	}
 
 	return false

--- a/internal/client/pool_test.go
+++ b/internal/client/pool_test.go
@@ -82,7 +82,6 @@ func TestClientPool_ClientConstruction(t *testing.T) {
 	t.Run("constructors", func(t *testing.T) {
 		pool := NewClientPool()
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				var client interface{}
 				switch tc.kind {

--- a/internal/client/record_roundtripper.go
+++ b/internal/client/record_roundtripper.go
@@ -217,8 +217,8 @@ func (r *recordingReader) Close() error {
 func parseSSEAndAssemble(sseContent string, apiStyle protocol.APIStyle) ([]string, map[string]any) {
 	chunks := make([]string, 0)
 
-	lines := strings.Split(sseContent, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(sseContent, "\n")
+	for line := range lines {
 		line = strings.TrimSpace(line)
 		// Skip empty lines and comments
 		if line == "" || strings.HasPrefix(line, ":") {

--- a/internal/command/oauth.go
+++ b/internal/command/oauth.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -330,9 +331,7 @@ func createProviderFromToken(appConfig *config.AppConfig, config *ProviderOAuthC
 
 	// Add extra fields from token metadata
 	if token.Metadata != nil {
-		for k, v := range token.Metadata {
-			oauthDetail.ExtraFields[k] = v
-		}
+		maps.Copy(oauthDetail.ExtraFields, token.Metadata)
 	}
 	if token.IDToken != "" {
 		oauthDetail.ExtraFields["id_token"] = token.IDToken

--- a/internal/command/tui/quickstart.go
+++ b/internal/command/tui/quickstart.go
@@ -727,7 +727,6 @@ func qsAgent(ctx StepContext, s quickstartState) (quickstartState, StepResult, e
 
 	agentUC := usecase.NewAgentUseCase(s.mgr.GetGlobalConfig(), "localhost")
 	for _, t := range s.selectedAgents {
-		t := t
 		req := &agent.ApplyAgentRequest{
 			AgentType:         t,
 			Provider:          s.provider.UUID,

--- a/internal/command/tui/quickstart.go
+++ b/internal/command/tui/quickstart.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -683,13 +684,7 @@ func qsAgent(ctx StepContext, s quickstartState) (quickstartState, StepResult, e
 		return s, StepContinue, nil
 	}
 
-	hasClaudeCode := false
-	for _, t := range s.selectedAgents {
-		if t == agent.AgentTypeClaudeCode {
-			hasClaudeCode = true
-			break
-		}
-	}
+	hasClaudeCode := slices.Contains(s.selectedAgents, agent.AgentTypeClaudeCode)
 
 	if hasClaudeCode {
 		uni, err := Confirm("Use unified mode for Claude Code? (single config for all models)", ConfirmOptions{

--- a/internal/data/provider_template.go
+++ b/internal/data/provider_template.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -234,9 +235,7 @@ func (tm *TemplateManager) GetAllTemplates() map[string]*ProviderTemplate {
 
 	// Return a copy to avoid concurrent modification
 	result := make(map[string]*ProviderTemplate, len(tm.templates))
-	for k, v := range tm.templates {
-		result[k] = v
-	}
+	maps.Copy(result, tm.templates)
 	return result
 }
 
@@ -326,9 +325,7 @@ func (tm *TemplateManager) fetchFromHTTP(ctx context.Context) (*ProviderTemplate
 		// Return current state without modification
 		tm.mu.RLock()
 		providers := make(map[string]*ProviderTemplate, len(tm.templates))
-		for k, v := range tm.templates {
-			providers[k] = v
-		}
+		maps.Copy(providers, tm.templates)
 		version := tm.version
 		lastUpdated := tm.lastUpdated
 		tm.mu.RUnlock()
@@ -516,9 +513,7 @@ func (tm *TemplateManager) mergeEmbeddedOnly(external map[string]*ProviderTempla
 	for id, tmpl := range tm.embedded {
 		merged[id] = deepCopyTemplate(tmpl)
 	}
-	for id, tmpl := range external {
-		merged[id] = tmpl
-	}
+	maps.Copy(merged, external)
 	return merged
 }
 
@@ -683,9 +678,7 @@ func deepCopyTemplate(tmpl *ProviderTemplate) *ProviderTemplate {
 	// Copy model capacities map
 	if tmpl.ModelCapacities != nil {
 		result.ModelCapacities = make(map[string]int, len(tmpl.ModelCapacities))
-		for k, v := range tmpl.ModelCapacities {
-			result.ModelCapacities[k] = v
-		}
+		maps.Copy(result.ModelCapacities, tmpl.ModelCapacities)
 	}
 
 	// Copy pointer scalars so the copy shares no memory with the original
@@ -708,9 +701,7 @@ func deepCopyCapabilitySchema(schema *CapabilitySchema) *CapabilitySchema {
 	// Deep copy ResultFormat.Structure if it exists
 	if schema.ResultFormat.Structure != nil {
 		result.ResultFormat.Structure = make(map[string]interface{})
-		for k, v := range schema.ResultFormat.Structure {
-			result.ResultFormat.Structure[k] = v
-		}
+		maps.Copy(result.ResultFormat.Structure, schema.ResultFormat.Structure)
 	}
 
 	return &result

--- a/internal/dataio/integration_test.go
+++ b/internal/dataio/integration_test.go
@@ -358,7 +358,7 @@ func TestProviderRoundTripByAuthType(t *testing.T) {
 // this is the boundary internal/dataio's export/import fix actually owns.
 func decodeExportedProvider(t *testing.T, jsonl string, wantUUID string) *typ.Provider {
 	t.Helper()
-	for _, line := range strings.Split(jsonl, "\n") {
+	for line := range strings.SplitSeq(jsonl, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue

--- a/internal/guardrails/core/command_normalized.go
+++ b/internal/guardrails/core/command_normalized.go
@@ -1,5 +1,7 @@
 package core
 
+import "slices"
+
 import "strings"
 
 // NormalizedCommand is a tool-agnostic semantic view used for matching.
@@ -185,21 +187,11 @@ func firstArgIn(args []string, values ...string) bool {
 		return false
 	}
 	first := args[0]
-	for _, value := range values {
-		if first == value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, first)
 }
 
 func containsArg(args []string, target string) bool {
-	for _, arg := range args {
-		if arg == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(args, target)
 }
 
 func hasArgSequence(args []string, sequence ...string) bool {
@@ -235,10 +227,8 @@ func appendUniqueString(items []string, value string) []string {
 	if value == "" {
 		return items
 	}
-	for _, item := range items {
-		if item == value {
-			return items
-		}
+	if slices.Contains(items, value) {
+		return items
 	}
 	return append(items, value)
 }

--- a/internal/guardrails/core/command_shell.go
+++ b/internal/guardrails/core/command_shell.go
@@ -3,6 +3,7 @@ package core
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"unicode"
 )
@@ -137,12 +138,7 @@ func ParseShellCommand(raw string) *ShellCommand {
 }
 
 func isShellOperator(tok string) bool {
-	for _, op := range shellOperators {
-		if tok == op {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(shellOperators, tok)
 }
 
 func isShellRedirect(tok string) bool {

--- a/internal/guardrails/core/command_shell_test.go
+++ b/internal/guardrails/core/command_shell_test.go
@@ -163,7 +163,6 @@ func TestIsInstallCommandPositiveCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if !isInstallCommand(tt.cmd) {
@@ -200,7 +199,6 @@ func TestIsInstallCommandNegativeCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if isInstallCommand(tt.cmd) {

--- a/internal/guardrails/core/content.go
+++ b/internal/guardrails/core/content.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 )
 
@@ -153,10 +154,5 @@ func (c Content) HasAny(targets []ContentType) bool {
 }
 
 func hasContentType(list []ContentType, target ContentType) bool {
-	for _, item := range list {
-		if item == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, target)
 }

--- a/internal/guardrails/core/credential_alias.go
+++ b/internal/guardrails/core/credential_alias.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"slices"
 	"sort"
 	"strings"
 )
@@ -29,10 +30,8 @@ func (s *CredentialMaskState) remember(credential ProtectedCredential) {
 	}
 	s.AliasToReal[credential.AliasToken] = credential.Secret
 	s.RealToAlias[credential.Secret] = credential.AliasToken
-	for _, id := range s.UsedRefs {
-		if id == credential.ID {
-			return
-		}
+	if slices.Contains(s.UsedRefs, credential.ID) {
+		return
 	}
 	s.UsedRefs = append(s.UsedRefs, credential.ID)
 }

--- a/internal/guardrails/core/scope.go
+++ b/internal/guardrails/core/scope.go
@@ -1,5 +1,7 @@
 package core
 
+import "slices"
+
 // Scope limits when a policy is applied.
 type Scope struct {
 	Scenarios  []string      `json:"scenarios,omitempty" yaml:"scenarios,omitempty"`
@@ -30,21 +32,11 @@ func (s Scope) Matches(input Input) bool {
 }
 
 func stringInSlice(value string, items []string) bool {
-	for _, item := range items {
-		if value == item {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(items, value)
 }
 
 func directionInSlice(value Direction, items []Direction) bool {
-	for _, item := range items {
-		if value == item {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(items, value)
 }
 
 func anyTagMatches(inputTags, scopeTags []string) bool {

--- a/internal/guardrails/model.go
+++ b/internal/guardrails/model.go
@@ -3,6 +3,7 @@ package guardrails
 import (
 	"context"
 	"errors"
+	"maps"
 	"sort"
 	"sync"
 	"time"
@@ -170,9 +171,7 @@ func (g *Guardrails) CredentialCacheSnapshot() CredentialCache {
 	defer g.mu.RUnlock()
 
 	out := NewCredentialCache()
-	for id, credential := range g.CredentialCache.ByID {
-		out.ByID[id] = credential
-	}
+	maps.Copy(out.ByID, g.CredentialCache.ByID)
 	for scenario, credentials := range g.CredentialCache.ByScenario {
 		copied := make([]guardrailscore.ProtectedCredential, len(credentials))
 		copy(copied, credentials)

--- a/internal/imagegen/dashscope.go
+++ b/internal/imagegen/dashscope.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"strings"
 	"time"
@@ -123,9 +124,7 @@ func (c *dashscopeClient) submit(ctx context.Context, req *Request) (string, err
 	}
 	// Allow callers to pass DashScope-native knobs (seed, prompt_extend,
 	// watermark, ...) straight through.
-	for k, v := range req.Extra {
-		params[k] = v
-	}
+	maps.Copy(params, req.Extra)
 
 	body := dashscopeSubmitBody{
 		Model:      req.Model,

--- a/internal/loadbalance/health_monitor.go
+++ b/internal/loadbalance/health_monitor.go
@@ -2,6 +2,7 @@ package loadbalance
 
 import (
 	"errors"
+	"maps"
 	"sync"
 	"time"
 
@@ -284,9 +285,7 @@ func (hm *HealthMonitor) GetAllHealth() map[string]*ServiceHealth {
 	defer hm.mutex.RUnlock()
 
 	result := make(map[string]*ServiceHealth, len(hm.services))
-	for k, v := range hm.services {
-		result[k] = v
-	}
+	maps.Copy(result, hm.services)
 	return result
 }
 

--- a/internal/mcp/local/adapter.go
+++ b/internal/mcp/local/adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/mcp/runtime"
@@ -29,12 +30,7 @@ func (a *MCPRuntimeAdapter) isSourceAllowed(sourceID string) bool {
 	if len(a.allowedSources) == 0 {
 		return true
 	}
-	for _, s := range a.allowedSources {
-		if s == sourceID {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(a.allowedSources, sourceID)
 }
 
 // ListTools returns all available tools from all configured MCP sources.

--- a/internal/mcp/runtime/builtin_registry.go
+++ b/internal/mcp/runtime/builtin_registry.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -47,9 +48,7 @@ func RegisterBuiltinTools(getConfig func() *typ.MCPRuntimeConfig, setConfig func
 	// Preserve user's environment variables (especially SERPER_API_KEY)
 	preservedEnv := make(map[string]string)
 	if existingWebtools != nil && existingWebtools.Env != nil {
-		for k, v := range existingWebtools.Env {
-			preservedEnv[k] = v
-		}
+		maps.Copy(preservedEnv, existingWebtools.Env)
 	}
 
 	// Ensure SERPER_API_KEY is always present (use ${SERPER_API_KEY} to reference system env)
@@ -113,9 +112,7 @@ func RegisterBuiltinTools(getConfig func() *typ.MCPRuntimeConfig, setConfig func
 			advisorTools = existingAdvisor.Tools
 		}
 		// Preserve user's custom environment variables
-		for k, v := range existingAdvisor.Env {
-			advisorEnv[k] = v
-		}
+		maps.Copy(advisorEnv, existingAdvisor.Env)
 		if existingAdvisor.Advisor != nil {
 			copied := *existingAdvisor.Advisor
 			advisorCfg = &copied

--- a/internal/mcp/runtime/env_refs.go
+++ b/internal/mcp/runtime/env_refs.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"maps"
 	"os"
 	"reflect"
 	"strconv"
@@ -59,9 +60,7 @@ func expandMCPSourceEnvRefs(source *typ.MCPSourceConfig, sourceIndex int, issues
 		sourceID = "sources[" + strconv.Itoa(sourceIndex) + "]"
 	}
 	sourceEnv := make(map[string]string, len(source.Env))
-	for k, v := range source.Env {
-		sourceEnv[k] = v
-	}
+	maps.Copy(sourceEnv, source.Env)
 	// Expand source env first, then use it as lookup for all other fields.
 	for k, v := range sourceEnv {
 		expanded, missing := expandStringEnvRefs(v, sourceEnv, true)

--- a/internal/mcp/runtime/runtime.go
+++ b/internal/mcp/runtime/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -747,9 +748,7 @@ func (r *Runtime) IsClientToolAvailable(sourceID string, toolName string) bool {
 		// Expand env refs first so IsConfigured sees resolved values.
 		expandedSource := source
 		expandedSource.Env = make(map[string]string, len(source.Env))
-		for k, v := range source.Env {
-			expandedSource.Env[k] = v
-		}
+		maps.Copy(expandedSource.Env, source.Env)
 		expandSourceEnvInPlace(expandedSource.Env)
 		ts, err := r.toolSourceFactory.CreateToolSource(expandedSource)
 		if err != nil || !ts.IsConfigured() {

--- a/internal/mcpserver/stream_rounds_test.go
+++ b/internal/mcpserver/stream_rounds_test.go
@@ -67,10 +67,10 @@ type sliceStream struct {
 	idx    int
 }
 
-func (s *sliceStream) Next() bool    { s.idx++; return s.idx <= len(s.events) }
-func (s *sliceStream) Current() any  { return s.events[s.idx-1] }
-func (s *sliceStream) Err() error    { return nil }
-func (s *sliceStream) Close() error  { return nil }
+func (s *sliceStream) Next() bool   { s.idx++; return s.idx <= len(s.events) }
+func (s *sliceStream) Current() any { return s.events[s.idx-1] }
+func (s *sliceStream) Err() error   { return nil }
+func (s *sliceStream) Close() error { return nil }
 
 type roundsForwarder struct {
 	rounds [][]anthropic.BetaRawMessageStreamEventUnion
@@ -118,7 +118,7 @@ func (e cannedExecutor) ExecuteTools(ctx context.Context, tools []Tool, m []map[
 // sseEventNames returns the `event:` names in order, as a client would read them.
 func sseEventNames(body string) []string {
 	var names []string
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		if strings.HasPrefix(line, "event: ") {
 			names = append(names, strings.TrimPrefix(line, "event: "))
 		}

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -145,13 +146,7 @@ func RateLimitMiddleware(rl *RateLimiter, authPaths ...string) gin.HandlerFunc {
 
 		// Track the attempt for auth endpoints
 		path := c.Request.URL.Path
-		isAuthPath := false
-		for _, authPath := range authPaths {
-			if path == authPath {
-				isAuthPath = true
-				break
-			}
-		}
+		isAuthPath := slices.Contains(authPaths, path)
 
 		if isAuthPath && c.Request.Method == "POST" {
 			if !rl.recordAttempt(ip) {

--- a/internal/protocol/request/anthropic_v1_to_openai.go
+++ b/internal/protocol/request/anthropic_v1_to_openai.go
@@ -1,6 +1,7 @@
 package request
 
 import (
+	"maps"
 	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -37,9 +38,7 @@ func convertAnthropicInputSchemaToOpenAIParameters(properties any, required []st
 	if schema, ok := properties.(map[string]any); ok {
 		if _, hasNestedProperties := schema["properties"]; hasNestedProperties {
 			parameters := make(shared.FunctionParameters, len(schema)+1)
-			for key, value := range schema {
-				parameters[key] = value
-			}
+			maps.Copy(parameters, schema)
 			if _, ok := parameters["type"]; !ok {
 				parameters["type"] = "object"
 			}

--- a/internal/protocol/request/openai_chat_to_openai_responses.go
+++ b/internal/protocol/request/openai_chat_to_openai_responses.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 
 	"github.com/openai/openai-go/v3"
@@ -325,12 +326,7 @@ func responseMessageWithContent(role string, content responses.ResponseInputMess
 }
 
 func chatTextPartsHaveCacheBreakpoint(parts []openai.ChatCompletionContentPartTextParam) bool {
-	for _, part := range parts {
-		if hasOpenAITextCacheBreakpoint(part) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(parts, hasOpenAITextCacheBreakpoint)
 }
 
 // ConvertChatToolsToResponsesTools converts Chat Completion tools to Responses API tools.

--- a/internal/protocol/stream/anthropic_helper.go
+++ b/internal/protocol/stream/anthropic_helper.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"sort"
 	"time"
@@ -239,9 +240,7 @@ func sendMessageDelta(c *gin.Context, state *streamState, stopReason string, flu
 		"stop_sequence": nil,
 	}
 	// Merge all collected extra fields
-	for k, v := range state.deltaExtras {
-		deltaMap[k] = v
-	}
+	maps.Copy(deltaMap, state.deltaExtras)
 
 	usageMap := map[string]interface{}{
 		"output_tokens": state.outputTokens,

--- a/internal/protocol/stream/anthropic_helper_test.go
+++ b/internal/protocol/stream/anthropic_helper_test.go
@@ -71,8 +71,8 @@ func collectStopEventIndexes(body string) []int {
 	if trimmed == "" {
 		return indexes
 	}
-	chunks := strings.Split(trimmed, "\n\n")
-	for _, chunk := range chunks {
+	chunks := strings.SplitSeq(trimmed, "\n\n")
+	for chunk := range chunks {
 		if strings.TrimSpace(chunk) == "" {
 			continue
 		}
@@ -134,7 +134,7 @@ func TestSendMessageDelta_WithCacheTokens(t *testing.T) {
 
 	// Extract the data line from SSE output
 	var usageMap map[string]interface{}
-	for _, line := range strings.Split(w.Body.String(), "\n") {
+	for line := range strings.SplitSeq(w.Body.String(), "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "data:") {
 			continue

--- a/internal/protocol/stream/anthropic_to_openai_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_test.go
@@ -133,7 +133,7 @@ func TestAnthropicToOpenAIStream_RealFormatUsage(t *testing.T) {
 	body := w.Body.String()
 	var lastPromptTokens, lastCompletionTokens float64
 	foundNonZeroUsage := false
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		if !strings.HasPrefix(line, "data: ") {
 			continue
 		}
@@ -208,7 +208,7 @@ func TestAnthropicToOpenAIStream_FinalChunkOmitsEmptyRole(t *testing.T) {
 	require.NoError(t, err)
 
 	sawFinishChunk := false
-	for _, line := range strings.Split(w.Body.String(), "\n") {
+	for line := range strings.SplitSeq(w.Body.String(), "\n") {
 		if !strings.HasPrefix(line, "data: ") {
 			continue
 		}

--- a/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
@@ -42,7 +42,6 @@ func TestAnthropicToOpenAIStream_VModelFullUsage(t *testing.T) {
 	)
 
 	for _, modelID := range []string{"virtual-stream-test", "virtual-stream-test-tool"} {
-		modelID := modelID
 		t.Run(modelID, func(t *testing.T) {
 			stream := client.Beta.Messages.NewStreaming(context.Background(), anthropic.BetaMessageNewParams{
 				Model:     anthropic.Model(modelID),

--- a/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
+++ b/internal/protocol/stream/anthropic_to_openai_vmodel_e2e_test.go
@@ -92,7 +92,7 @@ func TestAnthropicToOpenAIStream_VModelFullUsage(t *testing.T) {
 func lastOpenAIChunkUsage(t *testing.T, body string) map[string]interface{} {
 	t.Helper()
 	var last map[string]interface{}
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "data:") {
 			continue

--- a/internal/protocol/stream/openai_chat_to_responses_test.go
+++ b/internal/protocol/stream/openai_chat_to_responses_test.go
@@ -388,9 +388,9 @@ func TestChatStreamUsage_NilDetails(t *testing.T) {
 // parseResponsesSSEEvents parses SSE response body into a map of events
 func parseResponsesSSEEvents(t *testing.T, body string) map[string]map[string]interface{} {
 	events := make(map[string]map[string]interface{})
-	lines := strings.Split(body, "\n")
+	lines := strings.SplitSeq(body, "\n")
 
-	for _, line := range lines {
+	for line := range lines {
 		line = strings.TrimSpace(line)
 
 		if strings.HasPrefix(line, "data: ") {

--- a/internal/protocol/stream/openai_helper.go
+++ b/internal/protocol/stream/openai_helper.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -177,9 +178,7 @@ func mergeMaps(base map[string]interface{}, extra map[string]interface{}) map[st
 	if base == nil {
 		base = make(map[string]interface{})
 	}
-	for k, v := range extra {
-		base[k] = v
-	}
+	maps.Copy(base, extra)
 	return base
 }
 

--- a/internal/protocol/stream/openai_responses_to_anthropic_converter.go
+++ b/internal/protocol/stream/openai_responses_to_anthropic_converter.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"time"
 
@@ -205,9 +206,7 @@ func (r *responsesToAnthropicConverter) emitMessageDelta(stopReason string) {
 		"stop_reason":   stopReason,
 		"stop_sequence": nil,
 	}
-	for k, v := range r.state.deltaExtras {
-		deltaMap[k] = v
-	}
+	maps.Copy(deltaMap, r.state.deltaExtras)
 	usageMap := r.Usage().ToAnthropicMessageDeltaUsageMap()
 	r.emitAnthropic(eventTypeMessageDelta, map[string]interface{}{
 		"type":  eventTypeMessageDelta,

--- a/internal/protocol/stream/openai_to_anthropic_converter.go
+++ b/internal/protocol/stream/openai_to_anthropic_converter.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sort"
 	"time"
 
@@ -462,9 +463,7 @@ func (c *openAIToAnthropicConverter) emitMessageDelta(stopReason string) {
 		"stop_reason":   stopReason,
 		"stop_sequence": nil,
 	}
-	for k, v := range c.state.deltaExtras {
-		deltaMap[k] = v
-	}
+	maps.Copy(deltaMap, c.state.deltaExtras)
 	usageMap := c.Usage().ToAnthropicMessageDeltaUsageMap()
 	c.emitAnthropic(eventTypeMessageDelta, map[string]interface{}{
 		"type":  eventTypeMessageDelta,

--- a/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
+++ b/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
@@ -117,7 +117,6 @@ func TestOpenAIToAnthropicStream_VModelFullUsage(t *testing.T) {
 	)
 
 	for _, modelID := range []string{"virtual-stream-test", "virtual-stream-test-tool"} {
-		modelID := modelID
 		t.Run(modelID, func(t *testing.T) {
 			stream := client.Chat.Completions.NewStreaming(context.Background(), openai.ChatCompletionNewParams{
 				Model: modelID,

--- a/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
+++ b/internal/protocol/stream/openai_to_anthropic_vmodel_e2e_test.go
@@ -178,7 +178,7 @@ func TestOpenAIToAnthropicStream_VModelFullUsage(t *testing.T) {
 func splitSSEEventsByType(body string) map[string]string {
 	out := make(map[string]string)
 	current := ""
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		switch {
 		case strings.HasPrefix(line, "event:"):
 			current = strings.TrimSpace(strings.TrimPrefix(line, "event:"))

--- a/internal/protocol/transform/chain.go
+++ b/internal/protocol/transform/chain.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go/v3"
@@ -195,9 +196,7 @@ func (ctx *TransformContext) configExtraForMetadata() map[string]any {
 		extra["device"] = ctx.Config.Device
 	}
 	// Merge any existing Extra entries (for backward compat with cursor_compat etc.)
-	for k, v := range ctx.Extra {
-		extra[k] = v
-	}
+	maps.Copy(extra, ctx.Extra)
 	return extra
 }
 

--- a/internal/protocolserver/failover_dispatch.go
+++ b/internal/protocolserver/failover_dispatch.go
@@ -21,6 +21,7 @@ package protocolserver
 
 import (
 	"bytes"
+	"maps"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -245,9 +246,7 @@ func (g *firstChunkGate) commit() {
 	}
 	g.committed = true
 	dst := g.real.Header()
-	for k, vs := range g.hdr {
-		dst[k] = vs
-	}
+	maps.Copy(dst, g.hdr)
 	status := g.status
 	if status == 0 {
 		status = http.StatusOK

--- a/internal/protocolserver/failover_dispatch_test.go
+++ b/internal/protocolserver/failover_dispatch_test.go
@@ -3,6 +3,7 @@ package protocolserver
 import (
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -413,13 +414,7 @@ func TestSelectFallbackService_TierVsRandomTactic(t *testing.T) {
 	}
 	// Random tactic doesn't guarantee tier ordering
 	validProviders := []string{"provider-a1", "provider-a2", "provider-b1", "provider-b2"}
-	found := false
-	for _, valid := range validProviders {
-		if randomService.Provider == valid {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(validProviders, randomService.Provider)
 	if !found {
 		t.Errorf("RandomTactic picked unexpected provider: %s", randomService.Provider)
 	}

--- a/internal/protocolserver/failover_logging_test.go
+++ b/internal/protocolserver/failover_logging_test.go
@@ -3,6 +3,7 @@ package protocolserver
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -29,9 +30,7 @@ func (h *logCapture) Levels() []logrus.Level { return logrus.AllLevels }
 func (h *logCapture) Fire(e *logrus.Entry) error {
 	// Copy fields to avoid mutation after Fire returns.
 	fields := make(logrus.Fields, len(e.Data))
-	for k, v := range e.Data {
-		fields[k] = v
-	}
+	maps.Copy(fields, e.Data)
 	h.entries = append(h.entries, &logrus.Entry{
 		Logger:  e.Logger,
 		Data:    fields,

--- a/internal/protocolserver/protocol_dispatch.go
+++ b/internal/protocolserver/protocol_dispatch.go
@@ -49,8 +49,8 @@ func ShouldUseGenericMCPForProvider(cfg *config.Config, provider *typ.Provider) 
 
 	// Parse comma-separated limits and check if provider is in the list
 	// This is a simple implementation - can be improved with proper parsing
-	parts := strings.Split(limits, ",")
-	for _, part := range parts {
+	parts := strings.SplitSeq(limits, ",")
+	for part := range parts {
 		if strings.TrimSpace(part) == provider.Name {
 			return true
 		}

--- a/internal/protocolserver/rule_flags.go
+++ b/internal/protocolserver/rule_flags.go
@@ -42,7 +42,7 @@ func parseBlockTools(raw string) []string {
 		return nil
 	}
 	var names []string
-	for _, part := range strings.Split(raw, ",") {
+	for part := range strings.SplitSeq(raw, ",") {
 		if name := strings.TrimSpace(part); name != "" {
 			names = append(names, name)
 		}

--- a/internal/protocoltest/cache_controls.go
+++ b/internal/protocoltest/cache_controls.go
@@ -2,6 +2,7 @@ package protocoltest
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 )
@@ -210,12 +211,7 @@ func countCacheMarkers(t flagTB, value any, markerKey, discriminator, wantValue 
 // a bug this suite should paper over — a dedicated vendor-transform suite
 // (protocoltest vendor category) exercises the allowlisted case.
 func cacheSurvivesPath(hops ...protocol.APIType) bool {
-	for _, hop := range hops {
-		if hop == protocol.TypeOpenAIChat {
-			return false
-		}
-	}
-	return true
+	return !slices.Contains(hops, protocol.TypeOpenAIChat)
 }
 
 func assertCapturedCacheState(t flagTB, env *TestEnv, target protocol.APIType, wantCached bool, label string) {

--- a/internal/protocoltest/cache_controls_test.go
+++ b/internal/protocoltest/cache_controls_test.go
@@ -8,9 +8,7 @@ import "testing"
 func TestCacheControls(t *testing.T) {
 	m := DefaultMatrix()
 	for _, pair := range m.Pairs {
-		pair := pair
 		for _, streaming := range m.Streaming {
-			streaming := streaming
 			t.Run("single/"+pair.String()+"/"+streamMode(streaming), func(t *testing.T) {
 				t.Parallel()
 				env := NewTestEnv(t)
@@ -21,9 +19,7 @@ func TestCacheControls(t *testing.T) {
 	}
 
 	for _, ic := range DefaultIdempotentCases() {
-		ic := ic
 		for _, streaming := range m.Streaming {
-			streaming := streaming
 			t.Run("aba/"+ic.Name+"/"+streamMode(streaming), func(t *testing.T) {
 				t.Parallel()
 				env := NewTestEnv(t)

--- a/internal/protocoltest/content_shapes_test.go
+++ b/internal/protocoltest/content_shapes_test.go
@@ -11,7 +11,6 @@ import "testing"
 // upstream. *testing.T satisfies the flagTB the cases use.
 func TestContentShapes(t *testing.T) {
 	for _, c := range contentShapeCases() {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			env := NewTestEnv(t)

--- a/internal/protocoltest/duo_test.go
+++ b/internal/protocoltest/duo_test.go
@@ -59,7 +59,6 @@ func TestDuoFunctional(t *testing.T) {
 	defer env.Close()
 
 	for _, route := range AllDuoRoutes() {
-		route := route
 		t.Run(route.Name, func(t *testing.T) {
 			checks := env.RunFunctionalChecks(route, 256*1024)
 			if len(checks) == 0 {
@@ -111,7 +110,6 @@ func TestDuoRouting(t *testing.T) {
 	defer env.Close()
 
 	for _, sc := range BuiltinRoutingScenarios() {
-		sc := sc
 		t.Run(sc.Name, func(t *testing.T) {
 			checks := env.RunRoutingScenario(sc)
 			if len(checks) == 0 {

--- a/internal/protocoltest/flag_test.go
+++ b/internal/protocoltest/flag_test.go
@@ -14,7 +14,6 @@ import (
 // observable effect. *testing.T satisfies the flagTB the cases use.
 func TestRuleFlags(t *testing.T) {
 	for _, fc := range ruleFlagCases() {
-		fc := fc
 		t.Run(fc.key, func(t *testing.T) {
 			t.Parallel()
 			env := NewTestEnv(t)

--- a/internal/protocoltest/vendor_transforms.go
+++ b/internal/protocoltest/vendor_transforms.go
@@ -145,9 +145,7 @@ func runVendorTransformCase(t flagTB, env *TestEnv, fx vendorFixture, streaming 
 func (m *Matrix) ExecuteAllVendorTransforms() []TestResult {
 	var cases []recorderCase
 	for _, fx := range vendorFixtures {
-		fx := fx
 		for _, streaming := range m.Streaming {
-			streaming := streaming
 			name := fmt.Sprintf("vendor/%s/%s", fx.name, streamMode(streaming))
 			cases = append(cases, recorderCase{
 				name:      name,

--- a/internal/protocoltest/vendor_transforms_test.go
+++ b/internal/protocoltest/vendor_transforms_test.go
@@ -10,9 +10,7 @@ import "testing"
 func TestVendorTransforms(t *testing.T) {
 	m := DefaultMatrix()
 	for _, fx := range vendorFixtures {
-		fx := fx
 		for _, streaming := range m.Streaming {
-			streaming := streaming
 			t.Run("vendor/"+fx.name+"/"+streamMode(streaming), func(t *testing.T) {
 				t.Parallel()
 				env := NewTestEnv(t)

--- a/internal/server/config/apply_config_claude.go
+++ b/internal/server/config/apply_config_claude.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -49,9 +50,7 @@ func buildClaudeSettings(base []byte, env map[string]string, applyOpts *applyOpt
 	if applyOpts.showThinkingSummaries != nil {
 		existingConfig["showThinkingSummaries"] = *applyOpts.showThinkingSummaries
 	}
-	for k, v := range applyOpts.extras {
-		existingConfig[k] = v
-	}
+	maps.Copy(existingConfig, applyOpts.extras)
 
 	output, err := json.MarshalIndent(existingConfig, "", "  ")
 	if err != nil {
@@ -480,9 +479,7 @@ func ApplyClaudeOnboarding(payload map[string]interface{}) (*ApplyResult, error)
 	}
 
 	// Merge top-level keys from payload
-	for k, v := range payload {
-		existingConfig[k] = v
-	}
+	maps.Copy(existingConfig, payload)
 
 	// Write the merged config
 	output, err := json.MarshalIndent(existingConfig, "", "  ")

--- a/internal/server/config/apply_config_codex.go
+++ b/internal/server/config/apply_config_codex.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -374,9 +375,7 @@ func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []strin
 	// default) and stamped into each generated profile so profiles are
 	// self-contained. Converted first so it can never carry a managed key.
 	coerced := prefs.toConfig()
-	for k, v := range coerced {
-		cfg[k] = v
-	}
+	maps.Copy(cfg, coerced)
 
 	// Managed fields — written after prefs so they always win, guaranteeing
 	// prefs cannot clobber them (defense in depth on top of the whitelist).
@@ -424,9 +423,7 @@ func mergeCodexConfig(cfg map[string]interface{}, baseURL string, models []strin
 			"model":          model,
 			"model_provider": codexGatewayProviderName,
 		}
-		for k, v := range coerced {
-			profile[k] = v
-		}
+		maps.Copy(profile, coerced)
 		profiles[sanitizeCodexProfileKey(model)] = profile
 	}
 	if len(profiles) > 0 {

--- a/internal/server/config/apply_config_codex.go
+++ b/internal/server/config/apply_config_codex.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -104,10 +105,8 @@ func codexEnumValue(key, val string) (string, bool) {
 	if val == "" {
 		return "", false
 	}
-	for _, allowed := range codexEnumValues[key] {
-		if val == allowed {
-			return val, true
-		}
+	if slices.Contains(codexEnumValues[key], val) {
+		return val, true
 	}
 	return "", false
 }

--- a/internal/server/config/apply_config_dsh.go
+++ b/internal/server/config/apply_config_dsh.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	yamlpkg "gopkg.in/yaml.v3"
@@ -77,10 +78,8 @@ var dshProtocolValues = []string{"openai-completions", "openai-responses", "anth
 // (read) so the two stay in lockstep.
 func dshProtocolValue(val string) (string, bool) {
 	val = strings.TrimSpace(val)
-	for _, allowed := range dshProtocolValues {
-		if val == allowed {
-			return val, true
-		}
+	if slices.Contains(dshProtocolValues, val) {
+		return val, true
 	}
 	return "", false
 }

--- a/internal/server/config/apply_config_dsh.go
+++ b/internal/server/config/apply_config_dsh.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -292,9 +293,7 @@ func mergeDshSettings(cfg map[string]interface{}, baseURL string, models []strin
 	}
 	// prefs.toConfig() always emits "api" (defaulting when unset/invalid), so
 	// the stanza literal above no longer needs a hardcoded default.
-	for k, v := range prefs.toConfig() {
-		stanza[k] = v
-	}
+	maps.Copy(stanza, prefs.toConfig())
 
 	providers[dshGatewayProviderName] = stanza
 	root["providers"] = providers

--- a/internal/server/config/apply_config_opencode.go
+++ b/internal/server/config/apply_config_opencode.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 )
@@ -89,9 +90,7 @@ func ApplyOpenCodeConfig(payload map[string]interface{}) (*ApplyResult, error) {
 
 	// Merge new providers from payload
 	if newProviders, ok := payload["provider"].(map[string]interface{}); ok {
-		for k, v := range newProviders {
-			existingProviders[k] = v
-		}
+		maps.Copy(existingProviders, newProviders)
 	}
 
 	existingConfig["provider"] = existingProviders

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 
 	"github.com/google/uuid"
@@ -627,12 +628,7 @@ func (c *Config) InsertDefaultRule() error {
 
 // hasMigrationCompleted reports whether the named one-time migration has already run.
 func (c *Config) hasMigrationCompleted(name string) bool {
-	for _, m := range c.MigrationsCompleted {
-		if m == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.MigrationsCompleted, name)
 }
 
 // markMigrationCompleted records a one-time migration as done so it is skipped on future startups.

--- a/internal/server/config/scenario.go
+++ b/internal/server/config/scenario.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/typ"
@@ -154,9 +155,7 @@ func (c *Config) findOrCreateScenarioConfigLocked(scenario typ.RuleScenario) *ty
 	if seed := c.scenarioConfigLocked(scenario); seed != nil {
 		newConfig.Flags = seed.Flags
 		newConfig.Extensions = make(map[string]interface{}, len(seed.Extensions))
-		for k, v := range seed.Extensions {
-			newConfig.Extensions[k] = v
-		}
+		maps.Copy(newConfig.Extensions, seed.Extensions)
 	}
 	c.Scenarios = append(c.Scenarios, newConfig)
 	return &c.Scenarios[len(c.Scenarios)-1]

--- a/internal/server/config/watcher.go
+++ b/internal/server/config/watcher.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 	"time"
 
@@ -140,10 +141,8 @@ func (cw *Watcher) isConfigEvent(event fsnotify.Event) bool {
 	}
 
 	// Check if event file is in our watch list
-	for _, watchFile := range cw.watchFiles {
-		if event.Name == watchFile {
-			return event.Op&(fsnotify.Write|fsnotify.Create) != 0
-		}
+	if slices.Contains(cw.watchFiles, event.Name) {
+		return event.Op&(fsnotify.Write|fsnotify.Create) != 0
 	}
 
 	return false
@@ -223,10 +222,8 @@ func (cw *Watcher) AddWatchFile(filepath string) error {
 	defer cw.mu.Unlock()
 
 	// Check if already watching
-	for _, f := range cw.watchFiles {
-		if f == filepath {
-			return nil // Already watching
-		}
+	if slices.Contains(cw.watchFiles, filepath) {
+		return nil // Already watching
 	}
 
 	// Add to watch list

--- a/internal/server/module/imbot/handler.go
+++ b/internal/server/module/imbot/handler.go
@@ -3,6 +3,7 @@ package imbot
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"strings"
 
@@ -192,9 +193,7 @@ func (h *Handler) CreateSettings(c *gin.Context) {
 			access.CapabilityRemoteControl: {Enabled: true},
 			access.CapabilityNotify:        {Enabled: false},
 		}
-		for name, value := range req.Capabilities {
-			initial[name] = value
-		}
+		maps.Copy(initial, req.Capabilities)
 		for name, value := range initial {
 			if err := h.accessStore.PutCapability(c.Request.Context(), access.BotCapability{BotUUID: created.UUID, Name: name, Enabled: value.Enabled, Config: value.Config}); err != nil {
 				_ = h.store.DeleteSettings(created.UUID)

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -1246,8 +1246,8 @@ func normalizeAPIBase(baseURL, pathSuffix string) string {
 	}
 
 	if strings.Contains(baseURL, "/v") {
-		parts := strings.Split(baseURL, "/")
-		for _, part := range parts {
+		parts := strings.SplitSeq(baseURL, "/")
+		for part := range parts {
 			if strings.HasPrefix(part, "v") && len(part) > 1 && part[1] >= '0' && part[1] <= '9' {
 				return baseURL
 			}

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"maps"
 	"net/http"
 	"net/url"
 	"strings"
@@ -1022,9 +1023,7 @@ func (h *Handler) createProviderFromToken(token *oauth.Token, issuer ai.Issuer, 
 
 	// Store account_id from token metadata for ChatGPT API
 	if token.Metadata != nil {
-		for k, v := range token.Metadata {
-			oauthDetail.ExtraFields[k] = v
-		}
+		maps.Copy(oauthDetail.ExtraFields, token.Metadata)
 	}
 	// Preserve id_token: required for native Codex `~/.codex/auth.json` export
 	// (chatgpt auth mode). Mirrors the CLI flow in internal/command/oauth.go.

--- a/internal/server/module/onboarding/extractor_test.go
+++ b/internal/server/module/onboarding/extractor_test.go
@@ -2,6 +2,7 @@ package onboarding
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -9,12 +10,7 @@ import (
 func newExt() *RuleExtractor { return NewRuleExtractor() }
 
 func contains(haystack []string, needle string) bool {
-	for _, s := range haystack {
-		if s == needle {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(haystack, needle)
 }
 
 func tokenValues(in []TokenCandidate) []string {

--- a/internal/servertest/utils_test.go
+++ b/internal/servertest/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -147,10 +148,5 @@ func NewTestServerFromConfig(appConfig *config.AppConfig) *TestServer {
 
 // containsStatus checks if status code is in expected list
 func containsStatus(actual int, expected []int) bool {
-	for _, code := range expected {
-		if actual == code {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(expected, actual)
 }

--- a/internal/shortcut/shortcut.go
+++ b/internal/shortcut/shortcut.go
@@ -146,7 +146,7 @@ func createWindowsShortcuts(opts Options, spec LaunchSpec) ([]string, error) {
 	}
 
 	var created []string
-	for _, line := range strings.Split(string(out), "\n") {
+	for line := range strings.SplitSeq(string(out), "\n") {
 		line = strings.TrimSpace(line)
 		if line != "" {
 			created = append(created, line)

--- a/internal/typ/flag_registry_test.go
+++ b/internal/typ/flag_registry_test.go
@@ -48,8 +48,8 @@ func TestRuleFlagRegistry_KeysMatchStructFields(t *testing.T) {
 	flagsType := reflect.TypeOf(RuleFlags{})
 
 	jsonTags := map[string]bool{}
-	for i := 0; i < flagsType.NumField(); i++ {
-		tag := flagsType.Field(i).Tag.Get("json")
+	for field := range flagsType.Fields() {
+		tag := field.Tag.Get("json")
 		name := strings.SplitN(tag, ",", 2)[0]
 		if name != "" && name != "-" {
 			jsonTags[name] = true

--- a/internal/typ/scenario_registry.go
+++ b/internal/typ/scenario_registry.go
@@ -258,8 +258,8 @@ const ProfileSeparator = ":"
 // "claude_code" returns ("claude_code", "").
 func ParseScenarioProfile(raw RuleScenario) (base RuleScenario, profileID string) {
 	rawStr := string(raw)
-	if idx := strings.Index(rawStr, ProfileSeparator); idx >= 0 {
-		return RuleScenario(rawStr[:idx]), rawStr[idx+1:]
+	if before, after, ok := strings.Cut(rawStr, ProfileSeparator); ok {
+		return RuleScenario(before), after
 	}
 	return raw, ""
 }

--- a/pkg/notify/provider/webhook/webhook.go
+++ b/pkg/notify/provider/webhook/webhook.go
@@ -4,6 +4,7 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"time"
 
@@ -98,9 +99,7 @@ func (p *Provider) Send(ctx context.Context, notification *notify.Notification) 
 	}
 
 	headers := make(map[string]string, len(p.headers)+1)
-	for k, v := range p.headers {
-		headers[k] = v
-	}
+	maps.Copy(headers, p.headers)
 	if p.authHeader != "" {
 		headers["Authorization"] = p.authHeader
 	}

--- a/remote/channel/imchannel/imprompter.go
+++ b/remote/channel/imchannel/imprompter.go
@@ -3,6 +3,7 @@ package imchannel
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -10,8 +11,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/agentboot"
-	"github.com/tingly-dev/tingly-box/remote/control/ask"
 	"github.com/tingly-dev/tingly-box/imbot"
+	"github.com/tingly-dev/tingly-box/remote/control/ask"
 )
 
 // IMPrompter implements ask.Prompter using IM (Telegram, etc.) for user interaction
@@ -253,9 +254,7 @@ func (p *IMPrompter) buildTimeoutQuestionResult(req ask.Request) ask.Result {
 	}
 
 	updatedInput := make(map[string]interface{})
-	for k, v := range req.Input {
-		updatedInput[k] = v
-	}
+	maps.Copy(updatedInput, req.Input)
 	updatedInput["answers"] = answers
 
 	return ask.Result{
@@ -355,9 +354,7 @@ func (p *IMPrompter) SubmitPartialAnswer(requestID, questionText, label string) 
 		answers[k] = v
 	}
 	updatedInput := make(map[string]interface{})
-	for k, v := range pending.request.Input {
-		updatedInput[k] = v
-	}
+	maps.Copy(updatedInput, pending.request.Input)
 	updatedInput["answers"] = answers
 
 	result := ask.Result{

--- a/remote/control/ask/tool_handlers.go
+++ b/remote/control/ask/tool_handlers.go
@@ -2,6 +2,7 @@ package ask
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -118,9 +119,7 @@ func (h *AskUserQuestionHandler) ParseResponse(req Request, response Response) (
 
 	// Build updated input with answers
 	updatedInput := make(map[string]interface{})
-	for k, v := range req.Input {
-		updatedInput[k] = v
-	}
+	maps.Copy(updatedInput, req.Input)
 	updatedInput["answers"] = answers
 
 	return Result{

--- a/remote/control/ask/tool_handlers.go
+++ b/remote/control/ask/tool_handlers.go
@@ -3,6 +3,7 @@ package ask
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -293,10 +294,8 @@ func ParseTextResponse(text string) (approved bool, remember bool, isValid bool)
 	text = normalizeText(text)
 
 	for _, opt := range PermissionOptions {
-		for _, input := range opt.Inputs {
-			if text == input {
-				return opt.Approved, opt.Remember, true
-			}
+		if slices.Contains(opt.Inputs, text) {
+			return opt.Approved, opt.Remember, true
 		}
 	}
 	return false, false, false

--- a/remote/control/smart_guide/config.go
+++ b/remote/control/smart_guide/config.go
@@ -1,6 +1,7 @@
 package smart_guide
 
 import (
+	"slices"
 	"time"
 )
 
@@ -105,10 +106,5 @@ func (c *SmartGuideConfig) IsToolEnabled(toolName string) bool {
 
 // IsHandoffCommand checks if text is a handoff command
 func (c *SmartGuideConfig) IsHandoffCommand(text string) bool {
-	for _, cmd := range c.HandoffCommands {
-		if text == cmd {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.HandoffCommands, text)
 }

--- a/remote/scenario/builtin/claudecode/decision.go
+++ b/remote/scenario/builtin/claudecode/decision.go
@@ -1,5 +1,7 @@
 package claudecode
 
+import "maps"
+
 import "github.com/tingly-dev/tingly-box/remote/interaction"
 
 // encodeDecision converts an interaction.Reply into the JSON shape
@@ -12,9 +14,7 @@ func encodeDecision(input HookInput, reply interaction.Reply) map[string]any {
 		if reply.Meta != nil {
 			if updated, ok := reply.Meta["updated_input"].(map[string]interface{}); ok {
 				if a, ok := updated["answers"].(map[string]interface{}); ok {
-					for k, v := range a {
-						answers[k] = v
-					}
+					maps.Copy(answers, a)
 				}
 			}
 		}

--- a/remote/scenario/builtin/claudecode/plugin.go
+++ b/remote/scenario/builtin/claudecode/plugin.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -309,9 +310,7 @@ func parseToolInput(input HookInput) map[string]interface{} {
 	if strings.TrimSpace(input.ToolInput) != "" {
 		var parsed map[string]interface{}
 		if err := json.Unmarshal([]byte(input.ToolInput), &parsed); err == nil {
-			for k, v := range parsed {
-				out[k] = v
-			}
+			maps.Copy(out, parsed)
 		} else {
 			out["_raw_input"] = input.ToolInput
 		}

--- a/swagger/convert.go
+++ b/swagger/convert.go
@@ -51,7 +51,7 @@ func parseValidationRules(schema *Schema, bindingTag string, goType reflect.Type
 		}
 	}
 
-	for _, rule := range strings.Split(bindingTag, ",") {
+	for rule := range strings.SplitSeq(bindingTag, ",") {
 		rule = strings.TrimSpace(rule)
 
 		switch {

--- a/swagger/model.go
+++ b/swagger/model.go
@@ -27,7 +27,7 @@ func (rm *RouteManager) getModelNameWithFallback(model interface{}, explicitName
 func generateAutoModelName(method, path, modelType string) string {
 	// Clean path and convert to PascalCase: /api/v1/users/:id -> ApiV1UsersId
 	var nameParts []string
-	for _, part := range strings.Split(path, "/") {
+	for part := range strings.SplitSeq(path, "/") {
 		part = strings.TrimPrefix(part, ":")
 		if part == "" {
 			continue
@@ -47,7 +47,7 @@ func generateAutoModelName(method, path, modelType string) string {
 func generateOperationID(method, swaggerPath string) string {
 	// Convert path to camelCase: /api/v1/auth/validate -> apiV1AuthValidate
 	var nameParts []string
-	for _, part := range strings.Split(swaggerPath, "/") {
+	for part := range strings.SplitSeq(swaggerPath, "/") {
 		// Remove braces from path params: {id} -> Id
 		part = strings.Trim(part, "{}")
 		if part == "" {

--- a/swagger/openapi_20260608_test.go
+++ b/swagger/openapi_20260608_test.go
@@ -3,6 +3,7 @@ package swagger
 import (
 	"encoding/json"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -148,12 +149,7 @@ func isIgnoredField(key string) bool {
 	ignoredFields := []string{
 		// Don't ignore any fields - we want to catch ALL siblings of $ref
 	}
-	for _, ignored := range ignoredFields {
-		if key == ignored {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(ignoredFields, key)
 }
 
 // TestOpenAPIWithRealRoutes tests with actual route definitions

--- a/swagger/schema.go
+++ b/swagger/schema.go
@@ -258,8 +258,8 @@ func tagName(tag string) string {
 	if tag == "" {
 		return ""
 	}
-	if idx := strings.Index(tag, ","); idx >= 0 {
-		return tag[:idx]
+	if before, _, ok := strings.Cut(tag, ","); ok {
+		return before
 	}
 	return tag
 }

--- a/swagger/schema.go
+++ b/swagger/schema.go
@@ -92,8 +92,8 @@ func (g *schemaGen) structSchema(t reflect.Type) Schema {
 // Embedded structs without an explicit json name are flattened, matching
 // encoding/json marshaling behavior.
 func (g *schemaGen) addStructFields(schema *Schema, t reflect.Type) {
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
+	for field := range t.Fields() {
+		field := field
 
 		// encoding/json promotes exported fields from anonymous embedded structs,
 		// including unexported helper types used for response composition.

--- a/swagger/schema.go
+++ b/swagger/schema.go
@@ -226,7 +226,7 @@ func (g *schemaGen) typeSchema(t reflect.Type) Schema {
 }
 
 func hasValidationRule(tag, rule string) bool {
-	for _, item := range strings.Split(tag, ",") {
+	for item := range strings.SplitSeq(tag, ",") {
 		if strings.TrimSpace(item) == rule {
 			return true
 		}

--- a/swagger/schema.go
+++ b/swagger/schema.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 )
@@ -267,10 +268,5 @@ func tagName(tag string) string {
 // (e.g. "omitempty" in `json:"name,omitempty"`).
 func hasJSONOption(tag, option string) bool {
 	parts := strings.Split(tag, ",")
-	for _, part := range parts[1:] {
-		if part == option {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(parts[1:], option)
 }

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -417,8 +417,8 @@ func modelQueryParams(model interface{}) []queryParamSpec {
 func structQueryParams(modelType reflect.Type) []queryParamSpec {
 	var parameters []queryParamSpec
 
-	for i := 0; i < modelType.NumField(); i++ {
-		field := modelType.Field(i)
+	for field := range modelType.Fields() {
+		field := field
 		if field.PkgPath != "" {
 			continue
 		}

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -295,7 +295,7 @@ func extractPathParams(path string) []Parameter {
 	var params []Parameter
 
 	// Find all path parameters like :name, :uuid, etc.
-	for _, part := range strings.Split(path, "/") {
+	for part := range strings.SplitSeq(path, "/") {
 		if !strings.HasPrefix(part, ":") {
 			continue
 		}

--- a/vmodel/anthropic/defaults.go
+++ b/vmodel/anthropic/defaults.go
@@ -66,7 +66,6 @@ func RegisterDefaults(r *Registry) {
 	}
 
 	for _, sc := range vmodel.DefaultSequenceConfigs() {
-		sc := sc
 		_ = r.Register(NewSequenceModel(&sc))
 	}
 }

--- a/vmodel/benchmark/check/assert.go
+++ b/vmodel/benchmark/check/assert.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -81,10 +82,8 @@ func AssertFinishReasonOneOf(accepted ...string) Assertion {
 	return Assertion{
 		Name: fmt.Sprintf("finish_reason_one_of(%v)", accepted),
 		Check: func(r *RoundTripResult) error {
-			for _, a := range accepted {
-				if r.FinishReason == a {
-					return nil
-				}
+			if slices.Contains(accepted, r.FinishReason) {
+				return nil
 			}
 			return fmt.Errorf("finish_reason: got %q, want one of %v", r.FinishReason, accepted)
 		},

--- a/vmodel/benchmark/scenario_responder.go
+++ b/vmodel/benchmark/scenario_responder.go
@@ -125,7 +125,7 @@ func (sr *scenarioResponder) detect(body []byte) scenario.Scenario {
 
 func (sr *scenarioResponder) detectFromURLOrBody(urlPath string, body []byte) scenario.Scenario {
 	const prefix = "virtual-model-"
-	for _, part := range strings.Split(urlPath, "/") {
+	for part := range strings.SplitSeq(urlPath, "/") {
 		if strings.HasPrefix(part, prefix) {
 			remaining := part[len(prefix):]
 			name := remaining

--- a/vmodel/openai/defaults.go
+++ b/vmodel/openai/defaults.go
@@ -32,7 +32,6 @@ func RegisterDefaults(r *Registry) {
 	}
 
 	for _, sc := range vmodel.DefaultSequenceConfigs() {
-		sc := sc
 		_ = r.Register(NewSequenceModel(&sc))
 	}
 }

--- a/vmodel/virtualserver/error_injection_test.go
+++ b/vmodel/virtualserver/error_injection_test.go
@@ -65,7 +65,6 @@ func TestErrorInjection_PreContent_OpenAI(t *testing.T) {
 	srv := newInjectionServer(t, model, nil)
 
 	for _, streaming := range []bool{false, true} {
-		streaming := streaming
 		t.Run(map[bool]string{false: "nonstream", true: "stream"}[streaming], func(t *testing.T) {
 			resp := postJSON(t, srv.URL+"/v1/chat/completions", map[string]any{
 				"model":    "inj-precontent-openai",

--- a/vmodel/virtualserver/stream_test_mocks_test.go
+++ b/vmodel/virtualserver/stream_test_mocks_test.go
@@ -46,7 +46,6 @@ func TestStreamTestMocks_OpenAIUsageChunk(t *testing.T) {
 	srv := newStreamTestServer(t)
 
 	for _, modelID := range []string{"virtual-stream-test", "virtual-stream-test-tool"} {
-		modelID := modelID
 		t.Run(modelID, func(t *testing.T) {
 			body := map[string]interface{}{
 				"model":  modelID,
@@ -86,7 +85,6 @@ func TestStreamTestMocks_AnthropicMessageDelta(t *testing.T) {
 	srv := newStreamTestServer(t)
 
 	for _, modelID := range []string{"virtual-stream-test", "virtual-stream-test-tool"} {
-		modelID := modelID
 		t.Run(modelID, func(t *testing.T) {
 			body := map[string]interface{}{
 				"model":      modelID,

--- a/vmodel/virtualserver/stream_test_mocks_test.go
+++ b/vmodel/virtualserver/stream_test_mocks_test.go
@@ -126,7 +126,7 @@ func TestStreamTestMocks_AnthropicMessageDelta(t *testing.T) {
 func lastUsageChunk(t *testing.T, body string) map[string]interface{} {
 	t.Helper()
 	var last map[string]interface{}
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "data:") {
 			continue
@@ -153,7 +153,7 @@ func lastUsageChunk(t *testing.T, body string) map[string]interface{} {
 
 func findSSEEventData(body, eventName string) string {
 	current := ""
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		switch {
 		case strings.HasPrefix(line, "event:"):
 			current = strings.TrimSpace(strings.TrimPrefix(line, "event:"))


### PR DESCRIPTION
## Summary
Sweep of mechanical lint fixes replacing manual loop constructs with modern Go stdlib equivalents, per analyzer suggestions.

## Key Changes

- **Map/slice copying**: loop copies now use `maps.Copy`; membership checks use `slices.Contains`.
- **Slice iteration**: index-and-cut patterns replaced with `slices.Cut`; `strings.Split` + range replaced with `string.SplitSeq`.
- **Loop modernization**: `for i := 0; i < n; i++` converted to range-over-int; duplicated loop variables removed.
