### PR TITLE
feat(dashboard): ranked Top lists and unified table cards on Team usage

### DIFF
--- a/frontend/src/components/dashboard/RosterAxis.tsx
+++ b/frontend/src/components/dashboard/RosterAxis.tsx
@@ -8,6 +8,8 @@ import {
     TableHead,
     TableRow,
     Typography,
+    alpha,
+    useTheme,
 } from '@mui/material';
 import { getTotalTokens, getCacheHitRate, hasCacheWrites } from './chartStyles';
 import { UsageMetricHeaderCells, UsageMetricValueCells } from './UsageMetricCells';
@@ -210,6 +212,7 @@ export function RosterBreakdownTable<D extends MetricRow>({
     noUsageHint?: string;
     usageMetricLabels: UsageMetricLabels;
 }) {
+    const theme = useTheme();
     const showCacheWrite = hasCacheWrites(items);
     if (items.length === 0) {
         return (
@@ -220,21 +223,24 @@ export function RosterBreakdownTable<D extends MetricRow>({
         );
     }
     return (
+        // No own border/radius: this table lives inside the detail-panel Paper,
+        // and a nested box-in-box read as a different table style than the
+        // roster table sitting flush in its card.
         <TableContainer
             sx={{
                 maxHeight: 520,
-                border: '1px solid',
-                borderColor: 'divider',
-                borderRadius: 1.5,
                 overscrollBehavior: 'contain',
             }}
             role="region"
             aria-label={ariaLabel}
         >
-            <Table stickyHeader sx={{ minWidth: showCacheWrite ? 1060 : 960 }}>
+            <Table stickyHeader sx={{ minWidth: showCacheWrite ? 1080 : 980 }}>
                 <TableHead>
                     <TableRow
                         sx={{
+                            // Same translucent sticky-header background as the
+                            // roster table, so both tables read as one style.
+                            backgroundColor: alpha(theme.palette.background.paper, 0.8),
                             '& .MuiTableCell-root': {
                                 fontWeight: 600,
                                 fontSize: '0.75rem',

--- a/frontend/src/components/dashboard/RosterTopList.test.ts
+++ b/frontend/src/components/dashboard/RosterTopList.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { computeShare, OTHERS_SHARE_KEY } from './RosterTopList';
+
+const item = (key: string, tokens: number) => ({ key, name: key, tokens });
+
+describe('computeShare', () => {
+    it('ranks by tokens, filters zero-usage, and computes shares against the full total', () => {
+        const { rows, others, total } = computeShare([
+            item('a', 100),
+            item('b', 300),
+            item('zero', 0),
+            item('c', 100),
+        ]);
+        expect(rows.map((r) => r.key)).toEqual(['b', 'a', 'c']);
+        expect(total).toBe(500);
+        expect(rows[0].share).toBe(60);
+        expect(others).toBeNull();
+    });
+
+    it('folds the tail beyond topN into a single others bucket', () => {
+        const items = [10, 9, 8, 7, 6, 5, 4, 3].map((n, i) => item(`s${i}`, n));
+        const { rows, others, total } = computeShare(items);
+        expect(rows).toHaveLength(6);
+        expect(total).toBe(52);
+        expect(others?.key).toBe(OTHERS_SHARE_KEY);
+        expect(others?.tokens).toBe(7); // 4 + 3
+        expect(others?.share).toBeCloseTo((7 / 52) * 100);
+    });
+
+    it('keeps every subject as its own row when at or below topN', () => {
+        const items = [5, 4, 3, 2, 1].map((n, i) => item(`s${i}`, n));
+        const { rows, others } = computeShare(items);
+        expect(rows).toHaveLength(5);
+        expect(others).toBeNull();
+    });
+
+    it('returns empty rows when nothing in the period has usage', () => {
+        const { rows, others, total } = computeShare([item('a', 0), item('b', 0)]);
+        expect(rows).toEqual([]);
+        expect(others).toBeNull();
+        expect(total).toBe(0);
+    });
+
+    it('splits evenly on ties', () => {
+        const { rows, total } = computeShare([item('a', 50), item('b', 50)]);
+        expect(total).toBe(100);
+        expect(rows[0].share).toBe(50);
+        expect(rows[1].share).toBe(50);
+    });
+});

--- a/frontend/src/components/dashboard/RosterTopList.tsx
+++ b/frontend/src/components/dashboard/RosterTopList.tsx
@@ -1,0 +1,180 @@
+// Ranked Top list for the Team usage page. Follows the active roster axis
+// (accounts / models / providers); clicking an entry selects the same subject
+// the roster row would — one selection state, no new modes. Numbers carry the
+// information; no bar-track decoration.
+
+import { Box, Stack, Typography, alpha, useTheme } from '@mui/material';
+
+export interface ShareBarItem {
+    key: string;
+    name: string;
+    tokens: number;
+}
+
+export interface ShareBarRow extends ShareBarItem {
+    /** Percentage of all axis tokens, 0–100. */
+    share: number;
+    /** 1-based rank within the ranked list (others gets rows.length + 1). */
+    rank: number;
+}
+
+export interface ShareResult {
+    rows: ShareBarRow[];
+    /** Aggregated tail beyond topN; null when every subject fits in rows. */
+    others: ShareBarRow | null;
+    /** Total tokens across every subject (the share denominator). */
+    total: number;
+}
+
+export const OTHERS_SHARE_KEY = '__others__';
+
+// Zero-usage subjects are dropped before ranking — a 0% entry is noise, and
+// the roster table already keeps them listed (registered access).
+export function computeShare(items: ShareBarItem[], topN = 6): ShareResult {
+    const active = items
+        .filter((item) => item.tokens > 0)
+        .sort((a, b) => b.tokens - a.tokens);
+    const total = active.reduce((sum, item) => sum + item.tokens, 0);
+    if (total === 0) {
+        return { rows: [], others: null, total: 0 };
+    }
+    const rows = active.slice(0, topN).map((item, index) => ({
+        ...item,
+        share: (item.tokens / total) * 100,
+        rank: index + 1,
+    }));
+    const tail = active.slice(topN);
+    const othersTokens = tail.reduce((sum, item) => sum + item.tokens, 0);
+    const others = tail.length > 0
+        ? { key: OTHERS_SHARE_KEY, name: '', tokens: othersTokens, share: (othersTokens / total) * 100, rank: rows.length + 1 }
+        : null;
+    return { rows, others, total };
+}
+
+interface RosterTopListProps {
+    items: ShareBarItem[];
+    selectedKey?: string;
+    onSelect?: (key: string) => void;
+    title: string;
+    othersLabel: string;
+    emptyLabel: string;
+    emptyHint?: string;
+}
+
+export default function RosterTopList({
+    items,
+    selectedKey,
+    onSelect,
+    title,
+    othersLabel,
+    emptyLabel,
+    emptyHint,
+}: RosterTopListProps) {
+    const theme = useTheme();
+    const { rows, others } = computeShare(items);
+
+    const renderRow = (row: ShareBarRow, isOthers: boolean) => {
+        const selected = !isOthers && row.key === selectedKey;
+        const clickable = !isOthers && !!onSelect;
+        return (
+            <Box
+                key={row.key}
+                onClick={clickable ? () => onSelect!(row.key) : undefined}
+                role={clickable ? 'button' : undefined}
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.25,
+                    py: 0.875,
+                    px: 1.25,
+                    borderRadius: 1.5,
+                    cursor: clickable ? 'pointer' : 'default',
+                    position: 'relative',
+                    transition: 'background-color 0.15s ease',
+                    backgroundColor: selected ? alpha(theme.palette.primary.main, 0.08) : 'transparent',
+                    boxShadow: selected ? `inset 3px 0 0 ${theme.palette.primary.main}` : 'none',
+                    '&:hover': clickable && !selected ? { bgcolor: 'action.hover' } : undefined,
+                }}
+            >
+                <Typography
+                    variant="body2"
+                    sx={{
+                        width: 18,
+                        flexShrink: 0,
+                        textAlign: 'right',
+                        color: 'text.secondary',
+                        fontVariantNumeric: 'tabular-nums',
+                    }}
+                >
+                    {row.rank}
+                </Typography>
+                <Typography
+                    variant="body2"
+                    noWrap
+                    sx={{
+                        flex: 1,
+                        minWidth: 0,
+                        fontWeight: selected ? 650 : 500,
+                        color: isOthers ? 'text.secondary' : 'text.primary',
+                    }}
+                >
+                    {isOthers ? othersLabel : row.name}
+                </Typography>
+                {/* Share % only — the absolute token counts sit one glance away
+                    in the adjacent table; repeating them here is noise. */}
+                <Typography variant="body2" sx={{ flexShrink: 0, fontWeight: 650, fontVariantNumeric: 'tabular-nums' }}>
+                    {row.share.toFixed(1)}%
+                </Typography>
+            </Box>
+        );
+    };
+
+    return (
+        <Box
+            sx={{
+                width: '100%',
+                flexGrow: 1,
+                display: 'flex',
+                flexDirection: 'column',
+                borderRadius: 2,
+                border: '1px solid',
+                borderColor: 'divider',
+                backgroundColor: 'background.paper',
+                overflow: 'hidden',
+            }}
+        >
+            {/* Header bar mirrors the table cards' header (same padding and
+                minHeight, 0.875rem title) so a Top list and its sibling table
+                read as one family — borders land at the same height. */}
+            <Box sx={{
+                minHeight: 72,
+                display: 'flex',
+                alignItems: 'center',
+                p: 2.5,
+                borderBottom: '1px solid',
+                borderColor: 'divider',
+            }}>
+                <Typography variant="h6" sx={{ fontWeight: 600, fontSize: '0.875rem' }}>
+                    {title}
+                </Typography>
+            </Box>
+            {rows.length === 0 ? (
+                <Box sx={{ flex: 1, minHeight: 200, display: 'grid', placeItems: 'center', textAlign: 'center' }}>
+                    <Box>
+                        <Typography variant="body1" sx={{ color: 'text.secondary' }}>{emptyLabel}</Typography>
+                        {emptyHint && (
+                            <Typography variant="caption" sx={{ color: 'text.disabled', mt: 0.5, display: 'block' }}>
+                                {emptyHint}
+                            </Typography>
+                        )}
+                    </Box>
+                </Box>
+            ) : (
+                <Stack spacing={0.25} sx={{ flex: 1, alignContent: 'center', p: 2 }}>
+                    {rows.map((row) => renderRow(row, false))}
+                    {others && renderRow(others, true)}
+                </Stack>
+            )}
+        </Box>
+    );
+}

--- a/frontend/src/components/dashboard/index.ts
+++ b/frontend/src/components/dashboard/index.ts
@@ -32,6 +32,8 @@ export {
     hasCacheWrites,
     getErrorRateColor,
 } from './chartStyles';
+export { default as RosterTopList, computeShare } from './RosterTopList';
+export type { ShareBarItem, ShareBarRow, ShareResult } from './RosterTopList';
 export {
     computeUsageSummary,
     filterAndSort,

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1220,7 +1220,6 @@ export default {
       "accountsUsingModel_other": "{{count}} accounts",
       "accountsUsingModelTitle": "Accounts using this model",
       "accountsUsingProviderTitle": "Accounts using this provider",
-      "allProviders": "All providers",
       "selectModel": "Select a model to see details.",
       "selectProvider": "Select a provider to see details.",
       "registeredUsers": "Registered users",
@@ -1239,7 +1238,6 @@ export default {
       "requests": "Requests",
       "averagePerUser": "{{value}} per active user",
       "errors": "Errors",
-      "allUsers": "All registered users",
       "rowHint": "Select a user to inspect their usage mix.",
       "search": "Search users",
       "sortBy": "Sort users",
@@ -1269,7 +1267,12 @@ export default {
       "noUsers": "No users match your search.",
       "noUsage": "No usage in this period",
       "noUsageHint": "The user remains listed because their access is registered.",
-      "selectUser": "Select a user to see details."
+      "selectUser": "Select a user to see details.",
+      "topAccounts": "Top accounts",
+      "topModels": "Top models",
+      "topProviders": "Top providers",
+      "others": "Others",
+      "noUsageHintShort": "Try a longer time range."
     },
     "agentNav": {
       "title": "Quick Start",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1219,7 +1219,6 @@ export default {
       "accountsUsingModel": "{{count}} 个账号",
       "accountsUsingModelTitle": "使用该模型的账号",
       "accountsUsingProviderTitle": "使用该 Provider 的账号",
-      "allProviders": "全部 Provider",
       "selectModel": "选择模型后查看详细用量。",
       "selectProvider": "选择 Provider 后查看详细用量。",
       "registeredUsers": "在册用户",
@@ -1236,7 +1235,6 @@ export default {
       "requests": "请求数",
       "averagePerUser": "活跃用户人均 {{value}} 次",
       "errors": "错误数",
-      "allUsers": "全部在册用户",
       "rowHint": "选择用户，查看具体用量构成。",
       "search": "搜索用户",
       "sortBy": "用户排序",
@@ -1266,7 +1264,12 @@ export default {
       "noUsers": "没有匹配的用户。",
       "noUsage": "本周期暂无用量",
       "noUsageHint": "该用户已在册，因此仍保留在列表中。",
-      "selectUser": "选择用户后查看详细用量。"
+      "selectUser": "选择用户后查看详细用量。",
+      "topAccounts": "用量最高的账户",
+      "topModels": "用量最高的模型",
+      "topProviders": "用量最高的服务商",
+      "others": "其他",
+      "noUsageHintShort": "试试更长的时间范围。"
     },
     "agentNav": {
       "title": "快速开始",

--- a/frontend/src/pages/UserUsagePage.tsx
+++ b/frontend/src/pages/UserUsagePage.tsx
@@ -27,12 +27,9 @@ import {
     useTheme,
 } from '@mui/material';
 import {
-    AccessTime,
     ArrowForward,
     Autorenew as CachedIcon,
     BarChart,
-    Block,
-    CheckCircle,
     Cloud,
     ErrorOutline,
     Refresh,
@@ -45,7 +42,7 @@ import SearchField from '@/components/SearchField';
 import {
     formatNumber,
     StatCard,
-    TOKEN_COLORS,
+    RosterTopList,
     getTotalTokens,
     getCacheHitRate,
     getCacheHitRateColor,
@@ -58,7 +55,7 @@ import {
     useRosterAxis,
     RosterBreakdownTable,
 } from '@/components/dashboard';
-import type { AggregatedStat, MetricRow, SortField, SortDirection, UsageMetricLabels } from '@/components/dashboard';
+import type { AggregatedStat, MetricRow, SortField, SortDirection, UsageMetricLabels, ShareBarItem } from '@/components/dashboard';
 import api from '@/services/api';
 
 type TimeRange = 'today' | '7d' | '30d' | '90d';
@@ -218,98 +215,49 @@ const UserUsageSkeleton = () => (
     </Box>
 );
 
-// Identity title/subtitle/status-chip block for the detail panel. Isolated
-// into its own component because the three axes' identity shapes genuinely
-// differ (account: name + user_id + enabled/primary + last-used/joined;
-// model: name + provider name; provider: name only) — inlining it kept the
-// page body dominated by one large three-way ternary.
+// Identity line for the detail card's header bar. Single baseline row (name +
+// id/provider + joined) so the header stays at the shared 72px minHeight and
+// its bottom border aligns with the sibling Top card's — a stacked subtitle
+// made this card visibly taller. Carries only what the selected roster row
+// does NOT already show; status chip and "last used" live in that row.
 function RosterDetailHeader({
     viewMode,
     selectedUser,
     selectedModel,
     selectedProvider,
-    accountsCount,
     t,
 }: {
     viewMode: ViewMode;
     selectedUser?: UserUsageRow;
     selectedModel?: AggregatedStat;
     selectedProvider?: AggregatedStat;
-    accountsCount: number;
     t: (key: string, options?: Record<string, unknown>) => string;
 }) {
     return (
-        <Box>
-            <Stack direction="row" spacing={2} sx={{ justifyContent: 'space-between', alignItems: 'flex-start' }}>
-                <Box sx={{ minWidth: 0 }}>
-                    <Typography variant="h6" noWrap sx={{ fontWeight: 650 }}>
-                        {viewMode === 'account'
-                            ? selectedUser!.display_name
-                            : viewMode === 'model'
-                            ? (selectedModel!.model || selectedModel!.key)
-                            : (selectedProvider!.provider_name || selectedProvider!.key)}
-                    </Typography>
-                    {viewMode !== 'provider' && (
-                        <Typography variant="body2" sx={{ fontFamily: viewMode === 'account' ? 'monospace' : undefined }}>
-                            {viewMode === 'account' ? selectedUser!.user_id : (selectedModel!.provider_name || '—')}
-                        </Typography>
-                    )}
-                </Box>
-                {viewMode === 'account' ? (
-                    selectedUser!.account_type === 'primary' ? (
-                        <Chip
-                            size="small"
-                            color="primary"
-                            label={t('dashboard.userUsage.primaryAccount', { defaultValue: 'Primary account' })}
-                            variant="outlined"
-                        />
-                    ) : (
-                        <Chip
-                            size="small"
-                            icon={selectedUser!.enabled ? <CheckCircle /> : <Block />}
-                            color={selectedUser!.enabled ? 'success' : 'default'}
-                            label={selectedUser!.enabled
-                                ? t('dashboard.userUsage.enabled', { defaultValue: 'Enabled' })
-                                : t('dashboard.userUsage.disabled', { defaultValue: 'Disabled' })}
-                            variant="outlined"
-                        />
-                    )
-                ) : (
-                    <Chip
-                        size="small"
-                        color="primary"
-                        variant="outlined"
-                        label={t('dashboard.userUsage.accountsUsingModel', {
-                            count: accountsCount,
-                            defaultValue: `${accountsCount} accounts`,
-                        })}
-                    />
-                )}
-            </Stack>
-            {viewMode === 'account' && (
-                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 0.5, sm: 2 }} sx={{ mt: 1.25 }}>
-                    <Stack direction="row" spacing={0.6} sx={{ alignItems: 'center' }}>
-                        <AccessTime sx={{ fontSize: 17, color: 'text.secondary' }} />
-                        <Typography variant="body2">
-                            {selectedUser!.account_type === 'primary'
-                                ? t('dashboard.userUsage.globalTokenUsage', { defaultValue: 'Usage through the global model token' })
-                                : selectedUser!.last_used_at
-                                ? t('dashboard.userUsage.lastUsed', {
-                                    value: formatDateTime(selectedUser!.last_used_at),
-                                    defaultValue: `Last used ${formatDateTime(selectedUser!.last_used_at)}`,
-                                })
-                                : t('dashboard.userUsage.neverUsed', { defaultValue: 'Never used' })}
-                        </Typography>
-                    </Stack>
-                    {selectedUser!.created_at && (
-                        <Typography variant="body2">
-                            {t('dashboard.userUsage.joined', {
-                                value: formatDateTime(selectedUser!.created_at),
-                                defaultValue: `Added ${formatDateTime(selectedUser!.created_at)}`,
-                            })}
-                        </Typography>
-                    )}
-                </Stack>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'baseline', gap: 1.5, minWidth: 0 }}>
+            <Typography variant="h6" noWrap sx={{ fontWeight: 650 }}>
+                {viewMode === 'account'
+                    ? selectedUser!.display_name
+                    : viewMode === 'model'
+                    ? (selectedModel!.model || selectedModel!.key)
+                    : (selectedProvider!.provider_name || selectedProvider!.key)}
+            </Typography>
+            {viewMode !== 'provider' && (
+                <Typography
+                    variant="body2"
+                    noWrap
+                    sx={{ color: 'text.secondary', fontFamily: viewMode === 'account' ? 'monospace' : undefined }}
+                >
+                    {viewMode === 'account' ? selectedUser!.user_id : (selectedModel!.provider_name || '—')}
+                </Typography>
+            )}
+            {viewMode === 'account' && selectedUser!.created_at && (
+                <Typography variant="body2" noWrap sx={{ color: 'text.secondary' }}>
+                    {t('dashboard.userUsage.joined', {
+                        value: formatDateTime(selectedUser!.created_at),
+                        defaultValue: `Added ${formatDateTime(selectedUser!.created_at)}`,
+                    })}
+                </Typography>
             )}
         </Box>
     );
@@ -318,7 +266,7 @@ function RosterDetailHeader({
 export default function UserUsagePage() {
     const { t } = useTranslation();
     const theme = useTheme();
-    const [range, setRange] = useState<TimeRange>('7d');
+    const [range, setRange] = useState<TimeRange>('today');
     const [viewMode, setViewMode] = useState<ViewMode>('account');
     const [tokens, setTokens] = useState<APITokenInfo[]>([]);
     const [userStats, setUserStats] = useState<AggregatedStat[]>([]);
@@ -481,6 +429,54 @@ export default function UserUsagePage() {
         : viewMode === 'model'
         ? selectedModel
         : selectedProvider;
+
+    // Share-bar input for the visual band — follows the active axis and uses
+    // each axis' own key space, so a bar click selects the exact roster row.
+    const shareItems = useMemo<ShareBarItem[]>(() => {
+        if (viewMode === 'account') {
+            return rows.map((row) => ({
+                key: accountKey(row),
+                name: row.display_name || row.user_id,
+                tokens: row.total_tokens,
+            }));
+        }
+        if (viewMode === 'model') {
+            return modelRoster.map((row) => ({
+                key: getModelKey(row),
+                name: modelName(row),
+                tokens: getTotalTokens(row),
+            }));
+        }
+        return providerRoster.map((row) => ({
+            key: getProviderKey(row),
+            name: providerName(row),
+            tokens: getTotalTokens(row),
+        }));
+    }, [viewMode, rows, modelRoster, providerRoster]);
+
+    // Detail-panel Top list input — ranks the selected subject's breakdown
+    // (their models, or the accounts using the selected model/provider).
+    // Display-only: the breakdown table has no row-selection state to link.
+    const detailList = viewMode === 'account'
+        ? accountAxis.detail
+        : viewMode === 'model'
+        ? modelAxis.detail
+        : providerAxis.detail;
+    const showDetailTop = !activeAxis.detailLoading && detailList.length > 0;
+    const detailShareItems = useMemo<ShareBarItem[]>(() => {
+        if (viewMode === 'account') {
+            return detailList.map((model) => ({
+                key: `${model.provider_uuid}-${model.model || model.key}`,
+                name: model.model || model.key,
+                tokens: getTotalTokens(model),
+            }));
+        }
+        return detailList.map((account) => ({
+            key: account.user_id || account.key,
+            name: accountDisplayName(account.user_id || account.key),
+            tokens: getTotalTokens(account),
+        }));
+    }, [viewMode, detailList, accountDisplayName]);
 
     // Single pass over the active axis' rows for every summary aggregate.
     const summary = useMemo(() => {
@@ -662,23 +658,6 @@ export default function UserUsagePage() {
                         <ToggleButtonGroup
                             size="small"
                             exclusive
-                            value={viewMode}
-                            onChange={(_, value: ViewMode | null) => value && setViewMode(value)}
-                            aria-label={t('dashboard.userUsage.viewMode', { defaultValue: 'View' })}
-                        >
-                            <ToggleButton value="account">
-                                {t('dashboard.userUsage.byAccount', { defaultValue: 'By account' })}
-                            </ToggleButton>
-                            <ToggleButton value="model">
-                                {t('dashboard.userUsage.byModel', { defaultValue: 'By model' })}
-                            </ToggleButton>
-                            <ToggleButton value="provider">
-                                {t('dashboard.userUsage.byProvider', { defaultValue: 'By provider' })}
-                            </ToggleButton>
-                        </ToggleButtonGroup>
-                        <ToggleButtonGroup
-                            size="small"
-                            exclusive
                             value={range}
                             onChange={(_, value: TimeRange | null) => value && setRange(value)}
                             aria-label={t('dashboard.userUsage.timeRange', { defaultValue: 'Time range' })}
@@ -719,14 +698,19 @@ export default function UserUsagePage() {
                 ))}
             </Grid>
 
+            {/* Roster table with the ranked Top list beside it (right) —
+                same active axis, one selection state; clicking a Top entry
+                selects the same subject the roster row would. Trend over time
+                is the personal Usage Dashboard's job, not this page's. */}
             <Grid container spacing={2} sx={{ alignItems: 'stretch' }}>
-                <Grid size={{ xs: 12 }} sx={{ display: 'flex' }}>
+                <Grid size={{ xs: 12, lg: 9 }} sx={{ display: 'flex', minWidth: 0 }}>
                     <Paper
                         elevation={0}
                         sx={{ ...usageTableCardSx, display: 'flex', flexDirection: 'column' }}
                     >
                         <Box
                             sx={{
+                                minHeight: 72,
                                 p: 2.5,
                                 display: 'flex',
                                 flexWrap: 'wrap',
@@ -737,14 +721,36 @@ export default function UserUsagePage() {
                                 borderColor: 'divider',
                             }}
                         >
-                            <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-                                <Typography variant="h6" sx={{ fontWeight: 600, fontSize: '0.875rem' }}>
-                                    {viewMode === 'account'
-                                        ? t('dashboard.userUsage.allUsers', { defaultValue: 'All registered users' })
-                                        : viewMode === 'model'
-                                        ? t('dashboard.userUsage.allModels', { defaultValue: 'All models' })
-                                        : t('dashboard.userUsage.allProviders', { defaultValue: 'All providers' })}
-                                </Typography>
+                            {/* Axis switcher lives on the table it controls
+                                (conventional dashboard position), and doubles
+                                as the card's title — a separate "All users"
+                                caption would repeat it. */}
+                            <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+                                <ToggleButtonGroup
+                                    size="small"
+                                    exclusive
+                                    value={viewMode}
+                                    onChange={(_, value: ViewMode | null) => value && setViewMode(value)}
+                                    aria-label={t('dashboard.userUsage.viewMode', { defaultValue: 'View' })}
+                                    sx={{
+                                        '& .MuiToggleButton-root': {
+                                            px: 1.5,
+                                            py: 0.25,
+                                            fontSize: '0.78rem',
+                                            textTransform: 'none',
+                                        },
+                                    }}
+                                >
+                                    <ToggleButton value="account">
+                                        {t('dashboard.userUsage.byAccount', { defaultValue: 'By account' })}
+                                    </ToggleButton>
+                                    <ToggleButton value="model">
+                                        {t('dashboard.userUsage.byModel', { defaultValue: 'By model' })}
+                                    </ToggleButton>
+                                    <ToggleButton value="provider">
+                                        {t('dashboard.userUsage.byProvider', { defaultValue: 'By provider' })}
+                                    </ToggleButton>
+                                </ToggleButtonGroup>
                                 <Chip
                                     size="small"
                                     label={activeAxis.visibleRows.length}
@@ -959,177 +965,132 @@ export default function UserUsagePage() {
                         )}
                     </Paper>
                 </Grid>
+                <Grid size={{ xs: 12, lg: 3, xl: 2.4 }} sx={{ display: 'flex', minWidth: 0 }}>
+                    <RosterTopList
+                        items={shareItems}
+                        selectedKey={activeAxis.selectedKey}
+                        onSelect={(key) => { activeAxis.setSelectedKey(key); scrollDetailIntoView(); }}
+                        title={viewMode === 'account'
+                            ? t('dashboard.userUsage.topAccounts', { defaultValue: 'Top accounts' })
+                            : viewMode === 'model'
+                            ? t('dashboard.userUsage.topModels', { defaultValue: 'Top models' })
+                            : t('dashboard.userUsage.topProviders', { defaultValue: 'Top providers' })}
+                        othersLabel={t('dashboard.userUsage.others', { defaultValue: 'Others' })}
+                        emptyLabel={t('dashboard.userUsage.noUsage', { defaultValue: 'No usage in this period' })}
+                        emptyHint={t('dashboard.userUsage.noUsageHintShort', { defaultValue: 'Try a longer time range.' })}
+                    />
+                </Grid>
 
-                <Grid
-                    ref={detailPanelRef}
-                    size={{ xs: 12 }}
-                    sx={{ display: 'flex', scrollMarginTop: { xs: 72, lg: 0 } }}
-                >
-                    <Paper elevation={0} sx={{ ...usageTableCardSx, display: 'flex' }}>
-                        <Box sx={{
-                            p: { xs: 2, sm: 2.5 },
-                            width: '100%',
-                            display: 'flex',
-                            flexDirection: 'column',
-                        }}>
-                        {detailSubject ? (
-                            <Stack spacing={2.5}>
+            </Grid>
+
+            {/* Detail section: the breakdown table gets the exact same card
+                anatomy as the roster card above (header bar + count chip +
+                flush table), so both tables read as one style. Subject
+                identity lives in the card's header bar; the "All models [N]"
+                sub-header it used to have is the same info as the chip. */}
+            <Grid
+                container
+                spacing={2}
+                ref={detailPanelRef}
+                sx={{ alignItems: 'stretch', scrollMarginTop: { xs: 72, lg: 0 } }}
+            >
+                {detailSubject ? (<>
+                    <Grid size={{ xs: 12, lg: showDetailTop ? 9 : 12 }} sx={{ display: 'flex', minWidth: 0 }}>
+                        <Paper elevation={0} sx={{ ...usageTableCardSx, display: 'flex', flexDirection: 'column' }}>
+                            <Box
+                                sx={{
+                                    minHeight: 72,
+                                    p: 2.5,
+                                    display: 'flex',
+                                    flexWrap: 'wrap',
+                                    alignItems: 'center',
+                                    justifyContent: 'space-between',
+                                    gap: 1.5,
+                                    borderBottom: '1px solid',
+                                    borderColor: 'divider',
+                                }}
+                            >
                                 <RosterDetailHeader
                                     viewMode={viewMode}
                                     selectedUser={selectedUser}
                                     selectedModel={selectedModel}
                                     selectedProvider={selectedProvider}
-                                    accountsCount={viewMode === 'model' ? modelAxis.detail.length : providerAxis.detail.length}
                                     t={t}
                                 />
-
-                                <Grid
-                                    container
-                                    sx={{
-                                        border: '1px solid',
-                                        borderColor: 'divider',
-                                        borderRadius: 1.5,
-                                        overflow: 'hidden',
-                                    }}
-                                >
-                                    {[
+                                <Chip size="small" label={activeAxis.detail.length} sx={{ height: 22 }} />
+                            </Box>
+                            {activeAxis.detailLoading ? (
+                                <Stack spacing={1.5} sx={{ overflow: 'hidden', p: 2.5 }}>
+                                    {Array.from({ length: 3 }).map((_, index) => <Skeleton key={index} variant="rounded" height={44} />)}
+                                </Stack>
+                            ) : viewMode === 'account' ? (
+                                <RosterBreakdownTable
+                                    items={accountAxis.detail}
+                                    rowKey={(model) => `${model.provider_uuid}-${model.model || model.key}`}
+                                    identityColumns={[
                                         {
-                                            label: t('dashboard.userUsage.input', { defaultValue: 'Input' }),
-                                            value: detailSubject.total_input_tokens,
-                                            color: TOKEN_COLORS.input.main,
-                                            detail: (detailSubject.cache_write_tokens || 0) > 0
-                                                ? t('dashboard.userUsage.cacheWriteIncluded', {
-                                                    value: formatNumber(detailSubject.cache_write_tokens || 0),
-                                                    defaultValue: `incl. ${formatNumber(detailSubject.cache_write_tokens || 0)} written`,
-                                                })
-                                                : '',
+                                            key: 'provider',
+                                            label: t('dashboard.userUsage.provider', { defaultValue: 'Provider' }),
+                                            render: (model) => model.provider_name || '—',
                                         },
                                         {
-                                            label: t('dashboard.userUsage.output', { defaultValue: 'Output' }),
-                                            value: detailSubject.total_output_tokens,
-                                            color: TOKEN_COLORS.output.main,
-                                            detail: '',
+                                            key: 'model',
+                                            label: t('dashboard.userUsage.model', { defaultValue: 'Model' }),
+                                            render: (model) => (
+                                                <Typography variant="body2" sx={{ fontWeight: 600 }}>{model.model || model.key}</Typography>
+                                            ),
                                         },
+                                    ]}
+                                    ariaLabel={t('dashboard.userUsage.allModels', { defaultValue: 'All models' })}
+                                    noUsageLabel={t('dashboard.userUsage.noUsage', { defaultValue: 'No usage in this period' })}
+                                    noUsageHint={t('dashboard.userUsage.noUsageHint', { defaultValue: 'The user remains listed because their access is registered.' })}
+                                    usageMetricLabels={usageMetricLabels}
+                                />
+                            ) : (
+                                <RosterBreakdownTable
+                                    items={activeAxis.detail}
+                                    rowKey={(account) => account.user_id || account.key}
+                                    identityColumns={[
                                         {
-                                            label: t('dashboard.userUsage.cacheRead', { defaultValue: 'Cache Read' }),
-                                            value: detailSubject.cache_read_tokens || 0,
-                                            color: TOKEN_COLORS.cache.main,
-                                            detail: '',
-                                        },
-                                        {
-                                            label: t('dashboard.userUsage.cacheHitRate', { defaultValue: 'Cache hit rate' }),
-                                            value: `${getCacheHitRate(detailSubject.cache_read_tokens || 0, detailSubject.total_input_tokens).toFixed(1)}%`,
-                                            color: theme.palette[getCacheHitRateColor(getCacheHitRate(detailSubject.cache_read_tokens || 0, detailSubject.total_input_tokens))].main,
-                                            detail: '',
-                                        },
-                                    ].map(({ label, value, color, detail }, index) => (
-                                        <Grid
-                                            key={label}
-                                            size={{ xs: 6, sm: 3 }}
-                                            sx={{
-                                                borderColor: 'divider',
-                                                borderRight: {
-                                                    xs: index % 2 === 0 ? '1px solid' : 0,
-                                                    sm: index < 3 ? '1px solid' : 0,
-                                                },
-                                                borderBottom: {
-                                                    xs: index < 2 ? '1px solid' : 0,
-                                                    sm: 0,
-                                                },
-                                            }}
-                                        >
-                                            <Box sx={{ px: 1.5, py: 1.25 }}>
-                                                <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
-                                                    <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: color, flexShrink: 0 }} />
-                                                    <Typography variant="subtitle2" sx={{ color: 'text.secondary' }}>{label}</Typography>
-                                                </Stack>
-                                                <Typography variant="h4" sx={{ fontVariantNumeric: 'tabular-nums', mt: 0.5 }}>
-                                                    {typeof value === 'number' ? formatNumber(value) : value}
-                                                </Typography>
-                                                {detail && (
-                                                    <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mt: 0.25 }}>
-                                                        {detail}
+                                            key: 'user',
+                                            label: t('dashboard.userUsage.user', { defaultValue: 'User' }),
+                                            render: (account) => (
+                                                <>
+                                                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                                                        {accountDisplayName(account.user_id || account.key)}
                                                     </Typography>
-                                                )}
-                                            </Box>
-                                        </Grid>
-                                    ))}
-                                </Grid>
-
-                                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                                    <Stack direction="row" sx={{ mb: 1.25, justifyContent: 'space-between', alignItems: 'baseline' }}>
-                                        <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
-                                            <Typography variant="subtitle2" sx={{ fontWeight: 650 }}>
-                                                {viewMode === 'account'
-                                                    ? t('dashboard.userUsage.allModels', { defaultValue: 'All models' })
-                                                    : viewMode === 'model'
-                                                    ? t('dashboard.userUsage.accountsUsingModelTitle', { defaultValue: 'Accounts using this model' })
-                                                    : t('dashboard.userUsage.accountsUsingProviderTitle', { defaultValue: 'Accounts using this provider' })}
-                                            </Typography>
-                                            <Chip size="small" label={activeAxis.detail.length} sx={{ height: 22 }} />
-                                        </Stack>
-                                        <Typography variant="body2">
-                                            {formatNumber(getTotalTokens(detailSubject))} {t('dashboard.userUsage.tokens', { defaultValue: 'tokens' }).toLocaleLowerCase()}
-                                        </Typography>
-                                    </Stack>
-                                    {activeAxis.detailLoading ? (
-                                        <Stack spacing={1.5} sx={{ overflow: 'hidden' }}>
-                                            {Array.from({ length: 3 }).map((_, index) => <Skeleton key={index} variant="rounded" height={44} />)}
-                                        </Stack>
-                                    ) : viewMode === 'account' ? (
-                                        <RosterBreakdownTable
-                                            items={accountAxis.detail}
-                                            rowKey={(model) => `${model.provider_uuid}-${model.model || model.key}`}
-                                            identityColumns={[
-                                                {
-                                                    key: 'provider',
-                                                    label: t('dashboard.userUsage.provider', { defaultValue: 'Provider' }),
-                                                    render: (model) => model.provider_name || '—',
-                                                },
-                                                {
-                                                    key: 'model',
-                                                    label: t('dashboard.userUsage.model', { defaultValue: 'Model' }),
-                                                    render: (model) => (
-                                                        <Typography variant="body2" sx={{ fontWeight: 600 }}>{model.model || model.key}</Typography>
-                                                    ),
-                                                },
-                                            ]}
-                                            ariaLabel={t('dashboard.userUsage.allModels', { defaultValue: 'All models' })}
-                                            noUsageLabel={t('dashboard.userUsage.noUsage', { defaultValue: 'No usage in this period' })}
-                                            noUsageHint={t('dashboard.userUsage.noUsageHint', { defaultValue: 'The user remains listed because their access is registered.' })}
-                                            usageMetricLabels={usageMetricLabels}
-                                        />
-                                    ) : (
-                                        <RosterBreakdownTable
-                                            items={activeAxis.detail}
-                                            rowKey={(account) => account.user_id || account.key}
-                                            identityColumns={[
-                                                {
-                                                    key: 'user',
-                                                    label: t('dashboard.userUsage.user', { defaultValue: 'User' }),
-                                                    render: (account) => (
-                                                        <>
-                                                            <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                                                                {accountDisplayName(account.user_id || account.key)}
-                                                            </Typography>
-                                                            <Typography variant="caption" sx={{ color: 'text.secondary', fontFamily: 'monospace' }}>
-                                                                {account.user_id || account.key}
-                                                            </Typography>
-                                                        </>
-                                                    ),
-                                                },
-                                            ]}
-                                            ariaLabel={viewMode === 'model'
-                                                ? t('dashboard.userUsage.accountsUsingModelTitle', { defaultValue: 'Accounts using this model' })
-                                                : t('dashboard.userUsage.accountsUsingProviderTitle', { defaultValue: 'Accounts using this provider' })}
-                                            noUsageLabel={t('dashboard.userUsage.noUsage', { defaultValue: 'No usage in this period' })}
-                                            usageMetricLabels={usageMetricLabels}
-                                        />
-                                    )}
-                                </Box>
-                            </Stack>
-                        ) : (
-                            <Box sx={{ height: '100%', display: 'grid', placeItems: 'center', textAlign: 'center' }}>
+                                                    <Typography variant="caption" sx={{ color: 'text.secondary', fontFamily: 'monospace' }}>
+                                                        {account.user_id || account.key}
+                                                    </Typography>
+                                                </>
+                                            ),
+                                        },
+                                    ]}
+                                    ariaLabel={viewMode === 'model'
+                                        ? t('dashboard.userUsage.accountsUsingModelTitle', { defaultValue: 'Accounts using this model' })
+                                        : t('dashboard.userUsage.accountsUsingProviderTitle', { defaultValue: 'Accounts using this provider' })}
+                                    noUsageLabel={t('dashboard.userUsage.noUsage', { defaultValue: 'No usage in this period' })}
+                                    usageMetricLabels={usageMetricLabels}
+                                />
+                            )}
+                        </Paper>
+                    </Grid>
+                    {showDetailTop && (
+                        <Grid size={{ xs: 12, lg: 3, xl: 2.4 }} sx={{ display: 'flex', minWidth: 0 }}>
+                            <RosterTopList
+                                items={detailShareItems}
+                                title={viewMode === 'account'
+                                    ? t('dashboard.userUsage.topModels', { defaultValue: 'Top models' })
+                                    : t('dashboard.userUsage.topAccounts', { defaultValue: 'Top accounts' })}
+                                othersLabel={t('dashboard.userUsage.others', { defaultValue: 'Others' })}
+                                emptyLabel={t('dashboard.userUsage.noUsage', { defaultValue: 'No usage in this period' })}
+                            />
+                        </Grid>
+                    )}
+                </>) : (
+                    <Grid size={{ xs: 12 }} sx={{ display: 'flex' }}>
+                        <Paper elevation={0} sx={{ ...usageTableCardSx, display: 'flex' }}>
+                            <Box sx={{ width: '100%', py: 6, display: 'grid', placeItems: 'center', textAlign: 'center' }}>
                                 <Box>
                                     {viewMode === 'account'
                                         ? <Users sx={{ fontSize: 42, color: 'text.disabled', mb: 1 }} />
@@ -1145,10 +1106,9 @@ export default function UserUsagePage() {
                                     </Typography>
                                 </Box>
                             </Box>
-                        )}
-                        </Box>
-                    </Paper>
-                </Grid>
+                        </Paper>
+                    </Grid>
+                )}
             </Grid>
         </Box>
     );


### PR DESCRIPTION
## Summary
The Team usage page was all numbers — its tables answered "exactly how much" but nothing answered "who dominates" at a glance. 

This adds axis-aware ranked Top lists beside each table and unifies the page on a single card grammar.

## Key Changes

- **Top lists**: ranked share% (top 6 + others) beside both the roster table and the detail breakdown, following the account/model/provider axis; clicking an entry selects the roster row.
- **Unified card grammar**: every table is a card with a matching 72px header bar; the breakdown table drops its nested border and gains the roster table's sticky-header style.
- **Axis switcher relocation**: the By-account/model/provider toggle moves from the page corner into the roster card header (conventional dashboard position), replacing the redundant card title.
- **De-duplication**: summary tiles, status/N-accounts chips, "last used" and token-count repeats removed — every number renders once, in the row that owns it.
- **Defaults**: the page now opens on Today instead of 7D.

## Notes

- At 1440px viewports the roster table's rightmost columns sit behind a horizontal scroll (natural width ~1290px); wider screens are unaffected.
