### PR TITLE
fix(protocol): preserve tool-channel images across remaining conversions

### DIFF
--- a/.design/harness-matrix.md
+++ b/.design/harness-matrix.md
@@ -578,6 +578,12 @@ See `contentShapeCases()` in `content_shapes.go` for current coverage. Extend
 that list, not the matrix's `Scenario`/`buildRequest`, when a future bug is
 "the gateway dropped an unusual request shape while forwarding it."
 
+The image cases (`*_image_content`) are the multimodal half of this suite,
+added for issue #1606 (tool-returned `image_url` parts corrupted in
+`role:"tool"` messages). The full catalog of where multimodal content can
+appear per protocol, and the conversion contract those cases enforce, lives
+in [`multimodal-content.md`](./multimodal-content.md).
+
 ### 10.2 Prompt-cache request suite (`cache_controls.go`)
 
 Prompt-cache metadata is also request-shaped and therefore cannot be exercised

--- a/.design/multimodal-content.md
+++ b/.design/multimodal-content.md
@@ -1,0 +1,122 @@
+# Multimodal content — protocol catalog & conversion contract
+
+Issue [#1606](https://github.com/tingly-dev/tingly-box/issues/1606) exposed a
+class of bugs where image content survived some conversion paths but was
+corrupted or silently dropped on others (most visibly: `image_url` parts in
+`role:"tool"` messages, which upstreams rejected with 400 on *every*
+subsequent request carrying that history). This document is the catalog the
+fix was driven from: every place multimodal content can legally appear in
+each protocol, what it converts to in each target, and the harness coverage
+that keeps it working.
+
+## 1. Where multimodal content lives, per protocol
+
+### OpenAI Chat Completions (`TypeOpenAIChat`)
+
+| Location | Part types | Notes |
+| --- | --- | --- |
+| `messages[role=user].content[]` | `text`, `image_url`, `input_audio`, `file` | classic multimodal user turn |
+| `messages[role=tool].content[]` | `text`, `image_url` (ecosystem) | how agent frameworks return tool screenshots. The upstream SDK types this as text-only; our `openai-go` fork widens `ChatCompletionToolMessageParamContentUnion.OfArrayOfContentParts` to the full content-part union — see §3 |
+| `messages[role=system/developer].content[]` | `text` only | never multimodal |
+| `messages[role=assistant].content[]` | `text`, `refusal` | never image-bearing on request side |
+
+### OpenAI Responses (`TypeOpenAIResponses`)
+
+| Location | Part types | Notes |
+| --- | --- | --- |
+| `input[type=message].content[]` | `input_text`, `input_image`, `input_file` | user/system message parts |
+| `input[type=function_call_output].output[]` | `input_text`, `input_image`, `input_file` | `output` is a string OR an item list; images ride the item list |
+
+### Anthropic Messages v1 / Beta (`TypeAnthropicV1` / `TypeAnthropicBeta`)
+
+| Location | Block types | Notes |
+| --- | --- | --- |
+| `messages[].content[]` (user) | `text`, `image`, `document`, `search_result` | image source: `base64` or `url` |
+| `tool_result.content[]` | `text`, `image`, `document`, `search_result`, `tool_reference` | how Claude-family tools return screenshots |
+| `system[]` | `text` only | |
+
+### Google Gemini (`TypeGoogle`)
+
+| Location | Part types | Notes |
+| --- | --- | --- |
+| `contents[].parts[]` | `text`, `inline_data`, `file_data` | user images as inline blobs |
+| `contents[].parts[].function_response.parts[]` | `inline_data` blobs | tool-returned media |
+
+## 2. Conversion contract
+
+The gateway's rule (issue #1606): **an image must survive every supported
+`(source → target)` request conversion in both the user channel and the tool
+channel** — either natively or, when a scenario routes to a text-only model,
+via the vision-proxy rewrite (`.design/vision-proxy.md`), never by silent
+corruption.
+
+Canonical mappings:
+
+| From | To OpenAI Chat | To Responses | To Anthropic | To Google |
+| --- | --- | --- | --- | --- |
+| user image | `image_url` part (data: URL for base64) | `input_image` | `image` block | `inline_data` |
+| tool image | `image_url` part in `role:"tool"` content | `input_image` in `function_call_output.output[]` | `image` in `tool_result.content[]` | `inline_data` in `function_response.parts[]` |
+
+Shared helpers:
+
+- `request.ParseImageURLToAnthropicSource` — splits an OpenAI `image_url.url`
+  into (mediaType, data) for data: URLs, or a remote URL.
+- `request.anthropicImageToOpenAIURL` / `imageBlockToOpenAIURL` /
+  `betaImageBlockToOpenAIURL` — Anthropic image source → OpenAI URL string.
+- `request.openAIImageURLToAnthropicBetaBlock` — the reverse.
+- `request.openAIToolMessageFromAnthropicToolResult` — tool_result (view) →
+  OpenAI tool message, preserving image entries.
+
+String-vs-array rule for tool results: text-only content keeps collapsing to
+the compact plain-string form (`content: "…"` / `output: "…"`); the array
+form is used exactly when the content carries images or cache breakpoints.
+This keeps wire output byte-stable for the overwhelmingly common text case.
+
+## 3. The openai-go fork extension
+
+Upstream `openai-go` types tool message content as
+`[]ChatCompletionContentPartTextParam` (text-only, matching OpenAI's
+published spec). Real agent traffic — and OpenAI-compatible upstreams such as
+Qwen/vLLM — use `image_url` parts inside tool messages. With the text-only
+union, the ingress parse itself corrupted the part
+(`{"type":"image_url","text":""}`), which is precisely the 400 in #1606.
+
+The fork (`libs/openai-go`) therefore widens
+`ChatCompletionToolMessageParamContentUnion.OfArrayOfContentParts` to
+`[]ChatCompletionContentPartUnionParam` (the same union user messages use)
+and teaches `openai.ToolMessage` to accept the union slice. Wire output for
+text-only content is unchanged. When syncing the fork with upstream, keep
+this extension — `chatcompletion_toolmessage_patch_test.go` (in the fork) locks it.
+
+## 4. Harness coverage (vmodel-driven)
+
+Per the TDD strategy on #1606, coverage lives at two levels:
+
+- **Unit** (`internal/protocol/request/image_conversions_test.go` — user
+  channel; `image_tool_conversions_test.go` — tool channel;
+  `internal/protocol/multimodal_roundtrip_test.go` — ingress round trip;
+  `internal/protocol/transform/consistency_multimodal_test.go` — orphan-tool
+  alignment).
+- **End-to-end** (`internal/protocoltest/content_shapes.go`, image cases):
+  bespoke requests through the real gateway, asserting on the request the
+  vmodel-backed VirtualServer actually captured upstream
+  (`VirtualServer.LastRequest`), for:
+  `chat→chat` (tool + user), `chat→responses` (tool), `chat→anthropic`
+  (tool), `anthropic→chat` (user + tool_result), `anthropic→responses`
+  (tool_result). Runs under both `go test ./internal/protocoltest` and
+  `harness matrix --mode=content_shapes`.
+
+## 5. Known gaps (out of scope of the #1606 fix, catalogued for follow-up)
+
+- **Audio / file / document parts**: `input_audio` and `file` Chat parts,
+  Responses `input_file`, and Anthropic `document` / `search_result` blocks
+  are passed through same-protocol but not yet mapped cross-protocol.
+- **Google targets**: user images convert (`inline_data`); tool images now
+  forward as `function_response` inline blobs on the OpenAI→Google path, but
+  the Anthropic→Google path still extracts text only from `tool_result`.
+- **Remote (http) image URLs → Google** are stubbed as `[Image: <url>]` text
+  because Gemini needs fetched bytes or `file_data`.
+- **Vision health probes**: the health monitor currently has no image-bearing
+  probe; #1606's comment showed a probe hitting the same corrupted-part 400.
+  Once a vision probe is added it must send both a user image and a
+  tool-image turn (both shapes in §2).

--- a/internal/protocol/multimodal_roundtrip_test.go
+++ b/internal/protocol/multimodal_roundtrip_test.go
@@ -1,0 +1,82 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestOpenAIChatToolMessageImagePartRoundTrip is the ingress-level regression
+// for issue #1606: an OpenAI Chat Completions request whose role:"tool"
+// message carries a multimodal content array must survive the gateway's
+// parse → re-marshal round trip byte-equivalent in meaning. Before the fix the
+// SDK union for tool message content only admitted text parts, so the
+// image_url part was re-serialized as {"type":"image_url","text":""} — the
+// payload was dropped and upstreams rejected the request with 400.
+func TestOpenAIChatToolMessageImagePartRoundTrip(t *testing.T) {
+	const imageURL = "data:image/png;base64,iVBORw0KGgo="
+	raw := []byte(`{
+		"model": "test-model",
+		"stream": false,
+		"messages": [
+			{"role": "user", "content": "analyze the image"},
+			{"role": "assistant", "content": "", "tool_calls": [
+				{"id": "call_1", "type": "function",
+				 "function": {"name": "vision_analyze", "arguments": "{}"}}
+			]},
+			{"role": "tool", "tool_call_id": "call_1", "content": [
+				{"type": "text", "text": "Image loaded. What color is it?"},
+				{"type": "image_url", "image_url": {"url": "` + imageURL + `"}}
+			]}
+		]
+	}`)
+
+	var req OpenAIChatCompletionRequest
+	require.NoError(t, json.Unmarshal(raw, &req))
+
+	out, err := json.Marshal(&req)
+	require.NoError(t, err)
+
+	parts := gjson.GetBytes(out, "messages.2.content")
+	require.True(t, parts.IsArray(), "tool message content should stay an array, got: %s", parts.Raw)
+	require.Len(t, parts.Array(), 2, "both content parts must survive")
+
+	textPart := parts.Array()[0]
+	assert.Equal(t, "text", textPart.Get("type").Str)
+	assert.Equal(t, "Image loaded. What color is it?", textPart.Get("text").Str)
+
+	imagePart := parts.Array()[1]
+	assert.Equal(t, "image_url", imagePart.Get("type").Str)
+	assert.Equal(t, imageURL, imagePart.Get("image_url.url").Str,
+		"image_url.url payload must survive the round trip")
+	assert.False(t, imagePart.Get("text").Exists(),
+		"image part must not grow a bogus text field")
+}
+
+// TestOpenAIChatToolMessageImageOnlyRoundTrip covers the image-only list
+// content row of the issue's control matrix.
+func TestOpenAIChatToolMessageImageOnlyRoundTrip(t *testing.T) {
+	const imageURL = "https://example.com/shot.png"
+	raw := []byte(`{
+		"model": "test-model",
+		"messages": [
+			{"role": "tool", "tool_call_id": "call_1", "content": [
+				{"type": "image_url", "image_url": {"url": "` + imageURL + `"}}
+			]}
+		]
+	}`)
+
+	var req OpenAIChatCompletionRequest
+	require.NoError(t, json.Unmarshal(raw, &req))
+	out, err := json.Marshal(&req)
+	require.NoError(t, err)
+
+	parts := gjson.GetBytes(out, "messages.0.content")
+	require.True(t, parts.IsArray())
+	require.Len(t, parts.Array(), 1)
+	assert.Equal(t, "image_url", parts.Array()[0].Get("type").Str)
+	assert.Equal(t, imageURL, parts.Array()[0].Get("image_url.url").Str)
+}

--- a/internal/protocol/request/anthropic_beta_to_responses.go
+++ b/internal/protocol/request/anthropic_beta_to_responses.go
@@ -126,19 +126,45 @@ func convertBetaUserMessageToResponsesInput(msg anthropic.BetaMessageParam) []re
 		// When there are tool_result blocks, we need to create separate items
 		for _, block := range msg.Content {
 			if block.OfToolResult != nil {
-				// Convert tool_result to Responses API function call output
+				// Convert tool_result to Responses API function call output.
+				// Image content entries (tool screenshots — issue #1606) keep
+				// the structured output item list as input_image items.
 				output := responses.ResponseInputItemFunctionCallOutputOutputUnionParam{}
-				content := convertBetaToolResultContent(block.OfToolResult.Content)
-				if !param.IsOmitted(block.OfToolResult.CacheControl) {
-					text := &responses.ResponseInputTextContentParam{
-						Text:                  content,
-						PromptCacheBreakpoint: responses.NewResponseInputTextContentPromptCacheBreakpointParam(),
+				hasCache := !param.IsOmitted(block.OfToolResult.CacheControl)
+				hasResultImage := false
+				for _, c := range block.OfToolResult.Content {
+					if c.OfImage != nil {
+						hasResultImage = true
 					}
-					output.OfResponseFunctionCallOutputItemArray = responses.ResponseFunctionCallOutputItemListParam{
-						{OfInputText: text},
-					}
+				}
+				if !hasResultImage && !hasCache {
+					output.OfString = ParamOpt(convertBetaToolResultContent(block.OfToolResult.Content))
 				} else {
-					output.OfString = ParamOpt(content)
+					outputItems := make(responses.ResponseFunctionCallOutputItemListParam, 0, len(block.OfToolResult.Content))
+					for _, c := range block.OfToolResult.Content {
+						switch {
+						case c.OfText != nil:
+							outputItems = append(outputItems, responses.ResponseFunctionCallOutputItemUnionParam{
+								OfInputText: &responses.ResponseInputTextContentParam{Text: c.OfText.Text},
+							})
+						case c.OfImage != nil:
+							url := betaImageBlockToOpenAIURL(c.OfImage)
+							if url == "" {
+								continue
+							}
+							outputItems = append(outputItems, responses.ResponseFunctionCallOutputItemUnionParam{
+								OfInputImage: &responses.ResponseInputImageContentParam{ImageURL: ParamOpt(url)},
+							})
+						}
+					}
+					if len(outputItems) == 0 {
+						output.OfString = ParamOpt("")
+					} else {
+						if hasCache {
+							markFunctionCallOutputBreakpoint(&outputItems[len(outputItems)-1])
+						}
+						output.OfResponseFunctionCallOutputItemArray = outputItems
+					}
 				}
 				outputItem := responses.ResponseInputItemFunctionCallOutputParam{
 					CallID: block.OfToolResult.ToolUseID,
@@ -148,6 +174,24 @@ func convertBetaUserMessageToResponsesInput(msg anthropic.BetaMessageParam) []re
 				items = append(items, responses.ResponseInputItemUnionParam{
 					OfFunctionCallOutput: &outputItem,
 				})
+			} else if block.OfImage != nil {
+				// Image content alongside tool results (issue #1606): forward
+				// as a user message with an input_image part instead of
+				// dropping it.
+				if url := betaImageBlockToOpenAIURL(block.OfImage); url != "" {
+					messageItem := responses.EasyInputMessageParam{
+						Type: responses.EasyInputMessageTypeMessage,
+						Role: responses.EasyInputMessageRole("user"),
+						Content: responses.EasyInputMessageContentUnionParam{
+							OfInputItemContentList: responses.ResponseInputMessageContentListParam{
+								{OfInputImage: &responses.ResponseInputImageParam{ImageURL: ParamOpt(url)}},
+							},
+						},
+					}
+					items = append(items, responses.ResponseInputItemUnionParam{
+						OfMessage: &messageItem,
+					})
+				}
 			} else if block.OfText != nil && block.OfText.Text != "" {
 				// Text content alongside tool results
 				content := responses.EasyInputMessageContentUnionParam{OfString: ParamOpt(block.OfText.Text)}

--- a/internal/protocol/request/anthropic_beta_to_responses.go
+++ b/internal/protocol/request/anthropic_beta_to_responses.go
@@ -126,71 +126,18 @@ func convertBetaUserMessageToResponsesInput(msg anthropic.BetaMessageParam) []re
 		// When there are tool_result blocks, we need to create separate items
 		for _, block := range msg.Content {
 			if block.OfToolResult != nil {
-				// Convert tool_result to Responses API function call output.
-				// Image content entries (tool screenshots — issue #1606) keep
-				// the structured output item list as input_image items.
-				output := responses.ResponseInputItemFunctionCallOutputOutputUnionParam{}
-				hasCache := !param.IsOmitted(block.OfToolResult.CacheControl)
-				hasResultImage := false
-				for _, c := range block.OfToolResult.Content {
-					if c.OfImage != nil {
-						hasResultImage = true
-					}
-				}
-				if !hasResultImage && !hasCache {
-					output.OfString = ParamOpt(convertBetaToolResultContent(block.OfToolResult.Content))
-				} else {
-					outputItems := make(responses.ResponseFunctionCallOutputItemListParam, 0, len(block.OfToolResult.Content))
-					for _, c := range block.OfToolResult.Content {
-						switch {
-						case c.OfText != nil:
-							outputItems = append(outputItems, responses.ResponseFunctionCallOutputItemUnionParam{
-								OfInputText: &responses.ResponseInputTextContentParam{Text: c.OfText.Text},
-							})
-						case c.OfImage != nil:
-							url := betaImageBlockToOpenAIURL(c.OfImage)
-							if url == "" {
-								continue
-							}
-							outputItems = append(outputItems, responses.ResponseFunctionCallOutputItemUnionParam{
-								OfInputImage: &responses.ResponseInputImageContentParam{ImageURL: ParamOpt(url)},
-							})
-						}
-					}
-					if len(outputItems) == 0 {
-						output.OfString = ParamOpt("")
-					} else {
-						if hasCache {
-							markFunctionCallOutputBreakpoint(&outputItems[len(outputItems)-1])
-						}
-						output.OfResponseFunctionCallOutputItemArray = outputItems
-					}
-				}
-				outputItem := responses.ResponseInputItemFunctionCallOutputParam{
-					CallID: block.OfToolResult.ToolUseID,
-					Output: output,
-					Status: "completed",
-				}
-				items = append(items, responses.ResponseInputItemUnionParam{
-					OfFunctionCallOutput: &outputItem,
-				})
+				// Bridge to the v1 view and share the tool_result →
+				// function_call_output conversion with the v1 converter
+				// (image entries included — issue #1606).
+				items = append(items, responsesFunctionCallOutputFromToolResult(viewAnthropicBetaBlock(block).OfToolResult))
 			} else if block.OfImage != nil {
 				// Image content alongside tool results (issue #1606): forward
 				// as a user message with an input_image part instead of
 				// dropping it.
 				if url := betaImageBlockToOpenAIURL(block.OfImage); url != "" {
-					messageItem := responses.EasyInputMessageParam{
-						Type: responses.EasyInputMessageTypeMessage,
-						Role: responses.EasyInputMessageRole("user"),
-						Content: responses.EasyInputMessageContentUnionParam{
-							OfInputItemContentList: responses.ResponseInputMessageContentListParam{
-								{OfInputImage: &responses.ResponseInputImageParam{ImageURL: ParamOpt(url)}},
-							},
-						},
-					}
-					items = append(items, responses.ResponseInputItemUnionParam{
-						OfMessage: &messageItem,
-					})
+					items = append(items, responseMessageWithContent("user", responses.ResponseInputMessageContentListParam{
+						{OfInputImage: &responses.ResponseInputImageParam{ImageURL: ParamOpt(url)}},
+					}))
 				}
 			} else if block.OfText != nil && block.OfText.Text != "" {
 				// Text content alongside tool results

--- a/internal/protocol/request/anthropic_v1_to_responses.go
+++ b/internal/protocol/request/anthropic_v1_to_responses.go
@@ -110,6 +110,17 @@ func convertV1MessagesToResponsesInput(messages []anthropic.MessageParam) respon
 	return inputItems
 }
 
+// markFunctionCallOutputBreakpoint stamps a prompt-cache breakpoint on a
+// function_call_output output item, whichever variant it holds.
+func markFunctionCallOutputBreakpoint(item *responses.ResponseFunctionCallOutputItemUnionParam) {
+	switch {
+	case item.OfInputText != nil:
+		item.OfInputText.PromptCacheBreakpoint = responses.NewResponseInputTextContentPromptCacheBreakpointParam()
+	case item.OfInputImage != nil:
+		item.OfInputImage.PromptCacheBreakpoint = responses.NewResponseInputImageContentPromptCacheBreakpointParam()
+	}
+}
+
 // convertV1UserMessageToResponsesInput converts Anthropic v1 user message to Responses API input items
 func convertV1UserMessageToResponsesInput(msg anthropic.MessageParam) []responses.ResponseInputItemUnionParam {
 	var items []responses.ResponseInputItemUnionParam
@@ -131,19 +142,45 @@ func convertV1UserMessageToResponsesInput(msg anthropic.MessageParam) []response
 		// When there are tool_result blocks, we need to create separate items
 		for _, block := range msg.Content {
 			if block.OfToolResult != nil {
-				// Convert tool_result to function_call_output
+				// Convert tool_result to function_call_output. Image content
+				// entries (tool screenshots — issue #1606) keep the
+				// structured output item list as input_image items.
 				output := responses.ResponseInputItemFunctionCallOutputOutputUnionParam{}
-				content := convertV1ToolResultContentToString(block.OfToolResult.Content)
-				if !param.IsOmitted(block.OfToolResult.CacheControl) {
-					text := &responses.ResponseInputTextContentParam{
-						Text:                  content,
-						PromptCacheBreakpoint: responses.NewResponseInputTextContentPromptCacheBreakpointParam(),
+				hasCache := !param.IsOmitted(block.OfToolResult.CacheControl)
+				hasResultImage := false
+				for _, c := range block.OfToolResult.Content {
+					if c.OfImage != nil {
+						hasResultImage = true
 					}
-					output.OfResponseFunctionCallOutputItemArray = responses.ResponseFunctionCallOutputItemListParam{
-						{OfInputText: text},
-					}
+				}
+				if !hasResultImage && !hasCache {
+					output.OfString = param.NewOpt(convertV1ToolResultContentToString(block.OfToolResult.Content))
 				} else {
-					output.OfString = param.NewOpt(content)
+					outputItems := make(responses.ResponseFunctionCallOutputItemListParam, 0, len(block.OfToolResult.Content))
+					for _, c := range block.OfToolResult.Content {
+						switch {
+						case c.OfText != nil:
+							outputItems = append(outputItems, responses.ResponseFunctionCallOutputItemUnionParam{
+								OfInputText: &responses.ResponseInputTextContentParam{Text: c.OfText.Text},
+							})
+						case c.OfImage != nil:
+							url := imageBlockToOpenAIURL(c.OfImage)
+							if url == "" {
+								continue
+							}
+							outputItems = append(outputItems, responses.ResponseFunctionCallOutputItemUnionParam{
+								OfInputImage: &responses.ResponseInputImageContentParam{ImageURL: param.NewOpt(url)},
+							})
+						}
+					}
+					if len(outputItems) == 0 {
+						output.OfString = param.NewOpt("")
+					} else {
+						if hasCache {
+							markFunctionCallOutputBreakpoint(&outputItems[len(outputItems)-1])
+						}
+						output.OfResponseFunctionCallOutputItemArray = outputItems
+					}
 				}
 				outputItem := responses.ResponseInputItemFunctionCallOutputParam{
 					CallID: block.OfToolResult.ToolUseID,
@@ -153,6 +190,24 @@ func convertV1UserMessageToResponsesInput(msg anthropic.MessageParam) []response
 				items = append(items, responses.ResponseInputItemUnionParam{
 					OfFunctionCallOutput: &outputItem,
 				})
+			} else if block.OfImage != nil {
+				// Image content alongside tool results (issue #1606): forward
+				// as a user message with an input_image part instead of
+				// dropping it.
+				if url := imageBlockToOpenAIURL(block.OfImage); url != "" {
+					messageItem := responses.EasyInputMessageParam{
+						Type: responses.EasyInputMessageTypeMessage,
+						Role: responses.EasyInputMessageRole("user"),
+						Content: responses.EasyInputMessageContentUnionParam{
+							OfInputItemContentList: responses.ResponseInputMessageContentListParam{
+								{OfInputImage: &responses.ResponseInputImageParam{ImageURL: param.NewOpt(url)}},
+							},
+						},
+					}
+					items = append(items, responses.ResponseInputItemUnionParam{
+						OfMessage: &messageItem,
+					})
+				}
 			} else if block.OfText != nil {
 				// Text content alongside tool results
 				content := responses.EasyInputMessageContentUnionParam{

--- a/internal/protocol/request/anthropic_v1_to_responses.go
+++ b/internal/protocol/request/anthropic_v1_to_responses.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"encoding/json"
+	"slices"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go/v3/packages/param"
@@ -121,6 +122,56 @@ func markFunctionCallOutputBreakpoint(item *responses.ResponseFunctionCallOutput
 	}
 }
 
+// responsesFunctionCallOutputFromToolResult converts a tool_result block into
+// a Responses function_call_output input item. Text-only results without
+// cache control collapse to the compact output string; results carrying
+// images (tool screenshots — issue #1606) or cache breakpoints keep the
+// structured output item list. Shared by the v1 and beta converters — the
+// beta path bridges through viewAnthropicBetaBlock first.
+func responsesFunctionCallOutputFromToolResult(block *anthropic.ToolResultBlockParam) responses.ResponseInputItemUnionParam {
+	output := responses.ResponseInputItemFunctionCallOutputOutputUnionParam{}
+	hasCache := !param.IsOmitted(block.CacheControl)
+	hasImage := slices.ContainsFunc(block.Content, func(c anthropic.ToolResultBlockParamContentUnion) bool {
+		return c.OfImage != nil
+	})
+
+	if !hasImage && !hasCache {
+		output.OfString = param.NewOpt(convertV1ToolResultContentToString(block.Content))
+	} else {
+		items := make(responses.ResponseFunctionCallOutputItemListParam, 0, len(block.Content))
+		for _, c := range block.Content {
+			switch {
+			case c.OfText != nil:
+				items = append(items, responses.ResponseFunctionCallOutputItemUnionParam{
+					OfInputText: &responses.ResponseInputTextContentParam{Text: c.OfText.Text},
+				})
+			case c.OfImage != nil:
+				if url := imageBlockToOpenAIURL(c.OfImage); url != "" {
+					items = append(items, responses.ResponseFunctionCallOutputItemUnionParam{
+						OfInputImage: &responses.ResponseInputImageContentParam{ImageURL: param.NewOpt(url)},
+					})
+				}
+			}
+		}
+		if len(items) == 0 {
+			output.OfString = param.NewOpt("")
+		} else {
+			if hasCache {
+				markFunctionCallOutputBreakpoint(&items[len(items)-1])
+			}
+			output.OfResponseFunctionCallOutputItemArray = items
+		}
+	}
+
+	return responses.ResponseInputItemUnionParam{
+		OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+			CallID: block.ToolUseID,
+			Output: output,
+			Status: "completed",
+		},
+	}
+}
+
 // convertV1UserMessageToResponsesInput converts Anthropic v1 user message to Responses API input items
 func convertV1UserMessageToResponsesInput(msg anthropic.MessageParam) []responses.ResponseInputItemUnionParam {
 	var items []responses.ResponseInputItemUnionParam
@@ -142,71 +193,15 @@ func convertV1UserMessageToResponsesInput(msg anthropic.MessageParam) []response
 		// When there are tool_result blocks, we need to create separate items
 		for _, block := range msg.Content {
 			if block.OfToolResult != nil {
-				// Convert tool_result to function_call_output. Image content
-				// entries (tool screenshots — issue #1606) keep the
-				// structured output item list as input_image items.
-				output := responses.ResponseInputItemFunctionCallOutputOutputUnionParam{}
-				hasCache := !param.IsOmitted(block.OfToolResult.CacheControl)
-				hasResultImage := false
-				for _, c := range block.OfToolResult.Content {
-					if c.OfImage != nil {
-						hasResultImage = true
-					}
-				}
-				if !hasResultImage && !hasCache {
-					output.OfString = param.NewOpt(convertV1ToolResultContentToString(block.OfToolResult.Content))
-				} else {
-					outputItems := make(responses.ResponseFunctionCallOutputItemListParam, 0, len(block.OfToolResult.Content))
-					for _, c := range block.OfToolResult.Content {
-						switch {
-						case c.OfText != nil:
-							outputItems = append(outputItems, responses.ResponseFunctionCallOutputItemUnionParam{
-								OfInputText: &responses.ResponseInputTextContentParam{Text: c.OfText.Text},
-							})
-						case c.OfImage != nil:
-							url := imageBlockToOpenAIURL(c.OfImage)
-							if url == "" {
-								continue
-							}
-							outputItems = append(outputItems, responses.ResponseFunctionCallOutputItemUnionParam{
-								OfInputImage: &responses.ResponseInputImageContentParam{ImageURL: param.NewOpt(url)},
-							})
-						}
-					}
-					if len(outputItems) == 0 {
-						output.OfString = param.NewOpt("")
-					} else {
-						if hasCache {
-							markFunctionCallOutputBreakpoint(&outputItems[len(outputItems)-1])
-						}
-						output.OfResponseFunctionCallOutputItemArray = outputItems
-					}
-				}
-				outputItem := responses.ResponseInputItemFunctionCallOutputParam{
-					CallID: block.OfToolResult.ToolUseID,
-					Output: output,
-					Status: "completed",
-				}
-				items = append(items, responses.ResponseInputItemUnionParam{
-					OfFunctionCallOutput: &outputItem,
-				})
+				items = append(items, responsesFunctionCallOutputFromToolResult(block.OfToolResult))
 			} else if block.OfImage != nil {
 				// Image content alongside tool results (issue #1606): forward
 				// as a user message with an input_image part instead of
 				// dropping it.
 				if url := imageBlockToOpenAIURL(block.OfImage); url != "" {
-					messageItem := responses.EasyInputMessageParam{
-						Type: responses.EasyInputMessageTypeMessage,
-						Role: responses.EasyInputMessageRole("user"),
-						Content: responses.EasyInputMessageContentUnionParam{
-							OfInputItemContentList: responses.ResponseInputMessageContentListParam{
-								{OfInputImage: &responses.ResponseInputImageParam{ImageURL: param.NewOpt(url)}},
-							},
-						},
-					}
-					items = append(items, responses.ResponseInputItemUnionParam{
-						OfMessage: &messageItem,
-					})
+					items = append(items, responseMessageWithContent("user", responses.ResponseInputMessageContentListParam{
+						{OfInputImage: &responses.ResponseInputImageParam{ImageURL: param.NewOpt(url)}},
+					}))
 				}
 			} else if block.OfText != nil {
 				// Text content alongside tool results

--- a/internal/protocol/request/anthropic_view.go
+++ b/internal/protocol/request/anthropic_view.go
@@ -92,13 +92,37 @@ func viewAnthropicBetaBlock(block anthropic.BetaContentBlockParamUnion) anthropi
 			CacheControl: viewAnthropicBetaCacheControl(&block.OfToolUse.CacheControl),
 		}}
 	case block.OfToolResult != nil:
+		// Preserve block boundaries: text AND image content entries both
+		// survive the beta→view bridge (issue #1606 — tool screenshots).
+		content := make([]anthropic.ToolResultBlockParamContentUnion, 0, len(block.OfToolResult.Content))
+		for _, c := range block.OfToolResult.Content {
+			switch {
+			case c.OfText != nil:
+				content = append(content, anthropic.ToolResultBlockParamContentUnion{
+					OfText: &anthropic.TextBlockParam{Text: c.OfText.Text},
+				})
+			case c.OfImage != nil:
+				image := &anthropic.ImageBlockParam{}
+				if c.OfImage.Source.OfBase64 != nil {
+					image.Source.OfBase64 = &anthropic.Base64ImageSourceParam{
+						Data:      c.OfImage.Source.OfBase64.Data,
+						MediaType: anthropic.Base64ImageSourceMediaType(c.OfImage.Source.OfBase64.MediaType),
+					}
+				} else if c.OfImage.Source.OfURL != nil {
+					image.Source.OfURL = &anthropic.URLImageSourceParam{
+						URL: c.OfImage.Source.OfURL.URL,
+					}
+				} else {
+					continue
+				}
+				content = append(content, anthropic.ToolResultBlockParamContentUnion{OfImage: image})
+			}
+		}
 		return anthropic.ContentBlockParamUnion{OfToolResult: &anthropic.ToolResultBlockParam{
 			ToolUseID:    block.OfToolResult.ToolUseID,
 			IsError:      block.OfToolResult.IsError,
 			CacheControl: viewAnthropicBetaCacheControl(&block.OfToolResult.CacheControl),
-			Content: []anthropic.ToolResultBlockParamContentUnion{{
-				OfText: &anthropic.TextBlockParam{Text: convertBetaToolResultContent(block.OfToolResult.Content)},
-			}},
+			Content:      content,
 		}}
 	case block.OfImage != nil:
 		image := &anthropic.ImageBlockParam{
@@ -410,34 +434,22 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropic.ContentBlockParamUnion)
 
 	switch {
 	case hasToolResult:
-		// When there are tool_result blocks, we need to create separate messages
-		var textBlocks []anthropic.ContentBlockParamUnion
+		// When there are tool_result blocks, we need to create separate
+		// messages. Text and image blocks alongside the tool results are
+		// re-emitted as a follow-up user message (issue #1606: images must
+		// not be dropped).
+		var leftoverBlocks []anthropic.ContentBlockParamUnion
 		for _, block := range blocks {
 			switch {
-			case block.OfText != nil:
-				textBlocks = append(textBlocks, block)
+			case block.OfText != nil, block.OfImage != nil:
+				leftoverBlocks = append(leftoverBlocks, block)
 			case block.OfToolResult != nil:
-				// Convert tool_result to OpenAI role="tool" message.
-				// Truncate tool_call_id to meet OpenAI's 40 character limit.
-				resultText := convertToolResultContent(block.OfToolResult.Content)
-				if hasAnthropicCacheControl(block.OfToolResult.CacheControl) {
-					part := openAITextPart(resultText, true)
-					result = append(result, openai.ChatCompletionMessageParamUnion{
-						OfTool: &openai.ChatCompletionToolMessageParam{
-							ToolCallID: truncateToolCallID(block.OfToolResult.ToolUseID),
-							Content: openai.ChatCompletionToolMessageParamContentUnion{
-								OfArrayOfContentParts: []openai.ChatCompletionContentPartUnionParam{{OfText: &part}},
-							},
-						},
-					})
-				} else {
-					result = append(result, openai.ToolMessage(resultText, truncateToolCallID(block.OfToolResult.ToolUseID)))
-				}
+				result = append(result, openAIToolMessageFromAnthropicToolResult(block.OfToolResult))
 			}
 		}
-		// If there was text content alongside tool results, add it as a user message
-		if len(textBlocks) > 0 {
-			result = append(result, convertAnthropicViewUserToOpenAI(textBlocks)...)
+		// If there was text/image content alongside tool results, add it as a user message
+		if len(leftoverBlocks) > 0 {
+			result = append(result, convertAnthropicViewUserToOpenAI(leftoverBlocks)...)
 		}
 	case hasImage || hasCache:
 		// Multimodal user message: emit an array of text + image_url content parts
@@ -478,6 +490,69 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropic.ContentBlockParamUnion)
 	}
 
 	return result
+}
+
+// openAIToolMessageFromAnthropicToolResult converts a normalized tool_result
+// block into an OpenAI role="tool" message. Text-only results without cache
+// control keep the compact plain-string content; results carrying image
+// blocks (tool screenshots — issue #1606) or cache breakpoints use the
+// content-part array so nothing is dropped. tool_call_id is truncated to
+// OpenAI's 40-character limit.
+func openAIToolMessageFromAnthropicToolResult(block *anthropic.ToolResultBlockParam) openai.ChatCompletionMessageParamUnion {
+	toolCallID := truncateToolCallID(block.ToolUseID)
+	hasCache := hasAnthropicCacheControl(block.CacheControl)
+	hasImage := false
+	for _, c := range block.Content {
+		if c.OfImage != nil {
+			hasImage = true
+		}
+	}
+
+	if !hasImage && !hasCache {
+		return openai.ToolMessage(convertToolResultContent(block.Content), toolCallID)
+	}
+
+	parts := make([]openai.ChatCompletionContentPartUnionParam, 0, len(block.Content))
+	for _, c := range block.Content {
+		switch {
+		case c.OfText != nil:
+			part := openAITextPart(c.OfText.Text, false)
+			parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfText: &part})
+		case c.OfImage != nil:
+			url := anthropicImageToOpenAIURL(c.OfImage)
+			if url == "" {
+				continue
+			}
+			parts = append(parts, openai.ChatCompletionContentPartUnionParam{
+				OfImageURL: &openai.ChatCompletionContentPartImageParam{
+					ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: url},
+				},
+			})
+		}
+	}
+	if len(parts) == 0 {
+		part := openAITextPart("", hasCache)
+		parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfText: &part})
+	} else if hasCache {
+		// Anthropic's cache_control on a tool_result covers the prefix ending
+		// at that block; mark the breakpoint on the message's last part.
+		last := &parts[len(parts)-1]
+		switch {
+		case last.OfText != nil:
+			last.OfText.PromptCacheBreakpoint = openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam()
+		case last.OfImageURL != nil:
+			last.OfImageURL.PromptCacheBreakpoint = openai.NewChatCompletionContentPartImagePromptCacheBreakpointParam()
+		}
+	}
+
+	return openai.ChatCompletionMessageParamUnion{
+		OfTool: &openai.ChatCompletionToolMessageParam{
+			ToolCallID: toolCallID,
+			Content: openai.ChatCompletionToolMessageParamContentUnion{
+				OfArrayOfContentParts: parts,
+			},
+		},
+	}
 }
 
 func openAITextPart(text string, cacheControl bool) openai.ChatCompletionContentPartTextParam {

--- a/internal/protocol/request/anthropic_view.go
+++ b/internal/protocol/request/anthropic_view.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -102,17 +103,8 @@ func viewAnthropicBetaBlock(block anthropic.BetaContentBlockParamUnion) anthropi
 					OfText: &anthropic.TextBlockParam{Text: c.OfText.Text},
 				})
 			case c.OfImage != nil:
-				image := &anthropic.ImageBlockParam{}
-				if c.OfImage.Source.OfBase64 != nil {
-					image.Source.OfBase64 = &anthropic.Base64ImageSourceParam{
-						Data:      c.OfImage.Source.OfBase64.Data,
-						MediaType: anthropic.Base64ImageSourceMediaType(c.OfImage.Source.OfBase64.MediaType),
-					}
-				} else if c.OfImage.Source.OfURL != nil {
-					image.Source.OfURL = &anthropic.URLImageSourceParam{
-						URL: c.OfImage.Source.OfURL.URL,
-					}
-				} else {
+				image := viewAnthropicBetaImage(c.OfImage)
+				if image.Source.OfBase64 == nil && image.Source.OfURL == nil {
 					continue
 				}
 				content = append(content, anthropic.ToolResultBlockParamContentUnion{OfImage: image})
@@ -125,22 +117,28 @@ func viewAnthropicBetaBlock(block anthropic.BetaContentBlockParamUnion) anthropi
 			Content:      content,
 		}}
 	case block.OfImage != nil:
-		image := &anthropic.ImageBlockParam{
-			CacheControl: viewAnthropicBetaCacheControl(&block.OfImage.CacheControl),
-		}
-		if block.OfImage.Source.OfBase64 != nil {
-			image.Source.OfBase64 = &anthropic.Base64ImageSourceParam{
-				Data:      block.OfImage.Source.OfBase64.Data,
-				MediaType: anthropic.Base64ImageSourceMediaType(block.OfImage.Source.OfBase64.MediaType),
-			}
-		} else if block.OfImage.Source.OfURL != nil {
-			image.Source.OfURL = &anthropic.URLImageSourceParam{
-				URL: block.OfImage.Source.OfURL.URL,
-			}
-		}
-		return anthropic.ContentBlockParamUnion{OfImage: image}
+		return anthropic.ContentBlockParamUnion{OfImage: viewAnthropicBetaImage(block.OfImage)}
 	}
 	return anthropic.ContentBlockParamUnion{}
+}
+
+// viewAnthropicBetaImage bridges a beta image block into the canonical v1
+// type, carrying the source (base64 or URL) and cache control across.
+func viewAnthropicBetaImage(img *anthropic.BetaImageBlockParam) *anthropic.ImageBlockParam {
+	image := &anthropic.ImageBlockParam{
+		CacheControl: viewAnthropicBetaCacheControl(&img.CacheControl),
+	}
+	if img.Source.OfBase64 != nil {
+		image.Source.OfBase64 = &anthropic.Base64ImageSourceParam{
+			Data:      img.Source.OfBase64.Data,
+			MediaType: anthropic.Base64ImageSourceMediaType(img.Source.OfBase64.MediaType),
+		}
+	} else if img.Source.OfURL != nil {
+		image.Source.OfURL = &anthropic.URLImageSourceParam{
+			URL: img.Source.OfURL.URL,
+		}
+	}
+	return image
 }
 
 func viewAnthropicBetaMessage(msg anthropic.BetaMessageParam) anthropic.MessageParam {
@@ -464,12 +462,7 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropic.ContentBlockParamUnion)
 				if url == "" {
 					continue
 				}
-				imagePart := openai.ChatCompletionContentPartImageParam{
-					ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: url},
-				}
-				if hasAnthropicCacheControl(block.OfImage.CacheControl) {
-					imagePart.PromptCacheBreakpoint = openai.NewChatCompletionContentPartImagePromptCacheBreakpointParam()
-				}
+				imagePart := openAIImagePart(url, hasAnthropicCacheControl(block.OfImage.CacheControl))
 				parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfImageURL: &imagePart})
 			}
 		}
@@ -501,12 +494,9 @@ func convertAnthropicViewUserToOpenAI(blocks []anthropic.ContentBlockParamUnion)
 func openAIToolMessageFromAnthropicToolResult(block *anthropic.ToolResultBlockParam) openai.ChatCompletionMessageParamUnion {
 	toolCallID := truncateToolCallID(block.ToolUseID)
 	hasCache := hasAnthropicCacheControl(block.CacheControl)
-	hasImage := false
-	for _, c := range block.Content {
-		if c.OfImage != nil {
-			hasImage = true
-		}
-	}
+	hasImage := slices.ContainsFunc(block.Content, func(c anthropic.ToolResultBlockParamContentUnion) bool {
+		return c.OfImage != nil
+	})
 
 	if !hasImage && !hasCache {
 		return openai.ToolMessage(convertToolResultContent(block.Content), toolCallID)
@@ -523,11 +513,8 @@ func openAIToolMessageFromAnthropicToolResult(block *anthropic.ToolResultBlockPa
 			if url == "" {
 				continue
 			}
-			parts = append(parts, openai.ChatCompletionContentPartUnionParam{
-				OfImageURL: &openai.ChatCompletionContentPartImageParam{
-					ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: url},
-				},
-			})
+			part := openAIImagePart(url, false)
+			parts = append(parts, openai.ChatCompletionContentPartUnionParam{OfImageURL: &part})
 		}
 	}
 	if len(parts) == 0 {
@@ -559,6 +546,18 @@ func openAITextPart(text string, cacheControl bool) openai.ChatCompletionContent
 	part := openai.ChatCompletionContentPartTextParam{Text: text}
 	if cacheControl {
 		part.PromptCacheBreakpoint = openai.NewChatCompletionContentPartTextPromptCacheBreakpointParam()
+	}
+	return part
+}
+
+// openAIImagePart is the image twin of openAITextPart: an image_url content
+// part from a URL string, optionally carrying a prompt-cache breakpoint.
+func openAIImagePart(url string, cacheControl bool) openai.ChatCompletionContentPartImageParam {
+	part := openai.ChatCompletionContentPartImageParam{
+		ImageURL: openai.ChatCompletionContentPartImageImageURLParam{URL: url},
+	}
+	if cacheControl {
+		part.PromptCacheBreakpoint = openai.NewChatCompletionContentPartImagePromptCacheBreakpointParam()
 	}
 	return part
 }

--- a/internal/protocol/request/any_to_google.go
+++ b/internal/protocol/request/any_to_google.go
@@ -1,6 +1,7 @@
 package request
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 
@@ -154,34 +155,26 @@ func ConvertOpenAIToGoogleRequest(req *openai.ChatCompletionNewParams, defaultMa
 
 		case msg.OfTool != nil:
 			// Tool result message → function_response in user content.
-			// Array-of-content-parts form joins its text parts; image parts
-			// (issue #1606) become inline-data function response blobs so
-			// they are not silently dropped.
+			// Text (string form, or joined array parts) becomes one blob;
+			// image_url parts (issue #1606) become typed inline-data blobs
+			// so they are not silently dropped.
+			parts := msg.OfTool.Content.OfArrayOfContentParts
+			text := msg.OfTool.Content.OfString.Value
+			if text == "" {
+				text = joinTextContentPartsFromUnion(parts)
+			}
 			responseParts := []*genai.FunctionResponsePart{}
-			if text := msg.OfTool.Content.OfString.Value; text != "" || len(msg.OfTool.Content.OfArrayOfContentParts) == 0 {
+			if text != "" || len(parts) == 0 {
 				responseParts = append(responseParts, &genai.FunctionResponsePart{
 					InlineData: &genai.FunctionResponseBlob{Data: []byte(text)},
 				})
-			} else {
-				if text := joinTextContentPartsFromUnion(msg.OfTool.Content.OfArrayOfContentParts); text != "" {
-					responseParts = append(responseParts, &genai.FunctionResponsePart{
-						InlineData: &genai.FunctionResponseBlob{Data: []byte(text)},
-					})
+			}
+			for _, part := range parts {
+				if part.OfImageURL == nil {
+					continue
 				}
-				for _, part := range msg.OfTool.Content.OfArrayOfContentParts {
-					if part.OfImageURL == nil {
-						continue
-					}
-					mediaType, data, _ := ParseImageURLToAnthropicSource(part.OfImageURL.ImageURL.URL)
-					if mediaType == "" || data == "" {
-						continue
-					}
-					responseParts = append(responseParts, &genai.FunctionResponsePart{
-						InlineData: &genai.FunctionResponseBlob{
-							MIMEType: mediaType,
-							Data:     []byte(data),
-						},
-					})
+				if blob := imageURLToGoogleBlob(part.OfImageURL.ImageURL.URL); blob != nil {
+					responseParts = append(responseParts, &genai.FunctionResponsePart{InlineData: blob})
 				}
 			}
 			toolContent := &genai.Content{
@@ -326,4 +319,22 @@ func ConvertAnthropicBetaToGoogleTools(tools []anthropic.BetaToolUnionParam) []*
 
 func ConvertAnthropicBetaToGoogleToolChoice(tc *anthropic.BetaToolChoiceUnionParam) *genai.ToolConfig {
 	return convertAnthropicToolChoiceViewToGoogle(viewAnthropicBetaToolChoice(tc))
+}
+
+// imageURLToGoogleBlob decodes an OpenAI image_url string (data: URL) into a
+// typed inline-data function-response blob. Returns nil for remote URLs and
+// undecodable payloads — Gemini inline data needs raw bytes, not a reference.
+func imageURLToGoogleBlob(url string) *genai.FunctionResponseBlob {
+	mediaType, data, _ := ParseImageURLToAnthropicSource(url)
+	if mediaType == "" || data == "" {
+		return nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return nil
+	}
+	return &genai.FunctionResponseBlob{
+		MIMEType: mediaType,
+		Data:     raw,
+	}
 }

--- a/internal/protocol/request/any_to_google.go
+++ b/internal/protocol/request/any_to_google.go
@@ -153,20 +153,44 @@ func ConvertOpenAIToGoogleRequest(req *openai.ChatCompletionNewParams, defaultMa
 			}
 
 		case msg.OfTool != nil:
-			// Tool result message → function_response in user content
+			// Tool result message → function_response in user content.
+			// Array-of-content-parts form joins its text parts; image parts
+			// (issue #1606) become inline-data function response blobs so
+			// they are not silently dropped.
+			responseParts := []*genai.FunctionResponsePart{}
+			if text := msg.OfTool.Content.OfString.Value; text != "" || len(msg.OfTool.Content.OfArrayOfContentParts) == 0 {
+				responseParts = append(responseParts, &genai.FunctionResponsePart{
+					InlineData: &genai.FunctionResponseBlob{Data: []byte(text)},
+				})
+			} else {
+				if text := joinTextContentPartsFromUnion(msg.OfTool.Content.OfArrayOfContentParts); text != "" {
+					responseParts = append(responseParts, &genai.FunctionResponsePart{
+						InlineData: &genai.FunctionResponseBlob{Data: []byte(text)},
+					})
+				}
+				for _, part := range msg.OfTool.Content.OfArrayOfContentParts {
+					if part.OfImageURL == nil {
+						continue
+					}
+					mediaType, data, _ := ParseImageURLToAnthropicSource(part.OfImageURL.ImageURL.URL)
+					if mediaType == "" || data == "" {
+						continue
+					}
+					responseParts = append(responseParts, &genai.FunctionResponsePart{
+						InlineData: &genai.FunctionResponseBlob{
+							MIMEType: mediaType,
+							Data:     []byte(data),
+						},
+					})
+				}
+			}
 			toolContent := &genai.Content{
 				Role: "user",
 				Parts: []*genai.Part{
 					{
 						FunctionResponse: &genai.FunctionResponse{
-							Name: msg.OfTool.ToolCallID,
-							Parts: []*genai.FunctionResponsePart{
-								{
-									InlineData: &genai.FunctionResponseBlob{
-										Data: []byte(msg.OfTool.Content.OfString.Value),
-									},
-								},
-							},
+							Name:  msg.OfTool.ToolCallID,
+							Parts: responseParts,
 						},
 					},
 				},

--- a/internal/protocol/request/image_tool_conversions_test.go
+++ b/internal/protocol/request/image_tool_conversions_test.go
@@ -46,27 +46,10 @@ func chatToolImageRequest(t *testing.T) *openai.ChatCompletionNewParams {
 	return req
 }
 
-// TestChatToolMessageImage_SDKParse verifies the openai-go union itself: a
-// tool message content array keeps its image_url part through parse+marshal.
-func TestChatToolMessageImage_SDKParse(t *testing.T) {
-	req := chatToolImageRequest(t)
-	out, err := json.Marshal(req)
-	require.NoError(t, err)
-
-	var m map[string]any
-	require.NoError(t, json.Unmarshal(out, &m))
-	msgs := m["messages"].([]any)
-	tool := msgs[2].(map[string]any)
-	parts, ok := tool["content"].([]any)
-	require.True(t, ok, "tool content should stay an array, got %v", tool["content"])
-	require.Len(t, parts, 2)
-
-	img := parts[1].(map[string]any)
-	assert.Equal(t, "image_url", img["type"])
-	imgURL, ok := img["image_url"].(map[string]any)
-	require.True(t, ok, "image_url field must survive, got part: %v", img)
-	assert.Equal(t, toolImgDataURL, imgURL["url"])
-}
+// The SDK-level parse/marshal survival of tool image parts is locked by the
+// fork's chatcompletion_toolmessage_patch_test.go and the gateway-level round
+// trip in internal/protocol/multimodal_roundtrip_test.go; the tests here
+// cover the conversions on top of the parsed request.
 
 // TestConvertOpenAIToAnthropic_ToolMessageImage: Chat tool message with
 // [text, image_url] must become an Anthropic tool_result whose content holds
@@ -150,32 +133,7 @@ func TestConvertOpenAIResponsesToChat_FunctionCallOutputImage(t *testing.T) {
 
 	out := ConvertOpenAIResponsesToChat(params, 1024)
 	require.NotNil(t, out)
-
-	var tool *openai.ChatCompletionToolMessageParam
-	for _, msg := range out.Messages {
-		if msg.OfTool != nil {
-			tool = msg.OfTool
-		}
-	}
-	require.NotNil(t, tool)
-
-	raw, err := json.Marshal(openai.ChatCompletionMessageParamUnion{OfTool: tool})
-	require.NoError(t, err)
-	var m map[string]any
-	require.NoError(t, json.Unmarshal(raw, &m))
-	parts, ok := m["content"].([]any)
-	require.True(t, ok, "tool content should be an array, got %v", m["content"])
-	require.Len(t, parts, 2)
-
-	text := parts[0].(map[string]any)
-	assert.Equal(t, "text", text["type"])
-	assert.Equal(t, "Image loaded.", text["text"])
-
-	img := parts[1].(map[string]any)
-	assert.Equal(t, "image_url", img["type"])
-	imgURL, ok := img["image_url"].(map[string]any)
-	require.True(t, ok, "image_url field must survive, got %v", img)
-	assert.Equal(t, toolImgDataURL, imgURL["url"])
+	assertOpenAIToolMessageHasImage(t, out, "Image loaded.")
 }
 
 // anthropicV1ToolResultImageRequest builds an Anthropic v1 request whose
@@ -251,7 +209,7 @@ func anthropicBetaToolResultImageRequest() *anthropic.BetaMessageNewParams {
 
 // assertOpenAIToolMessageHasImage marshals the OpenAI request and asserts the
 // tool message carries [text, image_url] content parts with the data URL.
-func assertOpenAIToolMessageHasImage(t *testing.T, out *openai.ChatCompletionNewParams) {
+func assertOpenAIToolMessageHasImage(t *testing.T, out *openai.ChatCompletionNewParams, expectedText string) {
 	t.Helper()
 	var tool *openai.ChatCompletionToolMessageParam
 	for _, msg := range out.Messages {
@@ -271,7 +229,7 @@ func assertOpenAIToolMessageHasImage(t *testing.T, out *openai.ChatCompletionNew
 
 	text := parts[0].(map[string]any)
 	assert.Equal(t, "text", text["type"])
-	assert.Equal(t, "took screenshot", text["text"])
+	assert.Equal(t, expectedText, text["text"])
 
 	img := parts[1].(map[string]any)
 	assert.Equal(t, "image_url", img["type"])
@@ -285,13 +243,13 @@ func assertOpenAIToolMessageHasImage(t *testing.T, out *openai.ChatCompletionNew
 // screenshot-tool shape).
 func TestConvertAnthropicV1ToOpenAI_ToolResultImage(t *testing.T) {
 	out, _ := ConvertAnthropicToOpenAIRequest(anthropicV1ToolResultImageRequest(), false, false, false)
-	assertOpenAIToolMessageHasImage(t, out)
+	assertOpenAIToolMessageHasImage(t, out, "took screenshot")
 }
 
 // TestConvertAnthropicBetaToOpenAI_ToolResultImage is the beta twin.
 func TestConvertAnthropicBetaToOpenAI_ToolResultImage(t *testing.T) {
 	out, _ := ConvertAnthropicBetaToOpenAIRequest(anthropicBetaToolResultImageRequest(), false, false, false)
-	assertOpenAIToolMessageHasImage(t, out)
+	assertOpenAIToolMessageHasImage(t, out, "took screenshot")
 }
 
 // assertResponsesFunctionCallOutputHasImage asserts the function_call_output

--- a/internal/protocol/request/image_tool_conversions_test.go
+++ b/internal/protocol/request/image_tool_conversions_test.go
@@ -1,0 +1,374 @@
+package request
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file is the tool-channel companion of image_conversions_test.go
+// (issue #1606): images returned by tools — OpenAI Chat tool messages with
+// image_url parts, Anthropic tool_result blocks with image content, Responses
+// function_call_output with input_image items — must survive every request
+// conversion, exactly like their user-message counterparts.
+
+const (
+	toolImgDataURL = "data:image/png;base64,iVBORw0KGgo="
+	toolImgHTTPURL = "https://example.com/screenshot.png"
+)
+
+// chatToolImageRequest builds, via JSON (the exact ingress path), a Chat
+// Completions request whose tool message carries [text, image_url] content.
+func chatToolImageRequest(t *testing.T) *openai.ChatCompletionNewParams {
+	t.Helper()
+	raw := []byte(`{
+		"model": "test-model",
+		"messages": [
+			{"role": "user", "content": "analyze the image"},
+			{"role": "assistant", "content": "", "tool_calls": [
+				{"id": "call_1", "type": "function",
+				 "function": {"name": "vision_analyze", "arguments": "{}"}}
+			]},
+			{"role": "tool", "tool_call_id": "call_1", "content": [
+				{"type": "text", "text": "Image loaded."},
+				{"type": "image_url", "image_url": {"url": "` + toolImgDataURL + `"}}
+			]}
+		]
+	}`)
+	req := &openai.ChatCompletionNewParams{}
+	require.NoError(t, json.Unmarshal(raw, req))
+	return req
+}
+
+// TestChatToolMessageImage_SDKParse verifies the openai-go union itself: a
+// tool message content array keeps its image_url part through parse+marshal.
+func TestChatToolMessageImage_SDKParse(t *testing.T) {
+	req := chatToolImageRequest(t)
+	out, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(out, &m))
+	msgs := m["messages"].([]any)
+	tool := msgs[2].(map[string]any)
+	parts, ok := tool["content"].([]any)
+	require.True(t, ok, "tool content should stay an array, got %v", tool["content"])
+	require.Len(t, parts, 2)
+
+	img := parts[1].(map[string]any)
+	assert.Equal(t, "image_url", img["type"])
+	imgURL, ok := img["image_url"].(map[string]any)
+	require.True(t, ok, "image_url field must survive, got part: %v", img)
+	assert.Equal(t, toolImgDataURL, imgURL["url"])
+}
+
+// TestConvertOpenAIToAnthropic_ToolMessageImage: Chat tool message with
+// [text, image_url] must become an Anthropic tool_result whose content holds
+// a text block AND an image block.
+func TestConvertOpenAIToAnthropic_ToolMessageImage(t *testing.T) {
+	out := ConvertOpenAIToAnthropicRequest(chatToolImageRequest(t), 1024)
+	require.NotNil(t, out)
+
+	var toolResult *anthropic.BetaToolResultBlockParam
+	for _, msg := range out.Messages {
+		for _, block := range msg.Content {
+			if block.OfToolResult != nil {
+				toolResult = block.OfToolResult
+			}
+		}
+	}
+	require.NotNil(t, toolResult, "tool message should become a tool_result block")
+	require.Len(t, toolResult.Content, 2, "text + image content must both survive")
+
+	require.NotNil(t, toolResult.Content[0].OfText)
+	assert.Equal(t, "Image loaded.", toolResult.Content[0].OfText.Text)
+
+	require.NotNil(t, toolResult.Content[1].OfImage, "image part must convert to an image block")
+	src := toolResult.Content[1].OfImage.Source
+	require.NotNil(t, src.OfBase64)
+	assert.Equal(t, "image/png", string(src.OfBase64.MediaType))
+	assert.Equal(t, "iVBORw0KGgo=", src.OfBase64.Data)
+}
+
+// TestConvertChatToOpenAIResponses_ToolMessageImage: Chat tool message with
+// image content must become a function_call_output whose output item list
+// carries input_text + input_image.
+func TestConvertChatToOpenAIResponses_ToolMessageImage(t *testing.T) {
+	out := ConvertChatToOpenAIResponses(chatToolImageRequest(t), 1024)
+	require.NotNil(t, out)
+
+	var fco *responses.ResponseInputItemFunctionCallOutputParam
+	for _, item := range out.Input.OfInputItemList {
+		if item.OfFunctionCallOutput != nil {
+			fco = item.OfFunctionCallOutput
+		}
+	}
+	require.NotNil(t, fco)
+
+	items := fco.Output.OfResponseFunctionCallOutputItemArray
+	require.Len(t, items, 2, "text + image output items must both survive, got output: %+v", fco.Output)
+
+	require.NotNil(t, items[0].OfInputText)
+	assert.Equal(t, "Image loaded.", items[0].OfInputText.Text)
+
+	require.NotNil(t, items[1].OfInputImage, "image part must convert to input_image")
+	assert.Equal(t, toolImgDataURL, items[1].OfInputImage.ImageURL.Value)
+}
+
+// TestConvertOpenAIResponsesToChat_FunctionCallOutputImage: a Responses
+// function_call_output with [input_text, input_image] must become a Chat tool
+// message with [text, image_url] parts.
+func TestConvertOpenAIResponsesToChat_FunctionCallOutputImage(t *testing.T) {
+	params := &responses.ResponseNewParams{
+		Model:           "test-model",
+		MaxOutputTokens: param.NewOpt(int64(100)),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: responses.ResponseInputParam{
+				{OfFunctionCall: &responses.ResponseFunctionToolCallParam{
+					CallID: "call_1", Name: "vision_analyze", Arguments: "{}",
+				}},
+				{OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+					CallID: "call_1",
+					Output: responses.ResponseInputItemFunctionCallOutputOutputUnionParam{
+						OfResponseFunctionCallOutputItemArray: responses.ResponseFunctionCallOutputItemListParam{
+							{OfInputText: &responses.ResponseInputTextContentParam{Text: "Image loaded."}},
+							{OfInputImage: &responses.ResponseInputImageContentParam{
+								ImageURL: param.NewOpt(toolImgDataURL),
+							}},
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	out := ConvertOpenAIResponsesToChat(params, 1024)
+	require.NotNil(t, out)
+
+	var tool *openai.ChatCompletionToolMessageParam
+	for _, msg := range out.Messages {
+		if msg.OfTool != nil {
+			tool = msg.OfTool
+		}
+	}
+	require.NotNil(t, tool)
+
+	raw, err := json.Marshal(openai.ChatCompletionMessageParamUnion{OfTool: tool})
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+	parts, ok := m["content"].([]any)
+	require.True(t, ok, "tool content should be an array, got %v", m["content"])
+	require.Len(t, parts, 2)
+
+	text := parts[0].(map[string]any)
+	assert.Equal(t, "text", text["type"])
+	assert.Equal(t, "Image loaded.", text["text"])
+
+	img := parts[1].(map[string]any)
+	assert.Equal(t, "image_url", img["type"])
+	imgURL, ok := img["image_url"].(map[string]any)
+	require.True(t, ok, "image_url field must survive, got %v", img)
+	assert.Equal(t, toolImgDataURL, imgURL["url"])
+}
+
+// anthropicV1ToolResultImageRequest builds an Anthropic v1 request whose
+// tool_result content holds [text, image].
+func anthropicV1ToolResultImageRequest() *anthropic.MessageNewParams {
+	return &anthropic.MessageNewParams{
+		Model:     "test-model",
+		MaxTokens: 100,
+		Messages: []anthropic.MessageParam{
+			{
+				Role: anthropic.MessageParamRoleAssistant,
+				Content: []anthropic.ContentBlockParamUnion{
+					anthropic.NewToolUseBlock("toolu_1", map[string]any{}, "screenshot"),
+				},
+			},
+			{
+				Role: anthropic.MessageParamRoleUser,
+				Content: []anthropic.ContentBlockParamUnion{
+					{OfToolResult: &anthropic.ToolResultBlockParam{
+						ToolUseID: "toolu_1",
+						Content: []anthropic.ToolResultBlockParamContentUnion{
+							{OfText: &anthropic.TextBlockParam{Text: "took screenshot"}},
+							{OfImage: &anthropic.ImageBlockParam{
+								Source: anthropic.ImageBlockParamSourceUnion{
+									OfBase64: &anthropic.Base64ImageSourceParam{
+										MediaType: "image/png",
+										Data:      "iVBORw0KGgo=",
+									},
+								},
+							}},
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// anthropicBetaToolResultImageRequest is the beta twin of the v1 fixture.
+func anthropicBetaToolResultImageRequest() *anthropic.BetaMessageNewParams {
+	return &anthropic.BetaMessageNewParams{
+		Model:     "test-model",
+		MaxTokens: 100,
+		Messages: []anthropic.BetaMessageParam{
+			{
+				Role: anthropic.BetaMessageParamRoleAssistant,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					anthropic.NewBetaToolUseBlock("toolu_1", map[string]any{}, "screenshot"),
+				},
+			},
+			{
+				Role: anthropic.BetaMessageParamRoleUser,
+				Content: []anthropic.BetaContentBlockParamUnion{
+					{OfToolResult: &anthropic.BetaToolResultBlockParam{
+						ToolUseID: "toolu_1",
+						Content: []anthropic.BetaToolResultBlockParamContentUnion{
+							{OfText: &anthropic.BetaTextBlockParam{Text: "took screenshot"}},
+							{OfImage: &anthropic.BetaImageBlockParam{
+								Source: anthropic.BetaImageBlockParamSourceUnion{
+									OfBase64: &anthropic.BetaBase64ImageSourceParam{
+										MediaType: "image/png",
+										Data:      "iVBORw0KGgo=",
+									},
+								},
+							}},
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// assertOpenAIToolMessageHasImage marshals the OpenAI request and asserts the
+// tool message carries [text, image_url] content parts with the data URL.
+func assertOpenAIToolMessageHasImage(t *testing.T, out *openai.ChatCompletionNewParams) {
+	t.Helper()
+	var tool *openai.ChatCompletionToolMessageParam
+	for _, msg := range out.Messages {
+		if msg.OfTool != nil {
+			tool = msg.OfTool
+		}
+	}
+	require.NotNil(t, tool, "expected a tool message")
+
+	raw, err := json.Marshal(openai.ChatCompletionMessageParamUnion{OfTool: tool})
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+	parts, ok := m["content"].([]any)
+	require.True(t, ok, "tool content should be a content-part array, got %v", m["content"])
+	require.Len(t, parts, 2, "text + image parts must both survive")
+
+	text := parts[0].(map[string]any)
+	assert.Equal(t, "text", text["type"])
+	assert.Equal(t, "took screenshot", text["text"])
+
+	img := parts[1].(map[string]any)
+	assert.Equal(t, "image_url", img["type"])
+	imgURL, ok := img["image_url"].(map[string]any)
+	require.True(t, ok, "image_url field must survive, got %v", img)
+	assert.Equal(t, toolImgDataURL, imgURL["url"])
+}
+
+// TestConvertAnthropicV1ToOpenAI_ToolResultImage: v1 tool_result images must
+// be forwarded as image_url parts on the OpenAI tool message (the Claude Code
+// screenshot-tool shape).
+func TestConvertAnthropicV1ToOpenAI_ToolResultImage(t *testing.T) {
+	out, _ := ConvertAnthropicToOpenAIRequest(anthropicV1ToolResultImageRequest(), false, false, false)
+	assertOpenAIToolMessageHasImage(t, out)
+}
+
+// TestConvertAnthropicBetaToOpenAI_ToolResultImage is the beta twin.
+func TestConvertAnthropicBetaToOpenAI_ToolResultImage(t *testing.T) {
+	out, _ := ConvertAnthropicBetaToOpenAIRequest(anthropicBetaToolResultImageRequest(), false, false, false)
+	assertOpenAIToolMessageHasImage(t, out)
+}
+
+// assertResponsesFunctionCallOutputHasImage asserts the function_call_output
+// output item list carries input_text + input_image.
+func assertResponsesFunctionCallOutputHasImage(t *testing.T, out *responses.ResponseNewParams) {
+	t.Helper()
+	var fco *responses.ResponseInputItemFunctionCallOutputParam
+	for _, item := range out.Input.OfInputItemList {
+		if item.OfFunctionCallOutput != nil {
+			fco = item.OfFunctionCallOutput
+		}
+	}
+	require.NotNil(t, fco, "expected a function_call_output item")
+
+	items := fco.Output.OfResponseFunctionCallOutputItemArray
+	require.Len(t, items, 2, "text + image output items must both survive, got output: %+v", fco.Output)
+
+	require.NotNil(t, items[0].OfInputText)
+	assert.Equal(t, "took screenshot", items[0].OfInputText.Text)
+
+	require.NotNil(t, items[1].OfInputImage, "image content must convert to input_image")
+	assert.Equal(t, toolImgDataURL, items[1].OfInputImage.ImageURL.Value)
+}
+
+// TestConvertAnthropicV1ToResponses_ToolResultImage: v1 tool_result images →
+// Responses input_image output items.
+func TestConvertAnthropicV1ToResponses_ToolResultImage(t *testing.T) {
+	out := ConvertAnthropicV1ToResponsesRequest(anthropicV1ToolResultImageRequest())
+	require.NotNil(t, out)
+	assertResponsesFunctionCallOutputHasImage(t, out)
+}
+
+// TestConvertAnthropicBetaToResponses_ToolResultImage is the beta twin.
+func TestConvertAnthropicBetaToResponses_ToolResultImage(t *testing.T) {
+	out := ConvertAnthropicBetaToResponsesRequest(anthropicBetaToolResultImageRequest())
+	require.NotNil(t, out)
+	assertResponsesFunctionCallOutputHasImage(t, out)
+}
+
+// TestConvertAnthropicV1ToOpenAI_ImageAlongsideToolResult: an image block that
+// sits NEXT TO a tool_result in the same user message must not be dropped; it
+// belongs on the follow-up user message.
+func TestConvertAnthropicV1ToOpenAI_ImageAlongsideToolResult(t *testing.T) {
+	req := &anthropic.MessageNewParams{
+		Model:     "test-model",
+		MaxTokens: 100,
+		Messages: []anthropic.MessageParam{
+			{
+				Role: anthropic.MessageParamRoleUser,
+				Content: []anthropic.ContentBlockParamUnion{
+					{OfToolResult: &anthropic.ToolResultBlockParam{
+						ToolUseID: "toolu_1",
+						Content: []anthropic.ToolResultBlockParamContentUnion{
+							{OfText: &anthropic.TextBlockParam{Text: "done"}},
+						},
+					}},
+					anthropic.NewTextBlock("compare with this:"),
+					anthropic.NewImageBlockBase64("image/png", "iVBORw0KGgo="),
+				},
+			},
+		},
+	}
+
+	out, _ := ConvertAnthropicToOpenAIRequest(req, false, false, false)
+
+	var user *openai.ChatCompletionUserMessageParam
+	for _, msg := range out.Messages {
+		if msg.OfUser != nil {
+			user = msg.OfUser
+		}
+	}
+	require.NotNil(t, user, "text+image beside tool_result should yield a user message")
+
+	parts := user.Content.OfArrayOfContentParts
+	require.Len(t, parts, 2, "text + image parts must both survive")
+	require.NotNil(t, parts[0].OfText)
+	assert.Equal(t, "compare with this:", parts[0].OfText.Text)
+	require.NotNil(t, parts[1].OfImageURL, "image beside tool_result must survive")
+	assert.Equal(t, toolImgDataURL, parts[1].OfImageURL.ImageURL.URL)
+}

--- a/internal/protocol/request/openai_to_anthropic.go
+++ b/internal/protocol/request/openai_to_anthropic.go
@@ -107,18 +107,41 @@ func ConvertOpenAIToAnthropicRequest(req *openai.ChatCompletionNewParams, defaul
 
 		case msg.OfTool != nil:
 			// Tool result message → tool_result block (must be USER role).
-			// Content may be a plain string or an array of text blocks.
-			content := msg.OfTool.Content.OfString.Value
+			// Content may be a plain string or an array of content parts;
+			// image_url parts (tool screenshots — issue #1606) become image
+			// blocks inside the tool_result content.
+			var block anthropic.BetaContentBlockParamUnion
 			hasCacheControl := false
-			if content == "" {
-				content = joinTextContentPartsFromUnion(msg.OfTool.Content.OfArrayOfContentParts)
+			if content := msg.OfTool.Content.OfString.Value; content != "" {
+				block = anthropic.NewBetaToolResultBlock(msg.OfTool.ToolCallID, content, false)
+			} else {
+				var resultBlocks []anthropic.BetaToolResultBlockParamContentUnion
 				for _, part := range msg.OfTool.Content.OfArrayOfContentParts {
-					if part.OfText != nil {
+					switch {
+					case part.OfText != nil:
+						if part.OfText.Text == "" {
+							continue
+						}
+						resultBlocks = append(resultBlocks, anthropic.BetaToolResultBlockParamContentUnion{
+							OfText: &anthropic.BetaTextBlockParam{Text: part.OfText.Text},
+						})
 						hasCacheControl = hasCacheControl || hasOpenAITextCacheBreakpoint(*part.OfText)
+					case part.OfImageURL != nil:
+						imageBlock, ok := openAIImageURLToAnthropicBetaBlock(part.OfImageURL.ImageURL.URL)
+						if !ok {
+							continue
+						}
+						resultBlocks = append(resultBlocks, anthropic.BetaToolResultBlockParamContentUnion{
+							OfImage: imageBlock.OfImage,
+						})
+						hasCacheControl = hasCacheControl || !openaiparam.IsOmitted(part.OfImageURL.PromptCacheBreakpoint)
 					}
 				}
+				block = anthropic.BetaContentBlockParamUnion{OfToolResult: &anthropic.BetaToolResultBlockParam{
+					ToolUseID: msg.OfTool.ToolCallID,
+					Content:   resultBlocks,
+				}}
 			}
-			block := anthropic.NewBetaToolResultBlock(msg.OfTool.ToolCallID, content, false)
 			if hasCacheControl {
 				block.OfToolResult.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
 			}

--- a/internal/protocol/transform/consistency_multimodal_test.go
+++ b/internal/protocol/transform/consistency_multimodal_test.go
@@ -1,0 +1,82 @@
+package transform
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAlignToolMessages_OrphanKeepsImageParts guards the orphan-tool-message
+// rewrite (issue #1606 family): when a tool message with multimodal content
+// has no matching tool_call and is downgraded to a user message, its
+// image_url parts must be carried over, not flattened to empty text.
+func TestAlignToolMessages_OrphanKeepsImageParts(t *testing.T) {
+	const imageURL = "data:image/png;base64,iVBORw0KGgo="
+	raw := []byte(`{
+		"model": "test-model",
+		"messages": [
+			{"role": "tool", "tool_call_id": "call_missing", "content": [
+				{"type": "text", "text": "Image loaded."},
+				{"type": "image_url", "image_url": {"url": "` + imageURL + `"}}
+			]}
+		]
+	}`)
+	req := &openai.ChatCompletionNewParams{}
+	require.NoError(t, json.Unmarshal(raw, req))
+
+	AlignToolMessagesForOpenAI(req)
+
+	require.Len(t, req.Messages, 1)
+	user := req.Messages[0].OfUser
+	require.NotNil(t, user, "orphan tool message should become a user message")
+
+	parts := user.Content.OfArrayOfContentParts
+	require.Len(t, parts, 2, "text + image parts must both survive the downgrade")
+	require.NotNil(t, parts[0].OfText)
+	assert.Equal(t, "Image loaded.", parts[0].OfText.Text)
+	require.NotNil(t, parts[1].OfImageURL, "image part must survive the downgrade")
+	assert.Equal(t, imageURL, parts[1].OfImageURL.ImageURL.URL)
+}
+
+// TestAlignToolMessages_MatchedToolMessageUntouched confirms the aligner does
+// not rewrite tool messages that do have a matching tool_call — their
+// multimodal content must pass through bit-identical.
+func TestAlignToolMessages_MatchedToolMessageUntouched(t *testing.T) {
+	const imageURL = "data:image/png;base64,iVBORw0KGgo="
+	raw := []byte(`{
+		"model": "test-model",
+		"messages": [
+			{"role": "assistant", "content": "", "tool_calls": [
+				{"id": "call_1", "type": "function",
+				 "function": {"name": "vision_analyze", "arguments": "{}"}}
+			]},
+			{"role": "tool", "tool_call_id": "call_1", "content": [
+				{"type": "image_url", "image_url": {"url": "` + imageURL + `"}}
+			]}
+		]
+	}`)
+	req := &openai.ChatCompletionNewParams{}
+	require.NoError(t, json.Unmarshal(raw, req))
+
+	AlignToolMessagesForOpenAI(req)
+
+	require.Len(t, req.Messages, 2)
+	tool := req.Messages[1].OfTool
+	require.NotNil(t, tool, "matched tool message must stay a tool message")
+
+	out, err := json.Marshal(req.Messages[1])
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(out, &m))
+	parts, ok := m["content"].([]any)
+	require.True(t, ok, "tool content should stay an array, got %v", m["content"])
+	require.Len(t, parts, 1)
+	img := parts[0].(map[string]any)
+	assert.Equal(t, "image_url", img["type"])
+	imgURL, ok := img["image_url"].(map[string]any)
+	require.True(t, ok, "image_url payload must survive, got %v", img)
+	assert.Equal(t, imageURL, imgURL["url"])
+}

--- a/internal/protocoltest/content_shapes.go
+++ b/internal/protocoltest/content_shapes.go
@@ -182,6 +182,81 @@ func anthropicSystemText(body map[string]any) (string, bool) {
 	return "", false
 }
 
+// ─── Image content-shape helpers (issue #1606) ───────────────────────────
+
+// chatMessageImageURL returns the image_url.url of the first image_url part
+// on the first message with the given role in a captured Chat request body.
+func chatMessageImageURL(body map[string]any, role string) (string, bool) {
+	msgs, _ := body["messages"].([]any)
+	for _, raw := range msgs {
+		msg, _ := raw.(map[string]any)
+		if msg["role"] != role {
+			continue
+		}
+		parts, _ := msg["content"].([]any)
+		for _, rawPart := range parts {
+			part, _ := rawPart.(map[string]any)
+			if part["type"] != "image_url" {
+				continue
+			}
+			img, _ := part["image_url"].(map[string]any)
+			url, ok := img["url"].(string)
+			return url, ok
+		}
+	}
+	return "", false
+}
+
+// responsesFunctionCallOutputImageURL returns the image_url of the first
+// input_image item in the first function_call_output of a captured OpenAI
+// Responses request body.
+func responsesFunctionCallOutputImageURL(body map[string]any) (string, bool) {
+	input, _ := body["input"].([]any)
+	for _, raw := range input {
+		item, _ := raw.(map[string]any)
+		if item["type"] != "function_call_output" {
+			continue
+		}
+		parts, _ := item["output"].([]any)
+		for _, rawPart := range parts {
+			part, _ := rawPart.(map[string]any)
+			if part["type"] != "input_image" {
+				continue
+			}
+			url, ok := part["image_url"].(string)
+			return url, ok
+		}
+	}
+	return "", false
+}
+
+// anthropicToolResultImageData returns the base64 data of the first image
+// block inside the first tool_result of a captured Anthropic request body.
+func anthropicToolResultImageData(body map[string]any) (string, bool) {
+	msgs, _ := body["messages"].([]any)
+	for _, raw := range msgs {
+		msg, _ := raw.(map[string]any)
+		blocks, _ := msg["content"].([]any)
+		for _, rawBlock := range blocks {
+			block, _ := rawBlock.(map[string]any)
+			if block["type"] != "tool_result" {
+				continue
+			}
+			parts, _ := block["content"].([]any)
+			for _, rawPart := range parts {
+				part, _ := rawPart.(map[string]any)
+				if part["type"] != "image" {
+					continue
+				}
+				source, _ := part["source"].(map[string]any)
+				data, ok := source["data"].(string)
+				return data, ok
+			}
+		}
+	}
+	return "", false
+}
+
 // ─── Cases ─────────────────────────────────────────────────────────────────
 
 func contentShapeCases() []contentShapeCase {
@@ -223,6 +298,65 @@ func contentShapeCases() []contentShapeCase {
 			"messages": []map[string]any{
 				{"role": "system", "content": []map[string]any{{"type": "text", "text": systemPrompt}}},
 				{"role": "user", "content": "Hello"},
+			},
+		}
+	}
+
+	// Image fixtures (issue #1606): a tiny data-URL image returned by a tool
+	// (the shape agent frameworks use for screenshots) and, on the Anthropic
+	// side, the equivalent base64 image inside a tool_result block.
+	const imgBase64 = "iVBORw0KGgo="
+	const imgDataURL = "data:image/png;base64," + imgBase64
+
+	toolImageBody := func() map[string]any {
+		return map[string]any{
+			"messages": slices.Concat(toolCallTurns, []map[string]any{
+				{"role": "tool", "tool_call_id": "call_1",
+					"content": []map[string]any{
+						{"type": "text", "text": "Image loaded."},
+						{"type": "image_url", "image_url": map[string]any{"url": imgDataURL}},
+					}},
+			}),
+		}
+	}
+	userImageBody := func() map[string]any {
+		return map[string]any{
+			"messages": []map[string]any{
+				{"role": "user", "content": []map[string]any{
+					{"type": "text", "text": "What color is this image?"},
+					{"type": "image_url", "image_url": map[string]any{"url": imgDataURL}},
+				}},
+			},
+		}
+	}
+	anthropicUserImageBody := func() map[string]any {
+		return map[string]any{
+			"max_tokens": 64,
+			"messages": []map[string]any{
+				{"role": "user", "content": []map[string]any{
+					{"type": "text", "text": "What color is this image?"},
+					{"type": "image", "source": map[string]any{
+						"type": "base64", "media_type": "image/png", "data": imgBase64,
+					}},
+				}},
+			},
+		}
+	}
+	anthropicToolResultImageBody := func() map[string]any {
+		return map[string]any{
+			"max_tokens": 64,
+			"messages": []map[string]any{
+				{"role": "assistant", "content": []map[string]any{
+					{"type": "tool_use", "id": "toolu_1", "name": "screenshot", "input": map[string]any{}},
+				}},
+				{"role": "user", "content": []map[string]any{
+					{"type": "tool_result", "tool_use_id": "toolu_1", "content": []map[string]any{
+						{"type": "text", "text": "took screenshot"},
+						{"type": "image", "source": map[string]any{
+							"type": "base64", "media_type": "image/png", "data": imgBase64,
+						}},
+					}},
+				}},
 			},
 		}
 	}
@@ -274,6 +408,53 @@ func contentShapeCases() []contentShapeCase {
 		{name: "chat_to_anthropic/system_array_content", run: func(t flagTB, env *TestEnv) {
 			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeAnthropicBeta, EndpointAnthropic,
 				systemArrayBody(), anthropicSystemText, systemPrompt)
+		}},
+
+		// ── Image content shapes (issue #1606) ─────────────────────────
+		// The gateway must forward tool-returned images (and user images)
+		// intact on every path; the tool-role image_url corruption in the
+		// Chat passthrough is the exact repro from the issue.
+		{name: "chat_to_chat/tool_image_content", run: func(t flagTB, env *TestEnv) {
+			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, EndpointChat,
+				toolImageBody(), func(body map[string]any) (string, bool) {
+					return chatMessageImageURL(body, "tool")
+				}, imgDataURL)
+		}},
+
+		{name: "chat_to_chat/user_image_content", run: func(t flagTB, env *TestEnv) {
+			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, EndpointChat,
+				userImageBody(), func(body map[string]any) (string, bool) {
+					return chatMessageImageURL(body, "user")
+				}, imgDataURL)
+		}},
+
+		{name: "chat_to_responses/tool_image_content", run: func(t flagTB, env *TestEnv) {
+			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIResponses, EndpointResponses,
+				toolImageBody(), responsesFunctionCallOutputImageURL, imgDataURL)
+		}},
+
+		{name: "chat_to_anthropic/tool_image_content", run: func(t flagTB, env *TestEnv) {
+			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeAnthropicBeta, EndpointAnthropic,
+				toolImageBody(), anthropicToolResultImageData, imgBase64)
+		}},
+
+		{name: "anthropic_to_chat/user_image_content", run: func(t flagTB, env *TestEnv) {
+			assertUpstreamText(t, env, protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, EndpointChat,
+				anthropicUserImageBody(), func(body map[string]any) (string, bool) {
+					return chatMessageImageURL(body, "user")
+				}, imgDataURL)
+		}},
+
+		{name: "anthropic_to_chat/tool_result_image_content", run: func(t flagTB, env *TestEnv) {
+			assertUpstreamText(t, env, protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, EndpointChat,
+				anthropicToolResultImageBody(), func(body map[string]any) (string, bool) {
+					return chatMessageImageURL(body, "tool")
+				}, imgDataURL)
+		}},
+
+		{name: "anthropic_to_responses/tool_result_image_content", run: func(t flagTB, env *TestEnv) {
+			assertUpstreamText(t, env, protocol.TypeAnthropicV1, protocol.TypeOpenAIResponses, EndpointResponses,
+				anthropicToolResultImageBody(), responsesFunctionCallOutputImageURL, imgDataURL)
 		}},
 	}
 }

--- a/internal/protocoltest/content_shapes.go
+++ b/internal/protocoltest/content_shapes.go
@@ -362,6 +362,8 @@ func contentShapeCases() []contentShapeCase {
 	}
 
 	assistantContent := func(body map[string]any) (string, bool) { return responsesMessageContent(body, "assistant") }
+	toolImageURL := func(body map[string]any) (string, bool) { return chatMessageImageURL(body, "tool") }
+	userImageURL := func(body map[string]any) (string, bool) { return chatMessageImageURL(body, "user") }
 	instructions := func(body map[string]any) (string, bool) {
 		v, ok := body["instructions"].(string)
 		return v, ok
@@ -416,16 +418,12 @@ func contentShapeCases() []contentShapeCase {
 		// Chat passthrough is the exact repro from the issue.
 		{name: "chat_to_chat/tool_image_content", run: func(t flagTB, env *TestEnv) {
 			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, EndpointChat,
-				toolImageBody(), func(body map[string]any) (string, bool) {
-					return chatMessageImageURL(body, "tool")
-				}, imgDataURL)
+				toolImageBody(), toolImageURL, imgDataURL)
 		}},
 
 		{name: "chat_to_chat/user_image_content", run: func(t flagTB, env *TestEnv) {
 			assertUpstreamText(t, env, protocol.TypeOpenAIChat, protocol.TypeOpenAIChat, EndpointChat,
-				userImageBody(), func(body map[string]any) (string, bool) {
-					return chatMessageImageURL(body, "user")
-				}, imgDataURL)
+				userImageBody(), userImageURL, imgDataURL)
 		}},
 
 		{name: "chat_to_responses/tool_image_content", run: func(t flagTB, env *TestEnv) {
@@ -440,16 +438,12 @@ func contentShapeCases() []contentShapeCase {
 
 		{name: "anthropic_to_chat/user_image_content", run: func(t flagTB, env *TestEnv) {
 			assertUpstreamText(t, env, protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, EndpointChat,
-				anthropicUserImageBody(), func(body map[string]any) (string, bool) {
-					return chatMessageImageURL(body, "user")
-				}, imgDataURL)
+				anthropicUserImageBody(), userImageURL, imgDataURL)
 		}},
 
 		{name: "anthropic_to_chat/tool_result_image_content", run: func(t flagTB, env *TestEnv) {
 			assertUpstreamText(t, env, protocol.TypeAnthropicV1, protocol.TypeOpenAIChat, EndpointChat,
-				anthropicToolResultImageBody(), func(body map[string]any) (string, bool) {
-					return chatMessageImageURL(body, "tool")
-				}, imgDataURL)
+				anthropicToolResultImageBody(), toolImageURL, imgDataURL)
 		}},
 
 		{name: "anthropic_to_responses/tool_result_image_content", run: func(t flagTB, env *TestEnv) {


### PR DESCRIPTION
## Summary
Completes #1606 on top of the v3.52.0 SDK upgrade (#1609): tool-returned images now survive every request conversion the fork's union widening did not yet cover, driven by a per-protocol multimodal catalog and vmodel-backed TDD tests that were all red before the fixes.

## Key Changes

- **Chat→Anthropic tool images**: `image_url` parts become `tool_result` image blocks instead of being text-joined away.
- **Anthropic→Chat/Responses tool images**: `tool_result` image content forwards as `image_url` parts / `input_image` output items via one shared converter (beta bridges through the view); images beside a `tool_result` in the same user message are re-emitted instead of dropped.
- **Chat→Google tool images**: array content contributes joined text plus decoded inline-data blobs to `function_response` (raw bytes, avoiding double base64 on the wire).
- **Regression coverage**: ingress round-trip of the issue repro, converter-pair unit tests, and 7 vmodel end-to-end image cases in `content_shapes` (runs under `go test` and `harness matrix --mode=content_shapes`).
- **Multimodal catalog**: `.design/multimodal-content.md` records where multimodal content lives per protocol, the conversion contract, and remaining gaps.

## Notes

- Follow-ups catalogued in the design doc: Anthropic→Google `tool_result` images, audio/file/document parts cross-protocol, and an image-bearing health probe.
- Fixes #1606
