### PR TITLE
feat(quota): report DeepSeek and remaining balances

### DIFF
--- a/ai/quota/fetcher/codex.go
+++ b/ai/quota/fetcher/codex.go
@@ -304,12 +304,14 @@ func (f *CodexFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota
 	if apiResp.Credits != nil && apiResp.Credits.HasCredits && !apiResp.Credits.Unlimited && apiResp.Credits.Balance != nil {
 		balance := float64(*apiResp.Credits.Balance)
 		usage.AddWindow("credits", &quota.UsageWindow{
-			Type:        quota.WindowTypeBalance,
-			Kind:        quota.WindowKindResource,
-			Unknown:     true,
-			Unit:        quota.UsageUnitCurrency,
-			Label:       "Credits Balance",
-			Description: fmt.Sprintf("$%.2f remaining", balance),
+			Type:         quota.WindowTypeBalance,
+			Kind:         quota.WindowKindResource,
+			Available:    &balance,
+			Unknown:      true,
+			Unit:         quota.UsageUnitCurrency,
+			CurrencyCode: "USD",
+			Label:        "Credits Balance",
+			Description:  fmt.Sprintf("$%.2f remaining", balance),
 		})
 	}
 

--- a/ai/quota/fetcher/codex_test.go
+++ b/ai/quota/fetcher/codex_test.go
@@ -179,6 +179,12 @@ func TestCodexFetcher_Fetch(t *testing.T) {
 	if !credits.Unknown {
 		t.Error("credits balance has no percentage; it must be marked unknown")
 	}
+	if credits.Available == nil || *credits.Available != 150 {
+		t.Errorf("credits Available = %v, want 150", credits.Available)
+	}
+	if credits.CurrencyCode != "USD" {
+		t.Errorf("credits CurrencyCode = %q, want USD", credits.CurrencyCode)
+	}
 	if credits.Description != "$150.00 remaining" {
 		t.Errorf("credits Description = %q, want '$150.00 remaining'", credits.Description)
 	}

--- a/ai/quota/fetcher/deepseek.go
+++ b/ai/quota/fetcher/deepseek.go
@@ -120,13 +120,14 @@ func (f *DeepSeekFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*qu
 			key = fmt.Sprintf("balance_%d", i)
 		}
 		usage.AddWindow(key, &quota.UsageWindow{
-			Type:        quota.WindowTypeBalance,
-			Kind:        quota.WindowKindResource,
-			Used:        total,
-			Unknown:     true,
-			Unit:        quota.UsageUnitCurrency,
-			Label:       currency + " Balance",
-			Description: fmt.Sprintf("Available: %.2f %s (granted: %.2f, topped up: %.2f)", total, currency, granted, toppedUp),
+			Type:         quota.WindowTypeBalance,
+			Kind:         quota.WindowKindResource,
+			Available:    &total,
+			Unknown:      true,
+			Unit:         quota.UsageUnitCurrency,
+			CurrencyCode: currency,
+			Label:        currency + " Balance",
+			Description:  fmt.Sprintf("Granted: %.2f %s · Topped up: %.2f %s", granted, currency, toppedUp, currency),
 		})
 	}
 

--- a/ai/quota/fetcher/deepseek.go
+++ b/ai/quota/fetcher/deepseek.go
@@ -1,0 +1,154 @@
+package fetcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/ai/quota"
+)
+
+const deepSeekAPIHost = "https://api.deepseek.com"
+
+// DeepSeekFetcher retrieves the balances available to a DeepSeek API key.
+type DeepSeekFetcher struct {
+	baseURL string
+}
+
+func NewDeepSeekFetcher() *DeepSeekFetcher {
+	return &DeepSeekFetcher{}
+}
+
+func (f *DeepSeekFetcher) Name() string                     { return "deepseek" }
+func (f *DeepSeekFetcher) ProviderType() quota.ProviderType { return quota.ProviderTypeDeepSeek }
+func (f *DeepSeekFetcher) RequiresAuth() ai.AuthType        { return ai.AuthTypeAPIKey }
+
+func (f *DeepSeekFetcher) Validate(provider *ai.Provider) error {
+	if provider == nil {
+		return fmt.Errorf("provider is nil")
+	}
+	if provider.GetAccessToken() == "" {
+		return fmt.Errorf("no API key available")
+	}
+	return nil
+}
+
+type deepSeekBalanceResponse struct {
+	IsAvailable bool                  `json:"is_available"`
+	Balances    []deepSeekBalanceInfo `json:"balance_infos"`
+}
+
+type deepSeekBalanceInfo struct {
+	Currency        string `json:"currency"`
+	TotalBalance    string `json:"total_balance"`
+	GrantedBalance  string `json:"granted_balance"`
+	ToppedUpBalance string `json:"topped_up_balance"`
+}
+
+func (f *DeepSeekFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quota.ProviderUsage, error) {
+	if err := f.Validate(provider); err != nil {
+		return nil, err
+	}
+
+	root := apiRoot(provider.APIBase, deepSeekAPIHost, "/v1")
+	if f.baseURL != "" {
+		root = strings.TrimRight(f.baseURL, "/")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, root+"/user/balance", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+provider.GetAccessToken())
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := quota.NewHTTPClient(provider.ProxyURL, 30*time.Second).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d%s", resp.StatusCode, errorDetail(body))
+	}
+
+	var apiResp deepSeekBalanceResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	now := time.Now()
+	usage := &quota.ProviderUsage{
+		ProviderUUID: provider.UUID,
+		ProviderName: provider.Name,
+		ProviderType: quota.ProviderTypeDeepSeek,
+		FetchedAt:    now,
+		ExpiresAt:    now.Add(5 * time.Minute),
+		RawResponse:  json.RawMessage(body),
+	}
+
+	for i, balance := range apiResp.Balances {
+		total, err := parseDeepSeekAmount("total_balance", balance.TotalBalance)
+		if err != nil {
+			return nil, fmt.Errorf("balance_infos[%d]: %w", i, err)
+		}
+		granted, err := parseDeepSeekAmount("granted_balance", balance.GrantedBalance)
+		if err != nil {
+			return nil, fmt.Errorf("balance_infos[%d]: %w", i, err)
+		}
+		toppedUp, err := parseDeepSeekAmount("topped_up_balance", balance.ToppedUpBalance)
+		if err != nil {
+			return nil, fmt.Errorf("balance_infos[%d]: %w", i, err)
+		}
+
+		currency := strings.TrimSpace(balance.Currency)
+		if currency == "" {
+			currency = "Unknown"
+		}
+		key := strings.ToLower(currency)
+		if key == "unknown" || hasWindowKey(usage, key) {
+			key = fmt.Sprintf("balance_%d", i)
+		}
+		usage.AddWindow(key, &quota.UsageWindow{
+			Type:        quota.WindowTypeBalance,
+			Kind:        quota.WindowKindResource,
+			Used:        total,
+			Unknown:     true,
+			Unit:        quota.UsageUnitCurrency,
+			Label:       currency + " Balance",
+			Description: fmt.Sprintf("Available: %.2f %s (granted: %.2f, topped up: %.2f)", total, currency, granted, toppedUp),
+		})
+	}
+
+	return usage, nil
+}
+
+func parseDeepSeekAmount(field, value string) (float64, error) {
+	amount, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", field, value, err)
+	}
+	if math.IsNaN(amount) || math.IsInf(amount, 0) || amount < 0 {
+		return 0, fmt.Errorf("invalid %s %q: amount must be a finite non-negative number", field, value)
+	}
+	return amount, nil
+}
+
+func hasWindowKey(usage *quota.ProviderUsage, key string) bool {
+	for _, window := range usage.Windows {
+		if window.Key == key {
+			return true
+		}
+	}
+	return false
+}

--- a/ai/quota/fetcher/deepseek_test.go
+++ b/ai/quota/fetcher/deepseek_test.go
@@ -1,0 +1,133 @@
+package fetcher
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/ai/quota"
+)
+
+func TestDeepSeekFetcherBalances(t *testing.T) {
+	const response = `{"is_available":true,"balance_infos":[{"currency":"CNY","total_balance":"81.41","granted_balance":"0.00","topped_up_balance":"81.41"},{"currency":"USD","total_balance":"2.50","granted_balance":"1.00","topped_up_balance":"1.50"}]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/user/balance" {
+			t.Errorf("path = %q, want /user/balance", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Errorf("Accept = %q, want application/json", got)
+		}
+		_, _ = w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	usage, err := (&DeepSeekFetcher{baseURL: server.URL}).Fetch(context.Background(), &ai.Provider{
+		UUID:  "deepseek-test",
+		Name:  "DeepSeek",
+		Token: "test-key",
+	})
+	if err != nil {
+		t.Fatalf("Fetch() error: %v", err)
+	}
+
+	checkInvariants(t, usage)
+	if usage.ProviderType != quota.ProviderTypeDeepSeek {
+		t.Errorf("ProviderType = %q, want deepseek", usage.ProviderType)
+	}
+	if string(usage.RawResponse) != response {
+		t.Errorf("RawResponse = %q, want %q", usage.RawResponse, response)
+	}
+	if len(usage.Windows) != 2 {
+		t.Fatalf("Windows = %d, want 2", len(usage.Windows))
+	}
+	if pct, ok := usage.Pct(); ok {
+		t.Errorf("Pct() = %v, true; balances have no original limit", pct)
+	}
+	if usage.RecoversAt() != nil {
+		t.Error("RecoversAt() should be nil for balances")
+	}
+
+	cny := findWindow(t, usage, "cny")
+	if cny.Kind != quota.WindowKindResource || !cny.Unknown {
+		t.Errorf("CNY semantics = kind %q unknown %v, want resource true", cny.Kind, cny.Unknown)
+	}
+	if cny.Used != 81.41 {
+		t.Errorf("CNY balance = %v, want 81.41", cny.Used)
+	}
+	if cny.Label != "CNY Balance" || !strings.Contains(cny.Description, "Available: 81.41 CNY") {
+		t.Errorf("CNY display = %q / %q", cny.Label, cny.Description)
+	}
+}
+
+func TestDeepSeekFetcherUsesConfiguredAPIRoot(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/user/balance" {
+			t.Errorf("path = %q, want /user/balance", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"is_available":true,"balance_infos":[]}`))
+	}))
+	defer server.Close()
+
+	usage, err := NewDeepSeekFetcher().Fetch(context.Background(), &ai.Provider{
+		UUID: "u", Name: "DeepSeek", Token: "k", APIBase: server.URL + "/v1",
+	})
+	if err != nil {
+		t.Fatalf("Fetch() error: %v", err)
+	}
+	if len(usage.Windows) != 0 {
+		t.Errorf("Windows = %d, want 0", len(usage.Windows))
+	}
+}
+
+func TestDeepSeekFetcherValidation(t *testing.T) {
+	fetcher := NewDeepSeekFetcher()
+	if err := fetcher.Validate(nil); err == nil {
+		t.Error("Validate(nil) should fail")
+	}
+	if err := fetcher.Validate(&ai.Provider{}); err == nil {
+		t.Error("Validate() without key should fail")
+	}
+}
+
+func TestDeepSeekFetcherRejectsMalformedBalance(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"is_available":true,"balance_infos":[{"currency":"CNY","total_balance":"not-a-number","granted_balance":"0.00","topped_up_balance":"0.00"}]}`))
+	}))
+	defer server.Close()
+
+	_, err := (&DeepSeekFetcher{baseURL: server.URL}).Fetch(context.Background(),
+		&ai.Provider{UUID: "u", Name: "DeepSeek", Token: "secret"})
+	if err == nil || !strings.Contains(err.Error(), "invalid total_balance") {
+		t.Fatalf("Fetch() error = %v, want invalid total_balance", err)
+	}
+	if strings.Contains(err.Error(), "secret") {
+		t.Error("Fetch() error exposes API key")
+	}
+}
+
+func TestDeepSeekFetcherReportsUpstreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key"}}`))
+	}))
+	defer server.Close()
+
+	_, err := (&DeepSeekFetcher{baseURL: server.URL}).Fetch(context.Background(),
+		&ai.Provider{UUID: "u", Name: "DeepSeek", Token: "secret"})
+	if err == nil || !strings.Contains(err.Error(), "401") || !strings.Contains(err.Error(), "invalid api key") {
+		t.Fatalf("Fetch() error = %v, want status and upstream detail", err)
+	}
+	if strings.Contains(err.Error(), "secret") {
+		t.Error("Fetch() error exposes API key")
+	}
+}

--- a/ai/quota/fetcher/deepseek_test.go
+++ b/ai/quota/fetcher/deepseek_test.go
@@ -61,10 +61,16 @@ func TestDeepSeekFetcherBalances(t *testing.T) {
 	if cny.Kind != quota.WindowKindResource || !cny.Unknown {
 		t.Errorf("CNY semantics = kind %q unknown %v, want resource true", cny.Kind, cny.Unknown)
 	}
-	if cny.Used != 81.41 {
-		t.Errorf("CNY balance = %v, want 81.41", cny.Used)
+	if cny.Available == nil || *cny.Available != 81.41 {
+		t.Errorf("CNY available = %v, want 81.41", cny.Available)
 	}
-	if cny.Label != "CNY Balance" || !strings.Contains(cny.Description, "Available: 81.41 CNY") {
+	if cny.Used != 0 {
+		t.Errorf("CNY used = %v, want 0 because upstream reports remaining balance", cny.Used)
+	}
+	if cny.CurrencyCode != "CNY" {
+		t.Errorf("CNY CurrencyCode = %q, want CNY", cny.CurrencyCode)
+	}
+	if cny.Label != "CNY Balance" || !strings.Contains(cny.Description, "Granted: 0.00 CNY") {
 		t.Errorf("CNY display = %q / %q", cny.Label, cny.Description)
 	}
 }

--- a/ai/quota/fetcher/invariants_test.go
+++ b/ai/quota/fetcher/invariants_test.go
@@ -1,6 +1,7 @@
 package fetcher
 
 import (
+	"math"
 	"testing"
 
 	"github.com/tingly-dev/tingly-box/ai/quota"
@@ -81,6 +82,13 @@ func checkWindow(t *testing.T, where string, w *quota.UsageWindow) {
 	}
 	if !w.Countable() && w.UsedPercent != 0 {
 		t.Errorf("%s: uncountable window still reports UsedPercent=%v", where, w.UsedPercent)
+	}
+
+	if w.Available != nil && (math.IsNaN(*w.Available) || math.IsInf(*w.Available, 0) || *w.Available < 0) {
+		t.Errorf("%s: Available = %v; want a finite non-negative amount", where, *w.Available)
+	}
+	if w.CurrencyCode != "" && w.Unit != quota.UsageUnitCurrency {
+		t.Errorf("%s: CurrencyCode = %q on unit %q", where, w.CurrencyCode, w.Unit)
 	}
 
 	if p := w.Percent(); p < 0 || p > 100 {

--- a/ai/quota/fetcher/kimi_code.go
+++ b/ai/quota/fetcher/kimi_code.go
@@ -358,8 +358,10 @@ func addKimiCodeWallet(usage *quota.ProviderUsage, wallet *kimiCodeBoosterWallet
 
 	total := wallet.Balance.Amount.Value / kimiCodeFixedPointCent / 100
 	remaining := 0.0
+	var available *float64
 	if wallet.Balance.AmountLeft.Valid {
 		remaining = wallet.Balance.AmountLeft.Value / kimiCodeFixedPointCent / 100
+		available = &remaining
 	}
 	used := total - remaining
 	if used < 0 {
@@ -377,13 +379,15 @@ func addKimiCodeWallet(usage *quota.ProviderUsage, wallet *kimiCodeBoosterWallet
 	// A wallet balance is topped up, not reset, so waiting brings none of it
 	// back. Both halves are known, so the proportion spent is still real.
 	usage.AddWindow("booster", &quota.UsageWindow{
-		Type:        quota.WindowTypeBalance,
-		Kind:        quota.WindowKindResource,
-		Used:        used,
-		Limit:       total,
-		Unit:        quota.UsageUnitCurrency,
-		Label:       "Booster balance",
-		Description: fmt.Sprintf("%.2f %s remaining", remaining, currency),
+		Type:         quota.WindowTypeBalance,
+		Kind:         quota.WindowKindResource,
+		Used:         used,
+		Limit:        total,
+		Available:    available,
+		Unit:         quota.UsageUnitCurrency,
+		CurrencyCode: currency,
+		Label:        "Booster balance",
+		Description:  fmt.Sprintf("%.2f %s remaining", remaining, currency),
 	})
 
 	if wallet.MonthlyUsed.PriceInCents.Valid || wallet.MonthlyChargeLimit.PriceInCents.Valid {

--- a/ai/quota/fetcher/kimi_code_test.go
+++ b/ai/quota/fetcher/kimi_code_test.go
@@ -111,6 +111,12 @@ func TestKimiCodeFetcherFetch(t *testing.T) {
 	if booster.Used != 100 || booster.Limit != 200 || booster.Unit != quota.UsageUnitCurrency {
 		t.Errorf("booster values = used %v, limit %v, unit %q", booster.Used, booster.Limit, booster.Unit)
 	}
+	if booster.Available == nil || *booster.Available != 100 {
+		t.Errorf("booster Available = %v, want 100", booster.Available)
+	}
+	if booster.CurrencyCode != "USD" {
+		t.Errorf("booster CurrencyCode = %q, want USD", booster.CurrencyCode)
+	}
 
 	if usage.Cost == nil {
 		t.Fatal("Cost is nil")

--- a/ai/quota/fetcher/kimik2.go
+++ b/ai/quota/fetcher/kimik2.go
@@ -119,6 +119,7 @@ func (f *KimiK2Fetcher) Fetch(ctx context.Context, provider *ai.Provider) (*quot
 		Kind:        quota.WindowKindResource,
 		Used:        consumed,
 		Limit:       total,
+		Available:   &remaining,
 		Unit:        quota.UsageUnitCredits,
 		Label:       "Credits",
 		Description: fmt.Sprintf("%.0f consumed, %.0f remaining", consumed, remaining),

--- a/ai/quota/fetcher/kimik2_test.go
+++ b/ai/quota/fetcher/kimik2_test.go
@@ -87,6 +87,9 @@ func TestKimiK2CreditsAreAResource(t *testing.T) {
 	if credits.Kind != quota.WindowKindResource {
 		t.Errorf("credits Kind = %q, want resource", credits.Kind)
 	}
+	if credits.Available == nil || *credits.Available != 700 {
+		t.Errorf("credits Available = %v, want 700", credits.Available)
+	}
 	if pct, ok := usage.Pct(); !ok || pct != 30 {
 		t.Fatalf("Pct() = %v, %v; want 30, true", pct, ok)
 	}

--- a/ai/quota/fetcher/openrouter.go
+++ b/ai/quota/fetcher/openrouter.go
@@ -118,14 +118,20 @@ func (f *OpenRouterFetcher) Fetch(ctx context.Context, provider *ai.Provider) (*
 	if data.Limit != nil && *data.Limit > 0 {
 		used := data.Usage
 		limit := *data.Limit
+		available := limit - used
+		if available < 0 {
+			available = 0
+		}
 		usage.AddWindow("key_limit", &quota.UsageWindow{
-			Type:        quota.WindowTypeBalance,
-			Kind:        quota.WindowKindResource,
-			Used:        used,
-			Limit:       limit,
-			Unit:        quota.UsageUnitCurrency,
-			Label:       "Key Limit",
-			Description: fmt.Sprintf("Balance: $%.2f / $%.2f", limit-used, limit),
+			Type:         quota.WindowTypeBalance,
+			Kind:         quota.WindowKindResource,
+			Used:         used,
+			Limit:        limit,
+			Available:    &available,
+			Unit:         quota.UsageUnitCurrency,
+			CurrencyCode: "USD",
+			Label:        "Key Limit",
+			Description:  fmt.Sprintf("Balance: $%.2f / $%.2f", available, limit),
 		})
 	}
 

--- a/ai/quota/fetcher/openrouter_test.go
+++ b/ai/quota/fetcher/openrouter_test.go
@@ -213,6 +213,12 @@ func TestOpenRouterKeyLimitIsAResource(t *testing.T) {
 	if keyLimit.Kind != quota.WindowKindResource {
 		t.Errorf("key_limit Kind = %q, want resource", keyLimit.Kind)
 	}
+	if keyLimit.Available == nil || *keyLimit.Available != 11.9 {
+		t.Errorf("key_limit Available = %v, want 11.9", keyLimit.Available)
+	}
+	if keyLimit.CurrencyCode != "USD" {
+		t.Errorf("key_limit CurrencyCode = %q, want USD", keyLimit.CurrencyCode)
+	}
 	if pct, ok := usage.Pct(); !ok || pct < 40.4 || pct > 40.6 {
 		t.Fatalf("Pct() = %v, %v; want ~40.5, true", pct, ok)
 	}

--- a/ai/quota/fetcher/register.go
+++ b/ai/quota/fetcher/register.go
@@ -9,6 +9,7 @@ import (
 func RegisterAll(r quota.FetcherRegistrar, logger *logrus.Logger) {
 	fetchers := []quota.Fetcher{
 		NewAnthropicFetcher(),
+		NewDeepSeekFetcher(),
 		NewOpenAIFetcher(),
 		NewGeminiFetcher(),
 		NewCursorFetcher(),

--- a/ai/quota/fetcher/taskfile_samples_test.go
+++ b/ai/quota/fetcher/taskfile_samples_test.go
@@ -72,8 +72,8 @@ func TestTaskfileSamples(t *testing.T) {
 	// DeepSeek only reports what remains. Without the original balance there is
 	// no honest percentage, and topping up — not waiting — restores the resource.
 	check(t, "deepseek", u, want{ok: false, windows: 1})
-	if got := findWindow(t, u, "cny").Used; got != 81.41 {
-		t.Errorf("deepseek: CNY balance = %v; want 81.41", got)
+	if available := findWindow(t, u, "cny").Available; available == nil || *available != 81.41 {
+		t.Errorf("deepseek: CNY available = %v; want 81.41", available)
 	}
 
 	// ── anthropic (build/Taskfile.quota.yml) ──

--- a/ai/quota/fetcher/taskfile_samples_test.go
+++ b/ai/quota/fetcher/taskfile_samples_test.go
@@ -61,12 +61,27 @@ func oauthProvider(name string) *ai.Provider {
 // a null utilization, a free plan whose "primary" window is a week long, a plan
 // that mixes a coding model with speech and image quotas.
 func TestTaskfileSamples(t *testing.T) {
+	// ── deepseek (build/Taskfile.quota.yml) ──
+	s := serve(t, `{"is_available":true,"balance_infos":[
+		{"currency":"CNY","total_balance":"81.41","granted_balance":"0.00","topped_up_balance":"81.41"}]}`)
+	u, err := (&DeepSeekFetcher{baseURL: s.URL}).Fetch(context.Background(),
+		&ai.Provider{UUID: "u", Name: "DeepSeek", Token: "k"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// DeepSeek only reports what remains. Without the original balance there is
+	// no honest percentage, and topping up — not waiting — restores the resource.
+	check(t, "deepseek", u, want{ok: false, windows: 1})
+	if got := findWindow(t, u, "cny").Used; got != 81.41 {
+		t.Errorf("deepseek: CNY balance = %v; want 81.41", got)
+	}
+
 	// ── anthropic (build/Taskfile.quota.yml) ──
-	s := serve(t, `{"five_hour":{"utilization":7.0,"resets_at":"2026-04-08T05:00:00.096458+00:00"},
+	s = serve(t, `{"five_hour":{"utilization":7.0,"resets_at":"2026-04-08T05:00:00.096458+00:00"},
 	"seven_day":{"utilization":1.0,"resets_at":"2026-04-14T15:00:01.096478+00:00"},
 	"seven_day_sonnet":{"utilization":1.0,"resets_at":"2026-04-14T15:00:01.096485+00:00"},
 	"extra_usage":{"is_enabled":true,"monthly_limit":7500,"used_credits":0.0,"utilization":null}}`)
-	u, err := (&AnthropicFetcher{baseURL: s.URL}).Fetch(context.Background(), oauthProvider("Claude"))
+	u, err = (&AnthropicFetcher{baseURL: s.URL}).Fetch(context.Background(), oauthProvider("Claude"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ai/quota/manager.go
+++ b/ai/quota/manager.go
@@ -363,6 +363,8 @@ func inferProviderType(provider *typ.Provider) ProviderType {
 	switch {
 	case hostIs(host, "anthropic.com"):
 		return ProviderTypeAnthropic
+	case hostIs(host, "api.deepseek.com"):
+		return ProviderTypeDeepSeek
 	//case hostIs(host, "openai.com", "openai.azure.com"):
 	//	return ProviderTypeOpenAI
 	case hostIs(host, "googleapis.com"), strings.Contains(host, "gemini"):

--- a/ai/quota/manager_test.go
+++ b/ai/quota/manager_test.go
@@ -113,6 +113,7 @@ func TestInferProviderTypeAPIBaseCaseInsensitive(t *testing.T) {
 		want    ProviderType
 	}{
 		{"HTTPS://API.ANTHROPIC.COM/V1", ProviderTypeAnthropic},
+		{"HTTPS://API.DEEPSEEK.COM/V1", ProviderTypeDeepSeek},
 		// OpenAI is intentionally unclassified (see the OpenAI-disabling
 		// commit): its legacy usage API's current requirements are unverified,
 		// so the manager skips it rather than reading it wrong.
@@ -259,6 +260,9 @@ func TestInferProviderTypeIgnoresPathAndLocalHosts(t *testing.T) {
 		{"vendor name only in the path", "https://gateway.example.com/proxy/openrouter.ai/api/v1", ""},
 		{"lookalike domain", "https://api.openai.com.evil.test/v1", ""},
 		{"scheme-less base", "api.anthropic.com/v1", ProviderTypeAnthropic},
+		{"scheme-less deepseek base", "api.deepseek.com/v1", ProviderTypeDeepSeek},
+		{"deepseek subdomain", "https://eu.api.deepseek.com/v1", ProviderTypeDeepSeek},
+		{"deepseek lookalike domain", "https://api.deepseek.com.evil.test/v1", ""},
 		{"subdomain of a vendor", "https://eu.api.anthropic.com/v1", ProviderTypeAnthropic},
 		{"kimi coding needs its path", "https://api.kimi.com/coding/v1", ProviderTypeKimiCode},
 		{"kimi without the coding path", "https://api.kimi.com/v1", ""},

--- a/ai/quota/types.go
+++ b/ai/quota/types.go
@@ -120,7 +120,7 @@ type UsageWindow struct {
 	// Quota data
 	Used        float64  `json:"used"`                // used amount
 	Limit       float64  `json:"limit"`               // quota limit (0 means unlimited)
-	Available   *float64 `json:"available,omitempty"` // amount currently available when upstream does not report the original limit
+	Available   *float64 `json:"available,omitempty"` // amount currently available or remaining, independent of whether a usage percentage is known
 	UsedPercent float64  `json:"used_percent"`        // usage percentage (0-100)
 
 	// Time window

--- a/ai/quota/types.go
+++ b/ai/quota/types.go
@@ -118,16 +118,18 @@ type UsageWindow struct {
 	Type WindowType `json:"type"` // session, weekly, monthly, daily, custom, balance
 
 	// Quota data
-	Used        float64 `json:"used"`         // used amount
-	Limit       float64 `json:"limit"`        // quota limit (0 means unlimited)
-	UsedPercent float64 `json:"used_percent"` // usage percentage (0-100)
+	Used        float64  `json:"used"`                // used amount
+	Limit       float64  `json:"limit"`               // quota limit (0 means unlimited)
+	Available   *float64 `json:"available,omitempty"` // amount currently available when upstream does not report the original limit
+	UsedPercent float64  `json:"used_percent"`        // usage percentage (0-100)
 
 	// Time window
 	ResetsAt      *time.Time `json:"resets_at,omitempty"`      // reset time (if known)
 	WindowMinutes int        `json:"window_minutes,omitempty"` // time window size (minutes)
 
 	// Unit information
-	Unit UsageUnit `json:"unit"` // tokens, requests, credits, usd
+	Unit         UsageUnit `json:"unit"`                    // tokens, requests, credits, currency
+	CurrencyCode string    `json:"currency_code,omitempty"` // ISO currency code when Unit is currency
 
 	// Metadata
 	Label       string `json:"label"`       // display label, e.g., "Session Quota"

--- a/ai/quota/types.go
+++ b/ai/quota/types.go
@@ -12,6 +12,7 @@ type ProviderType string
 
 const (
 	ProviderTypeAnthropic  ProviderType = "anthropic"
+	ProviderTypeDeepSeek   ProviderType = "deepseek"
 	ProviderTypeOpenAI     ProviderType = "openai"
 	ProviderTypeGoogle     ProviderType = "google"
 	ProviderTypeGemini     ProviderType = "gemini"

--- a/build/Taskfile.quota.yml
+++ b/build/Taskfile.quota.yml
@@ -6,6 +6,26 @@ vars:
   PROXY: ""
 
 tasks:
+  deepseek:
+    cmds:
+      - |
+        echo "example"
+        cat << EOF
+        {
+            "is_available": true,
+            "balance_infos": [
+                {
+                    "currency": "CNY",
+                    "total_balance": "81.41",
+                    "granted_balance": "0.00",
+                    "topped_up_balance": "81.41"
+                }
+            ]
+        }
+        EOF
+      - |
+        curl https://api.deepseek.com/user/balance \
+          -H "Authorization: Bearer ${{.DEEPSEEK_API_KEY}}"
   anthropic:
     cmds:
       - |

--- a/frontend/src/components/credential/QuotaBarItem.tsx
+++ b/frontend/src/components/credential/QuotaBarItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, Stack, Tooltip, Typography, tooltipClasses } from '@mui/material';
 import type { QuotaWindow } from '@/types/quota';
-import { formatQuotaPercent, formatQuotaUsage, isCountable } from '@/types/quota';
+import { formatQuotaAvailable, formatQuotaPercent, formatQuotaUsage, isCountable } from '@/types/quota';
 import { QUOTA_COLORS, formatNumber } from '../dashboard/chartStyles';
 
 interface QuotaBarItemProps {
@@ -67,6 +67,9 @@ export function QuotaBarItem({ window, showDetails = false, percentLabel, barCol
 
   const resetTime = formatResetTime();
   const detailedInfo = formatQuotaUsage(window, { formatNumber: formatNumber });
+  const availableInfo = countable
+    ? formatQuotaAvailable(window, formatNumber)
+    : undefined;
 
   const tooltipContent = (
     <Box
@@ -85,6 +88,11 @@ export function QuotaBarItem({ window, showDetails = false, percentLabel, barCol
       <Typography variant="body2" sx={{ display: 'block', mb: 0.5 }}>
         {detailedInfo}
       </Typography>
+      {availableInfo && (
+        <Typography variant="caption" sx={{ color: "text.secondary", display: 'block' }}>
+          Available: {availableInfo}
+        </Typography>
+      )}
       {resetTime && (
         <Typography variant="caption" sx={{
           color: "text.secondary"

--- a/frontend/src/types/quota.test.ts
+++ b/frontend/src/types/quota.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { formatQuotaUsage } from './quota';
+
+const baseWindow = {
+    used: 0,
+    limit: 0,
+    used_percent: 0,
+    unit: 'currency',
+    unknown: true,
+};
+
+describe('formatQuotaUsage', () => {
+    it('shows a reported available balance even when its percentage is unknown', () => {
+        expect(formatQuotaUsage({
+            ...baseWindow,
+            available: 81.41,
+            currency_code: 'CNY',
+        })).toBe('81.41 CNY');
+    });
+
+    it('keeps truly unknown values distinct from a zero balance', () => {
+        expect(formatQuotaUsage(baseWindow)).toBe('not reported');
+        expect(formatQuotaUsage({
+            ...baseWindow,
+            available: 0,
+            currency_code: 'CNY',
+        })).toBe('0 CNY');
+    });
+});

--- a/frontend/src/types/quota.test.ts
+++ b/frontend/src/types/quota.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatQuotaUsage } from './quota';
+import { formatQuotaAvailable, formatQuotaUsage } from './quota';
 
 const baseWindow = {
     used: 0,
@@ -16,6 +16,21 @@ describe('formatQuotaUsage', () => {
             available: 81.41,
             currency_code: 'CNY',
         })).toBe('81.41 CNY');
+    });
+
+    it('preserves countable usage while exposing available balance separately', () => {
+        const window = {
+            ...baseWindow,
+            unknown: false,
+            used: 30,
+            limit: 100,
+            used_percent: 30,
+            unit: 'credits',
+            available: 70,
+        };
+
+        expect(formatQuotaUsage(window)).toBe('30 / 100 credits');
+        expect(formatQuotaAvailable(window)).toBe('70 credits');
     });
 
     it('keeps truly unknown values distinct from a zero balance', () => {

--- a/frontend/src/types/quota.ts
+++ b/frontend/src/types/quota.ts
@@ -16,6 +16,8 @@ export type QuotaWindow = UsageWindow & {
     kind?: 'limit' | 'resource';
     unknown?: boolean;
     unlimited?: boolean;
+    available?: number;
+    currency_code?: string;
 };
 
 /** The fields that decide whether a window has a figure to show. */
@@ -110,7 +112,7 @@ interface FormatQuotaUsageOptions {
     formatNumber?: (value: number) => string;
 }
 
-type QuotaUsageValues = CountableFields & Pick<UsageWindow, 'used' | 'used_percent' | 'unit'>;
+type QuotaUsageValues = CountableFields & Pick<QuotaWindow, 'used' | 'used_percent' | 'unit' | 'available' | 'currency_code'>;
 
 export function formatQuotaPercent(window: QuotaUsageValues): string {
     return `${window.used_percent.toFixed(0)}%`;
@@ -120,6 +122,13 @@ export function formatQuotaUsage(
     window: QuotaUsageValues,
     { includePercent = false, formatNumber = String }: FormatQuotaUsageOptions = {}
 ): string {
+    if (window.available !== undefined) {
+        const unit = window.currency_code || window.unit;
+        const value = window.unit === 'currency'
+            ? window.available.toLocaleString('en-US', { maximumFractionDigits: 2 })
+            : formatNumber(window.available);
+        return `${value}${unit ? ` ${unit}` : ''}`;
+    }
     if (!isCountable(window)) {
         // No figure to show, so show none — "0 / 0 (0%)" would read as unused.
         return window.unknown ? 'not reported' : 'no limit';

--- a/frontend/src/types/quota.ts
+++ b/frontend/src/types/quota.ts
@@ -118,18 +118,26 @@ export function formatQuotaPercent(window: QuotaUsageValues): string {
     return `${window.used_percent.toFixed(0)}%`;
 }
 
+export function formatQuotaAvailable(
+    window: Pick<QuotaWindow, 'available' | 'currency_code' | 'unit'>,
+    formatNumber: (value: number) => string = String
+): string | undefined {
+    if (window.available === undefined) return undefined;
+
+    const unit = window.currency_code || window.unit;
+    const value = window.unit === 'currency'
+        ? window.available.toLocaleString('en-US', { maximumFractionDigits: 2 })
+        : formatNumber(window.available);
+    return `${value}${unit ? ` ${unit}` : ''}`;
+}
+
 export function formatQuotaUsage(
     window: QuotaUsageValues,
     { includePercent = false, formatNumber = String }: FormatQuotaUsageOptions = {}
 ): string {
-    if (window.available !== undefined) {
-        const unit = window.currency_code || window.unit;
-        const value = window.unit === 'currency'
-            ? window.available.toLocaleString('en-US', { maximumFractionDigits: 2 })
-            : formatNumber(window.available);
-        return `${value}${unit ? ` ${unit}` : ''}`;
-    }
     if (!isCountable(window)) {
+        const available = formatQuotaAvailable(window, formatNumber);
+        if (available !== undefined) return available;
         // No figure to show, so show none — "0 / 0 (0%)" would read as unused.
         return window.unknown ? 'not reported' : 'no limit';
     }

--- a/internal/command/quota.go
+++ b/internal/command/quota.go
@@ -272,6 +272,16 @@ func printWindowWithProgress(window *quota.UsageWindow) {
 	// printing one would read as a green "0.00 / 0.00 (0.0%)". What it does
 	// carry (this month's spend, a balance) goes out as-is.
 	if !window.Countable() {
+		if window.Available != nil {
+			unit := string(window.Unit)
+			value := formatUsageValue(*window.Available, window.Unit)
+			if window.Unit == quota.UsageUnitCurrency {
+				value = fmt.Sprintf("%.2f", *window.Available)
+				unit = window.CurrencyCode
+			}
+			fmt.Printf("· %s: %s%s\n", window.Label, value, formatQuotaUnit(unit))
+			return
+		}
 		fmt.Printf("· %s: %s\n", window.Label, cmp.Or(window.Description, "no limit reported"))
 		return
 	}
@@ -295,6 +305,13 @@ func printWindowWithProgress(window *quota.UsageWindow) {
 
 	// Print line: [icon] Label: usage [progress_bar] reset_info
 	fmt.Printf("%s %s: %s [%s]%s\n", statusIcon, window.Label, usageStr, progressBar, resetInfo)
+}
+
+func formatQuotaUnit(unit string) string {
+	if unit == "" {
+		return ""
+	}
+	return " " + unit
 }
 
 // renderProgressBar creates a visual progress bar

--- a/internal/command/quota.go
+++ b/internal/command/quota.go
@@ -272,14 +272,8 @@ func printWindowWithProgress(window *quota.UsageWindow) {
 	// printing one would read as a green "0.00 / 0.00 (0.0%)". What it does
 	// carry (this month's spend, a balance) goes out as-is.
 	if !window.Countable() {
-		if window.Available != nil {
-			unit := string(window.Unit)
-			value := formatUsageValue(*window.Available, window.Unit)
-			if window.Unit == quota.UsageUnitCurrency {
-				value = fmt.Sprintf("%.2f", *window.Available)
-				unit = window.CurrencyCode
-			}
-			fmt.Printf("· %s: %s%s\n", window.Label, value, formatQuotaUnit(unit))
+		if available := formatAvailableQuota(window); available != "" {
+			fmt.Printf("· %s: %s\n", window.Label, available)
 			return
 		}
 		fmt.Printf("· %s: %s\n", window.Label, cmp.Or(window.Description, "no limit reported"))
@@ -302,9 +296,26 @@ func printWindowWithProgress(window *quota.UsageWindow) {
 	if window.ResetsAt != nil {
 		resetInfo = fmt.Sprintf(" — %s", formatResetTime(*window.ResetsAt))
 	}
+	if available := formatAvailableQuota(window); available != "" {
+		resetInfo += " — available " + available
+	}
 
 	// Print line: [icon] Label: usage [progress_bar] reset_info
 	fmt.Printf("%s %s: %s [%s]%s\n", statusIcon, window.Label, usageStr, progressBar, resetInfo)
+}
+
+func formatAvailableQuota(window *quota.UsageWindow) string {
+	if window.Available == nil {
+		return ""
+	}
+
+	unit := string(window.Unit)
+	value := formatUsageValue(*window.Available, window.Unit)
+	if window.Unit == quota.UsageUnitCurrency {
+		value = fmt.Sprintf("%.2f", *window.Available)
+		unit = window.CurrencyCode
+	}
+	return value + formatQuotaUnit(unit)
 }
 
 func formatQuotaUnit(unit string) string {


### PR DESCRIPTION
## Summary
DeepSeek balances were unavailable, while known remaining balances could appear as “not reported.” 
Quota views now expose concrete balances without inventing percentages. It also implement #1616.

## Key Changes
- **DeepSeek support**: Fetch and display authenticated, multi-currency balances.
- **Safe detection**: Infer DeepSeek only from its official API hostname family.
- **Balance semantics**: Represent remaining amounts independently from usage percentages.
- **Consistent coverage**: Surface available Codex, Kimi, and OpenRouter balances.
- **Presentation**: Preserve countable progress bars while showing remaining amounts as details.

## Testing
- Go quota tests and CLI build pass; focused frontend tests and lint pass.
