### PR TITLE
bugfix(server,frontend): stop persisting probe axes; echo request axes in result

### DIFF
--- a/frontend/src/components/probe/ProbeDialog.tsx
+++ b/frontend/src/components/probe/ProbeDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, memo, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useEffect, memo, useCallback, useMemo } from 'react';
 import {
     Dialog,
     DialogTitle,
@@ -33,7 +33,6 @@ import { runProbe, buildProbeCurl, type ProbeCurlResult } from './runProbe';
 import {
     type ProbeAxes,
     resolveInitialAxes,
-    persistAxes,
     protocolAvailability,
     scopeAvailable,
 } from './probeConfig';
@@ -453,8 +452,9 @@ export const ProbeDialog: React.FC<ProbeDialogProps> = ({
     }, [open, provider, targetType, targetId]);
 
     // Reset on open — do NOT auto-run; the user clicks Run Test. State comes
-    // from the association chain (props → initialResult → persisted config →
-    // defaults), so the toggles always describe the result on screen.
+    // from the association chain (props → initialResult → defaults), so the
+    // toggles always describe the result on screen. Axes are deliberately not
+    // persisted across opens — a probe's defaults must be predictable.
     useEffect(() => {
         if (open) {
             setAxes(resolveInitialAxes({ targetType, thinkingLevel, initialResult, provider: providerInfo }));
@@ -469,7 +469,7 @@ export const ProbeDialog: React.FC<ProbeDialogProps> = ({
     }, [open, thinkingLevel, initialResult]);
 
     // Clamp the protocol axis when the provider record arrives (or changes):
-    // a persisted protocol that this target can't speak falls back to the
+    // a result-echoed protocol that this target can't speak falls back to the
     // concrete default.
     const protoAvail = useMemo(() => protocolAvailability(providerInfo), [providerInfo]);
     useEffect(() => {
@@ -487,17 +487,6 @@ export const ProbeDialog: React.FC<ProbeDialogProps> = ({
             return prev;
         });
     }, [protoAvail]);
-
-    // Persist any manual change (not the programmatic resets above) so the
-    // dialog re-opens in the shape the user last used on this surface.
-    const axesInitialized = useRef(false);
-    useEffect(() => {
-        if (!axesInitialized.current) {
-            axesInitialized.current = true;
-            return;
-        }
-        if (open) persistAxes(targetType, axes);
-    }, [axes, open, targetType]);
 
     // Protocol axis per target type: providers reduce to what they can speak;
     // rule targets are locked to their scenario's protocol.

--- a/frontend/src/components/probe/probeConfig.ts
+++ b/frontend/src/components/probe/probeConfig.ts
@@ -3,8 +3,11 @@ import type { Provider } from '@/types/provider';
 
 // ProbeAxes is the panel's orthogonal control state. Every axis is one knob:
 // Shape (stream) × Tool × Thinking × Protocol × Scope (direct) — plus the
-// optional message override. Persisted per target-type so the dialog re-opens
-// in the shape the user last used on that surface.
+// optional message override. Axes are NOT persisted across dialog opens: a
+// probe is a diagnostic whose defaults must be predictable, and hidden
+// (collapsed-panel) state that silently sticks is worse than re-setting a
+// knob. Reopening a stored result restores its axes from the result's
+// request-echo fields instead — the visible state always matches the data.
 export interface ProbeAxes {
     stream: boolean;
     tool: boolean;
@@ -23,36 +26,12 @@ export const DEFAULT_AXES: ProbeAxes = {
     direct: false,
 };
 
-const STORAGE_PREFIX = 'tb.probe.config.';
-
-// loadPersistedAxes restores the last-used axes for a target-type surface.
-// Anything malformed (or from an older shape) is ignored.
-export function loadPersistedAxes(targetType: ProbeTargetType): Partial<ProbeAxes> | null {
-    try {
-        const raw = localStorage.getItem(STORAGE_PREFIX + targetType);
-        if (!raw) return null;
-        const parsed = JSON.parse(raw);
-        if (typeof parsed !== 'object' || parsed === null) return null;
-        return parsed as Partial<ProbeAxes>;
-    } catch {
-        return null;
-    }
-}
-
-export function persistAxes(targetType: ProbeTargetType, axes: ProbeAxes) {
-    try {
-        localStorage.setItem(STORAGE_PREFIX + targetType, JSON.stringify(axes));
-    } catch {
-        // localStorage unavailable (private mode etc.) — persistence is best-effort.
-    }
-}
-
 // resolveInitialAxes applies the open-time association priority:
 //   1. explicit prop overrides (thinkingLevel prop)
 //   2. the pre-computed initialResult — the visible state must match the
-//      result the user is looking at (shape from result.data.stream)
-//   3. last-used axes persisted for this target-type surface
-//   4. defaults (Stream / no tool / no thinking / provider's primary protocol / Through TB)
+//      result the user is looking at; the backend echoes the request axes
+//      (stream/tool/direct/protocol/thinking) so every axis is restorable
+//   3. defaults (Stream / no tool / no thinking / provider's primary protocol / Through TB)
 export function resolveInitialAxes(opts: {
     targetType: ProbeTargetType;
     thinkingLevel?: ProbeThinking;
@@ -61,20 +40,22 @@ export function resolveInitialAxes(opts: {
 }): ProbeAxes {
     const axes: ProbeAxes = { ...DEFAULT_AXES };
 
-    // Priority 3: persisted last-used config.
-    Object.assign(axes, loadPersistedAxes(opts.targetType));
-
     // Priority 2: a pre-loaded result wins — the toggles must describe the
     // request that produced it.
-    if (opts.initialResult?.data && typeof opts.initialResult.data.stream === 'boolean') {
-        axes.stream = opts.initialResult.data.stream;
+    const data = opts.initialResult?.data;
+    if (data) {
+        if (typeof data.stream === 'boolean') axes.stream = data.stream;
+        if (typeof data.tool === 'boolean') axes.tool = data.tool;
+        if (typeof data.direct === 'boolean') axes.direct = data.direct;
+        if (data.protocol) axes.protocol = data.protocol;
+        if (data.thinking) axes.thinking = data.thinking;
     }
 
     // Priority 1: explicit prop (kept for callers that know better).
     if (opts.thinkingLevel) axes.thinking = opts.thinkingLevel;
 
     // Protocol/scope availability clamp (e.g. '' protocol for google targets
-    // is fine, but a persisted anthropic protocol must not stick onto a
+    // is fine, but a result-echoed anthropic protocol must not stick onto a
     // provider that can't speak it).
     const avail = protocolAvailability(opts.provider ?? null);
     if (avail.locked) {

--- a/frontend/src/types/probe.ts
+++ b/frontend/src/types/probe.ts
@@ -66,6 +66,13 @@ export interface ProbeResultData {
     latency_ms: number;
     request_url?: string;
     stream?: boolean;
+    // Request-echo axes — the exact combination that produced this result.
+    // The probe panel does not persist axes across opens, so reopening a
+    // stored result restores its control state from this echo.
+    tool?: boolean;
+    direct?: boolean;
+    protocol?: ProbeProtocol;
+    thinking?: ProbeThinking;
     // Canonical token usage (same shape as protocol.TokenUsage on the backend):
     // input_tokens / output_tokens / cache_read_tokens / cache_write_tokens /
     // reasoning_tokens. Present for OpenAI Chat/Responses and Anthropic probes

--- a/internal/probe/types.go
+++ b/internal/probe/types.go
@@ -39,10 +39,17 @@ type Result struct {
 	LatencyMs    int64  `json:"latency_ms"`
 	ErrorMessage string `json:"error_message,omitempty"`
 
-	// Streaming mode indicator (true for streaming probes; redundant with the
+	// Request-echo axes — the exact stream/tool/direct/protocol/thinking
+	// combination that produced this result. Stream is redundant with the
 	// caller's test_mode but kept explicit so consumers don't have to infer the
-	// response shape from Content).
-	Stream bool `json:"stream,omitempty"`
+	// response shape from Content; the rest let a consumer reopening a stored
+	// result restore the control state that produced it (the frontend probe
+	// dialog does not persist axes, so the echo is the only source).
+	Stream   bool          `json:"stream,omitempty"`
+	Tool     bool          `json:"tool,omitempty"`
+	Direct   bool          `json:"direct,omitempty"`
+	Protocol ProbeProtocol `json:"protocol,omitempty"`
+	Thinking ThinkingLevel `json:"thinking,omitempty"`
 
 	// Usage is the normalized token usage for the probe round-trip, parsed via
 	// internal/protocol/usage from each provider's native usage struct. It uses

--- a/internal/server/module/probe/handler.go
+++ b/internal/server/module/probe/handler.go
@@ -97,6 +97,18 @@ func (h *Handler) HandleE2EProbe(c *gin.Context) {
 		return
 	}
 
+	// Stamp the request axes onto the result (including the cached-hit path,
+	// whose result carries no axes of its own). Consumers reopening a stored
+	// result restore the exact control state that produced it from this echo.
+	stream, tool := req.ResolveAxes()
+	if data != nil {
+		data.Stream = stream
+		data.Tool = tool
+		data.Direct = req.Direct
+		data.Protocol = req.Protocol
+		data.Thinking = req.Thinking
+	}
+
 	// LatencyMs is owned by the SDK probe (pure upstream round-trip time) — do
 	// not overwrite it here.
 	c.JSON(http.StatusOK, E2EResponse{Success: true, Data: data})


### PR DESCRIPTION
## Summary
Remembered advanced probe settings (tool/thinking/protocol) silently shaped every later probe while the Advanced panel sat collapsed — hidden state users couldn't see or recall. 

The probe panel now starts from defaults on every open.

## Key Changes

- **No cross-open memory**: probe axes are no longer persisted to localStorage; a probe is a diagnostic whose defaults must be predictable.
- **Result-driven restore**: the backend echoes stream/tool/direct/protocol/thinking onto the probe Result, so reopening a stored result restores the exact control state that produced it (previously only `stream` was echoed, so toggles could disagree with the data on screen).
