### PR TITLE
feat(frontend): fall back to browser language when no explicit choice is saved

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -13,7 +13,21 @@ const resources = {
     },
 };
 
-// Custom language detector that defaults to English when localStorage is empty
+// Detect a supported language from the browser's configured languages,
+// falling back to English when nothing matches.
+const detectBrowserLanguage = (): 'en' | 'zh' => {
+    const browserLangs = navigator.languages && navigator.languages.length > 0 ? navigator.languages : [navigator.language];
+    for (const lang of browserLangs) {
+        if (!lang) continue;
+        const normalized = lang.toLowerCase();
+        if (normalized.startsWith('zh')) return 'zh';
+        if (normalized.startsWith('en')) return 'en';
+    }
+    return 'en';
+};
+
+// Custom language detector: an explicit user choice (persisted to localStorage
+// by i18n.changeLanguage) always wins; otherwise fall back to the browser's language.
 const languageDetectorOptions = {
     // Order and sources where to look for language
     order: ['localStorage'],
@@ -21,13 +35,13 @@ const languageDetectorOptions = {
     lookupLocalStorage: 'i18nextLng',
     // Cache user language
     caches: ['localStorage'],
-    // Custom detection function - check localStorage first, default to 'en' if empty
+    // Custom detection function - check localStorage first, else detect from the browser
     detection: () => {
         const stored = localStorage.getItem('i18nextLng');
         if (stored && (stored === 'en' || stored === 'zh')) {
             return stored;
         }
-        return 'en'; // Default to English
+        return detectBrowserLanguage();
     },
 };
 


### PR DESCRIPTION
## Summary
When no language was saved yet, the UI always defaulted to English instead of respecting the browser's configured language.

## Key Changes

- **First-visit language**: detector now matches `navigator.languages`/`navigator.language` against `en`/`zh` when `localStorage` has no saved preference; an explicit choice made via the language toggle still always wins.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MZFg3TVpHKFmvhf1ki1Y7w)_