### PR TITLE
fix(OAuth): token refresh to handle poisoned/missing expiry and malformed responses

### DIFF
--- a/.design/failover.pencil.md
+++ b/.design/failover.pencil.md
@@ -48,7 +48,7 @@ Legend: `║`/`▼` = control flow · boxes = phases · `┐┘` brackets group 
         ▼   inspect gate after the attempt
   ┌────────────────────────────────────────────────────────────────────────────┐
   │ committed?  (first real stream chunk already flushed) ──────────► DONE ✓     │
-  │ retryable?  (429 / 5xx,  or setup-fail → failAttemptSetup=500)               │
+  │ retryable?  (401/403 / 429 / 5xx,  or setup-fail → failAttemptSetup=500)     │
   │      selectFallbackService(tried, style = "")   ← pool spans ALL styles      │
   │           next candidate → Discard buffer, loop ↺                            │
   │           exhausted      → flush last buffered error ──────────► DONE ✗      │
@@ -73,6 +73,16 @@ Legend: `║`/`▼` = control flow · boxes = phases · `┐┘` brackets group 
   └─────────────────────────────┘        └─────────────────────────────┘
                                               ▲ after commit, retry is impossible
 ```
+
+## Why 401/403 is retryable
+
+Inbound auth is settled by middleware long before the gate exists, so a 401 that
+reaches the loop always came from a provider: a token caught mid-refresh, a
+rotated or revoked key, a provider-side account flag. That is a property of one
+credential, not of the request — which is exactly what a sibling service is for.
+The attempt is also reported to the health monitor (like 429), so the broken
+credential stops winning selection on the next request instead of 401ing every
+caller until someone notices.
 
 ## Why it's safe (the one invariant)
 

--- a/.design/oauth.md
+++ b/.design/oauth.md
@@ -57,12 +57,46 @@ AuthorizeOAuth  ──▶  SessionState (pending)  ──▶  user signs in upst
 - **Expiry** — `OAuthDetail.IsExpired` (`ai/provider.go`) treats a token as expired
   within a 5-minute buffer; `Provider.IsOAuthExpired` exposes it.
 - **Background refresh** — `OAuthRefresher`
-  (`internal/server/background/oauth_refresher.go`) runs every ~10 min, refreshing
-  tokens inside the 5-min buffer using the stored refresh token, and gives up on
-  credentials expired more than ~72h ago.
+  (`internal/server/module/tokenrefresh/refresher.go`) ticks every ~2 min (+≤10%
+  jitter) and refreshes any token due within 15 min, using the stored refresh
+  token. It gives up on credentials expired more than ~72h ago.
 - **Manual refresh** — `POST /oauth/refresh` (`RefreshOAuthToken`) overwrites the
   access/refresh tokens, expiry, and Codex `id_token` **in place** on the provider.
   It only works while the refresh token is still valid.
+
+### Why the buffer must exceed the tick
+
+Nothing on the request path refreshes on demand — the background loop is the only
+thing keeping a token alive — so the refresh window is a hard client-visible
+contract, not a tuning knob:
+
+```
+  interval > buffer  (the old 10 min / 5 min)      buffer > interval  (2 min / 15 min)
+
+  ──tick──────────────tick──────────────tick──     ──t──t──t──t──t──t──t──t──t──t──
+        │  buffer │                                     │◄──── buffer ────►│
+        └─ due ───┴─ EXPIRED ─┐                         └─ due            expiry
+                   ~5-6 min of│401 on every request       ~7 chances to refresh,
+                              ▼                            0 min expired
+```
+
+With the old numbers a perfectly healthy credential produced a 5–6 minute 401
+window **once per token lifetime**, because a token that came due just after a
+tick waited a full interval for the next one. The buffer now spans ~7 ticks, so a
+transient token-endpoint failure costs a retry instead of a client-visible 401.
+
+### Failure modes the refresh path defends against
+
+| Response | Old behavior | Now |
+|---|---|---|
+| No `expires_in` | `ExpiresAt` = `0001-01-01T00:00:00Z` → reads as "expired 2000 years ago" → trips the 72h cutoff → **silently never refreshed again** | stored as `""` (no known expiry), matching the create path; already-poisoned rows are re-refreshed instead of skipped (`minPlausibleExpiryYear`) |
+| 200 with no `access_token` | blank credential persisted over a working one → guaranteed 401 | refresh rejected, existing credential kept |
+| Non-200 | error carried only the body's **length** — undiagnosable | error carries the body (single-line, 512-byte cap), so it reaches the log and the "Token refresh failed" dialog |
+| Codex `id_token` | updated by manual refresh only, stale after a background refresh | both paths keep it in lockstep with the access token |
+
+An upstream 401/403 is also a failover trigger (`internal/protocolserver/failover_dispatch.go`):
+a broken credential on one service falls over to a sibling and is reported to the
+health monitor, instead of surfacing to the client as "Please run /login".
 
 ## Re-authentication (in place)
 
@@ -134,7 +168,7 @@ authorize(provider_uuid) ──▶ SessionState.TargetProviderUUID
 | `internal/server/module/oauth/handler.go` | authorize, callback, device-code poll, refresh, revoke; `createProviderFromToken` (create + re-auth) |
 | `internal/server/module/oauth/types.go` | request/response models; `OAuthAuthorizeRequest.provider_uuid` |
 | `internal/server/module/oauth/routes.go` | route registration |
-| `internal/server/background/oauth_refresher.go` | periodic background refresh |
+| `internal/server/module/tokenrefresh/refresher.go` | periodic background refresh; expiry/credential guards |
 | `internal/server/config/provider.go` | `AddProvider` / `UpdateProvider` / `DeleteProvider` + rule cleanup |
 | `frontend/src/components/OAuthDialog.tsx` | provider picker + direct/re-auth mode (`reauthProviderUuid`) |
 | `frontend/src/components/OAuthTable.tsx` | provider list, expiry display, Refresh / Reauthorize actions |

--- a/ai/oauth/manager.go
+++ b/ai/oauth/manager.go
@@ -675,7 +675,13 @@ func (m *Manager) refreshToken(ctx context.Context, issuer ai.Issuer, refreshTok
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("refresh token failed: status %d, body: %d", resp.StatusCode, len(string(body)))
+		// Carry the issuer's own words, not just how many bytes it used to say
+		// them. This error is what the refresher logs and what the "Token
+		// refresh failed" dialog shows, and "invalid_grant" vs. "invalid_client"
+		// vs. a proxy's HTML error page are three completely different fixes.
+		// The body of a failed token exchange carries no secret of ours — the
+		// request did not succeed, so there is no token in it.
+		return nil, fmt.Errorf("refresh token failed: status %d, body: %s", resp.StatusCode, truncateForError(body))
 	}
 
 	// Parse response directly into Token
@@ -707,6 +713,13 @@ func (m *Manager) RefreshToken(ctx context.Context, userID string, issuer ai.Iss
 
 	token.Issuer = issuer
 
+	// A 200 with no access token is not a refresh — it is a response shape we
+	// do not understand. Failing here keeps callers from persisting a blank
+	// credential (and a zero expiry) over a token that still works.
+	if token.AccessToken == "" {
+		return nil, fmt.Errorf("refresh token: %w: response carried no access_token", ErrTokenExchangeFailed)
+	}
+
 	// Preserve old refresh token if new one is not returned
 	// Some OAuth providers don't return a new refresh token on each refresh
 	if token.RefreshToken == "" {
@@ -719,6 +732,25 @@ func (m *Manager) RefreshToken(ctx context.Context, userID string, issuer ai.Iss
 	}
 
 	return token, nil
+}
+
+// maxErrorBodyBytes bounds how much of an upstream error body is quoted back
+// into an error string, so a runaway HTML page from a proxy cannot flood the
+// logs or the UI.
+const maxErrorBodyBytes = 512
+
+// truncateForError renders an upstream error body as a single-line, bounded
+// string suitable for embedding in an error message.
+func truncateForError(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return "<empty>"
+	}
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) > maxErrorBodyBytes {
+		return s[:maxErrorBodyBytes] + "...(truncated)"
+	}
+	return s
 }
 
 // RevokeToken removes a token for a user and provider

--- a/internal/protocolserver/failover_dispatch.go
+++ b/internal/protocolserver/failover_dispatch.go
@@ -78,7 +78,18 @@ func (ph *ProtocolHandler) FailAttemptSetup(c *gin.Context, err error) {
 // errors as 500. 502 covers the explicit "upstream stream failed" path.
 // Keeping both means refactors that change one helper's status code
 // don't silently break failover.
+//
+// 401/403 are here because an upstream auth failure is a property of one
+// credential, not of the request: an OAuth token caught mid-refresh, a rotated
+// or revoked API key, a provider-side quota flag. The inbound caller's own
+// token is checked by middleware long before the gate is installed, so a 401
+// reaching this point always came from a provider — and answering it with a
+// sibling service is the whole reason a rule holds more than one. Without
+// this, a single stale credential turns into "Please run /login" on the
+// client while healthy services sit idle.
 var retryableUpstreamStatuses = map[int]bool{
+	http.StatusUnauthorized:        true,
+	http.StatusForbidden:           true,
 	http.StatusTooManyRequests:     true,
 	http.StatusBadGateway:          true,
 	http.StatusServiceUnavailable:  true,
@@ -430,8 +441,16 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 		// fallback means final usage tracking only sees the fallback's success,
 		// so record a failed 429 attempt here or the next request would select
 		// the rate-limited service again before SmartRouting/LB evaluation.
-		if status == http.StatusTooManyRequests && ph.deps.HealthMonitor != nil {
-			ph.deps.HealthMonitor.ReportRateLimit(serviceID)
+		if ph.deps.HealthMonitor != nil {
+			switch status {
+			case http.StatusTooManyRequests:
+				ph.deps.HealthMonitor.ReportRateLimit(serviceID)
+			case http.StatusUnauthorized, http.StatusForbidden:
+				// Same reasoning as the 429 case: the fallback's success is all
+				// the final usage tracking sees, so the broken credential would
+				// keep winning selection on every subsequent request.
+				ph.deps.HealthMonitor.ReportAuthError(serviceID, status)
+			}
 		}
 
 		loadbalance.RecordServiceFailure(rule.UUID, serviceID)

--- a/internal/protocolserver/failover_dispatch_test.go
+++ b/internal/protocolserver/failover_dispatch_test.go
@@ -232,9 +232,9 @@ func TestIsRetryableStatus(t *testing.T) {
 		{0, false},   // writer never written → terminal, no retry
 		{200, false}, // 2xx → success
 		{201, false},
-		{400, false}, // 4xx (not 429) → client error, don't retry
-		{401, false},
-		{403, false},
+		{400, false}, // 4xx (not auth/rate-limit) → client error, don't retry
+		{401, true},  // upstream credential problem → try another service
+		{403, true},
 		{404, false},
 		{422, false},
 		{429, true}, // rate limit

--- a/internal/server/load_balance_test.go
+++ b/internal/server/load_balance_test.go
@@ -205,9 +205,11 @@ func TestLBScenario_RateLimit_HealthExclusion(t *testing.T) {
 
 // ============ Special status: 401 auth error ============
 //
-// 401 is terminal (not retryable — no failover masks it) AND marks the service
-// immediately unhealthy (auth error, no threshold), so it's excluded next request.
-func TestLBScenario_AuthError_TerminalAndExcluded(t *testing.T) {
+// 401 is a property of one credential (token caught mid-refresh, rotated key),
+// not of the request — the caller's own auth was settled by middleware long
+// before this point. So it fails over to a healthy sibling AND marks the service
+// immediately unhealthy (auth error, no threshold), excluding it next request.
+func TestLBScenario_AuthError_FailsOverAndExcluded(t *testing.T) {
 	t0 := svc("deepseek", "deepseek-pro", 0, true)
 	t1 := svc("deepseek", "deepseek-flash", 1, true)
 	id0, id1 := t0.ServiceID(), t1.ServiceID()
@@ -218,12 +220,12 @@ func TestLBScenario_AuthError_TerminalAndExcluded(t *testing.T) {
 	require.NoError(t, err)
 	defer cleanup()
 
-	// req1: t0 → 401. Non-retryable → terminal: the client sees 401 even though
-	// t1 is healthy (auth errors are never failed over).
+	// req1: t0 → 401 → failover to t1, which serves the request. The client
+	// never sees the broken credential.
 	tr, err := sim.Request("")
 	require.NoError(t, err)
-	require.Equal(t, []string{id0}, tr.Attempts, "401 is terminal — no failover to t1")
-	require.Equal(t, 401, tr.FinalStatus)
+	require.Equal(t, []string{id0, id1}, tr.Attempts, "401 fails over to the healthy sibling")
+	require.Equal(t, 200, tr.FinalStatus)
 	require.Equal(t, "unhealthy", sim.HealthStates()[id0], "401 marks the service immediately unhealthy")
 
 	// req2: t0 health-excluded → t1 selected.

--- a/internal/server/module/oauth/handler.go
+++ b/internal/server/module/oauth/handler.go
@@ -632,7 +632,14 @@ func (h *Handler) RefreshOAuthToken(c *gin.Context) {
 	if token.RefreshToken != "" {
 		provider.OAuthDetail.RefreshToken = token.RefreshToken
 	}
-	provider.OAuthDetail.ExpiresAt = token.Expiry.Format(time.RFC3339)
+	// A zero Expiry (issuer returned no expires_in) must not be formatted
+	// verbatim: "0001-01-01T00:00:00Z" reads as "expired long ago" everywhere
+	// downstream and permanently parks the credential. Store "" — no known
+	// expiry — exactly like the create path does.
+	provider.OAuthDetail.ExpiresAt = ""
+	if !token.Expiry.IsZero() {
+		provider.OAuthDetail.ExpiresAt = token.Expiry.Format(time.RFC3339)
+	}
 	// Codex's native auth.json export reads id_token from ExtraFields. Keep
 	// it in lockstep with AccessToken so refreshed providers don't ship an
 	// expired identity assertion alongside a fresh bearer.
@@ -660,7 +667,7 @@ func (h *Handler) RefreshOAuthToken(c *gin.Context) {
 	resp.Data.AccessToken = token.AccessToken
 	resp.Data.RefreshToken = token.RefreshToken
 	resp.Data.TokenType = "Bearer"
-	resp.Data.ExpiresAt = token.Expiry.Format(time.RFC3339)
+	resp.Data.ExpiresAt = provider.OAuthDetail.ExpiresAt
 	resp.Data.ProviderType = string(token.Issuer)
 
 	c.JSON(http.StatusOK, resp)

--- a/internal/server/module/tokenrefresh/refresher.go
+++ b/internal/server/module/tokenrefresh/refresher.go
@@ -14,15 +14,32 @@ import (
 )
 
 const (
-	// defaultCheckInterval is how often to check for tokens needing refresh
-	defaultCheckInterval = 10 * time.Minute
-	// defaultRefreshBuffer is how long before expiry to refresh a token (matches OAuth package default)
-	defaultRefreshBuffer = 5 * time.Minute
+	// defaultCheckInterval is how often to check for tokens needing refresh.
+	//
+	// This MUST stay well below defaultRefreshBuffer. The refresher is the only
+	// thing that keeps a token alive — nothing refreshes on the request path --
+	// so a token that falls due between two ticks is a hard 401 for every client
+	// request until the next tick. With interval > buffer that window is
+	// guaranteed once per token lifetime, however healthy the credential is.
+	defaultCheckInterval = 2 * time.Minute
+	// defaultRefreshBuffer is how long before expiry a token is refreshed.
+	//
+	// Sized as a multiple of defaultCheckInterval, not as "just before expiry":
+	// it buys ~7 refresh attempts before the token actually dies, so a transient
+	// token-endpoint failure costs a retry instead of a client-visible 401.
+	defaultRefreshBuffer = 15 * time.Minute
 	// maxExpiryDuration is the maximum time after token expiry to attempt refresh
 	// Tokens expired longer than this will not be refreshed (72 hours = 3 days)
 	maxExpiryDuration = 72 * time.Hour
 	// jitterPercent is the maximum jitter percentage to add to the check interval
 	jitterPercent = 0.10 // 10% jitter
+	// minPlausibleExpiryYear guards against a poisoned expires_at. A refresh
+	// response without expires_in used to be persisted as a zero time
+	// ("0001-01-01T00:00:00Z"), which reads as "expired ~2000 years ago" and
+	// therefore trips maxExpiryDuration — permanently parking the credential in
+	// "skipping refresh" while every request 401s. Such timestamps are treated
+	// as unknown (refresh now) instead of as ancient.
+	minPlausibleExpiryYear = 2000
 )
 
 // tokenManager defines the interface for token refresh operations
@@ -249,9 +266,13 @@ func (tr *OAuthRefresher) CheckAndRefreshTokens() {
 		// Refresh if token is expired OR will expire within buffer window
 		// BUT skip if token expired too long ago (more than maxExpiryDuration)
 		timeSinceExpiry := now.Sub(expiresAt)
-		if expiresAt.Before(now.Add(buffer)) || expiresAt.Before(now) {
-			// Check if token expired too long ago
-			if timeSinceExpiry > maxExpiryDuration {
+		if expiresAt.Before(now.Add(buffer)) {
+			// A timestamp that predates OAuth itself is a poisoned or unknown
+			// expiry, not a credential abandoned for years. Refreshing it is how
+			// such a row heals; skipping it is how a provider ends up 401ing
+			// forever with nothing but a warning in the log.
+			expiryIsPlausible := expiresAt.Year() >= minPlausibleExpiryYear
+			if expiryIsPlausible && timeSinceExpiry > maxExpiryDuration {
 				logger.WithFields(logrus.Fields{
 					"provider":          provider.Name,
 					"expiresAt":         provider.OAuthDetail.ExpiresAt,
@@ -259,6 +280,12 @@ func (tr *OAuthRefresher) CheckAndRefreshTokens() {
 					"maxExpiryDuration": maxExpiryDuration,
 				}).Warn("Token expired too long ago, skipping refresh")
 				continue
+			}
+			if !expiryIsPlausible {
+				logger.WithFields(logrus.Fields{
+					"provider":  provider.Name,
+					"expiresAt": provider.OAuthDetail.ExpiresAt,
+				}).Warn("Implausible expires_at, treating as unknown and refreshing")
 			}
 			tr.refreshProviderToken(provider)
 			refreshCount++
@@ -299,7 +326,17 @@ func (tr *OAuthRefresher) refreshProviderToken(provider *typ.Provider) {
 	)
 
 	if err != nil {
-		logger.WithError(err).Error("Failed to refresh token")
+		logger.WithField("issuer", issuer).
+			WithField("expiresAt", provider.OAuthDetail.ExpiresAt).
+			WithError(err).Error("Failed to refresh token")
+		return
+	}
+
+	// Never persist a blank credential over a working one: writing "" here turns
+	// a token that is merely near expiry into a guaranteed 401 on every request,
+	// and the next cycle would happily overwrite it again.
+	if token.AccessToken == "" {
+		logger.WithField("issuer", issuer).Error("Refresh returned an empty access token, keeping the current credential")
 		return
 	}
 
@@ -308,7 +345,17 @@ func (tr *OAuthRefresher) refreshProviderToken(provider *typ.Provider) {
 	if token.RefreshToken != "" {
 		provider.OAuthDetail.RefreshToken = token.RefreshToken
 	}
-	provider.OAuthDetail.ExpiresAt = token.Expiry.Format(time.RFC3339)
+	provider.OAuthDetail.ExpiresAt = formatExpiry(token.Expiry)
+	// Keep the Codex id_token in lockstep with the access token, the same way
+	// the manual POST /oauth/refresh path does — a background refresh that
+	// leaves a stale identity assertion behind is an auth failure waiting to
+	// happen on the next native-config export.
+	if token.IDToken != "" {
+		if provider.OAuthDetail.ExtraFields == nil {
+			provider.OAuthDetail.ExtraFields = map[string]interface{}{}
+		}
+		provider.OAuthDetail.ExtraFields["id_token"] = token.IDToken
+	}
 
 	if err := tr.serverConfig.UpdateProvider(provider.UUID, provider); err != nil {
 		logger.WithError(err).Error("Failed to update provider")
@@ -317,4 +364,19 @@ func (tr *OAuthRefresher) refreshProviderToken(provider *typ.Provider) {
 
 	// Note: Client pool invalidation is handled automatically by Config.UpdateProvider() via hooks
 	logger.WithField("expiresAt", provider.OAuthDetail.ExpiresAt).Info("Token refreshed successfully")
+}
+
+// formatExpiry renders a token expiry for storage in OAuthDetail.ExpiresAt.
+//
+// A zero Expiry means the issuer returned no expires_in. Formatting it verbatim
+// yields "0001-01-01T00:00:00Z", which every consumer then reads as "expired
+// two millennia ago": IsExpired() is permanently true, and CheckAndRefreshTokens
+// used to write the credential off as beyond maxExpiryDuration. The create path
+// (createProviderFromToken) already stores "" — meaning "no known expiry" — so
+// the refresh paths store the same thing.
+func formatExpiry(expiry time.Time) string {
+	if expiry.IsZero() {
+		return ""
+	}
+	return expiry.Format(time.RFC3339)
 }

--- a/internal/server/module/tokenrefresh/refresher_test.go
+++ b/internal/server/module/tokenrefresh/refresher_test.go
@@ -93,12 +93,23 @@ func TestNewOAuthRefresher(t *testing.T) {
 		t.Error("ServerConfig not set correctly")
 	}
 
-	if refresher.checkInterval != 10*time.Minute {
-		t.Errorf("Expected check interval 10m, got %v", refresher.checkInterval)
+	if refresher.checkInterval != defaultCheckInterval {
+		t.Errorf("Expected check interval %v, got %v", defaultCheckInterval, refresher.checkInterval)
 	}
 
-	if refresher.refreshBuffer != 5*time.Minute {
-		t.Errorf("Expected refresh buffer 5m, got %v", refresher.refreshBuffer)
+	if refresher.refreshBuffer != defaultRefreshBuffer {
+		t.Errorf("Expected refresh buffer %v, got %v", defaultRefreshBuffer, refresher.refreshBuffer)
+	}
+
+	// The invariant the whole design rests on: a token must come due for
+	// refresh several ticks before it actually expires. With the buffer at or
+	// below the tick interval there is a window, once per token lifetime, where
+	// the token is dead and the next check has not run yet — and nothing on the
+	// request path refreshes on demand, so every client request in that window
+	// is a hard 401.
+	maxTick := defaultCheckInterval + time.Duration(float64(defaultCheckInterval)*jitterPercent)
+	if defaultRefreshBuffer <= maxTick {
+		t.Errorf("refresh buffer %v must exceed the jittered check interval %v", defaultRefreshBuffer, maxTick)
 	}
 }
 
@@ -375,5 +386,128 @@ func TestOAuthRefresherSkipExpiredTooLong(t *testing.T) {
 
 	if mockMgr.refreshCalled {
 		t.Error("Expected RefreshToken NOT to be called for token expired more than 72h ago")
+	}
+}
+
+// scriptedTokenRefresher returns a caller-supplied token (or error) so tests can
+// exercise the odd refresh responses that used to poison a stored credential.
+type scriptedTokenRefresher struct {
+	token         *oauth.Token
+	err           error
+	refreshCalled bool
+}
+
+func (m *scriptedTokenRefresher) RefreshToken(ctx context.Context, userID string, issuer ai.Issuer, refreshToken string, opts ...oauth.Option) (*oauth.Token, error) {
+	m.refreshCalled = true
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.token, nil
+}
+
+// oauthProviderFixture builds a single-provider config plus a refresher wired to
+// the given manager, using the production interval/buffer defaults.
+func oauthProviderFixture(mgr tokenManager, expiresAt string) (*mockConfig, *OAuthRefresher, *typ.Provider) {
+	provider := &typ.Provider{
+		UUID:     "provider-uuid",
+		Name:     "TestOAuthProvider",
+		APIBase:  "https://api.test.com",
+		APIStyle: protocol.APIStyleOpenAI,
+		AuthType: typ.AuthTypeOAuth,
+		OAuthDetail: &typ.OAuthDetail{
+			AccessToken:  "old_access_token",
+			RefreshToken: "refresh_token_123",
+			ProviderType: "claude_code",
+			UserID:       "test-user",
+			ExpiresAt:    expiresAt,
+		},
+	}
+	cfg := &mockConfig{Config: &config.Config{}}
+	cfg.Providers = append(cfg.Providers, provider)
+	return cfg, &OAuthRefresher{
+		manager:       mgr,
+		serverConfig:  cfg,
+		checkInterval: defaultCheckInterval,
+		refreshBuffer: defaultRefreshBuffer,
+		rng:           rand.New(rand.NewSource(42)),
+	}, provider
+}
+
+// TestOAuthRefresherHealsPoisonedExpiry covers the credential that reads as
+// "expired in year 1" — what a refresh response without expires_in used to
+// persist. Such a row trips maxExpiryDuration, so the refresher used to skip it
+// forever while every client request 401ed.
+func TestOAuthRefresherHealsPoisonedExpiry(t *testing.T) {
+	mgr := &scriptedTokenRefresher{token: &oauth.Token{
+		AccessToken:  "new_access_token",
+		RefreshToken: "refresh_token_123",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}}
+	cfg, refresher, _ := oauthProviderFixture(mgr, time.Time{}.Format(time.RFC3339))
+
+	refresher.CheckAndRefreshTokens()
+
+	if !mgr.refreshCalled {
+		t.Fatal("Expected a provider with a zero expires_at to be refreshed, not written off as ancient")
+	}
+	updated, err := cfg.GetProviderByUUID("provider-uuid")
+	if err != nil {
+		t.Fatalf("Failed to get updated provider: %v", err)
+	}
+	if updated.OAuthDetail.AccessToken != "new_access_token" {
+		t.Errorf("Expected the healed access token, got %q", updated.OAuthDetail.AccessToken)
+	}
+	if updated.OAuthDetail.IsExpired() {
+		t.Error("Expected the healed provider to carry a future expiry")
+	}
+}
+
+// TestOAuthRefresherStoresUnknownExpiryAsEmpty pins the storage shape for a
+// refresh response that carries no expires_in: "" (no known expiry), never the
+// formatted zero time.
+func TestOAuthRefresherStoresUnknownExpiryAsEmpty(t *testing.T) {
+	mgr := &scriptedTokenRefresher{token: &oauth.Token{
+		AccessToken:  "new_access_token",
+		RefreshToken: "refresh_token_123",
+		// Expiry deliberately zero: issuer returned no expires_in.
+	}}
+	cfg, refresher, _ := oauthProviderFixture(mgr, time.Now().Add(1*time.Minute).Format(time.RFC3339))
+
+	refresher.CheckAndRefreshTokens()
+
+	updated, err := cfg.GetProviderByUUID("provider-uuid")
+	if err != nil {
+		t.Fatalf("Failed to get updated provider: %v", err)
+	}
+	if updated.OAuthDetail.ExpiresAt != "" {
+		t.Errorf("Expected an unknown expiry to be stored as empty, got %q", updated.OAuthDetail.ExpiresAt)
+	}
+	if updated.OAuthDetail.AccessToken != "new_access_token" {
+		t.Errorf("Expected access token 'new_access_token', got %q", updated.OAuthDetail.AccessToken)
+	}
+}
+
+// TestOAuthRefresherKeepsCredentialOnEmptyAccessToken makes sure a malformed
+// 200 never overwrites a working token with "" — that turns a token which is
+// merely near expiry into a guaranteed 401 on every request.
+func TestOAuthRefresherKeepsCredentialOnEmptyAccessToken(t *testing.T) {
+	mgr := &scriptedTokenRefresher{token: &oauth.Token{
+		AccessToken:  "",
+		RefreshToken: "rotated_refresh_token",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}}
+	cfg, refresher, _ := oauthProviderFixture(mgr, time.Now().Add(1*time.Minute).Format(time.RFC3339))
+
+	refresher.CheckAndRefreshTokens()
+
+	updated, err := cfg.GetProviderByUUID("provider-uuid")
+	if err != nil {
+		t.Fatalf("Failed to get updated provider: %v", err)
+	}
+	if updated.OAuthDetail.AccessToken != "old_access_token" {
+		t.Errorf("Expected the previous access token to survive, got %q", updated.OAuthDetail.AccessToken)
+	}
+	if updated.OAuthDetail.RefreshToken != "refresh_token_123" {
+		t.Errorf("Expected the previous refresh token to survive, got %q", updated.OAuthDetail.RefreshToken)
 	}
 }


### PR DESCRIPTION
## Summary

OAuth token refresh was silently skipping credentials with missing or zero expiry timestamps, and persisting blank access tokens over working ones. This left providers in a permanently broken state where every request returned 401. The fix detects implausible expiry values, rejects malformed refresh responses, and adjusts the refresh interval/buffer to eliminate a guaranteed 401 window that occurred once per token lifetime.

## Key Changes

- **Poisoned expiry detection**: Credentials with zero or pre-2000 expiry timestamps (from refresh responses without `expires_in`) are now treated as unknown and refreshed instead of skipped forever, healing previously broken rows.
- **Malformed response rejection**: Refresh responses with a blank `access_token` are rejected, keeping the existing working credential instead of overwriting it with an empty string.
- **Refresh timing**: Reduced `defaultCheckInterval` from 10 min to 2 min and increased `defaultRefreshBuffer` from 5 min to 15 min, so the buffer spans ~7 refresh ticks instead of 0.5. This eliminates a guaranteed 5–6 minute 401 window that occurred once per token lifetime when a token came due just after a tick.
- **Error diagnostics**: Token refresh errors now include the upstream response body (truncated to 512 bytes, single-line) instead of just its length, making failures diagnosable in logs and the UI.
- **ID token sync**: Background refresh now keeps the Codex `id_token` in lockstep with the access token, matching the manual refresh path.
- **Failover on auth errors**: 401/403 responses from upstream services now trigger failover to a healthy sibling instead of being terminal, since they represent a broken credential (token mid-refresh, rotated key) not a client auth failure.

## Minor

- Added `formatExpiry()` helper to consistently store unknown expiry as `""` across create and refresh paths.
- Added comprehensive test coverage for poisoned expiry healing, malformed response handling, and the refresh timing invariant.
- Updated `.design/oauth.md` and `.design/failover.pencil.md` with detailed rationale for the timing and failover changes.
- Improved health monitor reporting to flag auth errors (401/403) the same way rate limits (429) are flagged, preventing broken credentials from winning selection on subsequent requests.

## Notes

The refresh interval/buffer change is a breaking change to timing behavior, but it fixes a correctness bug (the guaranteed 401 window) and improves resilience to transient failures. No migration is needed; the new defaults apply immediately on restart.

https://claude.ai/code/session_01Ry9iYbAmhd2WNVMaoD7Nyu