### PR TITLE
feat(server): isolate sharing-key routing and auth by team

### DIFF
--- a/internal/constant/tracking_ctx.go
+++ b/internal/constant/tracking_ctx.go
@@ -5,6 +5,7 @@ package constant
 // writer/reader contract without import cycles or duplicated string literals.
 const (
 	// Authentication metadata.
+	CtxKeyAuthKind                  = "auth_kind"                   // string (see AuthKind* constants)
 	CtxKeyUserID                    = "user_id"                     // string
 	CtxKeyEnterpriseUserID          = "enterprise_user_id"          // string
 	CtxKeyEnterpriseDepartmentID    = "enterprise_department_id"    // string
@@ -43,4 +44,12 @@ const (
 
 	// Guardrail runtime metadata.
 	CtxKeyCredentialMaskState = "guardrails_credential_mask_state" // *guardrails/core.CredentialMaskState
+)
+
+// Authentication principal kinds recorded in CtxKeyAuthKind. Keep these
+// separate from user_id: user_id identifies who generated usage, while the
+// principal kind determines which model surfaces that identity may access.
+const (
+	AuthKindGlobalModelToken = "global_model_token"
+	AuthKindSharingKey       = "sharing_key"
 )

--- a/internal/constant/tracking_ctx.go
+++ b/internal/constant/tracking_ctx.go
@@ -7,6 +7,7 @@ const (
 	// Authentication metadata.
 	CtxKeyAuthKind                  = "auth_kind"                   // string (see AuthKind* constants)
 	CtxKeyUserID                    = "user_id"                     // string
+	CtxKeyTeamID                    = "team_id"                     // string (authorized team identity)
 	CtxKeyEnterpriseUserID          = "enterprise_user_id"          // string
 	CtxKeyEnterpriseDepartmentID    = "enterprise_department_id"    // string
 	CtxKeyEnterpriseKeyPrefix       = "enterprise_key_prefix"       // string

--- a/internal/db/api_token_store.go
+++ b/internal/db/api_token_store.go
@@ -15,6 +15,7 @@ type APITokenRecord struct {
 	ID           uint       `gorm:"primaryKey;autoIncrement;column:id"`
 	TokenID      string     `gorm:"uniqueIndex;column:token_id;not null;size:64"` // Token identifier (jti)
 	UserID       string     `gorm:"index:idx_api_token_user_id;not null;column:user_id;size:64"`
+	TeamID       string     `gorm:"index:idx_api_token_team_id;not null;default:'00000000-0000-0000-0000-000000000001';column:team_id;size:36"`
 	DisplayName  string     `gorm:"column:display_name;size:256"`
 	Enabled      bool       `gorm:"column:enabled;default:true"`
 	ExpiresAt    *time.Time `gorm:"column:expires_at;index"`
@@ -44,8 +45,9 @@ const defaultLastUsedDebounce = 10 * time.Minute
 // api_tokens table by TokenID the same way ProviderStore mirrors providers.
 type APITokenStore struct {
 	storeConn
-	mu    sync.RWMutex
-	cache map[string]*APITokenRecord
+	mu        sync.RWMutex
+	cache     map[string]*APITokenRecord
+	teamStore *TeamStore
 
 	// lastUsedDebounce is the minimum interval between persisted
 	// last_used_at writes for the same token; see UpdateLastUsed.
@@ -59,12 +61,23 @@ func NewAPITokenStore(baseDir string) (*APITokenStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("api token store: %w", err)
 	}
-	return newAPITokenStore(ownedConn(db))
+	conn := ownedConn(db)
+	teamStore, err := newTeamStore(conn)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	store, err := newAPITokenStore(conn, teamStore)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return store, nil
 }
 
 // newAPITokenStore finishes setting up an APITokenStore (migrate + cache
 // load) over an already-open connection -- see newProviderStore.
-func newAPITokenStore(conn storeConn) (*APITokenStore, error) {
+func newAPITokenStore(conn storeConn, teamStore *TeamStore) (*APITokenStore, error) {
 	if err := conn.db.AutoMigrate(&APITokenRecord{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate API token database: %w", err)
 	}
@@ -77,6 +90,7 @@ func newAPITokenStore(conn storeConn) (*APITokenStore, error) {
 	store := &APITokenStore{
 		storeConn:        conn,
 		cache:            make(map[string]*APITokenRecord),
+		teamStore:        teamStore,
 		lastUsedDebounce: defaultLastUsedDebounce,
 	}
 	if err := store.loadCache(); err != nil {
@@ -128,16 +142,24 @@ func ensureAPITokenSchema(db *gorm.DB) error {
 			db.Exec(`DROP INDEX IF EXISTS idx_api_token_user_uuid`)
 		}
 	}
+	// Existing sharing keys predate teams. They all represented the one legacy
+	// team, so bind empty rows to the stable default team without rotating keys.
+	if err := db.Model(&APITokenRecord{}).
+		Where("team_id IS NULL OR team_id = ''").
+		Update("team_id", DefaultTeamID).Error; err != nil {
+		return fmt.Errorf("failed to backfill API token team IDs: %w", err)
+	}
 	return nil
 }
 
 // createTokenRecord is a private helper that creates a token record with the given parameters.
 // The caller must hold s.mu.Lock() before calling this function.
-func (s *APITokenStore) createTokenRecord(userID, tokenID, displayName, createdBy string, expiresAt *time.Time) (*APITokenRecord, error) {
+func (s *APITokenStore) createTokenRecord(userID, tokenID, teamID, displayName, createdBy string, expiresAt *time.Time) (*APITokenRecord, error) {
 	now := time.Now()
 	record := &APITokenRecord{
 		TokenID:     tokenID,
 		UserID:      userID,
+		TeamID:      teamID,
 		DisplayName: displayName,
 		Enabled:     true,
 		ExpiresAt:   expiresAt,
@@ -156,17 +178,35 @@ func (s *APITokenStore) createTokenRecord(userID, tokenID, displayName, createdB
 
 // CreateTokenWithTokenID creates a new API token record with a specific token ID
 func (s *APITokenStore) CreateTokenWithTokenID(userID, tokenID, displayName, createdBy string, expiresAt *time.Time) (*APITokenRecord, error) {
+	return s.CreateTokenForTeam(userID, tokenID, DefaultTeamID, displayName, createdBy, expiresAt)
+}
+
+// CreateTokenForTeam creates a sharing key bound to exactly one enabled team.
+func (s *APITokenStore) CreateTokenForTeam(userID, tokenID, teamID, displayName, createdBy string, expiresAt *time.Time) (*APITokenRecord, error) {
 	if userID == "" {
 		return nil, errors.New("user ID cannot be empty")
 	}
 	if tokenID == "" {
 		return nil, errors.New("token ID cannot be empty")
 	}
+	if teamID == "" {
+		return nil, errors.New("team ID cannot be empty")
+	}
+	if s.teamStore == nil {
+		return nil, errors.New("team store is not initialized")
+	}
+	team, err := s.teamStore.Get(teamID)
+	if err != nil {
+		return nil, err
+	}
+	if !team.Enabled {
+		return nil, fmt.Errorf("team '%s' is disabled", teamID)
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.createTokenRecord(userID, tokenID, displayName, createdBy, expiresAt)
+	return s.createTokenRecord(userID, tokenID, teamID, displayName, createdBy, expiresAt)
 }
 
 // ValidateToken validates a token ID and returns the associated token record
@@ -182,9 +222,49 @@ func (s *APITokenStore) ValidateToken(tokenID string) (*APITokenRecord, error) {
 	if !ok || !record.Enabled {
 		return nil, fmt.Errorf("token not found or disabled")
 	}
+	if s.teamStore == nil {
+		return nil, errors.New("team store is not initialized")
+	}
+	team, err := s.teamStore.Get(record.TeamID)
+	if err != nil || !team.Enabled {
+		return nil, fmt.Errorf("token team not found or disabled")
+	}
 
 	clone := *record
 	return &clone, nil
+}
+
+// MoveTokenToTeam rebinds a sharing key without changing its raw token. The
+// cache is updated before the method returns, so the next request observes the
+// new authorization scope immediately.
+func (s *APITokenStore) MoveTokenToTeam(tokenID, teamID string) error {
+	if tokenID == "" || teamID == "" {
+		return errors.New("token ID and team ID are required")
+	}
+	if s.teamStore == nil {
+		return errors.New("team store is not initialized")
+	}
+	team, err := s.teamStore.Get(teamID)
+	if err != nil {
+		return err
+	}
+	if !team.Enabled {
+		return fmt.Errorf("team '%s' is disabled", teamID)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := s.db.Model(&APITokenRecord{}).Where("token_id = ?", tokenID).Update("team_id", teamID)
+	if result.Error != nil {
+		return fmt.Errorf("failed to move token: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("token with ID '%s' not found", tokenID)
+	}
+	if record, ok := s.cache[tokenID]; ok {
+		record.TeamID = teamID
+	}
+	return nil
 }
 
 // RevokeToken revokes a token by setting enabled to false

--- a/internal/db/api_token_store.go
+++ b/internal/db/api_token_store.go
@@ -222,6 +222,9 @@ func (s *APITokenStore) ValidateToken(tokenID string) (*APITokenRecord, error) {
 	if !ok || !record.Enabled {
 		return nil, fmt.Errorf("token not found or disabled")
 	}
+	if record.ExpiresAt != nil && record.ExpiresAt.Before(time.Now()) {
+		return nil, fmt.Errorf("token expired")
+	}
 	if s.teamStore == nil {
 		return nil, errors.New("team store is not initialized")
 	}

--- a/internal/db/store_manager.go
+++ b/internal/db/store_manager.go
@@ -34,6 +34,7 @@ type storeSet struct {
 	ruleStore          *RuleStore
 	imbotSettingsStore *ImBotSettingsStore
 	modelStore         *ModelStore
+	teamStore          *TeamStore
 	apiTokenStore      *APITokenStore
 	remoteChatStore    *RemoteChatStore
 	remoteSessionStore *RemoteSessionStore
@@ -51,6 +52,7 @@ func (s *storeSet) initialized() map[string]bool {
 		"rule":           s.ruleStore != nil,
 		"imbotSettings":  s.imbotSettingsStore != nil,
 		"model":          s.modelStore != nil,
+		"team":           s.teamStore != nil,
 		"apiToken":       s.apiTokenStore != nil,
 		"remoteChats":    s.remoteChatStore != nil,
 		"remoteSessions": s.remoteSessionStore != nil,
@@ -159,7 +161,10 @@ func (sm *StoreManager) initStores() error {
 	if sm.modelStore, err = newModelStore(conn); err != nil {
 		errs = append(errs, fmt.Errorf("model store: %w", err))
 	}
-	if sm.apiTokenStore, err = newAPITokenStore(conn); err != nil {
+	if sm.teamStore, err = newTeamStore(conn); err != nil {
+		errs = append(errs, fmt.Errorf("team store: %w", err))
+	}
+	if sm.apiTokenStore, err = newAPITokenStore(conn, sm.teamStore); err != nil {
 		errs = append(errs, fmt.Errorf("api token store: %w", err))
 	}
 	if err = sm.initRemoteStores(); err != nil {
@@ -281,6 +286,14 @@ func (sm *StoreManager) Model() *ModelStore {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 	return sm.modelStore
+}
+
+// Team returns the TeamStore (thread-safe).
+// Returns nil if the store is not initialized or after Close() has been called.
+func (sm *StoreManager) Team() *TeamStore {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.teamStore
 }
 
 // APIToken returns the APITokenStore (thread-safe).

--- a/internal/db/store_manager_test.go
+++ b/internal/db/store_manager_test.go
@@ -113,6 +113,7 @@ func TestStoreManager_Accessors(t *testing.T) {
 		{"Provider", func() interface{} { return sm.Provider() }},
 		{"ImBotSettings", func() interface{} { return sm.ImBotSettings() }},
 		{"Model", func() interface{} { return sm.Model() }},
+		{"Team", func() interface{} { return sm.Team() }},
 		{"APIToken", func() interface{} { return sm.APIToken() }},
 	}
 
@@ -155,6 +156,9 @@ func TestStoreManager_Close(t *testing.T) {
 	}
 	if sm.Model() != nil {
 		t.Error("Model() should return nil after Close()")
+	}
+	if sm.Team() != nil {
+		t.Error("Team() should return nil after Close()")
 	}
 	if sm.APIToken() != nil {
 		t.Error("APIToken() should return nil after Close()")
@@ -202,7 +206,7 @@ func TestStoreManager_HealthCheck(t *testing.T) {
 
 	expectedStores := []string{
 		"stats", "usage", "provider",
-		"imbotSettings", "model", "apiToken",
+		"imbotSettings", "model", "team", "apiToken",
 		"remoteChats", "remoteSessions", "botAccess",
 	}
 	for _, name := range expectedStores {

--- a/internal/db/team_store.go
+++ b/internal/db/team_store.go
@@ -1,0 +1,229 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const (
+	// DefaultTeamID is stable across upgrades so legacy sharing keys can be
+	// backfilled deterministically before user-created teams exist.
+	DefaultTeamID   = "00000000-0000-0000-0000-000000000001"
+	DefaultTeamSlug = "default"
+	DefaultTeamName = "Default Team"
+)
+
+// TeamRecord is an authorization and routing boundary for sharing keys.
+// Human-readable names and slugs may change; ID is the durable identity stored
+// on tokens, rules, and usage records.
+type TeamRecord struct {
+	ID        string    `gorm:"primaryKey;column:id;size:36" json:"id"`
+	Slug      string    `gorm:"uniqueIndex;column:slug;not null;size:64" json:"slug"`
+	Name      string    `gorm:"column:name;not null;size:128" json:"name"`
+	Enabled   bool      `gorm:"column:enabled;not null;default:true" json:"enabled"`
+	CreatedAt time.Time `gorm:"column:created_at" json:"created_at"`
+	UpdatedAt time.Time `gorm:"column:updated_at" json:"updated_at"`
+}
+
+func (TeamRecord) TableName() string { return "teams" }
+
+// TeamStore persists teams and mirrors them in memory because every sharing
+// request must confirm that its owning team still exists and is enabled.
+type TeamStore struct {
+	storeConn
+	mu    sync.RWMutex
+	cache map[string]*TeamRecord
+}
+
+func NewTeamStore(baseDir string) (*TeamStore, error) {
+	db, err := openTinglyDB(baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("team store: %w", err)
+	}
+	return newTeamStore(ownedConn(db))
+}
+
+func newTeamStore(conn storeConn) (*TeamStore, error) {
+	if err := conn.db.AutoMigrate(&TeamRecord{}); err != nil {
+		return nil, fmt.Errorf("failed to migrate teams: %w", err)
+	}
+
+	defaultTeam := TeamRecord{
+		ID:      DefaultTeamID,
+		Slug:    DefaultTeamSlug,
+		Name:    DefaultTeamName,
+		Enabled: true,
+	}
+	if err := conn.db.Where("id = ?", DefaultTeamID).FirstOrCreate(&defaultTeam).Error; err != nil {
+		return nil, fmt.Errorf("failed to ensure default team: %w", err)
+	}
+
+	store := &TeamStore{storeConn: conn, cache: make(map[string]*TeamRecord)}
+	if err := store.loadCache(); err != nil {
+		return nil, fmt.Errorf("failed to load team cache: %w", err)
+	}
+	return store, nil
+}
+
+func (s *TeamStore) loadCache() error {
+	var records []TeamRecord
+	if err := s.db.Find(&records).Error; err != nil {
+		return err
+	}
+	s.cache = make(map[string]*TeamRecord, len(records))
+	for i := range records {
+		record := records[i]
+		s.cache[record.ID] = &record
+	}
+	return nil
+}
+
+func validateTeamFields(name, slug string) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("team name cannot be empty")
+	}
+	if slug == "" || len(slug) > 64 {
+		return errors.New("team slug must be between 1 and 64 characters")
+	}
+	for i := 0; i < len(slug); i++ {
+		ch := slug[i]
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' || ch == '_' {
+			continue
+		}
+		return errors.New("team slug may contain only lowercase letters, digits, '-' and '_'")
+	}
+	return nil
+}
+
+func cloneTeam(record *TeamRecord) *TeamRecord {
+	if record == nil {
+		return nil
+	}
+	clone := *record
+	return &clone
+}
+
+func (s *TeamStore) Create(name, slug string) (*TeamRecord, error) {
+	name = strings.TrimSpace(name)
+	slug = strings.TrimSpace(slug)
+	if err := validateTeamFields(name, slug); err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record := &TeamRecord{ID: uuid.NewString(), Name: name, Slug: slug, Enabled: true}
+	if err := s.db.Create(record).Error; err != nil {
+		return nil, fmt.Errorf("failed to create team: %w", err)
+	}
+	s.cache[record.ID] = record
+	return cloneTeam(record), nil
+}
+
+func (s *TeamStore) Get(id string) (*TeamRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	record, ok := s.cache[id]
+	if !ok {
+		return nil, fmt.Errorf("team '%s' not found", id)
+	}
+	return cloneTeam(record), nil
+}
+
+func (s *TeamStore) List() []TeamRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	records := make([]TeamRecord, 0, len(s.cache))
+	for _, record := range s.cache {
+		records = append(records, *record)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].CreatedAt.Equal(records[j].CreatedAt) {
+			return records[i].ID < records[j].ID
+		}
+		return records[i].CreatedAt.Before(records[j].CreatedAt)
+	})
+	return records
+}
+
+func (s *TeamStore) Update(id, name, slug string) (*TeamRecord, error) {
+	name = strings.TrimSpace(name)
+	slug = strings.TrimSpace(slug)
+	if err := validateTeamFields(name, slug); err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.cache[id]
+	if !ok {
+		return nil, fmt.Errorf("team '%s' not found", id)
+	}
+	if err := s.db.Model(&TeamRecord{}).Where("id = ?", id).Updates(map[string]any{
+		"name": name,
+		"slug": slug,
+	}).Error; err != nil {
+		return nil, fmt.Errorf("failed to update team: %w", err)
+	}
+	record.Name = name
+	record.Slug = slug
+	record.UpdatedAt = time.Now()
+	return cloneTeam(record), nil
+}
+
+func (s *TeamStore) SetEnabled(id string, enabled bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.cache[id]
+	if !ok {
+		return fmt.Errorf("team '%s' not found", id)
+	}
+	if err := s.db.Model(&TeamRecord{}).Where("id = ?", id).Update("enabled", enabled).Error; err != nil {
+		return fmt.Errorf("failed to update team enabled state: %w", err)
+	}
+	record.Enabled = enabled
+	record.UpdatedAt = time.Now()
+	return nil
+}
+
+func (s *TeamStore) Delete(id string) error {
+	if id == DefaultTeamID {
+		return errors.New("default team cannot be deleted")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.cache[id]; !ok {
+		return fmt.Errorf("team '%s' not found", id)
+	}
+	if err := s.db.Transaction(func(tx *gorm.DB) error {
+		if tx.Migrator().HasTable(&APITokenRecord{}) {
+			var tokenCount int64
+			if err := tx.Model(&APITokenRecord{}).Where("team_id = ?", id).Count(&tokenCount).Error; err != nil {
+				return err
+			}
+			if tokenCount > 0 {
+				return fmt.Errorf("team still owns %d sharing key(s)", tokenCount)
+			}
+		}
+		result := tx.Where("id = ?", id).Delete(&TeamRecord{})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return fmt.Errorf("team '%s' not found", id)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	delete(s.cache, id)
+	return nil
+}

--- a/internal/db/team_store_test.go
+++ b/internal/db/team_store_test.go
@@ -1,0 +1,145 @@
+package db
+
+import "testing"
+
+func TestTeamStore_EnsuresDefaultAndCRUD(t *testing.T) {
+	store, err := NewTeamStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	defaultTeam, err := store.Get(DefaultTeamID)
+	if err != nil {
+		t.Fatalf("get default team: %v", err)
+	}
+	if defaultTeam.Slug != DefaultTeamSlug || !defaultTeam.Enabled {
+		t.Fatalf("unexpected default team: %#v", defaultTeam)
+	}
+
+	created, err := store.Create("Engineering", "engineering")
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	if created.ID == "" || created.ID == DefaultTeamID {
+		t.Fatalf("unexpected created ID: %q", created.ID)
+	}
+
+	updated, err := store.Update(created.ID, "Platform", "platform")
+	if err != nil {
+		t.Fatalf("update team: %v", err)
+	}
+	if updated.Name != "Platform" || updated.Slug != "platform" {
+		t.Fatalf("unexpected update: %#v", updated)
+	}
+
+	if err := store.SetEnabled(created.ID, false); err != nil {
+		t.Fatalf("disable team: %v", err)
+	}
+	disabled, _ := store.Get(created.ID)
+	if disabled.Enabled {
+		t.Fatal("team remained enabled")
+	}
+	if err := store.Delete(created.ID); err != nil {
+		t.Fatalf("delete team: %v", err)
+	}
+	if _, err := store.Get(created.ID); err == nil {
+		t.Fatal("deleted team still exists")
+	}
+	if err := store.Delete(DefaultTeamID); err == nil {
+		t.Fatal("default team deletion should be rejected")
+	}
+}
+
+func TestTeamStore_RejectsInvalidAndDuplicateSlugs(t *testing.T) {
+	store, err := NewTeamStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	for _, slug := range []string{"", "Upper", "has space", "has/slash"} {
+		if _, err := store.Create("Team", slug); err == nil {
+			t.Errorf("Create with slug %q succeeded", slug)
+		}
+	}
+	if _, err := store.Create("One", "one"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create("Another", "one"); err == nil {
+		t.Fatal("duplicate slug should be rejected")
+	}
+}
+
+func TestAPITokenStore_DefaultBindingMoveAndTeamDisable(t *testing.T) {
+	dir := t.TempDir()
+	manager, err := NewStoreManager(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+
+	teams := manager.Team()
+	tokens := manager.APIToken()
+	record, err := tokens.CreateTokenWithTokenID("user", "tb-share-default", "default", "admin", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.TeamID != DefaultTeamID {
+		t.Fatalf("default team ID = %q", record.TeamID)
+	}
+
+	other, err := teams.Create("Other", "other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tokens.MoveTokenToTeam(record.TokenID, other.ID); err != nil {
+		t.Fatalf("move token: %v", err)
+	}
+	moved, err := tokens.ValidateToken(record.TokenID)
+	if err != nil {
+		t.Fatalf("validate moved token: %v", err)
+	}
+	if moved.TeamID != other.ID {
+		t.Fatalf("moved team ID = %q, want %q", moved.TeamID, other.ID)
+	}
+	if err := teams.Delete(other.ID); err == nil {
+		t.Fatal("team with sharing keys should not be deleted")
+	}
+	if err := teams.SetEnabled(other.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tokens.ValidateToken(record.TokenID); err == nil {
+		t.Fatal("token for disabled team should be rejected")
+	}
+}
+
+func TestAPITokenStore_BackfillsEmptyTeamID(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewAPITokenStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateTokenWithTokenID("user", "tb-share-legacy", "legacy", "admin", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.Model(&APITokenRecord{}).Where("token_id = ?", "tb-share-legacy").Update("team_id", "").Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := NewAPITokenStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	record, err := reopened.ValidateToken("tb-share-legacy")
+	if err != nil {
+		t.Fatalf("validate backfilled token: %v", err)
+	}
+	if record.TeamID != DefaultTeamID {
+		t.Fatalf("backfilled team ID = %q", record.TeamID)
+	}
+}

--- a/internal/db/usage_daily.go
+++ b/internal/db/usage_daily.go
@@ -163,7 +163,7 @@ func (us *UsageStore) aggregatedStatsFromDaily(q UsageStatsQuery) ([]AggregatedS
 		return nil, false, nil
 	}
 	// Dimensions/filters not present in usage_daily require the raw table.
-	if q.Scenario != "" || q.RuleUUID != "" || q.Status != "" {
+	if q.Scenario != "" || q.RuleUUID != "" || q.TeamID != "" || q.Status != "" {
 		return nil, false, nil
 	}
 	if q.StartTime.IsZero() || q.EndTime.IsZero() {

--- a/internal/db/usage_record.go
+++ b/internal/db/usage_record.go
@@ -21,6 +21,7 @@ type UsageRecord struct {
 	Scenario     string    `gorm:"column:scenario;index:idx_scenario;not null"`
 	RuleUUID     string    `gorm:"column:rule_uuid;index:idx_rule"`
 	UserID       string    `gorm:"column:user_id;index:idx_user;not null;default:''"`
+	TeamID       string    `gorm:"column:team_id;index:idx_team;not null;default:''"`
 	RequestModel string    `gorm:"column:request_model"`
 	Timestamp    time.Time `gorm:"column:timestamp;index:idx_timestamp;index:idx_timestamp_scenario;not null"`
 	InputTokens  int       `gorm:"column:input_tokens;not null"`
@@ -229,6 +230,7 @@ type UsageStatsQuery struct {
 	Scenario  string
 	RuleUUID  string
 	UserID    string
+	TeamID    string
 	Status    string
 	Limit     int
 	SortBy    string // total_tokens, request_count, avg_latency
@@ -300,6 +302,7 @@ var usageFilterColumns = map[string]struct{}{
 	"scenario":      {},
 	"rule_uuid":     {},
 	"user_id":       {},
+	"team_id":       {},
 	"status":        {},
 	"error_code":    {},
 }
@@ -336,13 +339,14 @@ func withStatsFilters(q UsageStatsQuery) func(*gorm.DB) *gorm.DB {
 
 // filterMap renders the query's set dimension fields as a column filter map.
 func (q UsageStatsQuery) filterMap() map[string]string {
-	filters := make(map[string]string, 6)
+	filters := make(map[string]string, 7)
 	for column, value := range map[string]string{
 		"provider_uuid": q.Provider,
 		"model":         q.Model,
 		"scenario":      q.Scenario,
 		"rule_uuid":     q.RuleUUID,
 		"user_id":       q.UserID,
+		"team_id":       q.TeamID,
 		"status":        q.Status,
 	} {
 		if value != "" {

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -327,7 +327,18 @@ func (am *AuthMiddleware) ModelAuthMiddleware() gin.HandlerFunc {
 				// This is an API token, validate it directly from database
 				tokenRecord, validateErr := am.apiTokenStore.ValidateToken(token)
 				if validateErr == nil && tokenRecord != nil {
+					// A sharing key is a team-scoped model credential, not a
+					// second global model token. Authorize the concrete Gin route
+					// template as well as the scenario parameter so new model
+					// surfaces fail closed and a client cannot select a suffix
+					// such as team:<other-scope>.
+					if !sharingKeyCanAccessModelSurface(c) {
+						abortWithError(c, http.StatusForbidden, "Sharing key is restricted to the team model endpoint", "forbidden_error")
+						return
+					}
+
 					// Token is valid and enabled
+					c.Set(constant.CtxKeyAuthKind, constant.AuthKindSharingKey)
 					c.Set(constant.CtxKeyUserID, tokenRecord.UserID)
 
 					// Update last used asynchronously
@@ -357,6 +368,7 @@ func (am *AuthMiddleware) ModelAuthMiddleware() gin.HandlerFunc {
 		if token == configToken || xApiKey == configToken {
 			// Set UserID to default admin for usage tracking consistency
 			// This matches the migrated user_id values in usage_records
+			c.Set(constant.CtxKeyAuthKind, constant.AuthKindGlobalModelToken)
 			c.Set(constant.CtxKeyUserID, db.DefaultAdminUserID)
 			contextJWT := strings.TrimSpace(c.GetHeader("X-TBE-Context-JWT"))
 			if contextJWT != "" {
@@ -390,4 +402,15 @@ func (am *AuthMiddleware) ModelAuthMiddleware() gin.HandlerFunc {
 
 		abortWithError(c, http.StatusUnauthorized, "Invalid model authorization token.", "invalid_request_error")
 	}
+}
+
+// sharingKeyCanAccessModelSurface is the sharing-principal authorization
+// boundary. Authentication middleware is reused by both /tingly/:scenario and
+// /virtual/* routes, so checking only for a valid token would turn every
+// sharing key into a global model credential. Match the registered route shape
+// (not the raw URL) and require the bare team scenario; both /tingly/team and
+// /tingly/team/v1 endpoints use this template prefix.
+func sharingKeyCanAccessModelSurface(c *gin.Context) bool {
+	return c.Param("scenario") == "team" &&
+		strings.HasPrefix(c.FullPath(), "/tingly/:scenario")
 }

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -327,6 +327,10 @@ func (am *AuthMiddleware) ModelAuthMiddleware() gin.HandlerFunc {
 				// This is an API token, validate it directly from database
 				tokenRecord, validateErr := am.apiTokenStore.ValidateToken(token)
 				if validateErr == nil && tokenRecord != nil {
+					if tokenRecord.TeamID == "" {
+						abortWithError(c, http.StatusUnauthorized, "Sharing key has no team binding", "invalid_token_error")
+						return
+					}
 					// A sharing key is a team-scoped model credential, not a
 					// second global model token. Authorize the concrete Gin route
 					// template as well as the scenario parameter so new model
@@ -340,6 +344,7 @@ func (am *AuthMiddleware) ModelAuthMiddleware() gin.HandlerFunc {
 					// Token is valid and enabled
 					c.Set(constant.CtxKeyAuthKind, constant.AuthKindSharingKey)
 					c.Set(constant.CtxKeyUserID, tokenRecord.UserID)
+					c.Set(constant.CtxKeyTeamID, tokenRecord.TeamID)
 
 					// Update last used asynchronously
 					go am.apiTokenStore.UpdateLastUsed(tokenRecord.TokenID)

--- a/internal/middleware/auth_bench_test.go
+++ b/internal/middleware/auth_bench_test.go
@@ -57,11 +57,11 @@ func BenchmarkModelAuthMiddleware_APIToken(b *testing.B) {
 
 	am := NewAuthMiddleware(cfg, nil, nil, store)
 	r := gin.New()
-	r.POST("/v1/chat/completions", am.ModelAuthMiddleware(), func(c *gin.Context) {
+	r.POST("/tingly/:scenario/v1/chat/completions", am.ModelAuthMiddleware(), func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req := httptest.NewRequest(http.MethodPost, "/tingly/team/v1/chat/completions", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	b.ReportAllocs()

--- a/internal/middleware/auth_sharing_scope_test.go
+++ b/internal/middleware/auth_sharing_scope_test.go
@@ -1,0 +1,108 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
+	"github.com/tingly-dev/tingly-box/internal/db"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+)
+
+const sharingScopeTestToken = "tb-share-valid"
+
+type sharingScopeTokenStore struct{}
+
+func (sharingScopeTokenStore) ValidateToken(tokenID string) (*db.APITokenRecord, error) {
+	if tokenID != sharingScopeTestToken {
+		return nil, errors.New("token not found or disabled")
+	}
+	return &db.APITokenRecord{TokenID: tokenID, UserID: "sharing-user", Enabled: true}, nil
+}
+
+func (sharingScopeTokenStore) UpdateLastUsed(string) error { return nil }
+
+func newSharingScopeTestRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{ModelToken: "global-model-token"}
+	cfg.MultiTenantConfig.Enabled = true
+	am := NewAuthMiddleware(cfg, nil, nil, sharingScopeTokenStore{})
+
+	router := gin.New()
+	handler := func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"auth_kind": c.GetString(constant.CtxKeyAuthKind),
+			"user_id":   c.GetString(constant.CtxKeyUserID),
+		})
+	}
+	router.POST("/tingly/:scenario/messages", am.ModelAuthMiddleware(), handler)
+	router.POST("/tingly/:scenario/v1/messages", am.ModelAuthMiddleware(), handler)
+	router.POST("/virtual/openai/v1/messages", am.ModelAuthMiddleware(), handler)
+	return router
+}
+
+func performModelAuthRequest(router http.Handler, path, token string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func TestModelAuthMiddleware_SharingKeySurfaceAuthorization(t *testing.T) {
+	router := newSharingScopeTestRouter()
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{name: "bare team endpoint", path: "/tingly/team/messages", wantStatus: http.StatusOK},
+		{name: "team v1 endpoint", path: "/tingly/team/v1/messages", wantStatus: http.StatusOK},
+		{name: "other scenario", path: "/tingly/openai/messages", wantStatus: http.StatusForbidden},
+		{name: "client selected team suffix", path: "/tingly/team:p1/messages", wantStatus: http.StatusForbidden},
+		{name: "virtual model surface", path: "/virtual/openai/v1/messages", wantStatus: http.StatusForbidden},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := performModelAuthRequest(router, tt.path, sharingScopeTestToken)
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d: %s", w.Code, tt.wantStatus, w.Body.String())
+			}
+			if tt.wantStatus == http.StatusOK {
+				if body := w.Body.String(); !strings.Contains(body, `"auth_kind":"sharing_key"`) || !strings.Contains(body, `"user_id":"sharing-user"`) {
+					t.Fatalf("unexpected sharing principal context: %s", body)
+				}
+			} else if !strings.Contains(w.Body.String(), `"type":"forbidden_error"`) {
+				t.Fatalf("expected forbidden_error: %s", w.Body.String())
+			}
+		})
+	}
+}
+
+func TestModelAuthMiddleware_GlobalTokenKeepsAllModelSurfaces(t *testing.T) {
+	router := newSharingScopeTestRouter()
+	for _, path := range []string{"/tingly/team/messages", "/tingly/openai/messages", "/virtual/openai/v1/messages"} {
+		w := performModelAuthRequest(router, path, "global-model-token")
+		if w.Code != http.StatusOK {
+			t.Errorf("%s status = %d, want 200: %s", path, w.Code, w.Body.String())
+			continue
+		}
+		if body := w.Body.String(); !strings.Contains(body, `"auth_kind":"global_model_token"`) || !strings.Contains(body, `"user_id":"admin"`) {
+			t.Errorf("%s unexpected global principal context: %s", path, body)
+		}
+	}
+}
+
+func TestModelAuthMiddleware_InvalidSharingKeyRemainsUnauthorized(t *testing.T) {
+	router := newSharingScopeTestRouter()
+	w := performModelAuthRequest(router, "/tingly/team/messages", "tb-share-invalid")
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/middleware/auth_sharing_scope_test.go
+++ b/internal/middleware/auth_sharing_scope_test.go
@@ -22,7 +22,7 @@ func (sharingScopeTokenStore) ValidateToken(tokenID string) (*db.APITokenRecord,
 	if tokenID != sharingScopeTestToken {
 		return nil, errors.New("token not found or disabled")
 	}
-	return &db.APITokenRecord{TokenID: tokenID, UserID: "sharing-user", Enabled: true}, nil
+	return &db.APITokenRecord{TokenID: tokenID, UserID: "sharing-user", TeamID: db.DefaultTeamID, Enabled: true}, nil
 }
 
 func (sharingScopeTokenStore) UpdateLastUsed(string) error { return nil }
@@ -38,6 +38,7 @@ func newSharingScopeTestRouter() *gin.Engine {
 		c.JSON(http.StatusOK, gin.H{
 			"auth_kind": c.GetString(constant.CtxKeyAuthKind),
 			"user_id":   c.GetString(constant.CtxKeyUserID),
+			"team_id":   c.GetString(constant.CtxKeyTeamID),
 		})
 	}
 	router.POST("/tingly/:scenario/messages", am.ModelAuthMiddleware(), handler)
@@ -75,7 +76,7 @@ func TestModelAuthMiddleware_SharingKeySurfaceAuthorization(t *testing.T) {
 				t.Fatalf("status = %d, want %d: %s", w.Code, tt.wantStatus, w.Body.String())
 			}
 			if tt.wantStatus == http.StatusOK {
-				if body := w.Body.String(); !strings.Contains(body, `"auth_kind":"sharing_key"`) || !strings.Contains(body, `"user_id":"sharing-user"`) {
+				if body := w.Body.String(); !strings.Contains(body, `"auth_kind":"sharing_key"`) || !strings.Contains(body, `"user_id":"sharing-user"`) || !strings.Contains(body, `"team_id":"`+db.DefaultTeamID+`"`) {
 					t.Fatalf("unexpected sharing principal context: %s", body)
 				}
 			} else if !strings.Contains(w.Body.String(), `"type":"forbidden_error"`) {

--- a/internal/protocolserver/routes.go
+++ b/internal/protocolserver/routes.go
@@ -50,28 +50,28 @@ func (ph *ProtocolHandler) RegisterRoutes(engine *gin.Engine, modelAuth gin.Hand
 // Anthropic surfaces on one group), each gated by modelAuth.
 func (ph *ProtocolHandler) SetupMixinEndpoints(group *gin.RouterGroup, modelAuth gin.HandlerFunc) {
 	// Chat completions endpoint (OpenAI compatible)
-	group.POST("/chat/completions", modelAuth, ph.HandleOpenAIChatCompletions)
+	group.POST("/chat/completions", modelAuth, ph.teamScopeMiddleware, ph.HandleOpenAIChatCompletions)
 
 	// Responses API endpoints (OpenAI compatible)
-	group.POST("/responses", modelAuth, ph.HandleResponsesCreate)
-	group.GET("/responses/:id", modelAuth, ph.HandleResponsesGet)
+	group.POST("/responses", modelAuth, ph.teamScopeMiddleware, ph.HandleResponsesCreate)
+	group.GET("/responses/:id", modelAuth, ph.teamScopeMiddleware, ph.HandleResponsesGet)
 
 	// Chat completions endpoint (Anthropic compatible)
-	group.POST("/messages", modelAuth, ph.HandleAnthropicMessages)
+	group.POST("/messages", modelAuth, ph.teamScopeMiddleware, ph.HandleAnthropicMessages)
 	// Count tokens endpoint (Anthropic compatible)
-	group.POST("/messages/count_tokens", modelAuth, ph.AnthropicCountTokens)
+	group.POST("/messages/count_tokens", modelAuth, ph.teamScopeMiddleware, ph.AnthropicCountTokens)
 
 	// Embeddings endpoint (OpenAI compatible)
-	group.POST("/embeddings", modelAuth, DeclareOperation("embeddings"), ph.HandleOpenAIEmbeddings)
+	group.POST("/embeddings", modelAuth, ph.teamScopeMiddleware, DeclareOperation("embeddings"), ph.HandleOpenAIEmbeddings)
 
 	// Image generation endpoint (OpenAI compatible).
 	// Routed directly to upstream POST /v1/images/generations; the Responses API
 	// (POST /responses with the image_generation tool) is exposed in parallel via
 	// the same scenario, with the caller choosing which surface to use.
-	group.POST("/images/generations", modelAuth, DeclareOperation("image_generation"), ph.HandleOpenAIImageGeneration)
+	group.POST("/images/generations", modelAuth, ph.teamScopeMiddleware, DeclareOperation("image_generation"), ph.HandleOpenAIImageGeneration)
 
 	// Models endpoint (routed by scenario: openai -> OpenAIListModels, anthropic/claude_code -> AnthropicListModels)
-	group.GET("/models", modelAuth, ph.ListModelsByScenario)
+	group.GET("/models", modelAuth, ph.teamScopeMiddleware, ph.ListModelsByScenario)
 }
 
 // SetupOpenAIEndpoints registers the OpenAI-only endpoint set on group.

--- a/internal/protocolserver/routes_middleware.go
+++ b/internal/protocolserver/routes_middleware.go
@@ -9,6 +9,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/client"
+	"github.com/tingly-dev/tingly-box/internal/constant"
+	"github.com/tingly-dev/tingly-box/internal/db"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -166,5 +168,38 @@ func (ph *ProtocolHandler) contextMiddleware(c *gin.Context) {
 		}
 	}
 
+	c.Next()
+}
+
+// teamScopeMiddleware converts the public, stable /tingly/team surface into
+// the routing scope authorized by the credential. It runs after model auth,
+// so the client cannot choose this value. The original URL remains unchanged:
+// usage and tracing keep the low-cardinality public scenario "team", while
+// rule lookup consumes the rewritten Gin parameter.
+//
+// The default team intentionally keeps the legacy bare "team" scope so all
+// existing rules remain usable without a destructive migration. Additional
+// teams use the isolated internal form "team:<stable-id>".
+func (ph *ProtocolHandler) teamScopeMiddleware(c *gin.Context) {
+	if c.Param("scenario") != string(typ.ScenarioTeam) {
+		c.Next()
+		return
+	}
+
+	teamID := c.GetString(constant.CtxKeyTeamID)
+	if teamID == "" {
+		// Global model auth has no explicit team claim. Preserve the historic
+		// /tingly/team behavior by treating it as the default team.
+		teamID = db.DefaultTeamID
+		c.Set(constant.CtxKeyTeamID, teamID)
+	}
+	if teamID != db.DefaultTeamID {
+		for i := range c.Params {
+			if c.Params[i].Key == "scenario" {
+				c.Params[i].Value = string(typ.ProfiledScenarioName(typ.ScenarioTeam, teamID))
+				break
+			}
+		}
+	}
 	c.Next()
 }

--- a/internal/protocolserver/team_scope_test.go
+++ b/internal/protocolserver/team_scope_test.go
@@ -1,0 +1,120 @@
+package protocolserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
+	"github.com/tingly-dev/tingly-box/internal/db"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestTeamScopeMiddleware_DerivesRoutingScopeFromAuthContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ph := &ProtocolHandler{}
+	router := gin.New()
+	router.POST("/tingly/:scenario/messages",
+		func(c *gin.Context) {
+			if teamID := c.GetHeader("X-Test-Team-ID"); teamID != "" {
+				c.Set(constant.CtxKeyTeamID, teamID)
+			}
+		},
+		ph.teamScopeMiddleware,
+		func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{
+				"scenario": c.Param("scenario"),
+				"team_id":  c.GetString(constant.CtxKeyTeamID),
+				"path":     c.Request.URL.Path,
+			})
+		},
+	)
+
+	tests := []struct {
+		name         string
+		path         string
+		teamID       string
+		wantScenario string
+		wantTeamID   string
+	}{
+		{name: "global auth defaults legacy team", path: "/tingly/team/messages", wantScenario: "team", wantTeamID: db.DefaultTeamID},
+		{name: "default sharing team keeps legacy scope", path: "/tingly/team/messages", teamID: db.DefaultTeamID, wantScenario: "team", wantTeamID: db.DefaultTeamID},
+		{name: "other sharing team gets isolated scope", path: "/tingly/team/messages", teamID: "team-a", wantScenario: "team:team-a", wantTeamID: "team-a"},
+		{name: "non-team scenario is unchanged", path: "/tingly/openai/messages", teamID: "team-a", wantScenario: "openai", wantTeamID: "team-a"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.path, nil)
+			if tt.teamID != "" {
+				req.Header.Set("X-Test-Team-ID", tt.teamID)
+			}
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+			}
+			body := w.Body.String()
+			for _, want := range []string{`"scenario":"` + tt.wantScenario + `"`, `"team_id":"` + tt.wantTeamID + `"`, `"path":"` + tt.path + `"`} {
+				if !strings.Contains(body, want) {
+					t.Fatalf("body %s does not contain %s", body, want)
+				}
+			}
+		})
+	}
+}
+
+func TestUsageRecordCarriesAuthenticatedTeam(t *testing.T) {
+	c, _ := gin.CreateTestContext(nil)
+	c.Set(constant.CtxKeyUserID, "user-a")
+	c.Set(constant.CtxKeyTeamID, "team-a")
+	provider := &typ.Provider{UUID: "provider-a", Name: "Provider A"}
+	record := (&ProtocolHandler{}).recordDetailedUsage(c, nil, provider, "model", "request-model", "team", 1, 2, false, "success", "", 3)
+	if record.TeamID != "team-a" {
+		t.Fatalf("TeamID = %q, want team-a", record.TeamID)
+	}
+}
+
+func TestTeamScopeMiddleware_SelectsOnlyAuthorizedTeamRules(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{Rules: []typ.Rule{
+		{UUID: "default-rule", Scenario: typ.ScenarioTeam, RequestModel: "shared-model", Active: true},
+		{UUID: "team-a-rule", Scenario: typ.RuleScenario("team:team-a"), RequestModel: "shared-model", Active: true},
+		{UUID: "team-b-rule", Scenario: typ.RuleScenario("team:team-b"), RequestModel: "shared-model", Active: true},
+	}}
+	ph := &ProtocolHandler{deps: ProtocolHandlerDeps{Config: cfg}}
+	router := gin.New()
+	router.POST("/tingly/:scenario/messages",
+		func(c *gin.Context) { c.Set(constant.CtxKeyTeamID, c.GetHeader("X-Test-Team-ID")) },
+		ph.teamScopeMiddleware,
+		func(c *gin.Context) {
+			rule, err := ph.determineRuleWithScenario(c, typ.RuleScenario(c.Param("scenario")), "shared-model")
+			if err != nil {
+				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{"rule": rule.UUID})
+		},
+	)
+
+	for _, tt := range []struct {
+		teamID   string
+		wantRule string
+	}{
+		{teamID: db.DefaultTeamID, wantRule: "default-rule"},
+		{teamID: "team-a", wantRule: "team-a-rule"},
+		{teamID: "team-b", wantRule: "team-b-rule"},
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/tingly/team/messages", nil)
+		req.Header.Set("X-Test-Team-ID", tt.teamID)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), `"rule":"`+tt.wantRule+`"`) {
+			t.Fatalf("team %s got status %d body %s; want %s", tt.teamID, w.Code, w.Body.String(), tt.wantRule)
+		}
+	}
+}

--- a/internal/protocolserver/usage_tracking.go
+++ b/internal/protocolserver/usage_tracking.go
@@ -362,6 +362,7 @@ func (ph *ProtocolHandler) recordDetailedUsage(c *gin.Context, rule *typ.Rule, p
 		Scenario:     scenario,
 		RequestModel: requestModel,
 		UserID:       GetUserIDFromContext(c), // Uses user_id or enterprise_user_id
+		TeamID:       c.GetString(constant.CtxKeyTeamID),
 		InputTokens:  inputTokens,
 		OutputTokens: outputTokens,
 		TotalTokens:  inputTokens + outputTokens,
@@ -396,6 +397,7 @@ func (ph *ProtocolHandler) recordDetailedUsageWithTokenUsage(c *gin.Context, rul
 		Scenario:         scenario,
 		RequestModel:     requestModel,
 		UserID:           GetUserIDFromContext(c), // Uses user_id or enterprise_user_id
+		TeamID:           c.GetString(constant.CtxKeyTeamID),
 		InputTokens:      usage.InputTokens,
 		OutputTokens:     usage.OutputTokens,
 		CacheReadTokens:  usage.CacheReadTokens,


### PR DESCRIPTION
## Summary
Sharing keys previously shared one global routing scope with no boundary between them. This lays the auth/routing foundation for teams — every key is bound to a team, requests are scoped to it server-side, and expired keys are actually rejected — while behavior for existing single-team deployments is unchanged (everything routes through the `default` team as before).

## Key Changes

- **Sharing keys bound to teams**: `TeamStore` + `APITokenRecord.TeamID` give every key a durable owning team, seeded with a stable `default` team for existing keys.
- **Team-scoped routing**: `teamScopeMiddleware` derives the routing scope from the authenticated credential, never from client input, so one team's rules can't be reached with another team's key.
- **Sharing-key access restricted to its team**: model-auth middleware rejects a key used against a surface outside its team's scope.
- **Sharing-key expiry enforced**: `ValidateToken` now rejects tokens past `ExpiresAt`, closing a pre-existing gap found while scoping keys to teams.
