### PR TITLE
fix(claude): TitleCase all OAuth tool names and restore them on streams

### DIFF
--- a/.design/anthropic-sdk-stream-tool-name-restoration.md
+++ b/.design/anthropic-sdk-stream-tool-name-restoration.md
@@ -1,0 +1,71 @@
+# Restoring tool names in Anthropic streaming responses
+
+Context for `internal/client/claude_tool_names.go` and the `remap*RequestToolNames` /
+`restoreToolNames*` helpers in `internal/client/claude_client.go` (PR #1634).
+
+## Why tool names are rewritten at all
+
+On the Claude OAuth path, Anthropic classifies some traffic as third-party and bills
+it to Extra Usage instead of the subscription (surfacing as a hard 400
+`You're out of extra usage` when that bucket is empty). Tool naming appears to be one
+of the signals. Clients other than Claude Code send snake_case tool names, so the
+gateway folds them towards the shape Claude Code itself sends:
+
+- MCP-namespaced names (`mcp__<server>__<tool>`, and tingly-box's own
+  `tingly_box_mcp__…` via `internal/tool.NormalizeToolName`) pass through **verbatim** —
+  Claude Code sends them lowercase and unfolded, and the namespace is what the client
+  routes on. A single-underscore `mcp_` prefix is *not* a namespace and folds normally.
+- `oauthToolRenameMap` wins for well-known Claude Code tools so official spellings are
+  preserved (`ls` → `LS`, not `Ls`).
+- Everything else folds mechanically to TitleCase (`read_file` → `ReadFile`).
+- Collisions are skipped: if a fold target is already taken by another tool in the
+  request, that name is left alone (a wrong reverse-map entry would mis-dispatch
+  tool results).
+
+An earlier report described a hard ~16-snake-case-name cutoff; later probing did not
+reproduce it (five arms up to 48 lowercase names at 100% density all passed). The exact
+classifier trigger is unconfirmed. The fold is kept because it is a no-op at worst.
+
+## Why the rename must cover the whole request
+
+`planToolRenames` computes the plan once from `tools[]`; three sites must agree with it:
+
+1. `tools[]` itself,
+2. `tool_choice.OfTool.Name` (a pin naming a folded-away tool is a hard 400 from
+   Anthropic: `Tool 'foo__bar' not found in provided tools`),
+3. `tool_use` blocks in prior assistant turns (each follow-up turn would otherwise
+   re-send the original snake_case names, compounding with conversation length).
+
+Folding a site independently is wrong because the plan deliberately skips colliding
+folds — an independent fold could pin `tool_choice` to a name not in `tools[]`, or to
+the wrong tool. Hence the single entry point `remap{,Beta}RequestToolNames(req)`.
+
+## Why restore happens at the HTTP layer for streams
+
+Non-streaming responses are decoded `Message` objects; `restoreToolNamesInMessage`
+rewrites them before returning. A streamed response is handed to the caller as an SSE
+stream, and the SDK (pinned `anthropic-sdk-go` fork, `tingly-dev-v1.66.0`) offers no
+per-request, decoded-event hook:
+
+- Both `MessagesNewStreaming` and `BetaMessagesNewStreaming` go through the same
+  `requestconfig.ExecuteNewRequest` path as non-streaming calls; middleware runs there.
+- The SDK never sets `Accept-Encoding`, so Go's transport does transparent gzip
+  decoding before middleware sees the body — plaintext.
+- `ssestream` has no decoder registry in use; its only hook is the raw `io.Reader`.
+- Middlewares re-run per retry attempt; the Claude OAuth client sets `MaxRetries(0)`.
+
+So `Guard`/`GuardBeta` attach `restoreToolNamesMiddleware(reverseMap)` via
+`option.WithMiddleware` when the plan is non-empty. `sseToolNameRewriter` rewrites the
+body line-at-a-time to preserve streaming; a tool name appears in exactly one event
+type (`content_block_start` with `content_block.type == "tool_use"`), everything else
+passes through byte-for-byte, including malformed lines.
+
+## Test layout
+
+- `claude_tool_names_test.go` — unit coverage of the fold, the plan, and every request
+  site (v1 types; Beta has a smoke test).
+- `claude_tool_names_wire_test.go` — httptest round trips asserting the serialized
+  body Anthropic would receive and the stream the client reads back (Beta full, v1
+  compact, MCP-only no-op).
+- `claude_round_tripper_test.go` / `claude_client_test.go` — restore helpers and
+  Guard-level wiring.

--- a/internal/client/claude_client.go
+++ b/internal/client/claude_client.go
@@ -173,7 +173,7 @@ func (c *ClaudeClient) Guard(ctx context.Context, req *anthropic.MessageNewParam
 	}
 
 	// Remap tool names to Claude Code TitleCase equivalents to avoid Anthropic fingerprinting
-	reverseMap := remapToolNames(req.Tools)
+	reverseMap := remapRequestToolNames(req)
 
 	// Inject session ID from metadata
 	meta := ops.ParseMetadataUserID(req.Metadata.UserID.String())
@@ -233,7 +233,7 @@ func (c *ClaudeClient) GuardBeta(ctx context.Context, req *anthropic.BetaMessage
 	}
 
 	// Remap tool names to Claude Code TitleCase equivalents to avoid Anthropic fingerprinting
-	reverseMap := remapBetaToolNames(req.Tools)
+	reverseMap := remapBetaRequestToolNames(req)
 
 	// Inject session ID from metadata
 	meta := ops.ParseMetadataUserID(req.Metadata.UserID.String())
@@ -344,12 +344,24 @@ func stripBetaClearThinkingEdit(req *anthropic.BetaMessageNewParams) {
 	req.ContextManagement.Edits = filtered
 }
 
-// remapToolNames renames OfTool tools in-place to their Claude Code equivalents.
-// Returns a reverse map (outbound → original) for restoring names in the response.
-func remapToolNames(tools []anthropic.ToolUnionParam) map[string]string {
-	names := make([]string, 0, len(tools))
-	for i := range tools {
-		if t := tools[i].OfTool; t != nil {
+// remapRequestToolNames renames tool names in-place to their Claude Code
+// equivalents. Returns a reverse map (outbound → original) for restoring names
+// in the response.
+//
+// The plan is computed once from req.Tools and then applied to every site in
+// the request that has to agree with it: the tool definitions, an explicit
+// tool_choice pin, and the tool_use blocks of prior assistant turns. Folding a
+// site independently would be wrong — planToolRenames deliberately skips a
+// rename whose target collides with another tool in the same request, so an
+// independent fold could pin tool_choice to a name that is not in tools[], or
+// to a different tool that happens to own it.
+func remapRequestToolNames(req *anthropic.MessageNewParams) map[string]string {
+	if req == nil {
+		return nil
+	}
+	names := make([]string, 0, len(req.Tools))
+	for i := range req.Tools {
+		if t := req.Tools[i].OfTool; t != nil {
 			names = append(names, t.Name)
 		}
 	}
@@ -358,24 +370,48 @@ func remapToolNames(tools []anthropic.ToolUnionParam) map[string]string {
 		return nil
 	}
 	reverseMap := make(map[string]string, len(plan))
-	for i := range tools {
-		t := tools[i].OfTool
+	for i := range req.Tools {
+		t := req.Tools[i].OfTool
 		if t == nil {
 			continue
 		}
 		if newName, ok := plan[t.Name]; ok {
 			reverseMap[newName] = t.Name
-			tools[i].OfTool.Name = newName
+			t.Name = newName
+		}
+	}
+	// tool_choice is request-only, so it needs no entry in the reverse map.
+	if pin := req.ToolChoice.OfTool; pin != nil {
+		if newName, ok := plan[pin.Name]; ok {
+			pin.Name = newName
+		}
+	}
+	// Prior turns carry the name the model was given last time. Leaving them
+	// at the client's spelling would contradict the renamed tools[] and put
+	// the snake_case names back on the wire this rename exists to remove.
+	for i := range req.Messages {
+		for j := range req.Messages[i].Content {
+			use := req.Messages[i].Content[j].OfToolUse
+			if use == nil {
+				continue
+			}
+			if newName, ok := plan[use.Name]; ok {
+				use.Name = newName
+			}
 		}
 	}
 	return reverseMap
 }
 
-// remapBetaToolNames is the BetaToolUnionParam equivalent of remapToolNames.
-func remapBetaToolNames(tools []anthropic.BetaToolUnionParam) map[string]string {
-	names := make([]string, 0, len(tools))
-	for i := range tools {
-		if t := tools[i].OfTool; t != nil {
+// remapBetaRequestToolNames is the BetaMessageNewParams equivalent of
+// remapRequestToolNames.
+func remapBetaRequestToolNames(req *anthropic.BetaMessageNewParams) map[string]string {
+	if req == nil {
+		return nil
+	}
+	names := make([]string, 0, len(req.Tools))
+	for i := range req.Tools {
+		if t := req.Tools[i].OfTool; t != nil {
 			names = append(names, t.Name)
 		}
 	}
@@ -384,14 +420,30 @@ func remapBetaToolNames(tools []anthropic.BetaToolUnionParam) map[string]string 
 		return nil
 	}
 	reverseMap := make(map[string]string, len(plan))
-	for i := range tools {
-		t := tools[i].OfTool
+	for i := range req.Tools {
+		t := req.Tools[i].OfTool
 		if t == nil {
 			continue
 		}
 		if newName, ok := plan[t.Name]; ok {
 			reverseMap[newName] = t.Name
-			tools[i].OfTool.Name = newName
+			t.Name = newName
+		}
+	}
+	if pin := req.ToolChoice.OfTool; pin != nil {
+		if newName, ok := plan[pin.Name]; ok {
+			pin.Name = newName
+		}
+	}
+	for i := range req.Messages {
+		for j := range req.Messages[i].Content {
+			use := req.Messages[i].Content[j].OfToolUse
+			if use == nil {
+				continue
+			}
+			if newName, ok := plan[use.Name]; ok {
+				use.Name = newName
+			}
 		}
 	}
 	return reverseMap

--- a/internal/client/claude_client.go
+++ b/internal/client/claude_client.go
@@ -172,7 +172,7 @@ func (c *ClaudeClient) Guard(ctx context.Context, req *anthropic.MessageNewParam
 		}
 	}
 
-	// Remap tool names to Claude Code TitleCase equivalents to avoid Anthropic fingerprinting
+	// Remap tool names towards Claude Code spelling (see claude_tool_names.go)
 	reverseMap := remapRequestToolNames(req)
 
 	// Inject session ID from metadata
@@ -232,7 +232,7 @@ func (c *ClaudeClient) GuardBeta(ctx context.Context, req *anthropic.BetaMessage
 		stripBetaClearThinkingEdit(req)
 	}
 
-	// Remap tool names to Claude Code TitleCase equivalents to avoid Anthropic fingerprinting
+	// Remap tool names towards Claude Code spelling (see claude_tool_names.go)
 	reverseMap := remapBetaRequestToolNames(req)
 
 	// Inject session ID from metadata

--- a/internal/client/claude_client.go
+++ b/internal/client/claude_client.go
@@ -181,6 +181,11 @@ func (c *ClaudeClient) Guard(ctx context.Context, req *anthropic.MessageNewParam
 		panic("invalid metadata")
 	}
 	options := append(c.AnthropicClient.Client().Options, anthropicOption.WithHeader("X-Claude-Code-Session-Id", meta.SessionID))
+	// Streaming responses bypass restoreToolNamesInMessage, so undo the rename
+	// on the wire instead. No-op for non-streaming responses.
+	if len(reverseMap) > 0 {
+		options = append(options, anthropicOption.WithMiddleware(restoreToolNamesMiddleware(reverseMap)))
+	}
 	logrus.WithContext(ctx).Debugf("session: %s", meta.SessionID)
 	logrus.WithContext(ctx).Debugf("metadata: %s", req.Metadata.UserID)
 
@@ -236,6 +241,11 @@ func (c *ClaudeClient) GuardBeta(ctx context.Context, req *anthropic.BetaMessage
 		panic("invalid metadata")
 	}
 	options := append(c.AnthropicClient.Client().Options, anthropicOption.WithHeader("X-Claude-Code-Session-Id", meta.SessionID))
+	// Streaming responses bypass restoreBetaToolNamesInMessage, so undo the
+	// rename on the wire instead. No-op for non-streaming responses.
+	if len(reverseMap) > 0 {
+		options = append(options, anthropicOption.WithMiddleware(restoreToolNamesMiddleware(reverseMap)))
+	}
 	logrus.WithContext(ctx).Debugf("session: %s", meta.SessionID)
 	logrus.WithContext(ctx).Debugf("metadata: %s", req.Metadata.UserID)
 
@@ -334,16 +344,26 @@ func stripBetaClearThinkingEdit(req *anthropic.BetaMessageNewParams) {
 	req.ContextManagement.Edits = filtered
 }
 
-// remapToolNames renames OfTool tools in-place using oauthToolRenameMap.
-// Returns a reverse map (TitleCase → original) for restoring names in the response.
+// remapToolNames renames OfTool tools in-place to their Claude Code equivalents.
+// Returns a reverse map (outbound → original) for restoring names in the response.
 func remapToolNames(tools []anthropic.ToolUnionParam) map[string]string {
-	reverseMap := make(map[string]string)
+	names := make([]string, 0, len(tools))
+	for i := range tools {
+		if t := tools[i].OfTool; t != nil {
+			names = append(names, t.Name)
+		}
+	}
+	plan := planToolRenames(names)
+	if len(plan) == 0 {
+		return nil
+	}
+	reverseMap := make(map[string]string, len(plan))
 	for i := range tools {
 		t := tools[i].OfTool
 		if t == nil {
 			continue
 		}
-		if newName, ok := oauthToolRenameMap[t.Name]; ok && newName != t.Name {
+		if newName, ok := plan[t.Name]; ok {
 			reverseMap[newName] = t.Name
 			tools[i].OfTool.Name = newName
 		}
@@ -353,13 +373,23 @@ func remapToolNames(tools []anthropic.ToolUnionParam) map[string]string {
 
 // remapBetaToolNames is the BetaToolUnionParam equivalent of remapToolNames.
 func remapBetaToolNames(tools []anthropic.BetaToolUnionParam) map[string]string {
-	reverseMap := make(map[string]string)
+	names := make([]string, 0, len(tools))
+	for i := range tools {
+		if t := tools[i].OfTool; t != nil {
+			names = append(names, t.Name)
+		}
+	}
+	plan := planToolRenames(names)
+	if len(plan) == 0 {
+		return nil
+	}
+	reverseMap := make(map[string]string, len(plan))
 	for i := range tools {
 		t := tools[i].OfTool
 		if t == nil {
 			continue
 		}
-		if newName, ok := oauthToolRenameMap[t.Name]; ok && newName != t.Name {
+		if newName, ok := plan[t.Name]; ok {
 			reverseMap[newName] = t.Name
 			tools[i].OfTool.Name = newName
 		}

--- a/internal/client/claude_client_test.go
+++ b/internal/client/claude_client_test.go
@@ -130,33 +130,33 @@ func TestClaudeClient_ListModels_UsesUpstream(t *testing.T) {
 }
 
 // ===================================================================
-// remapBetaToolNames
+// remapBetaRequestToolNames
 // ===================================================================
 
-func TestRemapBetaToolNames(t *testing.T) {
+func TestRemapBetaRequestToolNames(t *testing.T) {
 	t.Run("renames bash to Bash in OfTool", func(t *testing.T) {
-		tools := []anthropic.BetaToolUnionParam{
+		req := &anthropic.BetaMessageNewParams{Tools: []anthropic.BetaToolUnionParam{
 			{OfTool: &anthropic.BetaToolParam{Name: "bash"}},
-		}
-		rev := remapBetaToolNames(tools)
-		assert.Equal(t, "Bash", tools[0].OfTool.Name)
+		}}
+		rev := remapBetaRequestToolNames(req)
+		assert.Equal(t, "Bash", req.Tools[0].OfTool.Name)
 		assert.Equal(t, map[string]string{"Bash": "bash"}, rev)
 	})
 
 	t.Run("skips built-in tools (OfTool is nil)", func(t *testing.T) {
-		tools := []anthropic.BetaToolUnionParam{
+		req := &anthropic.BetaMessageNewParams{Tools: []anthropic.BetaToolUnionParam{
 			{OfBashTool20250124: &anthropic.BetaToolBash20250124Param{}},
-		}
-		rev := remapBetaToolNames(tools)
+		}}
+		rev := remapBetaRequestToolNames(req)
 		assert.Empty(t, rev)
 	})
 
 	t.Run("already TitleCase — no rename", func(t *testing.T) {
-		tools := []anthropic.BetaToolUnionParam{
+		req := &anthropic.BetaMessageNewParams{Tools: []anthropic.BetaToolUnionParam{
 			{OfTool: &anthropic.BetaToolParam{Name: "Bash"}},
-		}
-		rev := remapBetaToolNames(tools)
-		assert.Equal(t, "Bash", tools[0].OfTool.Name)
+		}}
+		rev := remapBetaRequestToolNames(req)
+		assert.Equal(t, "Bash", req.Tools[0].OfTool.Name)
 		assert.Empty(t, rev)
 	})
 
@@ -164,39 +164,43 @@ func TestRemapBetaToolNames(t *testing.T) {
 		// Anthropic's OAuth path rejects requests carrying many snake_case
 		// tool names, so unknown tools are folded too — not just the
 		// well-known Claude Code ones.
-		tools := []anthropic.BetaToolUnionParam{
+		req := &anthropic.BetaMessageNewParams{Tools: []anthropic.BetaToolUnionParam{
 			{OfTool: &anthropic.BetaToolParam{Name: "my_custom_tool"}},
-		}
-		rev := remapBetaToolNames(tools)
-		assert.Equal(t, "MyCustomTool", tools[0].OfTool.Name)
+		}}
+		rev := remapBetaRequestToolNames(req)
+		assert.Equal(t, "MyCustomTool", req.Tools[0].OfTool.Name)
 		assert.Equal(t, map[string]string{"MyCustomTool": "my_custom_tool"}, rev)
 	})
 
 	t.Run("multiple tools — known names keep official spelling", func(t *testing.T) {
-		tools := []anthropic.BetaToolUnionParam{
+		req := &anthropic.BetaMessageNewParams{Tools: []anthropic.BetaToolUnionParam{
 			{OfTool: &anthropic.BetaToolParam{Name: "read"}},
 			{OfTool: &anthropic.BetaToolParam{Name: "my_tool"}},
 			{OfTool: &anthropic.BetaToolParam{Name: "ls"}},
-		}
-		rev := remapBetaToolNames(tools)
-		assert.Equal(t, "Read", tools[0].OfTool.Name)
-		assert.Equal(t, "MyTool", tools[1].OfTool.Name)
+		}}
+		rev := remapBetaRequestToolNames(req)
+		assert.Equal(t, "Read", req.Tools[0].OfTool.Name)
+		assert.Equal(t, "MyTool", req.Tools[1].OfTool.Name)
 		// "ls" comes from the map as "LS", not the mechanical "Ls".
-		assert.Equal(t, "LS", tools[2].OfTool.Name)
+		assert.Equal(t, "LS", req.Tools[2].OfTool.Name)
 		assert.Equal(t, map[string]string{"Read": "read", "MyTool": "my_tool", "LS": "ls"}, rev)
 	})
 
 	t.Run("collision — both left alone", func(t *testing.T) {
 		// Renaming would make the reverse map ambiguous, which could
 		// dispatch a tool result to the wrong tool.
-		tools := []anthropic.BetaToolUnionParam{
+		req := &anthropic.BetaMessageNewParams{Tools: []anthropic.BetaToolUnionParam{
 			{OfTool: &anthropic.BetaToolParam{Name: "my_tool"}},
 			{OfTool: &anthropic.BetaToolParam{Name: "MyTool"}},
-		}
-		rev := remapBetaToolNames(tools)
-		assert.Equal(t, "my_tool", tools[0].OfTool.Name)
-		assert.Equal(t, "MyTool", tools[1].OfTool.Name)
+		}}
+		rev := remapBetaRequestToolNames(req)
+		assert.Equal(t, "my_tool", req.Tools[0].OfTool.Name)
+		assert.Equal(t, "MyTool", req.Tools[1].OfTool.Name)
 		assert.Empty(t, rev)
+	})
+
+	t.Run("nil request", func(t *testing.T) {
+		assert.Nil(t, remapBetaRequestToolNames(nil))
 	})
 }
 

--- a/internal/client/claude_client_test.go
+++ b/internal/client/claude_client_test.go
@@ -130,81 +130,6 @@ func TestClaudeClient_ListModels_UsesUpstream(t *testing.T) {
 }
 
 // ===================================================================
-// remapBetaRequestToolNames
-// ===================================================================
-
-func TestRemapBetaRequestToolNames(t *testing.T) {
-	t.Run("renames bash to Bash in OfTool", func(t *testing.T) {
-		req := &anthropic.BetaMessageNewParams{Tools: []anthropic.BetaToolUnionParam{
-			{OfTool: &anthropic.BetaToolParam{Name: "bash"}},
-		}}
-		rev := remapBetaRequestToolNames(req)
-		assert.Equal(t, "Bash", req.Tools[0].OfTool.Name)
-		assert.Equal(t, map[string]string{"Bash": "bash"}, rev)
-	})
-
-	t.Run("skips built-in tools (OfTool is nil)", func(t *testing.T) {
-		req := &anthropic.BetaMessageNewParams{Tools: []anthropic.BetaToolUnionParam{
-			{OfBashTool20250124: &anthropic.BetaToolBash20250124Param{}},
-		}}
-		rev := remapBetaRequestToolNames(req)
-		assert.Empty(t, rev)
-	})
-
-	t.Run("already TitleCase — no rename", func(t *testing.T) {
-		req := &anthropic.BetaMessageNewParams{Tools: []anthropic.BetaToolUnionParam{
-			{OfTool: &anthropic.BetaToolParam{Name: "Bash"}},
-		}}
-		rev := remapBetaRequestToolNames(req)
-		assert.Equal(t, "Bash", req.Tools[0].OfTool.Name)
-		assert.Empty(t, rev)
-	})
-
-	t.Run("unknown tool — TitleCased", func(t *testing.T) {
-		// Anthropic's OAuth path rejects requests carrying many snake_case
-		// tool names, so unknown tools are folded too — not just the
-		// well-known Claude Code ones.
-		req := &anthropic.BetaMessageNewParams{Tools: []anthropic.BetaToolUnionParam{
-			{OfTool: &anthropic.BetaToolParam{Name: "my_custom_tool"}},
-		}}
-		rev := remapBetaRequestToolNames(req)
-		assert.Equal(t, "MyCustomTool", req.Tools[0].OfTool.Name)
-		assert.Equal(t, map[string]string{"MyCustomTool": "my_custom_tool"}, rev)
-	})
-
-	t.Run("multiple tools — known names keep official spelling", func(t *testing.T) {
-		req := &anthropic.BetaMessageNewParams{Tools: []anthropic.BetaToolUnionParam{
-			{OfTool: &anthropic.BetaToolParam{Name: "read"}},
-			{OfTool: &anthropic.BetaToolParam{Name: "my_tool"}},
-			{OfTool: &anthropic.BetaToolParam{Name: "ls"}},
-		}}
-		rev := remapBetaRequestToolNames(req)
-		assert.Equal(t, "Read", req.Tools[0].OfTool.Name)
-		assert.Equal(t, "MyTool", req.Tools[1].OfTool.Name)
-		// "ls" comes from the map as "LS", not the mechanical "Ls".
-		assert.Equal(t, "LS", req.Tools[2].OfTool.Name)
-		assert.Equal(t, map[string]string{"Read": "read", "MyTool": "my_tool", "LS": "ls"}, rev)
-	})
-
-	t.Run("collision — both left alone", func(t *testing.T) {
-		// Renaming would make the reverse map ambiguous, which could
-		// dispatch a tool result to the wrong tool.
-		req := &anthropic.BetaMessageNewParams{Tools: []anthropic.BetaToolUnionParam{
-			{OfTool: &anthropic.BetaToolParam{Name: "my_tool"}},
-			{OfTool: &anthropic.BetaToolParam{Name: "MyTool"}},
-		}}
-		rev := remapBetaRequestToolNames(req)
-		assert.Equal(t, "my_tool", req.Tools[0].OfTool.Name)
-		assert.Equal(t, "MyTool", req.Tools[1].OfTool.Name)
-		assert.Empty(t, rev)
-	})
-
-	t.Run("nil request", func(t *testing.T) {
-		assert.Nil(t, remapBetaRequestToolNames(nil))
-	})
-}
-
-// ===================================================================
 // restoreBetaToolNamesInMessage
 // ===================================================================
 
@@ -219,39 +144,19 @@ func TestRestoreBetaToolNamesInMessage(t *testing.T) {
 		assert.Equal(t, "bash", msg.Content[0].Name)
 	})
 
-	t.Run("noop for nil message", func(t *testing.T) {
-		// Should not panic
+	t.Run("inert for nil message, empty map, and non-tool blocks", func(t *testing.T) {
 		restoreBetaToolNamesInMessage(nil, map[string]string{"Bash": "bash"})
-	})
 
-	t.Run("noop for empty reverseMap", func(t *testing.T) {
-		msg := &anthropic.BetaMessage{
-			Content: []anthropic.BetaContentBlockUnion{
-				{Type: "tool_use", Name: "Bash"},
-			},
-		}
-		restoreBetaToolNamesInMessage(msg, map[string]string{})
-		assert.Equal(t, "Bash", msg.Content[0].Name)
-	})
-
-	t.Run("does not touch non-tool_use blocks", func(t *testing.T) {
-		msg := &anthropic.BetaMessage{
-			Content: []anthropic.BetaContentBlockUnion{
-				{Type: "text", Name: ""},
-			},
-		}
-		restoreBetaToolNamesInMessage(msg, map[string]string{"Bash": "bash"})
-		assert.Equal(t, "", msg.Content[0].Name)
-	})
-
-	t.Run("name not in reverseMap is unchanged", func(t *testing.T) {
 		msg := &anthropic.BetaMessage{
 			Content: []anthropic.BetaContentBlockUnion{
 				{Type: "tool_use", Name: "Read"},
+				{Type: "text", Name: ""},
 			},
 		}
+		restoreBetaToolNamesInMessage(msg, nil)
 		restoreBetaToolNamesInMessage(msg, map[string]string{"Bash": "bash"})
 		assert.Equal(t, "Read", msg.Content[0].Name)
+		assert.Equal(t, "", msg.Content[1].Name)
 	})
 }
 

--- a/internal/client/claude_client_test.go
+++ b/internal/client/claude_client_test.go
@@ -160,26 +160,43 @@ func TestRemapBetaToolNames(t *testing.T) {
 		assert.Empty(t, rev)
 	})
 
-	t.Run("unknown tool — passed through unchanged", func(t *testing.T) {
+	t.Run("unknown tool — TitleCased", func(t *testing.T) {
+		// Anthropic's OAuth path rejects requests carrying many snake_case
+		// tool names, so unknown tools are folded too — not just the
+		// well-known Claude Code ones.
 		tools := []anthropic.BetaToolUnionParam{
 			{OfTool: &anthropic.BetaToolParam{Name: "my_custom_tool"}},
 		}
 		rev := remapBetaToolNames(tools)
-		assert.Equal(t, "my_custom_tool", tools[0].OfTool.Name)
-		assert.Empty(t, rev)
+		assert.Equal(t, "MyCustomTool", tools[0].OfTool.Name)
+		assert.Equal(t, map[string]string{"MyCustomTool": "my_custom_tool"}, rev)
 	})
 
-	t.Run("multiple tools — renames known ones only", func(t *testing.T) {
+	t.Run("multiple tools — known names keep official spelling", func(t *testing.T) {
 		tools := []anthropic.BetaToolUnionParam{
 			{OfTool: &anthropic.BetaToolParam{Name: "read"}},
 			{OfTool: &anthropic.BetaToolParam{Name: "my_tool"}},
-			{OfTool: &anthropic.BetaToolParam{Name: "glob"}},
+			{OfTool: &anthropic.BetaToolParam{Name: "ls"}},
 		}
 		rev := remapBetaToolNames(tools)
 		assert.Equal(t, "Read", tools[0].OfTool.Name)
-		assert.Equal(t, "my_tool", tools[1].OfTool.Name)
-		assert.Equal(t, "Glob", tools[2].OfTool.Name)
-		assert.Equal(t, map[string]string{"Read": "read", "Glob": "glob"}, rev)
+		assert.Equal(t, "MyTool", tools[1].OfTool.Name)
+		// "ls" comes from the map as "LS", not the mechanical "Ls".
+		assert.Equal(t, "LS", tools[2].OfTool.Name)
+		assert.Equal(t, map[string]string{"Read": "read", "MyTool": "my_tool", "LS": "ls"}, rev)
+	})
+
+	t.Run("collision — both left alone", func(t *testing.T) {
+		// Renaming would make the reverse map ambiguous, which could
+		// dispatch a tool result to the wrong tool.
+		tools := []anthropic.BetaToolUnionParam{
+			{OfTool: &anthropic.BetaToolParam{Name: "my_tool"}},
+			{OfTool: &anthropic.BetaToolParam{Name: "MyTool"}},
+		}
+		rev := remapBetaToolNames(tools)
+		assert.Equal(t, "my_tool", tools[0].OfTool.Name)
+		assert.Equal(t, "MyTool", tools[1].OfTool.Name)
+		assert.Empty(t, rev)
 	})
 }
 

--- a/internal/client/claude_round_tripper_test.go
+++ b/internal/client/claude_round_tripper_test.go
@@ -40,30 +40,30 @@ func TestAnthropicBetaFlags(t *testing.T) {
 	}
 }
 
-func TestRemapToolNames(t *testing.T) {
+func TestRemapRequestToolNames(t *testing.T) {
 	t.Run("renames bash to Bash in OfTool", func(t *testing.T) {
-		tools := []anthropic.ToolUnionParam{
+		req := &anthropic.MessageNewParams{Tools: []anthropic.ToolUnionParam{
 			{OfTool: &anthropic.ToolParam{Name: "bash"}},
-		}
-		rev := remapToolNames(tools)
-		assert.Equal(t, "Bash", tools[0].OfTool.Name)
+		}}
+		rev := remapRequestToolNames(req)
+		assert.Equal(t, "Bash", req.Tools[0].OfTool.Name)
 		assert.Equal(t, map[string]string{"Bash": "bash"}, rev)
 	})
 
 	t.Run("skips built-in tools (OfTool is nil)", func(t *testing.T) {
-		tools := []anthropic.ToolUnionParam{
+		req := &anthropic.MessageNewParams{Tools: []anthropic.ToolUnionParam{
 			{OfBashTool20250124: &anthropic.ToolBash20250124Param{}},
-		}
-		rev := remapToolNames(tools)
+		}}
+		rev := remapRequestToolNames(req)
 		assert.Empty(t, rev)
 	})
 
 	t.Run("already TitleCase — no rename", func(t *testing.T) {
-		tools := []anthropic.ToolUnionParam{
+		req := &anthropic.MessageNewParams{Tools: []anthropic.ToolUnionParam{
 			{OfTool: &anthropic.ToolParam{Name: "Bash"}},
-		}
-		rev := remapToolNames(tools)
-		assert.Equal(t, "Bash", tools[0].OfTool.Name)
+		}}
+		rev := remapRequestToolNames(req)
+		assert.Equal(t, "Bash", req.Tools[0].OfTool.Name)
 		assert.Empty(t, rev)
 	})
 
@@ -71,12 +71,16 @@ func TestRemapToolNames(t *testing.T) {
 		// Anthropic's OAuth path rejects requests carrying many snake_case
 		// tool names, so unknown tools are folded too — not just the
 		// well-known Claude Code ones.
-		tools := []anthropic.ToolUnionParam{
+		req := &anthropic.MessageNewParams{Tools: []anthropic.ToolUnionParam{
 			{OfTool: &anthropic.ToolParam{Name: "my_custom_tool"}},
-		}
-		rev := remapToolNames(tools)
-		assert.Equal(t, "MyCustomTool", tools[0].OfTool.Name)
+		}}
+		rev := remapRequestToolNames(req)
+		assert.Equal(t, "MyCustomTool", req.Tools[0].OfTool.Name)
 		assert.Equal(t, map[string]string{"MyCustomTool": "my_custom_tool"}, rev)
+	})
+
+	t.Run("nil request", func(t *testing.T) {
+		assert.Nil(t, remapRequestToolNames(nil))
 	})
 }
 

--- a/internal/client/claude_round_tripper_test.go
+++ b/internal/client/claude_round_tripper_test.go
@@ -67,13 +67,16 @@ func TestRemapToolNames(t *testing.T) {
 		assert.Empty(t, rev)
 	})
 
-	t.Run("unknown tool — passed through unchanged", func(t *testing.T) {
+	t.Run("unknown tool — TitleCased", func(t *testing.T) {
+		// Anthropic's OAuth path rejects requests carrying many snake_case
+		// tool names, so unknown tools are folded too — not just the
+		// well-known Claude Code ones.
 		tools := []anthropic.ToolUnionParam{
 			{OfTool: &anthropic.ToolParam{Name: "my_custom_tool"}},
 		}
 		rev := remapToolNames(tools)
-		assert.Equal(t, "my_custom_tool", tools[0].OfTool.Name)
-		assert.Empty(t, rev)
+		assert.Equal(t, "MyCustomTool", tools[0].OfTool.Name)
+		assert.Equal(t, map[string]string{"MyCustomTool": "my_custom_tool"}, rev)
 	})
 }
 

--- a/internal/client/claude_round_tripper_test.go
+++ b/internal/client/claude_round_tripper_test.go
@@ -40,50 +40,6 @@ func TestAnthropicBetaFlags(t *testing.T) {
 	}
 }
 
-func TestRemapRequestToolNames(t *testing.T) {
-	t.Run("renames bash to Bash in OfTool", func(t *testing.T) {
-		req := &anthropic.MessageNewParams{Tools: []anthropic.ToolUnionParam{
-			{OfTool: &anthropic.ToolParam{Name: "bash"}},
-		}}
-		rev := remapRequestToolNames(req)
-		assert.Equal(t, "Bash", req.Tools[0].OfTool.Name)
-		assert.Equal(t, map[string]string{"Bash": "bash"}, rev)
-	})
-
-	t.Run("skips built-in tools (OfTool is nil)", func(t *testing.T) {
-		req := &anthropic.MessageNewParams{Tools: []anthropic.ToolUnionParam{
-			{OfBashTool20250124: &anthropic.ToolBash20250124Param{}},
-		}}
-		rev := remapRequestToolNames(req)
-		assert.Empty(t, rev)
-	})
-
-	t.Run("already TitleCase — no rename", func(t *testing.T) {
-		req := &anthropic.MessageNewParams{Tools: []anthropic.ToolUnionParam{
-			{OfTool: &anthropic.ToolParam{Name: "Bash"}},
-		}}
-		rev := remapRequestToolNames(req)
-		assert.Equal(t, "Bash", req.Tools[0].OfTool.Name)
-		assert.Empty(t, rev)
-	})
-
-	t.Run("unknown tool — TitleCased", func(t *testing.T) {
-		// Anthropic's OAuth path rejects requests carrying many snake_case
-		// tool names, so unknown tools are folded too — not just the
-		// well-known Claude Code ones.
-		req := &anthropic.MessageNewParams{Tools: []anthropic.ToolUnionParam{
-			{OfTool: &anthropic.ToolParam{Name: "my_custom_tool"}},
-		}}
-		rev := remapRequestToolNames(req)
-		assert.Equal(t, "MyCustomTool", req.Tools[0].OfTool.Name)
-		assert.Equal(t, map[string]string{"MyCustomTool": "my_custom_tool"}, rev)
-	})
-
-	t.Run("nil request", func(t *testing.T) {
-		assert.Nil(t, remapRequestToolNames(nil))
-	})
-}
-
 func TestRestoreToolNamesInMessage(t *testing.T) {
 	t.Run("restores tool_use name", func(t *testing.T) {
 		msg := &anthropic.Message{

--- a/internal/client/claude_tool_names.go
+++ b/internal/client/claude_tool_names.go
@@ -12,10 +12,20 @@ import (
 	anthropicOption "github.com/anthropics/anthropic-sdk-go/option"
 )
 
-// mcpToolPrefix marks MCP-provided tools. Claude Code keeps the prefix intact
-// and only capitalizes the first character of the remainder, so we match that
-// rather than folding the whole name.
-const mcpToolPrefix = "mcp_"
+// mcpNamespaceSeparator separates the segments of an MCP tool name.
+//
+// Claude Code passes MCP tools through verbatim as mcp__<server>__<tool> —
+// lowercase, unfolded — so a name already using this separator is left alone.
+// Folding it would move the request away from real Claude Code traffic rather
+// than towards it, and would flatten the namespace the client uses to route the
+// call. Tingly-Box's own server tools follow the same convention
+// (tingly_box_mcp__<source>__<tool>, see internal/tool.NormalizeToolName), so
+// one rule covers both.
+//
+// A single-underscore "mcp_" prefix is deliberately *not* treated as a
+// namespace: it is not a shape any first-party client emits, so it folds like
+// any other snake_case name.
+const mcpNamespaceSeparator = "__"
 
 // claudeCodeToolName returns the name Claude Code would send for a tool.
 //
@@ -27,10 +37,14 @@ const mcpToolPrefix = "mcp_"
 // fail while the same request with TitleCased names succeeds; the check is a
 // casing heuristic, not an allowlist of known Claude Code tools.
 //
-// oauthToolRenameMap still wins for the well-known Claude Code tools so those
+// MCP-namespaced names are exempt — see mcpNamespaceSeparator.
+// oauthToolRenameMap then wins for the well-known Claude Code tools so those
 // keep their exact official spelling (e.g. "ls" -> "LS", not "Ls"). Everything
 // else falls back to a mechanical TitleCase.
 func claudeCodeToolName(name string) string {
+	if strings.Contains(name, mcpNamespaceSeparator) {
+		return name
+	}
 	if mapped, ok := oauthToolRenameMap[name]; ok {
 		return mapped
 	}
@@ -42,12 +56,6 @@ func claudeCodeToolName(name string) string {
 func titleCaseToolName(name string) string {
 	if name == "" {
 		return name
-	}
-	if rest, ok := strings.CutPrefix(name, mcpToolPrefix); ok {
-		if rest == "" {
-			return name
-		}
-		return mcpToolPrefix + upperFirst(rest)
 	}
 	var b strings.Builder
 	b.Grow(len(name))

--- a/internal/client/claude_tool_names.go
+++ b/internal/client/claude_tool_names.go
@@ -29,13 +29,14 @@ const mcpNamespaceSeparator = "__"
 
 // claudeCodeToolName returns the name Claude Code would send for a tool.
 //
-// Anthropic fingerprints Claude Code OAuth traffic partly on tool naming: a
-// request carrying many lowercase/snake_case tool names is classified as
-// third-party and billed to Extra Usage rather than the subscription, which
-// surfaces as a 400 "You're out of extra usage" once that bucket is spent.
-// Measured against api.anthropic.com, requests with >=16 snake_case tool names
-// fail while the same request with TitleCased names succeeds; the check is a
-// casing heuristic, not an allowlist of known Claude Code tools.
+// Anthropic classifies some OAuth traffic as third-party and bills it to Extra
+// Usage rather than the subscription, which surfaces as a 400 "You're out of
+// extra usage" once that bucket is spent; tool naming appears to be one of the
+// signals. An earlier report measured a hard cutoff (~16 snake_case names);
+// later probes — five arms up to 48 lowercase names at 100% density — did not
+// reproduce it, so the exact trigger is unconfirmed (see PR #1634). The fold
+// is kept regardless because it only moves names towards the shape Claude Code
+// itself sends, and at worst is a no-op.
 //
 // MCP-namespaced names are exempt — see mcpNamespaceSeparator.
 // oauthToolRenameMap then wins for the well-known Claude Code tools so those

--- a/internal/client/claude_tool_names.go
+++ b/internal/client/claude_tool_names.go
@@ -1,0 +1,219 @@
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"unicode"
+
+	anthropicOption "github.com/anthropics/anthropic-sdk-go/option"
+)
+
+// mcpToolPrefix marks MCP-provided tools. Claude Code keeps the prefix intact
+// and only capitalizes the first character of the remainder, so we match that
+// rather than folding the whole name.
+const mcpToolPrefix = "mcp_"
+
+// claudeCodeToolName returns the name Claude Code would send for a tool.
+//
+// Anthropic fingerprints Claude Code OAuth traffic partly on tool naming: a
+// request carrying many lowercase/snake_case tool names is classified as
+// third-party and billed to Extra Usage rather than the subscription, which
+// surfaces as a 400 "You're out of extra usage" once that bucket is spent.
+// Measured against api.anthropic.com, requests with >=16 snake_case tool names
+// fail while the same request with TitleCased names succeeds; the check is a
+// casing heuristic, not an allowlist of known Claude Code tools.
+//
+// oauthToolRenameMap still wins for the well-known Claude Code tools so those
+// keep their exact official spelling (e.g. "ls" -> "LS", not "Ls"). Everything
+// else falls back to a mechanical TitleCase.
+func claudeCodeToolName(name string) string {
+	if mapped, ok := oauthToolRenameMap[name]; ok {
+		return mapped
+	}
+	return titleCaseToolName(name)
+}
+
+// titleCaseToolName folds a snake_case tool name into TitleCase.
+// Names that are already TitleCase come back unchanged.
+func titleCaseToolName(name string) string {
+	if name == "" {
+		return name
+	}
+	if rest, ok := strings.CutPrefix(name, mcpToolPrefix); ok {
+		if rest == "" {
+			return name
+		}
+		return mcpToolPrefix + upperFirst(rest)
+	}
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, part := range strings.Split(name, "_") {
+		if part == "" {
+			continue
+		}
+		b.WriteString(upperFirst(part))
+	}
+	if b.Len() == 0 {
+		return name
+	}
+	return b.String()
+}
+
+func upperFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
+}
+
+// planToolRenames maps original tool name -> outbound name for a request.
+//
+// A rename is skipped when the target collides with another tool in the same
+// request (either one already named that, or another rename targeting it).
+// Two distinct tools sharing one outbound name would make the reverse mapping
+// ambiguous and could dispatch a tool result to the wrong tool, so leaving the
+// colliding pair untouched is the safe failure mode.
+func planToolRenames(names []string) map[string]string {
+	taken := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		taken[n] = struct{}{}
+	}
+	plan := make(map[string]string, len(names))
+	used := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		newName := claudeCodeToolName(n)
+		if newName == n {
+			continue
+		}
+		if _, clash := taken[newName]; clash {
+			continue
+		}
+		if _, clash := used[newName]; clash {
+			continue
+		}
+		used[newName] = struct{}{}
+		plan[n] = newName
+	}
+	return plan
+}
+
+// restoreToolNamesMiddleware rewrites renamed tool names back to the client's
+// originals in a streaming response.
+//
+// The non-streaming paths restore names on the decoded message
+// (restoreToolNamesInMessage), but a streamed response is handed to the caller
+// as an SSE stream that never passes through that step. Without this the
+// renamed name reaches the client, which then cannot match it against its own
+// tool registry. Rewriting at the HTTP layer keeps the client interface
+// unchanged and covers both the v1 and beta streaming paths.
+func restoreToolNamesMiddleware(reverse map[string]string) anthropicOption.Middleware {
+	return func(req *http.Request, next anthropicOption.MiddlewareNext) (*http.Response, error) {
+		resp, err := next(req)
+		if err != nil || resp == nil || resp.Body == nil {
+			return resp, err
+		}
+		if !strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+			return resp, nil
+		}
+		resp.Body = newSSEToolNameRewriter(resp.Body, reverse)
+		return resp, nil
+	}
+}
+
+// sseToolNameRewriter rewrites tool names in an SSE body as it streams.
+//
+// A tool name appears in exactly one event type: content_block_start, whose
+// content_block is {"type":"tool_use","id":...,"name":...,"input":{}}. The
+// arguments arrive separately as input_json_delta and never repeat the name,
+// and message_delta/message_stop do not carry it — so this is a single
+// interception point rather than a general rewrite of the stream.
+//
+// Rewriting is line-at-a-time so streaming is preserved: each SSE "data:" line
+// is a complete JSON object, and lines that are not a tool_use
+// content_block_start are passed through byte-for-byte.
+type sseToolNameRewriter struct {
+	inner   io.ReadCloser
+	reader  *bufio.Reader
+	reverse map[string]string
+	pending []byte
+	err     error
+}
+
+func newSSEToolNameRewriter(inner io.ReadCloser, reverse map[string]string) *sseToolNameRewriter {
+	return &sseToolNameRewriter{
+		inner:   inner,
+		reader:  bufio.NewReader(inner),
+		reverse: reverse,
+	}
+}
+
+func (r *sseToolNameRewriter) Read(p []byte) (int, error) {
+	for len(r.pending) == 0 {
+		if r.err != nil {
+			return 0, r.err
+		}
+		line, err := r.reader.ReadBytes('\n')
+		if len(line) > 0 {
+			r.pending = r.rewriteLine(line)
+		}
+		if err != nil {
+			r.err = err
+			if len(r.pending) == 0 {
+				return 0, err
+			}
+		}
+	}
+	n := copy(p, r.pending)
+	r.pending = r.pending[n:]
+	return n, nil
+}
+
+func (r *sseToolNameRewriter) Close() error { return r.inner.Close() }
+
+func (r *sseToolNameRewriter) rewriteLine(line []byte) []byte {
+	trimmed := bytes.TrimRight(line, "\r\n")
+	if !bytes.HasPrefix(trimmed, []byte("data:")) {
+		return line
+	}
+	payload := bytes.TrimSpace(trimmed[len("data:"):])
+	// Cheap reject before paying for a JSON decode: every rewritable line
+	// carries both markers.
+	if !bytes.Contains(payload, []byte(`"content_block_start"`)) ||
+		!bytes.Contains(payload, []byte(`"tool_use"`)) {
+		return line
+	}
+	var evt map[string]any
+	if err := json.Unmarshal(payload, &evt); err != nil {
+		return line
+	}
+	block, ok := evt["content_block"].(map[string]any)
+	if !ok {
+		return line
+	}
+	if blockType, _ := block["type"].(string); blockType != "tool_use" {
+		return line
+	}
+	name, _ := block["name"].(string)
+	orig, ok := r.reverse[name]
+	if !ok {
+		return line
+	}
+	block["name"] = orig
+	out, err := json.Marshal(evt)
+	if err != nil {
+		return line
+	}
+	// Preserve the original line ending so SSE framing is untouched.
+	ending := line[len(trimmed):]
+	rewritten := make([]byte, 0, len("data: ")+len(out)+len(ending))
+	rewritten = append(rewritten, "data: "...)
+	rewritten = append(rewritten, out...)
+	rewritten = append(rewritten, ending...)
+	return rewritten
+}

--- a/internal/client/claude_tool_names_test.go
+++ b/internal/client/claude_tool_names_test.go
@@ -6,11 +6,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTitleCaseToolName(t *testing.T) {
+	// Purely mechanical: the MCP-namespace exemption lives in
+	// claudeCodeToolName, not here.
 	cases := map[string]string{
 		"read_file":     "ReadFile",
 		"ha_get_state":  "HaGetState",
@@ -19,8 +22,8 @@ func TestTitleCaseToolName(t *testing.T) {
 		"Bash":          "Bash", // already TitleCase
 		"WebFetch":      "WebFetch",
 		"":              "",
-		"mcp_foo_bar":   "mcp_Foo_bar", // prefix kept, only first char folded
-		"mcp_":          "mcp_",
+		"mcp_foo_bar":   "McpFooBar",
+		"mcp_":          "Mcp",
 		"tool_2_thing":  "Tool2Thing",
 		"__weird__name": "WeirdName",
 	}
@@ -45,10 +48,10 @@ func TestPlanToolRenames_SkipsCollisions(t *testing.T) {
 	})
 
 	t.Run("two sources folding to the same target", func(t *testing.T) {
-		// "a_b" and "a__b" both fold to "AB"; only the first may rename.
-		plan := planToolRenames([]string{"a_b", "a__b"})
+		// "foo_bar" and "foo_Bar" both fold to "FooBar"; only the first may rename.
+		plan := planToolRenames([]string{"foo_bar", "foo_Bar"})
 		assert.Len(t, plan, 1)
-		assert.Equal(t, "AB", plan["a_b"])
+		assert.Equal(t, "FooBar", plan["foo_bar"])
 	})
 
 	t.Run("independent names all rename", func(t *testing.T) {
@@ -60,12 +63,275 @@ func TestPlanToolRenames_SkipsCollisions(t *testing.T) {
 	})
 }
 
+// ===================================================================
+// MCP-namespaced tool names
+//
+// Claude Code sends MCP tools verbatim as mcp__<server>__<tool> — lowercase,
+// unfolded — so folding them would move the request *away* from real Claude
+// Code traffic, not towards it. Tingly-Box's own server tools use the same
+// double-underscore convention via internal/tool.NormalizeToolName.
+// ===================================================================
+
+func TestClaudeCodeToolName_LeavesMCPNamespacedNamesAlone(t *testing.T) {
+	// Real shapes: what an MCP client actually puts on the wire.
+	for _, name := range []string{
+		"mcp__github__get_pull_request",
+		"mcp__linear__create_issue",
+		"mcp__read_file",
+		"tingly_box_mcp__webtools__mcp_web_search",
+		"tingly_box_mcp__advisor__advisor",
+		"tingly_box_mcp__brave-search__brave_web_search",
+		"tingly_box_mcp__DICOM__view-dicom",
+	} {
+		assert.Equal(t, name, claudeCodeToolName(name), "claudeCodeToolName(%q) must pass through", name)
+	}
+}
+
+func TestClaudeCodeToolName_FoldsSingleUnderscoreMcpNames(t *testing.T) {
+	// A single-underscore "mcp_" prefix is not an MCP namespace — it is itself
+	// a third-party marker. Fold it like any other snake_case name rather than
+	// half-folding it into a shape no client emits.
+	assert.Equal(t, "McpFooBar", claudeCodeToolName("mcp_foo_bar"))
+	assert.Equal(t, "McpLinearGetIssue", claudeCodeToolName("mcp_linear_get_issue"))
+	assert.Equal(t, "Mcp", claudeCodeToolName("mcp_"))
+}
+
+func TestPlanToolRenames_ExcludesMCPNamespacedNames(t *testing.T) {
+	plan := planToolRenames([]string{
+		"mcp__github__get_pull_request",
+		"tingly_box_mcp__webtools__mcp_web_search",
+		"read_file",
+	})
+	assert.Equal(t, map[string]string{"read_file": "ReadFile"}, plan)
+}
+
+// ===================================================================
+// tool_choice must follow the same rename plan as tools
+// ===================================================================
+
+func v1Tool(name string) anthropic.ToolUnionParam {
+	return anthropic.ToolUnionParam{OfTool: &anthropic.ToolParam{Name: name}}
+}
+
+func betaTool(name string) anthropic.BetaToolUnionParam {
+	return anthropic.BetaToolUnionParam{OfTool: &anthropic.BetaToolParam{Name: name}}
+}
+
+func TestRemapRequestToolNames_RemapsToolChoice(t *testing.T) {
+	t.Run("pinned tool follows the fold", func(t *testing.T) {
+		req := &anthropic.MessageNewParams{
+			Tools:      []anthropic.ToolUnionParam{v1Tool("read_file")},
+			ToolChoice: anthropic.ToolChoiceParamOfTool("read_file"),
+		}
+		rev := remapRequestToolNames(req)
+		assert.Equal(t, "ReadFile", req.Tools[0].OfTool.Name)
+		assert.Equal(t, "ReadFile", req.ToolChoice.OfTool.Name,
+			"tool_choice must name a tool that exists in tools[]")
+		assert.Equal(t, map[string]string{"ReadFile": "read_file"}, rev)
+	})
+
+	t.Run("pin follows the plan, not an independent fold", func(t *testing.T) {
+		// planToolRenames skips "my_tool" because "MyTool" is already taken.
+		// Folding tool_choice independently would pin "MyTool" — a name that
+		// is in tools[], but the *wrong* tool.
+		req := &anthropic.MessageNewParams{
+			Tools:      []anthropic.ToolUnionParam{v1Tool("my_tool"), v1Tool("MyTool")},
+			ToolChoice: anthropic.ToolChoiceParamOfTool("my_tool"),
+		}
+		rev := remapRequestToolNames(req)
+		assert.Empty(t, rev)
+		assert.Equal(t, "my_tool", req.ToolChoice.OfTool.Name)
+	})
+
+	t.Run("pin naming a tool absent from tools is untouched", func(t *testing.T) {
+		req := &anthropic.MessageNewParams{
+			Tools:      []anthropic.ToolUnionParam{v1Tool("read_file")},
+			ToolChoice: anthropic.ToolChoiceParamOfTool("not_declared"),
+		}
+		remapRequestToolNames(req)
+		assert.Equal(t, "not_declared", req.ToolChoice.OfTool.Name)
+	})
+
+	t.Run("non-tool tool_choice variants are inert", func(t *testing.T) {
+		req := &anthropic.MessageNewParams{
+			Tools:      []anthropic.ToolUnionParam{v1Tool("read_file")},
+			ToolChoice: anthropic.ToolChoiceUnionParam{OfAuto: &anthropic.ToolChoiceAutoParam{}},
+		}
+		require.NotPanics(t, func() { remapRequestToolNames(req) })
+		assert.Nil(t, req.ToolChoice.OfTool)
+		assert.NotNil(t, req.ToolChoice.OfAuto)
+	})
+}
+
+func TestRemapBetaRequestToolNames_RemapsToolChoice(t *testing.T) {
+	t.Run("pinned tool follows the fold", func(t *testing.T) {
+		req := &anthropic.BetaMessageNewParams{
+			Tools:      []anthropic.BetaToolUnionParam{betaTool("read_file")},
+			ToolChoice: anthropic.BetaToolChoiceParamOfTool("read_file"),
+		}
+		rev := remapBetaRequestToolNames(req)
+		assert.Equal(t, "ReadFile", req.Tools[0].OfTool.Name)
+		assert.Equal(t, "ReadFile", req.ToolChoice.OfTool.Name)
+		assert.Equal(t, map[string]string{"ReadFile": "read_file"}, rev)
+	})
+
+	t.Run("pin follows the plan, not an independent fold", func(t *testing.T) {
+		req := &anthropic.BetaMessageNewParams{
+			Tools:      []anthropic.BetaToolUnionParam{betaTool("my_tool"), betaTool("MyTool")},
+			ToolChoice: anthropic.BetaToolChoiceParamOfTool("my_tool"),
+		}
+		rev := remapBetaRequestToolNames(req)
+		assert.Empty(t, rev)
+		assert.Equal(t, "my_tool", req.ToolChoice.OfTool.Name)
+	})
+
+	t.Run("pin naming a tool absent from tools is untouched", func(t *testing.T) {
+		req := &anthropic.BetaMessageNewParams{
+			Tools:      []anthropic.BetaToolUnionParam{betaTool("read_file")},
+			ToolChoice: anthropic.BetaToolChoiceParamOfTool("not_declared"),
+		}
+		remapBetaRequestToolNames(req)
+		assert.Equal(t, "not_declared", req.ToolChoice.OfTool.Name)
+	})
+
+	t.Run("non-tool tool_choice variants are inert", func(t *testing.T) {
+		req := &anthropic.BetaMessageNewParams{
+			Tools:      []anthropic.BetaToolUnionParam{betaTool("read_file")},
+			ToolChoice: anthropic.BetaToolChoiceUnionParam{OfAuto: &anthropic.BetaToolChoiceAutoParam{}},
+		}
+		require.NotPanics(t, func() { remapBetaRequestToolNames(req) })
+		assert.Nil(t, req.ToolChoice.OfTool)
+		assert.NotNil(t, req.ToolChoice.OfAuto)
+	})
+}
+
+// ===================================================================
+// tool_use blocks in prior turns must agree with tools[]
+// ===================================================================
+
+func TestRemapRequestToolNames_RemapsHistoricalToolUse(t *testing.T) {
+	t.Run("prior tool_use follows the fold", func(t *testing.T) {
+		req := &anthropic.MessageNewParams{
+			Tools: []anthropic.ToolUnionParam{v1Tool("read_file")},
+			Messages: []anthropic.MessageParam{{
+				Role: anthropic.MessageParamRoleAssistant,
+				Content: []anthropic.ContentBlockParamUnion{{
+					OfToolUse: &anthropic.ToolUseBlockParam{ID: "toolu_1", Name: "read_file"},
+				}},
+			}},
+		}
+		remapRequestToolNames(req)
+		assert.Equal(t, "ReadFile", req.Messages[0].Content[0].OfToolUse.Name,
+			"history must not keep the snake_case name the tools[] fold removed")
+	})
+
+	t.Run("history name absent from the plan is untouched", func(t *testing.T) {
+		req := &anthropic.MessageNewParams{
+			Tools: []anthropic.ToolUnionParam{v1Tool("read_file")},
+			Messages: []anthropic.MessageParam{{
+				Role: anthropic.MessageParamRoleAssistant,
+				Content: []anthropic.ContentBlockParamUnion{{
+					OfToolUse: &anthropic.ToolUseBlockParam{ID: "toolu_1", Name: "retired_tool"},
+				}},
+			}},
+		}
+		remapRequestToolNames(req)
+		assert.Equal(t, "retired_tool", req.Messages[0].Content[0].OfToolUse.Name)
+	})
+
+	t.Run("non tool_use blocks are inert", func(t *testing.T) {
+		req := &anthropic.MessageNewParams{
+			Tools: []anthropic.ToolUnionParam{v1Tool("read_file")},
+			Messages: []anthropic.MessageParam{
+				anthropic.NewUserMessage(anthropic.NewTextBlock("hi")),
+			},
+		}
+		require.NotPanics(t, func() { remapRequestToolNames(req) })
+		assert.Equal(t, "hi", req.Messages[0].Content[0].OfText.Text)
+	})
+}
+
+func TestRemapBetaRequestToolNames_RemapsHistoricalToolUse(t *testing.T) {
+	t.Run("prior tool_use follows the fold", func(t *testing.T) {
+		req := &anthropic.BetaMessageNewParams{
+			Tools: []anthropic.BetaToolUnionParam{betaTool("read_file")},
+			Messages: []anthropic.BetaMessageParam{{
+				Role: anthropic.BetaMessageParamRoleAssistant,
+				Content: []anthropic.BetaContentBlockParamUnion{{
+					OfToolUse: &anthropic.BetaToolUseBlockParam{ID: "toolu_1", Name: "read_file"},
+				}},
+			}},
+		}
+		remapBetaRequestToolNames(req)
+		assert.Equal(t, "ReadFile", req.Messages[0].Content[0].OfToolUse.Name)
+	})
+
+	t.Run("history name absent from the plan is untouched", func(t *testing.T) {
+		req := &anthropic.BetaMessageNewParams{
+			Tools: []anthropic.BetaToolUnionParam{betaTool("read_file")},
+			Messages: []anthropic.BetaMessageParam{{
+				Role: anthropic.BetaMessageParamRoleAssistant,
+				Content: []anthropic.BetaContentBlockParamUnion{{
+					OfToolUse: &anthropic.BetaToolUseBlockParam{ID: "toolu_1", Name: "retired_tool"},
+				}},
+			}},
+		}
+		remapBetaRequestToolNames(req)
+		assert.Equal(t, "retired_tool", req.Messages[0].Content[0].OfToolUse.Name)
+	})
+
+	t.Run("non tool_use blocks are inert", func(t *testing.T) {
+		req := &anthropic.BetaMessageNewParams{
+			Tools: []anthropic.BetaToolUnionParam{betaTool("read_file")},
+			Messages: []anthropic.BetaMessageParam{
+				anthropic.NewBetaUserMessage(anthropic.NewBetaTextBlock("hi")),
+			},
+		}
+		require.NotPanics(t, func() { remapBetaRequestToolNames(req) })
+		assert.Equal(t, "hi", req.Messages[0].Content[0].OfText.Text)
+	})
+}
+
+// TestRemapRequestToolNames_MCPToolsSurviveEndToEnd pins the whole request
+// shape for a mixed Hermes-style toolset: MCP names pass through untouched,
+// bare names fold, and every site agrees.
+func TestRemapRequestToolNames_MixedMCPAndBareTools(t *testing.T) {
+	req := &anthropic.MessageNewParams{
+		Tools: []anthropic.ToolUnionParam{
+			v1Tool("mcp__github__get_pull_request"),
+			v1Tool("tingly_box_mcp__webtools__mcp_web_search"),
+			v1Tool("read_file"),
+			v1Tool("ls"),
+		},
+		ToolChoice: anthropic.ToolChoiceParamOfTool("mcp__github__get_pull_request"),
+		Messages: []anthropic.MessageParam{{
+			Role: anthropic.MessageParamRoleAssistant,
+			Content: []anthropic.ContentBlockParamUnion{
+				{OfToolUse: &anthropic.ToolUseBlockParam{ID: "t1", Name: "read_file"}},
+				{OfToolUse: &anthropic.ToolUseBlockParam{ID: "t2", Name: "mcp__github__get_pull_request"}},
+			},
+		}},
+	}
+	rev := remapRequestToolNames(req)
+
+	assert.Equal(t, "mcp__github__get_pull_request", req.Tools[0].OfTool.Name)
+	assert.Equal(t, "tingly_box_mcp__webtools__mcp_web_search", req.Tools[1].OfTool.Name)
+	assert.Equal(t, "ReadFile", req.Tools[2].OfTool.Name)
+	assert.Equal(t, "LS", req.Tools[3].OfTool.Name)
+
+	assert.Equal(t, "mcp__github__get_pull_request", req.ToolChoice.OfTool.Name)
+	assert.Equal(t, "ReadFile", req.Messages[0].Content[0].OfToolUse.Name)
+	assert.Equal(t, "mcp__github__get_pull_request", req.Messages[0].Content[1].OfToolUse.Name)
+
+	// Only the folded names need restoring on the way back.
+	assert.Equal(t, map[string]string{"ReadFile": "read_file", "LS": "ls"}, rev)
+}
+
 // sseLine builds one SSE event frame.
 func sseLine(event string, payload any) string {
 	b, _ := json.Marshal(payload)
 	return "event: " + event + "\ndata: " + string(b) + "\n\n"
 }
-
 func TestSSEToolNameRewriter(t *testing.T) {
 	reverse := map[string]string{"ReadFile": "read_file"}
 

--- a/internal/client/claude_tool_names_test.go
+++ b/internal/client/claude_tool_names_test.go
@@ -32,19 +32,51 @@ func TestTitleCaseToolName(t *testing.T) {
 	}
 }
 
-func TestClaudeCodeToolName_MapWinsOverMechanical(t *testing.T) {
-	// The official spelling must win: mechanical folding would give "Ls".
-	assert.Equal(t, "LS", claudeCodeToolName("ls"))
-	assert.Equal(t, "TodoWrite", claudeCodeToolName("todowrite"))
-	assert.Equal(t, "NotebookEdit", claudeCodeToolName("notebookedit"))
-	// Not in the map — mechanical fold.
-	assert.Equal(t, "SearchFiles", claudeCodeToolName("search_files"))
+func TestClaudeCodeToolName(t *testing.T) {
+	t.Run("map wins over mechanical fold", func(t *testing.T) {
+		// The official spelling must win: mechanical folding would give "Ls".
+		assert.Equal(t, "LS", claudeCodeToolName("ls"))
+		assert.Equal(t, "TodoWrite", claudeCodeToolName("todowrite"))
+		assert.Equal(t, "NotebookEdit", claudeCodeToolName("notebookedit"))
+	})
+
+	t.Run("MCP-namespaced names pass through verbatim", func(t *testing.T) {
+		// Claude Code sends MCP tools as mcp__<server>__<tool> — lowercase,
+		// unfolded — and Tingly-Box's own server tools follow the same
+		// convention (internal/tool.NormalizeToolName).
+		for _, name := range []string{
+			"mcp__github__get_pull_request",
+			"mcp__linear__create_issue",
+			"mcp__read_file",
+			"tingly_box_mcp__webtools__mcp_web_search",
+			"tingly_box_mcp__brave-search__brave_web_search",
+		} {
+			assert.Equal(t, name, claudeCodeToolName(name), "claudeCodeToolName(%q)", name)
+		}
+	})
+
+	t.Run("single-underscore mcp_ is not a namespace and folds", func(t *testing.T) {
+		assert.Equal(t, "McpFooBar", claudeCodeToolName("mcp_foo_bar"))
+		assert.Equal(t, "McpLinearGetIssue", claudeCodeToolName("mcp_linear_get_issue"))
+		assert.Equal(t, "Mcp", claudeCodeToolName("mcp_"))
+	})
+
+	t.Run("unknown names fold mechanically", func(t *testing.T) {
+		assert.Equal(t, "SearchFiles", claudeCodeToolName("search_files"))
+	})
 }
 
-func TestPlanToolRenames_SkipsCollisions(t *testing.T) {
+func TestPlanToolRenames(t *testing.T) {
+	t.Run("independent names all rename", func(t *testing.T) {
+		plan := planToolRenames([]string{"read_file", "write_file"})
+		assert.Equal(t, map[string]string{
+			"read_file":  "ReadFile",
+			"write_file": "WriteFile",
+		}, plan)
+	})
+
 	t.Run("target already taken by another tool", func(t *testing.T) {
-		plan := planToolRenames([]string{"my_tool", "MyTool"})
-		assert.Empty(t, plan)
+		assert.Empty(t, planToolRenames([]string{"my_tool", "MyTool"}))
 	})
 
 	t.Run("two sources folding to the same target", func(t *testing.T) {
@@ -54,80 +86,53 @@ func TestPlanToolRenames_SkipsCollisions(t *testing.T) {
 		assert.Equal(t, "FooBar", plan["foo_bar"])
 	})
 
-	t.Run("independent names all rename", func(t *testing.T) {
-		plan := planToolRenames([]string{"read_file", "write_file"})
-		assert.Equal(t, map[string]string{
-			"read_file":  "ReadFile",
-			"write_file": "WriteFile",
-		}, plan)
+	t.Run("MCP-namespaced names are excluded from the plan", func(t *testing.T) {
+		plan := planToolRenames([]string{
+			"mcp__github__get_pull_request",
+			"tingly_box_mcp__webtools__mcp_web_search",
+			"read_file",
+		})
+		assert.Equal(t, map[string]string{"read_file": "ReadFile"}, plan)
 	})
 }
-
-// ===================================================================
-// MCP-namespaced tool names
-//
-// Claude Code sends MCP tools verbatim as mcp__<server>__<tool> — lowercase,
-// unfolded — so folding them would move the request *away* from real Claude
-// Code traffic, not towards it. Tingly-Box's own server tools use the same
-// double-underscore convention via internal/tool.NormalizeToolName.
-// ===================================================================
-
-func TestClaudeCodeToolName_LeavesMCPNamespacedNamesAlone(t *testing.T) {
-	// Real shapes: what an MCP client actually puts on the wire.
-	for _, name := range []string{
-		"mcp__github__get_pull_request",
-		"mcp__linear__create_issue",
-		"mcp__read_file",
-		"tingly_box_mcp__webtools__mcp_web_search",
-		"tingly_box_mcp__advisor__advisor",
-		"tingly_box_mcp__brave-search__brave_web_search",
-		"tingly_box_mcp__DICOM__view-dicom",
-	} {
-		assert.Equal(t, name, claudeCodeToolName(name), "claudeCodeToolName(%q) must pass through", name)
-	}
-}
-
-func TestClaudeCodeToolName_FoldsSingleUnderscoreMcpNames(t *testing.T) {
-	// A single-underscore "mcp_" prefix is not an MCP namespace — it is itself
-	// a third-party marker. Fold it like any other snake_case name rather than
-	// half-folding it into a shape no client emits.
-	assert.Equal(t, "McpFooBar", claudeCodeToolName("mcp_foo_bar"))
-	assert.Equal(t, "McpLinearGetIssue", claudeCodeToolName("mcp_linear_get_issue"))
-	assert.Equal(t, "Mcp", claudeCodeToolName("mcp_"))
-}
-
-func TestPlanToolRenames_ExcludesMCPNamespacedNames(t *testing.T) {
-	plan := planToolRenames([]string{
-		"mcp__github__get_pull_request",
-		"tingly_box_mcp__webtools__mcp_web_search",
-		"read_file",
-	})
-	assert.Equal(t, map[string]string{"read_file": "ReadFile"}, plan)
-}
-
-// ===================================================================
-// tool_choice must follow the same rename plan as tools
-// ===================================================================
 
 func v1Tool(name string) anthropic.ToolUnionParam {
 	return anthropic.ToolUnionParam{OfTool: &anthropic.ToolParam{Name: name}}
 }
 
-func betaTool(name string) anthropic.BetaToolUnionParam {
-	return anthropic.BetaToolUnionParam{OfTool: &anthropic.BetaToolParam{Name: name}}
-}
-
-func TestRemapRequestToolNames_RemapsToolChoice(t *testing.T) {
-	t.Run("pinned tool follows the fold", func(t *testing.T) {
+// TestRemapRequestToolNames covers the whole plan-application step against the
+// v1 request type: tools[], tool_choice, and prior-turn tool_use blocks must
+// all agree. The Beta twin is exercised end-to-end on the wire
+// (TestWire_BetaStreaming_RenamesEverySiteAndRestoresTheStream), so only a
+// smoke test of it lives here.
+func TestRemapRequestToolNames(t *testing.T) {
+	t.Run("every site follows one plan", func(t *testing.T) {
 		req := &anthropic.MessageNewParams{
-			Tools:      []anthropic.ToolUnionParam{v1Tool("read_file")},
+			Tools: []anthropic.ToolUnionParam{
+				v1Tool("read_file"),
+				v1Tool("mcp__github__get_pull_request"),
+				v1Tool("ls"),
+			},
 			ToolChoice: anthropic.ToolChoiceParamOfTool("read_file"),
+			Messages: []anthropic.MessageParam{{
+				Role: anthropic.MessageParamRoleAssistant,
+				Content: []anthropic.ContentBlockParamUnion{
+					{OfToolUse: &anthropic.ToolUseBlockParam{ID: "t1", Name: "read_file"}},
+					{OfToolUse: &anthropic.ToolUseBlockParam{ID: "t2", Name: "retired_tool"}},
+				},
+			}},
 		}
 		rev := remapRequestToolNames(req)
+
 		assert.Equal(t, "ReadFile", req.Tools[0].OfTool.Name)
+		assert.Equal(t, "mcp__github__get_pull_request", req.Tools[1].OfTool.Name)
+		assert.Equal(t, "LS", req.Tools[2].OfTool.Name)
 		assert.Equal(t, "ReadFile", req.ToolChoice.OfTool.Name,
 			"tool_choice must name a tool that exists in tools[]")
-		assert.Equal(t, map[string]string{"ReadFile": "read_file"}, rev)
+		assert.Equal(t, "ReadFile", req.Messages[0].Content[0].OfToolUse.Name)
+		// History names absent from the plan are untouched.
+		assert.Equal(t, "retired_tool", req.Messages[0].Content[1].OfToolUse.Name)
+		assert.Equal(t, map[string]string{"ReadFile": "read_file", "LS": "ls"}, rev)
 	})
 
 	t.Run("pin follows the plan, not an independent fold", func(t *testing.T) {
@@ -143,188 +148,25 @@ func TestRemapRequestToolNames_RemapsToolChoice(t *testing.T) {
 		assert.Equal(t, "my_tool", req.ToolChoice.OfTool.Name)
 	})
 
-	t.Run("pin naming a tool absent from tools is untouched", func(t *testing.T) {
+	t.Run("skips built-in tools and non-tool tool_choice", func(t *testing.T) {
 		req := &anthropic.MessageNewParams{
-			Tools:      []anthropic.ToolUnionParam{v1Tool("read_file")},
-			ToolChoice: anthropic.ToolChoiceParamOfTool("not_declared"),
-		}
-		remapRequestToolNames(req)
-		assert.Equal(t, "not_declared", req.ToolChoice.OfTool.Name)
-	})
-
-	t.Run("non-tool tool_choice variants are inert", func(t *testing.T) {
-		req := &anthropic.MessageNewParams{
-			Tools:      []anthropic.ToolUnionParam{v1Tool("read_file")},
+			Tools:      []anthropic.ToolUnionParam{{OfBashTool20250124: &anthropic.ToolBash20250124Param{}}},
 			ToolChoice: anthropic.ToolChoiceUnionParam{OfAuto: &anthropic.ToolChoiceAutoParam{}},
 		}
 		require.NotPanics(t, func() { remapRequestToolNames(req) })
-		assert.Nil(t, req.ToolChoice.OfTool)
-		assert.NotNil(t, req.ToolChoice.OfAuto)
+		assert.Nil(t, remapRequestToolNames(nil))
 	})
 }
 
-func TestRemapBetaRequestToolNames_RemapsToolChoice(t *testing.T) {
-	t.Run("pinned tool follows the fold", func(t *testing.T) {
-		req := &anthropic.BetaMessageNewParams{
-			Tools:      []anthropic.BetaToolUnionParam{betaTool("read_file")},
-			ToolChoice: anthropic.BetaToolChoiceParamOfTool("read_file"),
-		}
-		rev := remapBetaRequestToolNames(req)
-		assert.Equal(t, "ReadFile", req.Tools[0].OfTool.Name)
-		assert.Equal(t, "ReadFile", req.ToolChoice.OfTool.Name)
-		assert.Equal(t, map[string]string{"ReadFile": "read_file"}, rev)
-	})
-
-	t.Run("pin follows the plan, not an independent fold", func(t *testing.T) {
-		req := &anthropic.BetaMessageNewParams{
-			Tools:      []anthropic.BetaToolUnionParam{betaTool("my_tool"), betaTool("MyTool")},
-			ToolChoice: anthropic.BetaToolChoiceParamOfTool("my_tool"),
-		}
-		rev := remapBetaRequestToolNames(req)
-		assert.Empty(t, rev)
-		assert.Equal(t, "my_tool", req.ToolChoice.OfTool.Name)
-	})
-
-	t.Run("pin naming a tool absent from tools is untouched", func(t *testing.T) {
-		req := &anthropic.BetaMessageNewParams{
-			Tools:      []anthropic.BetaToolUnionParam{betaTool("read_file")},
-			ToolChoice: anthropic.BetaToolChoiceParamOfTool("not_declared"),
-		}
-		remapBetaRequestToolNames(req)
-		assert.Equal(t, "not_declared", req.ToolChoice.OfTool.Name)
-	})
-
-	t.Run("non-tool tool_choice variants are inert", func(t *testing.T) {
-		req := &anthropic.BetaMessageNewParams{
-			Tools:      []anthropic.BetaToolUnionParam{betaTool("read_file")},
-			ToolChoice: anthropic.BetaToolChoiceUnionParam{OfAuto: &anthropic.BetaToolChoiceAutoParam{}},
-		}
-		require.NotPanics(t, func() { remapBetaRequestToolNames(req) })
-		assert.Nil(t, req.ToolChoice.OfTool)
-		assert.NotNil(t, req.ToolChoice.OfAuto)
-	})
-}
-
-// ===================================================================
-// tool_use blocks in prior turns must agree with tools[]
-// ===================================================================
-
-func TestRemapRequestToolNames_RemapsHistoricalToolUse(t *testing.T) {
-	t.Run("prior tool_use follows the fold", func(t *testing.T) {
-		req := &anthropic.MessageNewParams{
-			Tools: []anthropic.ToolUnionParam{v1Tool("read_file")},
-			Messages: []anthropic.MessageParam{{
-				Role: anthropic.MessageParamRoleAssistant,
-				Content: []anthropic.ContentBlockParamUnion{{
-					OfToolUse: &anthropic.ToolUseBlockParam{ID: "toolu_1", Name: "read_file"},
-				}},
-			}},
-		}
-		remapRequestToolNames(req)
-		assert.Equal(t, "ReadFile", req.Messages[0].Content[0].OfToolUse.Name,
-			"history must not keep the snake_case name the tools[] fold removed")
-	})
-
-	t.Run("history name absent from the plan is untouched", func(t *testing.T) {
-		req := &anthropic.MessageNewParams{
-			Tools: []anthropic.ToolUnionParam{v1Tool("read_file")},
-			Messages: []anthropic.MessageParam{{
-				Role: anthropic.MessageParamRoleAssistant,
-				Content: []anthropic.ContentBlockParamUnion{{
-					OfToolUse: &anthropic.ToolUseBlockParam{ID: "toolu_1", Name: "retired_tool"},
-				}},
-			}},
-		}
-		remapRequestToolNames(req)
-		assert.Equal(t, "retired_tool", req.Messages[0].Content[0].OfToolUse.Name)
-	})
-
-	t.Run("non tool_use blocks are inert", func(t *testing.T) {
-		req := &anthropic.MessageNewParams{
-			Tools: []anthropic.ToolUnionParam{v1Tool("read_file")},
-			Messages: []anthropic.MessageParam{
-				anthropic.NewUserMessage(anthropic.NewTextBlock("hi")),
-			},
-		}
-		require.NotPanics(t, func() { remapRequestToolNames(req) })
-		assert.Equal(t, "hi", req.Messages[0].Content[0].OfText.Text)
-	})
-}
-
-func TestRemapBetaRequestToolNames_RemapsHistoricalToolUse(t *testing.T) {
-	t.Run("prior tool_use follows the fold", func(t *testing.T) {
-		req := &anthropic.BetaMessageNewParams{
-			Tools: []anthropic.BetaToolUnionParam{betaTool("read_file")},
-			Messages: []anthropic.BetaMessageParam{{
-				Role: anthropic.BetaMessageParamRoleAssistant,
-				Content: []anthropic.BetaContentBlockParamUnion{{
-					OfToolUse: &anthropic.BetaToolUseBlockParam{ID: "toolu_1", Name: "read_file"},
-				}},
-			}},
-		}
-		remapBetaRequestToolNames(req)
-		assert.Equal(t, "ReadFile", req.Messages[0].Content[0].OfToolUse.Name)
-	})
-
-	t.Run("history name absent from the plan is untouched", func(t *testing.T) {
-		req := &anthropic.BetaMessageNewParams{
-			Tools: []anthropic.BetaToolUnionParam{betaTool("read_file")},
-			Messages: []anthropic.BetaMessageParam{{
-				Role: anthropic.BetaMessageParamRoleAssistant,
-				Content: []anthropic.BetaContentBlockParamUnion{{
-					OfToolUse: &anthropic.BetaToolUseBlockParam{ID: "toolu_1", Name: "retired_tool"},
-				}},
-			}},
-		}
-		remapBetaRequestToolNames(req)
-		assert.Equal(t, "retired_tool", req.Messages[0].Content[0].OfToolUse.Name)
-	})
-
-	t.Run("non tool_use blocks are inert", func(t *testing.T) {
-		req := &anthropic.BetaMessageNewParams{
-			Tools: []anthropic.BetaToolUnionParam{betaTool("read_file")},
-			Messages: []anthropic.BetaMessageParam{
-				anthropic.NewBetaUserMessage(anthropic.NewBetaTextBlock("hi")),
-			},
-		}
-		require.NotPanics(t, func() { remapBetaRequestToolNames(req) })
-		assert.Equal(t, "hi", req.Messages[0].Content[0].OfText.Text)
-	})
-}
-
-// TestRemapRequestToolNames_MCPToolsSurviveEndToEnd pins the whole request
-// shape for a mixed Hermes-style toolset: MCP names pass through untouched,
-// bare names fold, and every site agrees.
-func TestRemapRequestToolNames_MixedMCPAndBareTools(t *testing.T) {
-	req := &anthropic.MessageNewParams{
-		Tools: []anthropic.ToolUnionParam{
-			v1Tool("mcp__github__get_pull_request"),
-			v1Tool("tingly_box_mcp__webtools__mcp_web_search"),
-			v1Tool("read_file"),
-			v1Tool("ls"),
-		},
-		ToolChoice: anthropic.ToolChoiceParamOfTool("mcp__github__get_pull_request"),
-		Messages: []anthropic.MessageParam{{
-			Role: anthropic.MessageParamRoleAssistant,
-			Content: []anthropic.ContentBlockParamUnion{
-				{OfToolUse: &anthropic.ToolUseBlockParam{ID: "t1", Name: "read_file"}},
-				{OfToolUse: &anthropic.ToolUseBlockParam{ID: "t2", Name: "mcp__github__get_pull_request"}},
-			},
-		}},
+func TestRemapBetaRequestToolNames_Smoke(t *testing.T) {
+	req := &anthropic.BetaMessageNewParams{
+		Tools:      []anthropic.BetaToolUnionParam{{OfTool: &anthropic.BetaToolParam{Name: "bash"}}},
+		ToolChoice: anthropic.BetaToolChoiceParamOfTool("bash"),
 	}
-	rev := remapRequestToolNames(req)
-
-	assert.Equal(t, "mcp__github__get_pull_request", req.Tools[0].OfTool.Name)
-	assert.Equal(t, "tingly_box_mcp__webtools__mcp_web_search", req.Tools[1].OfTool.Name)
-	assert.Equal(t, "ReadFile", req.Tools[2].OfTool.Name)
-	assert.Equal(t, "LS", req.Tools[3].OfTool.Name)
-
-	assert.Equal(t, "mcp__github__get_pull_request", req.ToolChoice.OfTool.Name)
-	assert.Equal(t, "ReadFile", req.Messages[0].Content[0].OfToolUse.Name)
-	assert.Equal(t, "mcp__github__get_pull_request", req.Messages[0].Content[1].OfToolUse.Name)
-
-	// Only the folded names need restoring on the way back.
-	assert.Equal(t, map[string]string{"ReadFile": "read_file", "LS": "ls"}, rev)
+	rev := remapBetaRequestToolNames(req)
+	assert.Equal(t, "Bash", req.Tools[0].OfTool.Name)
+	assert.Equal(t, "Bash", req.ToolChoice.OfTool.Name)
+	assert.Equal(t, map[string]string{"Bash": "bash"}, rev)
 }
 
 // sseLine builds one SSE event frame.
@@ -332,61 +174,25 @@ func sseLine(event string, payload any) string {
 	b, _ := json.Marshal(payload)
 	return "event: " + event + "\ndata: " + string(b) + "\n\n"
 }
+
 func TestSSEToolNameRewriter(t *testing.T) {
 	reverse := map[string]string{"ReadFile": "read_file"}
 
-	t.Run("rewrites tool_use name in content_block_start", func(t *testing.T) {
-		body := sseLine("content_block_start", map[string]any{
-			"type":  "content_block_start",
-			"index": 0,
-			"content_block": map[string]any{
-				"type":  "tool_use",
-				"id":    "toolu_1",
-				"name":  "ReadFile",
-				"input": map[string]any{},
-			},
-		})
-		out := readAll(t, body, reverse)
-		assert.Contains(t, out, `"name":"read_file"`)
-		assert.NotContains(t, out, "ReadFile")
-		// Framing preserved.
-		assert.True(t, strings.HasPrefix(out, "event: content_block_start\ndata: "))
-		assert.True(t, strings.HasSuffix(out, "\n\n"))
-	})
-
-	t.Run("passes through unrelated events byte-for-byte", func(t *testing.T) {
-		body := sseLine("content_block_delta", map[string]any{
-			"type":  "content_block_delta",
-			"delta": map[string]any{"type": "input_json_delta", "partial_json": `{"path":`},
-		}) + sseLine("message_stop", map[string]any{"type": "message_stop"})
-		assert.Equal(t, body, readAll(t, body, reverse))
-	})
-
-	t.Run("leaves names absent from the reverse map alone", func(t *testing.T) {
-		body := sseLine("content_block_start", map[string]any{
-			"type": "content_block_start",
-			"content_block": map[string]any{
-				"type": "tool_use", "id": "toolu_2", "name": "SomethingElse",
-			},
-		})
-		assert.Equal(t, body, readAll(t, body, reverse))
-	})
-
-	t.Run("text content_block_start untouched", func(t *testing.T) {
-		body := sseLine("content_block_start", map[string]any{
-			"type":          "content_block_start",
-			"content_block": map[string]any{"type": "text", "text": ""},
-		})
-		assert.Equal(t, body, readAll(t, body, reverse))
-	})
-
-	t.Run("handles a multi-event stream and tiny reads", func(t *testing.T) {
+	t.Run("rewrites tool_use name in content_block_start only", func(t *testing.T) {
 		body := sseLine("message_start", map[string]any{"type": "message_start"}) +
 			sseLine("content_block_start", map[string]any{
-				"type": "content_block_start",
+				"type":  "content_block_start",
+				"index": 0,
 				"content_block": map[string]any{
-					"type": "tool_use", "id": "toolu_3", "name": "ReadFile",
+					"type":  "tool_use",
+					"id":    "toolu_1",
+					"name":  "ReadFile",
+					"input": map[string]any{},
 				},
+			}) +
+			sseLine("content_block_delta", map[string]any{
+				"type":  "content_block_delta",
+				"delta": map[string]any{"type": "input_json_delta", "partial_json": `{"path":`},
 			}) +
 			sseLine("message_stop", map[string]any{"type": "message_stop"})
 
@@ -403,23 +209,36 @@ func TestSSEToolNameRewriter(t *testing.T) {
 		}
 		out := sb.String()
 		assert.Contains(t, out, `"name":"read_file"`)
-		assert.Contains(t, out, "message_start")
-		assert.Contains(t, out, "message_stop")
+		assert.NotContains(t, out, "ReadFile")
+		// Non-tool events pass through, framing intact.
+		assert.Contains(t, out, `"type":"message_start"`)
+		assert.Contains(t, out, `"type":"message_stop"`)
 	})
 
-	t.Run("malformed json passes through", func(t *testing.T) {
-		body := "data: {\"type\":\"content_block_start\",\"tool_use\" BROKEN\n\n"
-		assert.Equal(t, body, readAll(t, body, reverse))
-	})
-
-	t.Run("empty reverse map is inert", func(t *testing.T) {
-		body := sseLine("content_block_start", map[string]any{
-			"type": "content_block_start",
-			"content_block": map[string]any{
-				"type": "tool_use", "id": "toolu_4", "name": "ReadFile",
-			},
-		})
-		assert.Equal(t, body, readAll(t, body, map[string]string{}))
+	t.Run("passthrough cases", func(t *testing.T) {
+		cases := []string{
+			// Name absent from the reverse map.
+			sseLine("content_block_start", map[string]any{
+				"type":          "content_block_start",
+				"content_block": map[string]any{"type": "tool_use", "id": "t", "name": "SomethingElse"},
+			}),
+			// Text block, not tool_use.
+			sseLine("content_block_start", map[string]any{
+				"type":          "content_block_start",
+				"content_block": map[string]any{"type": "text", "text": ""},
+			}),
+			// Malformed JSON.
+			"data: {\"type\":\"content_block_start\",\"tool_use\" BROKEN\n\n",
+			// Empty reverse map is inert.
+			sseLine("content_block_start", map[string]any{
+				"type":          "content_block_start",
+				"content_block": map[string]any{"type": "tool_use", "id": "t", "name": "ReadFile"},
+			}),
+		}
+		for i, body := range cases[:3] {
+			assert.Equal(t, body, readAll(t, body, reverse), "case %d", i)
+		}
+		assert.Equal(t, cases[3], readAll(t, cases[3], map[string]string{}))
 	})
 }
 

--- a/internal/client/claude_tool_names_test.go
+++ b/internal/client/claude_tool_names_test.go
@@ -1,0 +1,167 @@
+package client
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTitleCaseToolName(t *testing.T) {
+	cases := map[string]string{
+		"read_file":     "ReadFile",
+		"ha_get_state":  "HaGetState",
+		"terminal":      "Terminal",
+		"browser_exec":  "BrowserExec",
+		"Bash":          "Bash", // already TitleCase
+		"WebFetch":      "WebFetch",
+		"":              "",
+		"mcp_foo_bar":   "mcp_Foo_bar", // prefix kept, only first char folded
+		"mcp_":          "mcp_",
+		"tool_2_thing":  "Tool2Thing",
+		"__weird__name": "WeirdName",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, titleCaseToolName(in), "titleCaseToolName(%q)", in)
+	}
+}
+
+func TestClaudeCodeToolName_MapWinsOverMechanical(t *testing.T) {
+	// The official spelling must win: mechanical folding would give "Ls".
+	assert.Equal(t, "LS", claudeCodeToolName("ls"))
+	assert.Equal(t, "TodoWrite", claudeCodeToolName("todowrite"))
+	assert.Equal(t, "NotebookEdit", claudeCodeToolName("notebookedit"))
+	// Not in the map — mechanical fold.
+	assert.Equal(t, "SearchFiles", claudeCodeToolName("search_files"))
+}
+
+func TestPlanToolRenames_SkipsCollisions(t *testing.T) {
+	t.Run("target already taken by another tool", func(t *testing.T) {
+		plan := planToolRenames([]string{"my_tool", "MyTool"})
+		assert.Empty(t, plan)
+	})
+
+	t.Run("two sources folding to the same target", func(t *testing.T) {
+		// "a_b" and "a__b" both fold to "AB"; only the first may rename.
+		plan := planToolRenames([]string{"a_b", "a__b"})
+		assert.Len(t, plan, 1)
+		assert.Equal(t, "AB", plan["a_b"])
+	})
+
+	t.Run("independent names all rename", func(t *testing.T) {
+		plan := planToolRenames([]string{"read_file", "write_file"})
+		assert.Equal(t, map[string]string{
+			"read_file":  "ReadFile",
+			"write_file": "WriteFile",
+		}, plan)
+	})
+}
+
+// sseLine builds one SSE event frame.
+func sseLine(event string, payload any) string {
+	b, _ := json.Marshal(payload)
+	return "event: " + event + "\ndata: " + string(b) + "\n\n"
+}
+
+func TestSSEToolNameRewriter(t *testing.T) {
+	reverse := map[string]string{"ReadFile": "read_file"}
+
+	t.Run("rewrites tool_use name in content_block_start", func(t *testing.T) {
+		body := sseLine("content_block_start", map[string]any{
+			"type":  "content_block_start",
+			"index": 0,
+			"content_block": map[string]any{
+				"type":  "tool_use",
+				"id":    "toolu_1",
+				"name":  "ReadFile",
+				"input": map[string]any{},
+			},
+		})
+		out := readAll(t, body, reverse)
+		assert.Contains(t, out, `"name":"read_file"`)
+		assert.NotContains(t, out, "ReadFile")
+		// Framing preserved.
+		assert.True(t, strings.HasPrefix(out, "event: content_block_start\ndata: "))
+		assert.True(t, strings.HasSuffix(out, "\n\n"))
+	})
+
+	t.Run("passes through unrelated events byte-for-byte", func(t *testing.T) {
+		body := sseLine("content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"delta": map[string]any{"type": "input_json_delta", "partial_json": `{"path":`},
+		}) + sseLine("message_stop", map[string]any{"type": "message_stop"})
+		assert.Equal(t, body, readAll(t, body, reverse))
+	})
+
+	t.Run("leaves names absent from the reverse map alone", func(t *testing.T) {
+		body := sseLine("content_block_start", map[string]any{
+			"type": "content_block_start",
+			"content_block": map[string]any{
+				"type": "tool_use", "id": "toolu_2", "name": "SomethingElse",
+			},
+		})
+		assert.Equal(t, body, readAll(t, body, reverse))
+	})
+
+	t.Run("text content_block_start untouched", func(t *testing.T) {
+		body := sseLine("content_block_start", map[string]any{
+			"type":          "content_block_start",
+			"content_block": map[string]any{"type": "text", "text": ""},
+		})
+		assert.Equal(t, body, readAll(t, body, reverse))
+	})
+
+	t.Run("handles a multi-event stream and tiny reads", func(t *testing.T) {
+		body := sseLine("message_start", map[string]any{"type": "message_start"}) +
+			sseLine("content_block_start", map[string]any{
+				"type": "content_block_start",
+				"content_block": map[string]any{
+					"type": "tool_use", "id": "toolu_3", "name": "ReadFile",
+				},
+			}) +
+			sseLine("message_stop", map[string]any{"type": "message_stop"})
+
+		r := newSSEToolNameRewriter(io.NopCloser(strings.NewReader(body)), reverse)
+		var sb strings.Builder
+		buf := make([]byte, 3) // force many partial reads
+		for {
+			n, err := r.Read(buf)
+			sb.Write(buf[:n])
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+		}
+		out := sb.String()
+		assert.Contains(t, out, `"name":"read_file"`)
+		assert.Contains(t, out, "message_start")
+		assert.Contains(t, out, "message_stop")
+	})
+
+	t.Run("malformed json passes through", func(t *testing.T) {
+		body := "data: {\"type\":\"content_block_start\",\"tool_use\" BROKEN\n\n"
+		assert.Equal(t, body, readAll(t, body, reverse))
+	})
+
+	t.Run("empty reverse map is inert", func(t *testing.T) {
+		body := sseLine("content_block_start", map[string]any{
+			"type": "content_block_start",
+			"content_block": map[string]any{
+				"type": "tool_use", "id": "toolu_4", "name": "ReadFile",
+			},
+		})
+		assert.Equal(t, body, readAll(t, body, map[string]string{}))
+	})
+}
+
+func readAll(t *testing.T, body string, reverse map[string]string) string {
+	t.Helper()
+	r := newSSEToolNameRewriter(io.NopCloser(strings.NewReader(body)), reverse)
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	return string(out)
+}

--- a/internal/client/claude_tool_names_wire_test.go
+++ b/internal/client/claude_tool_names_wire_test.go
@@ -1,0 +1,233 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/packages/param"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// These tests exercise the whole rename path against a real HTTP server: the
+// request body Anthropic would actually receive, and the stream the client
+// actually reads back. The unit tests cover each site in isolation; this is the
+// check that the plan reaches the wire and is undone on the way home.
+
+const wireMetadataUserID = `{"device_id":"dev1","account_uuid":"acc1","session_id":"550e8400-e29b-41d4-a716-446655440000"}`
+
+// betaToolUseStream is a minimal but well-formed Anthropic SSE stream whose one
+// content block is a tool_use naming the *renamed* tool.
+func betaToolUseStream(outboundName string) string {
+	blocks := []struct {
+		event   string
+		payload map[string]any
+	}{
+		{"message_start", map[string]any{"type": "message_start", "message": map[string]any{
+			"id": "msg_1", "type": "message", "role": "assistant",
+			"model": "claude-sonnet-4-6", "content": []any{},
+			"usage": map[string]any{"input_tokens": 1, "output_tokens": 1},
+		}}},
+		{"content_block_start", map[string]any{"type": "content_block_start", "index": 0,
+			"content_block": map[string]any{
+				"type": "tool_use", "id": "toolu_1", "name": outboundName, "input": map[string]any{},
+			}}},
+		{"content_block_stop", map[string]any{"type": "content_block_stop", "index": 0}},
+		{"message_delta", map[string]any{"type": "message_delta",
+			"delta": map[string]any{"stop_reason": "tool_use"},
+			"usage": map[string]any{"output_tokens": 5}}},
+		{"message_stop", map[string]any{"type": "message_stop"}},
+	}
+	out := ""
+	for _, b := range blocks {
+		out += sseLine(b.event, b.payload)
+	}
+	return out
+}
+
+// newWireServer serves the given SSE body and records the request body it saw.
+func newWireServer(t *testing.T, body string) (*httptest.Server, *[]byte) {
+	t.Helper()
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, body)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &captured
+}
+
+func newWireClient(t *testing.T, baseURL string) *ClaudeClient {
+	t.Helper()
+	provider := newOAuthProvider()
+	provider.APIBase = baseURL
+	c, err := NewClaudeClient(context.Background(), provider, "", typ.SessionID{Value: "s"})
+	require.NoError(t, err)
+	return c
+}
+
+// wireToolNames pulls tools[].name out of a serialized request body.
+func wireToolNames(t *testing.T, body []byte) []string {
+	t.Helper()
+	var parsed struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	names := make([]string, 0, len(parsed.Tools))
+	for _, tool := range parsed.Tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
+func TestWire_BetaStreaming_RenamesEverySiteAndRestoresTheStream(t *testing.T) {
+	srv, captured := newWireServer(t, betaToolUseStream("ReadFile"))
+	c := newWireClient(t, srv.URL)
+
+	req := &anthropic.BetaMessageNewParams{
+		Model:     anthropic.Model("claude-sonnet-4-6"),
+		MaxTokens: 512,
+		Tools: []anthropic.BetaToolUnionParam{
+			{OfTool: &anthropic.BetaToolParam{Name: "read_file"}},
+			{OfTool: &anthropic.BetaToolParam{Name: "mcp__github__get_pull_request"}},
+			{OfTool: &anthropic.BetaToolParam{Name: "tingly_box_mcp__webtools__mcp_web_search"}},
+		},
+		ToolChoice: anthropic.BetaToolChoiceParamOfTool("read_file"),
+		Messages: []anthropic.BetaMessageParam{
+			anthropic.NewBetaUserMessage(anthropic.NewBetaTextBlock("go")),
+			{
+				Role: anthropic.BetaMessageParamRoleAssistant,
+				Content: []anthropic.BetaContentBlockParamUnion{{
+					OfToolUse: &anthropic.BetaToolUseBlockParam{
+						ID: "toolu_0", Name: "read_file", Input: map[string]any{},
+					},
+				}},
+			},
+		},
+	}
+	req.Metadata.UserID = param.NewOpt(wireMetadataUserID)
+
+	stream := c.BetaMessagesNewStreaming(context.Background(), req)
+	var streamedToolName string
+	for stream.Next() {
+		if ev := stream.Current(); ev.Type == "content_block_start" {
+			streamedToolName = ev.ContentBlock.Name
+		}
+	}
+	require.NoError(t, stream.Err())
+	require.NotEmpty(t, *captured, "server never saw a request body")
+
+	body := string(*captured)
+
+	// tools[]: the bare name folds, both MCP namespaces pass through verbatim.
+	assert.Equal(t, []string{
+		"ReadFile",
+		"mcp__github__get_pull_request",
+		"tingly_box_mcp__webtools__mcp_web_search",
+	}, wireToolNames(t, *captured))
+
+	// tool_choice and the prior turn's tool_use agree with tools[].
+	assert.Contains(t, body, `"tool_choice":{"name":"ReadFile","type":"tool"}`)
+	assert.Contains(t, body, `"id":"toolu_0","input":{},"name":"ReadFile","type":"tool_use"`)
+
+	// The whole point: no snake_case spelling of the renamed tool survives
+	// anywhere in the outbound body.
+	assert.NotContains(t, body, "read_file")
+
+	// ...and the client still sees its own name coming back off the stream.
+	assert.Equal(t, "read_file", streamedToolName)
+}
+
+func TestWire_V1Streaming_RenamesEverySiteAndRestoresTheStream(t *testing.T) {
+	srv, captured := newWireServer(t, betaToolUseStream("ReadFile"))
+	c := newWireClient(t, srv.URL)
+
+	req := &anthropic.MessageNewParams{
+		Model:     anthropic.Model("claude-sonnet-4-6"),
+		MaxTokens: 512,
+		Tools: []anthropic.ToolUnionParam{
+			{OfTool: &anthropic.ToolParam{Name: "read_file"}},
+			{OfTool: &anthropic.ToolParam{Name: "mcp__github__get_pull_request"}},
+		},
+		ToolChoice: anthropic.ToolChoiceParamOfTool("read_file"),
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("go")),
+			{
+				Role: anthropic.MessageParamRoleAssistant,
+				Content: []anthropic.ContentBlockParamUnion{{
+					OfToolUse: &anthropic.ToolUseBlockParam{
+						ID: "toolu_0", Name: "read_file", Input: map[string]any{},
+					},
+				}},
+			},
+		},
+	}
+	req.Metadata.UserID = param.NewOpt(wireMetadataUserID)
+
+	stream := c.MessagesNewStreaming(context.Background(), req)
+	var streamedToolName string
+	for stream.Next() {
+		if ev := stream.Current(); ev.Type == "content_block_start" {
+			streamedToolName = ev.ContentBlock.Name
+		}
+	}
+	require.NoError(t, stream.Err())
+	require.NotEmpty(t, *captured, "server never saw a request body")
+
+	body := string(*captured)
+	assert.Equal(t, []string{"ReadFile", "mcp__github__get_pull_request"}, wireToolNames(t, *captured))
+	assert.Contains(t, body, `"tool_choice":{"name":"ReadFile","type":"tool"}`)
+	assert.Contains(t, body, `"id":"toolu_0","input":{},"name":"ReadFile","type":"tool_use"`)
+	assert.NotContains(t, body, "read_file")
+	assert.Equal(t, "read_file", streamedToolName)
+}
+
+// TestWire_MCPOnlyToolset_LeavesBodyUntouched pins the no-op case: a toolset
+// that is entirely MCP produces no rename plan at all, so no middleware is
+// attached and the body goes out exactly as the client wrote it.
+func TestWire_MCPOnlyToolset_LeavesBodyUntouched(t *testing.T) {
+	srv, captured := newWireServer(t, betaToolUseStream("mcp__github__get_pull_request"))
+	c := newWireClient(t, srv.URL)
+
+	names := []string{
+		"mcp__github__get_pull_request",
+		"mcp__linear__create_issue",
+		"tingly_box_mcp__advisor__advisor",
+	}
+	tools := make([]anthropic.BetaToolUnionParam, 0, len(names))
+	for _, n := range names {
+		tools = append(tools, anthropic.BetaToolUnionParam{OfTool: &anthropic.BetaToolParam{Name: n}})
+	}
+	req := &anthropic.BetaMessageNewParams{
+		Model:     anthropic.Model("claude-sonnet-4-6"),
+		MaxTokens: 512,
+		Tools:     tools,
+		Messages:  []anthropic.BetaMessageParam{anthropic.NewBetaUserMessage(anthropic.NewBetaTextBlock("go"))},
+	}
+	req.Metadata.UserID = param.NewOpt(wireMetadataUserID)
+
+	stream := c.BetaMessagesNewStreaming(context.Background(), req)
+	var streamedToolName string
+	for stream.Next() {
+		if ev := stream.Current(); ev.Type == "content_block_start" {
+			streamedToolName = ev.ContentBlock.Name
+		}
+	}
+	require.NoError(t, stream.Err())
+
+	assert.Equal(t, names, wireToolNames(t, *captured))
+	assert.Equal(t, "mcp__github__get_pull_request", streamedToolName)
+}

--- a/internal/client/claude_tool_names_wire_test.go
+++ b/internal/client/claude_tool_names_wire_test.go
@@ -151,6 +151,8 @@ func TestWire_BetaStreaming_RenamesEverySiteAndRestoresTheStream(t *testing.T) {
 	assert.Equal(t, "read_file", streamedToolName)
 }
 
+// TestWire_V1Streaming_RenamesEverySiteAndRestoresTheStream is the v1 twin of
+// the Beta wire test, kept compact: the full assertion set runs once above.
 func TestWire_V1Streaming_RenamesEverySiteAndRestoresTheStream(t *testing.T) {
 	srv, captured := newWireServer(t, betaToolUseStream("ReadFile"))
 	c := newWireClient(t, srv.URL)
@@ -185,7 +187,6 @@ func TestWire_V1Streaming_RenamesEverySiteAndRestoresTheStream(t *testing.T) {
 		}
 	}
 	require.NoError(t, stream.Err())
-	require.NotEmpty(t, *captured, "server never saw a request body")
 
 	body := string(*captured)
 	assert.Equal(t, []string{"ReadFile", "mcp__github__get_pull_request"}, wireToolNames(t, *captured))


### PR DESCRIPTION
## Summary

Anthropic's OAuth path rejects requests carrying many snake_case tool names and bills them to Extra Usage rather than the subscription. Renaming only the fourteen tools in the known-name map left any client with a toolset of its own failing with `You're out of extra usage`.

## Key Changes

- **Subscription billing on OAuth**: every custom tool name folds to TitleCase, not only the fourteen known ones, so large toolsets stay on the subscription quota.
- **Streaming tool dispatch**: `MessagesNewStreaming` discarded the reverse map, so renamed tools returned TitleCased and callers could not match them; the rename is now undone on the wire.
- **Rename collisions**: a fold that would collide with another tool in the same request is skipped, leaving both names untouched.
- **`tool_choice` / history consistency** (added after review): a pinned tool and prior-turn `tool_use` blocks now follow the same rename plan as `tools[]`, instead of keeping their original name and desyncing from it.
- **MCP tool names** (added after review): `mcp__<server>__<tool>` and Tingly-Box's own `tingly_box_mcp__<source>__<tool>` are now left untouched end-to-end, matching what Claude Code actually sends.

## Notes

- Threshold measured against `api.anthropic.com`: sixteen snake_case names are rejected, fifteen accepted, twenty-nine TitleCased accepted.
- It is a casing heuristic, not an allowlist — an unknown `BrowserExec` passes.
