### PR TITLE
build(docker): make the source image buildable and fork-pushable

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -50,7 +50,7 @@ runs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ inputs.registry }}/tingly-dev/${{ inputs.image_name }}
+        images: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}
         tags: |
           type=raw,value=${{ inputs.version }}
           type=raw,value=latest
@@ -76,11 +76,11 @@ runs:
         ## Docker Image Published :rocket:
 
         **Tag:** `${{ inputs.version }}`
-        **Image:** `${{ inputs.registry }}/tingly-dev/${{ inputs.image_name }}:${{ inputs.version }}`
+        **Image:** `${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}:${{ inputs.version }}`
 
         ### Pull Command
         ```bash
-        docker pull ${{ inputs.registry }}/tingly-dev/${{ inputs.image_name }}:${{ inputs.version }}
+        docker pull ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}:${{ inputs.version }}
         ```
 
         ### Run Command
@@ -90,6 +90,6 @@ runs:
           --name tingly-box \
           -p 12580:12580 \
           -v `pwd`/tingly-data:/app/.tingly-box \
-          ${{ inputs.registry }}/tingly-dev/${{ inputs.image_name }}:${{ inputs.version }}
+          ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}:${{ inputs.version }}
         ```
         EOF

--- a/.github/workflows/docker-source.yml
+++ b/.github/workflows/docker-source.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: 'linux/amd64'
         type: string
+      dockerfile:
+        description: 'Dockerfile to build from'
+        required: false
+        default: './build/docker/docker.build.Dockerfile'
+        type: string
 
 env: {}
 
@@ -55,6 +60,6 @@ jobs:
         with:
           image_name: tingly-box
           version: ${{ github.event.inputs.image_tag }}
-          dockerfile: ./build/docker/docker.build.Dockerfile
+          dockerfile: ${{ github.event.inputs.dockerfile }}
           platforms: ${{ github.event.inputs.platforms }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-source.yml
+++ b/.github/workflows/docker-source.yml
@@ -1,0 +1,60 @@
+name: Docker Source Image Build and Push
+
+# Builds the image from the checked-out source via
+# build/docker/docker.build.Dockerfile, rather than repackaging a published
+# npm release the way docker-npx.yml does. Dispatch this against the ref you
+# want built, so a branch's own changes actually reach the image.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Tag for the image (e.g. patched, v1.2.3-rc1)'
+        required: false
+        default: 'source'
+        type: string
+      platforms:
+        description: 'Target platforms (e.g. linux/amd64, linux/arm64)'
+        required: false
+        default: 'linux/amd64'
+        type: string
+
+env: {}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # The SDK forks are submodules wired in through local `replace`
+          # directives. Without them the Dockerfile's fallback clones each
+          # fork's branch HEAD instead of the pinned commit, so the image
+          # would be built against SDK code this ref was never tested on.
+          submodules: recursive
+
+      # image_tag reaches a run: block through the composite action's step
+      # summary. Dispatch is limited to write-access users, but docker-npx.yml
+      # validates its tag for the same reason and this one should too.
+      - name: Validate image tag
+        env:
+          IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+        run: |
+          if ! printf '%s' "$IMAGE_TAG" | grep -qE '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$'; then
+            echo "Invalid image tag: must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$" >&2
+            exit 1
+          fi
+
+      - name: Build and push Docker image
+        uses: ./.github/actions/docker-build-push
+        with:
+          image_name: tingly-box
+          version: ${{ github.event.inputs.image_tag }}
+          dockerfile: ./build/docker/docker.build.Dockerfile
+          platforms: ${{ github.event.inputs.platforms }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/build/docker/docker.build.Dockerfile
+++ b/build/docker/docker.build.Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage build for Tingly Box
 # Stage 1: Build
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Install git, nodejs, npm, pnpm, gcc (for CGO), and other build dependencies
 RUN apk add --no-cache git nodejs npm ca-certificates tzdata curl jq gcc musl-dev
@@ -38,6 +38,19 @@ RUN if [ ! -f libs/go-genai/go.mod ]; then \
 
 # Download dependencies (must be after source copy due to local replace directive)
 RUN go mod download
+
+# Build the web UI before the binary. internal/server/webui_handler.go serves
+# the dashboard from the embedded internal/web/dist; without this step the
+# binary compiles fine and then returns HTTP 500 for every UI route.
+# Mirrors Taskfile's web:build, minus the swagger regeneration — openapi.json
+# is committed, so gen:api needs no Go tooling.
+RUN cd frontend && \
+    pnpm install --no-frozen-lockfile && \
+    pnpm gen:api && \
+    pnpm build && \
+    cd .. && \
+    mkdir -p internal/web/dist && \
+    cp -R frontend/dist/* internal/web/dist/
 
 # Build with static linking for SQLite (musl)
 RUN CGO_ENABLED=1 \

--- a/build/docker/docker.build.Dockerfile
+++ b/build/docker/docker.build.Dockerfile
@@ -2,11 +2,8 @@
 # Stage 1: Build
 FROM golang:1.26-alpine AS builder
 
-# Install git, nodejs, npm, pnpm, gcc (for CGO), and other build dependencies
+# Install git, nodejs, npm, gcc (for CGO), and other build dependencies
 RUN apk add --no-cache git nodejs npm ca-certificates tzdata curl jq gcc musl-dev
-
-# Install pnpm
-RUN npm install -g pnpm
 
 # Install Task (task runner)
 RUN go install github.com/go-task/task/v3/cmd/task@latest
@@ -43,8 +40,11 @@ RUN go mod download
 # the dashboard from the embedded internal/web/dist; without this step the
 # binary compiles fine and then returns HTTP 500 for every UI route.
 # Mirrors Taskfile's web:build, minus the swagger regeneration — openapi.json
-# is committed, so gen:api needs no Go tooling.
+# is committed, so gen:api needs no Go tooling. pnpm is installed at the
+# version package.json pins: a newer global pnpm self-provisions that pin and
+# fails integrity, since @pnpm/exe.<platform> is absent from pnpm-lock.yaml.
 RUN cd frontend && \
+    npm install -g "pnpm@$(node -p "require('./package.json').packageManager.split('@')[1]")" && \
     pnpm install --no-frozen-lockfile && \
     pnpm gen:api && \
     pnpm build && \


### PR DESCRIPTION
## Summary

`docker.build.Dockerfile` could not produce a working image and no workflow referenced it, so there was no path from repository source to a running container.

## Key Changes

- **Source builds compile**: the builder moves to `golang:1.26-alpine`, matching the `go 1.26` that go.mod already requires.
- **Dashboard reachable**: the web UI is built and embedded, without which the binary compiles and then returns HTTP 500 for every UI route.
- **Fork registries**: the image name follows `github.repository_owner` rather than a hardcoded namespace, and a dispatchable workflow builds any ref with submodules initialised.
