### PR TITLE
fix(visionproxy): stop silently dropping images a reasoning model describes

### DIFF
--- a/internal/vision/visionproxy/vision_budget_test.go
+++ b/internal/vision/visionproxy/vision_budget_test.go
@@ -1,0 +1,56 @@
+package visionproxy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVisionMaxTokens(t *testing.T) {
+	t.Run("defaults when unset", func(t *testing.T) {
+		t.Setenv(visionMaxTokensEnv, "")
+		assert.Equal(t, int64(defaultVisionMaxTokens), visionMaxTokens())
+	})
+
+	t.Run("environment overrides", func(t *testing.T) {
+		t.Setenv(visionMaxTokensEnv, "4096")
+		assert.Equal(t, int64(4096), visionMaxTokens())
+	})
+
+	t.Run("surrounding whitespace tolerated", func(t *testing.T) {
+		t.Setenv(visionMaxTokensEnv, "  2048\n")
+		assert.Equal(t, int64(2048), visionMaxTokens())
+	})
+
+	// A bad value must not silently become a tiny budget — that is the very
+	// failure this knob exists to prevent.
+	for _, bad := range []string{"nonsense", "0", "-1", "12.5"} {
+		t.Run("rejects "+bad, func(t *testing.T) {
+			t.Setenv(visionMaxTokensEnv, bad)
+			assert.Equal(t, int64(defaultVisionMaxTokens), visionMaxTokens())
+		})
+	}
+}
+
+// The default exists to satisfy Anthropic's required max_tokens, not to bound
+// cost, so it must sit far above what any describe call actually writes.
+// Measured: qwen3.5:397b yields zero content tokens at 256 on every attempt,
+// and a description of roughly 400 characters when it has room.
+func TestDefaultVisionMaxTokens_DoesNotBindInPractice(t *testing.T) {
+	assert.GreaterOrEqual(t, defaultVisionMaxTokens, 4096,
+		"a cap this low truncates descriptions and strips the image instead")
+}
+
+func TestErrTruncatedBeforeContent_IsActionable(t *testing.T) {
+	err := errTruncatedBeforeContent("qwen3.5:397b", 256)
+	require.Error(t, err)
+	msg := err.Error()
+	// Name the model, the budget that was exhausted, and the knob to turn.
+	assert.Contains(t, msg, "qwen3.5:397b")
+	assert.Contains(t, msg, "256")
+	assert.Contains(t, msg, visionMaxTokensEnv)
+	assert.True(t, strings.Contains(msg, "no") || strings.Contains(msg, "before"),
+		"must convey that nothing was written, not that the model failed")
+}

--- a/internal/vision/visionproxy/vision_proxy_client.go
+++ b/internal/vision/visionproxy/vision_proxy_client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -48,7 +50,62 @@ type poolVisionClient struct {
 }
 
 const defaultVisionPrompt = "Describe this image concisely; output plain text only."
-const defaultVisionMaxTokens = 256
+
+// defaultVisionMaxTokens caps the describe call. The cap exists only because
+// Anthropic requires max_tokens on every request; it is not a cost control.
+// What the describe call costs is decided by which model the vision proxy
+// points at, and truncating that model's output saves nothing — it destroys
+// the description and the image along with it. So the value is set high
+// enough never to bind in practice rather than tuned to a workload.
+//
+// Reasoning models make a small cap actively harmful: they spend the budget
+// on their chain of thought before writing any content, so the caller gets an
+// empty string rather than a short description. Measured against
+// qwen3.5:397b on a photograph, the previous cap of 256 returned zero content
+// tokens on every attempt; 1024 succeeded on 4 of 5, 2048 on all 5. The
+// prompt already asks for a concise answer, which is what actually keeps the
+// response short.
+const defaultVisionMaxTokens = 4096
+
+// visionMaxTokensEnv overrides defaultVisionMaxTokens: an escape hatch for a
+// backend that thinks past even a generous default, or for capping a metered
+// one. The describe call is one hop deep inside a request, so it has to be
+// adjustable without a rebuild. Values below 1 are ignored.
+const visionMaxTokensEnv = "TINGLY_VISION_MAX_TOKENS"
+
+// visionMaxTokens resolves the describe budget, preferring the environment.
+func visionMaxTokens() int64 {
+	if raw := strings.TrimSpace(os.Getenv(visionMaxTokensEnv)); raw != "" {
+		if n, err := strconv.ParseInt(raw, 10, 64); err == nil && n > 0 {
+			return n
+		}
+		logrus.Warnf("vision adapter: ignoring invalid %s=%q", visionMaxTokensEnv, raw)
+	}
+	return defaultVisionMaxTokens
+}
+
+// warnTruncatedDescription reports a description the model was still writing
+// when it hit the cap. Unlike the empty case this is not an error — a partial
+// description still beats stripping the image — but it is a silent downgrade
+// of the caller's input, so it must not pass unremarked.
+func warnTruncatedDescription(model string, budget int64, text string) {
+	logrus.Warnf(
+		"vision adapter: model %q hit the %d-token cap mid-description; "+
+			"the image was described from a truncated answer (%d chars). Raise %s",
+		model, budget, len(text), visionMaxTokensEnv)
+}
+
+// errTruncatedBeforeContent reports the specific failure where the model hit
+// the token cap without emitting any content. It is distinct from a genuinely
+// empty answer: the caller strips the image either way, but only this one is
+// fixed by raising the budget, and saying so is the difference between an
+// actionable log line and a mystery.
+func errTruncatedBeforeContent(model string, budget int64) error {
+	return fmt.Errorf(
+		"vision adapter: model %q spent all %d tokens before writing any description "+
+			"(typical of reasoning models); raise %s",
+		model, budget, visionMaxTokensEnv)
+}
 
 // NewPoolVisionClient builds the production vision client backed by the
 // shared SDK pool. resolver is typically the routing.ProviderResolver
@@ -106,9 +163,10 @@ func (a *poolVisionClient) describeViaAnthropic(ctx context.Context, provider *t
 	// for vision requests. Use the shared SDK assembler to fold the events
 	// back into a *BetaMessage so we surface a non-streaming result without
 	// hand-rolling the accumulation logic.
+	budget := visionMaxTokens()
 	stream := c.BetaMessagesNewStreaming(ctx, &anthropic.BetaMessageNewParams{
 		Model:     anthropic.Model(model),
-		MaxTokens: defaultVisionMaxTokens,
+		MaxTokens: budget,
 		Messages: []anthropic.BetaMessageParam{
 			{
 				Role: anthropic.BetaMessageParamRoleUser,
@@ -136,7 +194,16 @@ func (a *poolVisionClient) describeViaAnthropic(ctx context.Context, provider *t
 			sb.WriteString(b.Text)
 		}
 	}
-	return strings.TrimSpace(sb.String()), nil
+	if text := strings.TrimSpace(sb.String()); text != "" {
+		if msg.StopReason == anthropic.BetaStopReasonMaxTokens {
+			warnTruncatedDescription(model, budget, text)
+		}
+		return text, nil
+	}
+	if msg.StopReason == anthropic.BetaStopReasonMaxTokens {
+		return "", errTruncatedBeforeContent(model, budget)
+	}
+	return "", nil
 }
 
 // describeViaOpenAI calls the OpenAI ChatCompletions endpoint with one user
@@ -157,9 +224,10 @@ func (a *poolVisionClient) describeViaOpenAI(ctx context.Context, provider *typ.
 	// (Qwen-VL, GLM-4V, custom proxies, etc.) only support streaming for
 	// multimodal inputs. Use the shared SDK assembler to fold the chunks
 	// back into a *ChatCompletion.
+	budget := visionMaxTokens()
 	stream := c.ChatCompletionsNewStreaming(ctx, openai.ChatCompletionNewParams{
 		Model:     openai.ChatModel(model),
-		MaxTokens: openai.Int(defaultVisionMaxTokens),
+		MaxTokens: openai.Int(budget),
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			{
 				OfUser: &openai.ChatCompletionUserMessageParam{
@@ -186,11 +254,21 @@ func (a *poolVisionClient) describeViaOpenAI(ctx context.Context, provider *typ.
 		return "", err
 	}
 	resp := asm.Finish()
+	truncated := false
 	for _, ch := range resp.Choices {
 		if text := strings.TrimSpace(ch.Message.Content); text != "" {
+			if ch.FinishReason == "length" {
+				warnTruncatedDescription(model, budget, text)
+			}
 			logrus.Debugf("openai: image description: %s", text)
 			return text, nil
 		}
+		if ch.FinishReason == "length" {
+			truncated = true
+		}
+	}
+	if truncated {
+		return "", errTruncatedBeforeContent(model, budget)
 	}
 
 	return "", nil


### PR DESCRIPTION
## Summary

The describe call was capped at a hardcoded 256 tokens. A reasoning model spends that on its chain of thought before writing any content, so the proxy collects an empty string, logs `empty description; stripping image`, and the request continues without the image — the caller is never told, and answers as though none was sent.

## Key Changes

- **Budget no longer binds**: the cap defaults to 4096 and reads `TINGLY_VISION_MAX_TOKENS`; it exists to satisfy Anthropic's required `max_tokens`, not to control cost, which is decided by the model the proxy points at.
- **Exhausted budget is reported**: hitting the cap with nothing written now returns an error naming the model, the budget, and the variable to raise, instead of being folded into the generic empty-description path.
- **Truncated descriptions are reported**: a description cut off mid-sentence is still used, but no longer passes unremarked — a 1-token cap previously yielded `description=A` with nothing logged.

## Notes

- Measured against qwen3.5:397b describing a photograph: 256 produced zero content tokens on every attempt, 1024 a usable description on 4 of 5, 2048 on all 5.
- Only the empty case is fixed by raising the budget; a genuinely empty answer stays a non-error strip, as before.
