### PR TITLE
ux(frontend): surface OAuth callback port hint for remote deployments

### DIFF
--- a/frontend/src/components/OAuthDialog.tsx
+++ b/frontend/src/components/OAuthDialog.tsx
@@ -17,7 +17,7 @@ import {
 import {Claude, Gemini, Google, Kimi, OpenAI, Qwen} from './BrandIcons';
 import {useEffect, useRef, useState} from 'react';
 import api from "@/services/api.ts";
-import {getOAuthRedirectPath} from "@/utils/protocol";
+import {getOAuthRedirectPath, isGuiMode} from "@/utils/protocol";
 
 // Type for timer (browser vs Node.js)
 type TimerId = ReturnType<typeof setTimeout>;
@@ -32,6 +32,21 @@ export interface OAuthProvider {
     enabled?: boolean;
     dev?: boolean;
     deviceCodeFlow?: boolean;
+    // Some upstream OAuth apps (Anthropic's Claude Code CLI client, OpenAI's Codex
+    // CLI client) only accept a redirect to this exact loopback port. Tingly-Box
+    // starts a temporary local listener on it for the callback — see
+    // ai/oauth/registry.go `CallbackPorts`.
+    callbackPort?: number;
+}
+
+// Loopback hostnames the browser and the Tingly-Box server would both resolve to
+// the same machine for — anything else means the callback port below needs to be
+// made reachable from wherever the browser is running (e.g. an SSH tunnel).
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+function isLikelyRemoteAccess(): boolean {
+    if (isGuiMode()) return false;
+    return !LOOPBACK_HOSTNAMES.has(window.location.hostname);
 }
 
 // Fallback hardcoded providers for development or when API is unavailable
@@ -44,6 +59,7 @@ export const FALLBACK_OAUTH_PROVIDERS: OAuthProvider[] = [
         icon: <Claude size={32}/>,
         color: '#D97757',
         enabled: true,
+        callbackPort: 54545,
     },
     {
         id: 'gemini',
@@ -81,6 +97,7 @@ export const FALLBACK_OAUTH_PROVIDERS: OAuthProvider[] = [
         icon: <OpenAI size={32}/>,
         color: '#10A37F',
         enabled: true,
+        callbackPort: 1455,
     },
     {
         id: 'kimi_code',
@@ -863,6 +880,43 @@ const OAuthDialog = ({open, onClose, onSuccess, autoStartProviderId, reauthProvi
                                             </Typography>
                                         </Box>
                                     </Stack>
+                                )}
+
+                                {/* Some providers (Claude Code, Codex) redirect the browser to a fixed
+                                    loopback port for the callback. On a remote deployment that port lives
+                                    on the server, not the browser's machine, so it needs to be forwarded. */}
+                                {provider?.callbackPort && (
+                                    isLikelyRemoteAccess() ? (
+                                        <Alert severity="warning">
+                                            <Typography variant="body2" sx={{fontWeight: 600}}>
+                                                Requires local port {provider.callbackPort}
+                                            </Typography>
+                                            <Typography variant="body2" sx={{mt: 0.5}}>
+                                                {name} redirects your browser to http://localhost:{provider.callbackPort} to
+                                                finish sign-in. Since this looks like a remote Tingly-Box, that port needs to
+                                                reach this server from the machine your browser is on — forward it first, e.g.:
+                                            </Typography>
+                                            <Box
+                                                component="code"
+                                                sx={{
+                                                    display: 'block',
+                                                    mt: 1,
+                                                    p: 1,
+                                                    bgcolor: 'action.hover',
+                                                    borderRadius: 1,
+                                                    fontFamily: 'monospace',
+                                                    fontSize: '0.8rem',
+                                                    overflowX: 'auto',
+                                                }}
+                                            >
+                                                ssh -L {provider.callbackPort}:localhost:{provider.callbackPort} user@your-server
+                                            </Box>
+                                        </Alert>
+                                    ) : (
+                                        <Typography variant="caption" sx={{color: 'text.secondary'}}>
+                                            Uses local port {provider.callbackPort} for the sign-in callback.
+                                        </Typography>
+                                    )
                                 )}
 
                                 {initError && (

--- a/frontend/src/components/OAuthDialog.tsx
+++ b/frontend/src/components/OAuthDialog.tsx
@@ -1,10 +1,11 @@
-import {Close, ContentCopy, Launch, OpenInNew} from '@/components/icons';
+import {Close, ContentCopy, ExpandLess, ExpandMore, Launch, OpenInNew} from '@/components/icons';
 import {
     Alert,
     Box,
     Button,
     Checkbox,
     CircularProgress,
+    Collapse,
     Dialog,
     DialogContent,
     DialogTitle,
@@ -17,7 +18,7 @@ import {
 import {Claude, Gemini, Google, Kimi, OpenAI, Qwen} from './BrandIcons';
 import {useEffect, useRef, useState} from 'react';
 import api from "@/services/api.ts";
-import {getOAuthRedirectPath, isGuiMode} from "@/utils/protocol";
+import {getOAuthRedirectPath} from "@/utils/protocol";
 
 // Type for timer (browser vs Node.js)
 type TimerId = ReturnType<typeof setTimeout>;
@@ -37,16 +38,6 @@ export interface OAuthProvider {
     // starts a temporary local listener on it for the callback — see
     // ai/oauth/registry.go `CallbackPorts`.
     callbackPort?: number;
-}
-
-// Loopback hostnames the browser and the Tingly-Box server would both resolve to
-// the same machine for — anything else means the callback port below needs to be
-// made reachable from wherever the browser is running (e.g. an SSH tunnel).
-const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
-
-function isLikelyRemoteAccess(): boolean {
-    if (isGuiMode()) return false;
-    return !LOOPBACK_HOSTNAMES.has(window.location.hostname);
 }
 
 // Fallback hardcoded providers for development or when API is unavailable
@@ -597,6 +588,9 @@ const OAuthDialog = ({open, onClose, onSuccess, autoStartProviderId, reauthProvi
     // For autoStartProviderId mode: whether user has clicked "Connect & Authorize"
     const [configConfirmed, setConfigConfirmed] = useState(false);
     const [authAttempt, setAuthAttempt] = useState(0);
+    // Collapsed by default: the port-forwarding note for fixed-callback-port
+    // providers (Claude Code, Codex) is only useful for remote deployments.
+    const [showPortForwardHelp, setShowPortForwardHelp] = useState(false);
 
     // Load saved proxy URL and global proxy setting from localStorage/config on mount
     useEffect(() => {
@@ -673,6 +667,7 @@ const OAuthDialog = ({open, onClose, onSuccess, autoStartProviderId, reauthProvi
         setAuthData(null);
         setConfigConfirmed(false);
         setAuthAttempt(0);
+        setShowPortForwardHelp(false);
         onClose();
     };
 
@@ -884,39 +879,49 @@ const OAuthDialog = ({open, onClose, onSuccess, autoStartProviderId, reauthProvi
 
                                 {/* Some providers (Claude Code, Codex) redirect the browser to a fixed
                                     loopback port for the callback. On a remote deployment that port lives
-                                    on the server, not the browser's machine, so it needs to be forwarded. */}
+                                    on the server, not the browser's machine, so it needs forwarding — shown
+                                    on demand rather than guessed at, since there's no reliable way to tell
+                                    local and remote access apart from here. */}
                                 {provider?.callbackPort && (
-                                    isLikelyRemoteAccess() ? (
-                                        <Alert severity="warning">
-                                            <Typography variant="body2" sx={{fontWeight: 600}}>
-                                                Requires local port {provider.callbackPort}
+                                    <Box>
+                                        <Stack direction="row" spacing={0.5} sx={{alignItems: 'center'}}>
+                                            <Typography variant="caption" sx={{color: 'text.secondary'}}>
+                                                Uses local port {provider.callbackPort} for the sign-in callback.
                                             </Typography>
-                                            <Typography variant="body2" sx={{mt: 0.5}}>
-                                                {name} redirects your browser to http://localhost:{provider.callbackPort} to
-                                                finish sign-in. Since this looks like a remote Tingly-Box, that port needs to
-                                                reach this server from the machine your browser is on — forward it first, e.g.:
-                                            </Typography>
-                                            <Box
-                                                component="code"
-                                                sx={{
-                                                    display: 'block',
-                                                    mt: 1,
-                                                    p: 1,
-                                                    bgcolor: 'action.hover',
-                                                    borderRadius: 1,
-                                                    fontFamily: 'monospace',
-                                                    fontSize: '0.8rem',
-                                                    overflowX: 'auto',
-                                                }}
+                                            <Button
+                                                size="small"
+                                                onClick={() => setShowPortForwardHelp((v) => !v)}
+                                                endIcon={showPortForwardHelp ? <ExpandLess fontSize="small"/> : <ExpandMore fontSize="small"/>}
+                                                sx={{minWidth: 0, py: 0, fontSize: 'caption.fontSize', textTransform: 'none'}}
                                             >
-                                                ssh -L {provider.callbackPort}:localhost:{provider.callbackPort} user@your-server
+                                                Running this remotely?
+                                            </Button>
+                                        </Stack>
+                                        <Collapse in={showPortForwardHelp} timeout="auto" unmountOnExit>
+                                            <Box sx={{mt: 1, p: 1.5, bgcolor: 'action.hover', borderRadius: 1}}>
+                                                <Typography variant="body2" sx={{color: 'text.secondary'}}>
+                                                    If Tingly-Box runs on a remote server, this callback still
+                                                    goes to <b>your</b> machine's port {provider.callbackPort} —
+                                                    forward it there before continuing, e.g.:
+                                                </Typography>
+                                                <Box
+                                                    component="code"
+                                                    sx={{
+                                                        display: 'block',
+                                                        mt: 1,
+                                                        p: 1,
+                                                        bgcolor: 'background.paper',
+                                                        borderRadius: 1,
+                                                        fontFamily: 'monospace',
+                                                        fontSize: '0.8rem',
+                                                        overflowX: 'auto',
+                                                    }}
+                                                >
+                                                    ssh -L {provider.callbackPort}:localhost:{provider.callbackPort} user@your-server
+                                                </Box>
                                             </Box>
-                                        </Alert>
-                                    ) : (
-                                        <Typography variant="caption" sx={{color: 'text.secondary'}}>
-                                            Uses local port {provider.callbackPort} for the sign-in callback.
-                                        </Typography>
-                                    )
+                                        </Collapse>
+                                    </Box>
                                 )}
 
                                 {initError && (


### PR DESCRIPTION
## Summary
Claude Code / Codex OAuth always redirects the browser to a fixed loopback port (54545 / 1455) for the callback, but the UI never told users which port, so a remote deployment silently failed with no clue why.

## Key Changes

- **OAuth connect dialog**: shows the fixed callback port up front, plus a collapsed-by-default "Running this remotely?" toggle revealing the `ssh -L` forwarding command — no local/remote detection, just available on demand.
