### PR TITLE
Responses stream: emit response.failed on abnormal termination

### DIFF
--- a/.design/stream-converter-pipeline.md
+++ b/.design/stream-converter-pipeline.md
@@ -191,6 +191,34 @@ conv.HookErr() != nil
   → SSE 错误事件已由 converter emit，调用方只需返回 error，不再发 SSE
 ```
 
+### 8.1 Responses 流的终止事件必须是 `response.failed`
+
+`HandleOpenAIResponsesStream` 异常终止（上游 clean EOF 无终止事件 / 上游读错误）时，
+**只发 `event: error` 帧是不够的**，必须先发一个 `response.failed`
+（`SendResponsesStreamFailure`）。
+
+原因来自本surface最严格的消费者 —— Codex：
+`codex-rs/codex-api/src/sse/responses.rs` 的 `process_responses_event`
+**没有 `"error"` 分支**，该帧落进 catch-all 被丢弃；流随后正常 EOF，
+客户端只能报出通用的 `stream closed before response.completed`，
+真实原因（上游截断 / 读错误 / 上游 in-band error）全部丢失 ——
+这正是"重试多少次都没用、也看不出是什么问题"的来源（#1384）。
+
+`response.failed` 则有分支：Codex 读 `response.error.{code,message}`，
+分类成 context window / quota / rate limit / retryable 并把 message 显示出来。
+因此约定：
+
+- `response.failed` 在前（协议终止事件，Codex 与通用 Responses 客户端都认），
+  `error` 帧在后（兼容只认它的老客户端）。
+- `response.error.code` 沿用既有语义：`upstream_truncated`（上游无终止事件）、
+  `stream_failed`（上游读/解码错误）。
+- 若流中已出现过 `response.id`，带上它，让失败挂在客户端正在接收的那个 response 上。
+
+配套：`describeResponsesStreamError` 补齐 SDK 丢掉的细节 —— openai-go 的
+ssestream 只要事件带顶层 `error` 键就中断流（`"error": null` 也算），
+message 取该值的 gjson 字符串形式，null / `{}` 都会得到空串，
+于是只剩一句 `received error while streaming: `。该函数把原始事件重新附回错误里。
+
 ---
 
 ## 9. 保留的旧机制

--- a/internal/protocol/stream/openai_helper.go
+++ b/internal/protocol/stream/openai_helper.go
@@ -4,12 +4,14 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	openaistream "github.com/openai/openai-go/v3/packages/ssestream"
 	"github.com/sirupsen/logrus"
 
 	"github.com/tingly-dev/tingly-box/internal/protocol"
@@ -245,4 +247,71 @@ func openaiChatSSEWriter(c *gin.Context) func(event interface{}) error {
 // writeSSEChunk writes a single SSE chunk — kept for callers in other files.
 func writeSSEChunk(c *gin.Context, _ interface{ Flush() }, chunk any) {
 	OpenAISSE(c, chunk)
+}
+
+// SendResponsesStreamFailure ends a Responses SSE stream the way the protocol
+// itself ends a failed turn: with a `response.failed` event carrying the reason,
+// followed by the legacy `error` frame.
+//
+// The terminal event is what makes the failure legible. A bare `event: error`
+// frame is dropped by the strictest consumer of this surface: Codex's SSE reader
+// (codex-rs, codex-api/src/sse/responses.rs) has no match arm for "error", so the
+// frame lands in the catch-all, nothing is recorded, and the stream still ends
+// with no terminal event — the client reports the generic "stream closed before
+// response.completed" and the actual reason (upstream truncation, read error,
+// in-band upstream error) is lost. That is also why retrying never helps: the
+// user never learns what to fix. "response.failed" IS handled there: the client
+// reads response.error.{code,message}, classifies it (context window, quota,
+// rate limit, otherwise retryable) and surfaces the message.
+//
+// responseID may be empty; when the stream already announced one, passing it
+// keeps the failure attached to the response the client was streaming.
+func SendResponsesStreamFailure(c *gin.Context, responseID, code, message string) {
+	response := map[string]interface{}{
+		"object": "response",
+		"status": "failed",
+		"error": map[string]interface{}{
+			"type":    "stream_error",
+			"code":    code,
+			"message": message,
+		},
+	}
+	if responseID != "" {
+		response["id"] = responseID
+	}
+	OpenAIResponsesEvent(c, "response.failed", map[string]interface{}{
+		"type":     "response.failed",
+		"response": response,
+	})
+	OpenAIResponsesEvent(c, "error", map[string]interface{}{
+		"error": map[string]interface{}{
+			"message": message,
+			"type":    "stream_error",
+			"code":    code,
+		},
+	})
+}
+
+// describeResponsesStreamError restores the detail the OpenAI SDK drops when it
+// aborts a stream on an in-band error event.
+//
+// ssestream ends the stream as soon as an event carries a top-level "error" key
+// and uses gjson's string form of that value as the message — which is empty for
+// `"error": null` and for `"error": {}`. The result is a bare "received error
+// while streaming: " with nothing to act on. Re-attach the raw event so the log
+// line and the client both name what actually arrived.
+func describeResponsesStreamError(err error) error {
+	var streamErr *openaistream.StreamError
+	if !errors.As(err, &streamErr) {
+		return err
+	}
+	detail := strings.TrimSpace(strings.TrimPrefix(streamErr.Message, "received error while streaming:"))
+	if detail != "" {
+		return err
+	}
+	raw := strings.TrimSpace(string(streamErr.Event.Data))
+	if raw == "" {
+		return err
+	}
+	return fmt.Errorf("upstream sent an error event with no message (raw event: %s)", raw)
 }

--- a/internal/protocol/stream/openai_passthrough.go
+++ b/internal/protocol/stream/openai_passthrough.go
@@ -340,6 +340,9 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 	usage := protocol.ZeroTokenUsage()
 	streamStart := time.Now()
 	sawTerminal := false
+	// Remembered so an abnormal termination can name the response the client
+	// was already streaming, instead of inventing an id it has never seen.
+	responseID := ""
 
 	protocol.RunLoop(c, func(w io.Writer) bool {
 		select {
@@ -410,7 +413,14 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 			// Codex CLI's ResponseCompleted decoder rejects events whose
 			// output_tokens_details lacks reasoning_tokens. Backfill 0 when the
 			// upstream provider (e.g. DeepSeek) omits it.
-			if respUsage.Exists() {
+			//
+			// gjson reports an explicit JSON null as existing, so the backfill
+			// must also require an object: response.created / response.in_progress
+			// carry "usage": null, and synthesizing a details-only usage block
+			// there would hand the client a usage object missing every required
+			// field (input_tokens/output_tokens/total_tokens) — worse than the
+			// null it replaced.
+			if respUsage.IsObject() {
 				if rt := respUsage.Get("output_tokens_details.reasoning_tokens"); rt.Exists() {
 					reasoningTokens = rt.Int()
 				} else {
@@ -425,6 +435,10 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 			if promptTokensTotal > 0 || outputTokens > 0 || cacheTokens > 0 || cacheWriteTokens > 0 || reasoningTokens > 0 {
 				usage = protocol.NewTokenUsageFull(int(promptTokensTotal-cacheTokens), int(outputTokens),
 					int(cacheTokens), int(cacheWriteTokens), int(reasoningTokens))
+			}
+
+			if id := resp.Get("id"); responseID == "" && id.Exists() {
+				responseID = id.String()
 			}
 
 			if model := resp.Get("model"); model.Exists() && model.String() != "" {
@@ -444,6 +458,7 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 			return usage, nil
 		}
 
+		err = describeResponsesStreamError(err)
 		logrus.WithContext(c.Request.Context()).Errorf("Responses stream error: %v", err)
 		// Stream failed before any content reached the client: surface a
 		// retryable 5xx so mid-request failover can try the next tier,
@@ -452,14 +467,7 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 			SendStreamingError(c, err)
 			return usage, err
 		}
-		errorChunk := map[string]interface{}{
-			"error": map[string]interface{}{
-				"message": err.Error(),
-				"type":    "stream_error",
-				"code":    "stream_failed",
-			},
-		}
-		OpenAIResponsesEvent(c, "error", errorChunk)
+		SendResponsesStreamFailure(c, responseID, "stream_failed", err.Error())
 		return usage, err
 	}
 
@@ -476,13 +484,8 @@ func HandleOpenAIResponsesStream(hc *protocol.HandleContext, stream ResponsesStr
 		logrus.WithContext(c.Request.Context()).
 			WithField("elapsed", time.Since(streamStart).Round(time.Second)).
 			Warn("upstream ended responses stream without a terminal event")
-		OpenAIResponsesEvent(c, "error", map[string]interface{}{
-			"error": map[string]interface{}{
-				"message": "upstream ended responses stream without a terminal event",
-				"type":    "stream_error",
-				"code":    "upstream_truncated",
-			},
-		})
+		SendResponsesStreamFailure(c, responseID, "upstream_truncated",
+			"upstream ended responses stream without a terminal event")
 		return usage, fmt.Errorf("upstream ended responses stream without a terminal event")
 	}
 

--- a/internal/protocol/stream/responses_failure_event_test.go
+++ b/internal/protocol/stream/responses_failure_event_test.go
@@ -1,0 +1,105 @@
+package stream
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	openaistream "github.com/openai/openai-go/v3/packages/ssestream"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// sseEventPayload returns the data payload of the named SSE event.
+func sseEventPayload(t *testing.T, body, event string) string {
+	t.Helper()
+	marker := "event: " + event + "\ndata: "
+	idx := strings.Index(body, marker)
+	require.GreaterOrEqual(t, idx, 0, "event %q not found in stream:\n%s", event, body)
+	rest := body[idx+len(marker):]
+	end := strings.Index(rest, "\n")
+	require.GreaterOrEqual(t, end, 0)
+	return rest[:end]
+}
+
+func newResponsesStreamContext(t *testing.T) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	w := &closeNotifyRecorder{ResponseRecorder: rec}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	return c, rec
+}
+
+// A truncated upstream must end the stream with response.failed, not only the
+// legacy `error` frame: Codex's SSE reader has no arm for "error" and drops it,
+// leaving the client with the generic "stream closed before response.completed"
+// and no reason at all.
+func TestHandleOpenAIResponsesStream_TruncationEmitsResponseFailed(t *testing.T) {
+	c, rec := newResponsesStreamContext(t)
+
+	decoder := newFakeResponsesDecoder([]string{
+		`{"type":"response.created","response":{"id":"resp_42","model":"upstream-model"}}`,
+		`{"type":"response.output_text.delta","item_id":"item_1","output_index":0,"delta":"partial"}`,
+	})
+	stream := openaistream.NewStream[responses.ResponseStreamEventUnion](decoder, nil)
+
+	_, err := HandleOpenAIResponsesStream(newTestHandleContext(c), stream, "gpt-4o")
+	require.Error(t, err)
+
+	payload := sseEventPayload(t, rec.Body.String(), "response.failed")
+	assert.Equal(t, "response.failed", gjson.Get(payload, "type").String())
+	assert.Equal(t, "failed", gjson.Get(payload, "response.status").String())
+	assert.Equal(t, "upstream_truncated", gjson.Get(payload, "response.error.code").String())
+	assert.Contains(t, gjson.Get(payload, "response.error.message").String(), "without a terminal event")
+	// The id the client was already streaming, not an invented one.
+	assert.Equal(t, "resp_42", gjson.Get(payload, "response.id").String())
+	// The legacy error frame stays for clients that key off it.
+	assert.Contains(t, rec.Body.String(), "upstream_truncated")
+	assert.NotContains(t, rec.Body.String(), "response.completed")
+}
+
+// response.created / response.in_progress carry "usage": null. Backfilling
+// reasoning_tokens there would replace the null with a usage object missing
+// every required field, which strict clients reject.
+func TestHandleOpenAIResponsesStream_NullUsageStaysNull(t *testing.T) {
+	c, rec := newResponsesStreamContext(t)
+
+	decoder := newFakeResponsesDecoder([]string{
+		`{"type":"response.created","response":{"id":"resp_1","model":"m","usage":null}}`,
+		`{"type":"response.completed","response":{"id":"resp_1","model":"m","usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":2},"output_tokens":3,"output_tokens_details":{"reasoning_tokens":1},"total_tokens":13}}}`,
+	})
+	stream := openaistream.NewStream[responses.ResponseStreamEventUnion](decoder, nil)
+
+	_, err := HandleOpenAIResponsesStream(newTestHandleContext(c), stream, "gpt-4o")
+	require.NoError(t, err)
+
+	created := sseEventPayload(t, rec.Body.String(), "response.created")
+	assert.Equal(t, gjson.Null, gjson.Get(created, "response.usage").Type,
+		"response.created must keep its null usage")
+}
+
+// An upstream event carrying only `"error": null` aborts the SDK stream with an
+// empty message; the raw event is the only diagnostic left, so keep it.
+func TestDescribeResponsesStreamError_EmptyInBandError(t *testing.T) {
+	raw := `{"type":"response.completed","error":null}`
+	err := describeResponsesStreamError(&openaistream.StreamError{
+		Message: "received error while streaming: ",
+		Event:   openaistream.Event{Type: "response.completed", Data: []byte(raw)},
+	})
+	assert.Contains(t, err.Error(), "error event with no message")
+	assert.Contains(t, err.Error(), raw)
+}
+
+func TestDescribeResponsesStreamError_KeepsRealMessage(t *testing.T) {
+	original := &openaistream.StreamError{
+		Message: `received error while streaming: {"message":"boom"}`,
+		Event:   openaistream.Event{Data: []byte(`{"error":{"message":"boom"}}`)},
+	}
+	assert.Equal(t, error(original), describeResponsesStreamError(original))
+}

--- a/internal/protocolserver/openai_responses.go
+++ b/internal/protocolserver/openai_responses.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/responses"
+	"github.com/tidwall/gjson"
 
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
@@ -269,7 +270,49 @@ func (ph *ProtocolHandler) convertToResponsesParams(bodyBytes []byte, actualMode
 		return nil, err
 	}
 
+	if err := checkResponsesInputSurvived(processedData, params); err != nil {
+		return nil, err
+	}
+
 	return params, nil
+}
+
+// checkResponsesInputSurvived rejects a request whose input array did not
+// survive deserialization into the SDK params.
+//
+// The input union decodes all-or-nothing: a single item whose `type` the pinned
+// SDK does not model makes the whole array decode to nothing — and it does so
+// *without an error*, so the request would otherwise go upstream carrying only
+// instructions and tools, with the entire conversation silently gone. Agentic
+// clients replay their whole history on every turn, so once such an item exists
+// the failure repeats on every retry for the rest of the session. Failing here
+// names the offending item instead of leaving the provider to reject (or worse,
+// half-answer) a conversation-less request.
+func checkResponsesInputSurvived(processedData []byte, params *responses.ResponseNewParams) error {
+	items := gjson.GetBytes(processedData, "input")
+	if !items.IsArray() || len(items.Array()) == 0 {
+		return nil
+	}
+	if len(params.Input.OfInputItemList) > 0 || params.Input.OfString.Valid() {
+		return nil
+	}
+
+	// Re-decode item by item: only the failure path pays for this, and the
+	// index+type it recovers is the whole point of the message.
+	for i, item := range items.Array() {
+		var decoded responses.ResponseInputItemUnionParam
+		if err := json.Unmarshal([]byte(item.Raw), &decoded); err != nil {
+			return fmt.Errorf("input[%d] (type %q) is not a supported Responses input item: %w",
+				i, item.Get("type").String(), err)
+		}
+		encoded, err := json.Marshal(decoded)
+		if err != nil || len(gjson.ParseBytes(encoded).Map()) == 0 {
+			return fmt.Errorf("input[%d] has unsupported type %q; the whole conversation would be dropped",
+				i, item.Get("type").String())
+		}
+	}
+
+	return fmt.Errorf("input items were dropped during conversion; the whole conversation would be sent empty")
 }
 
 // HandleResponsesGet handles GET /v1/responses/{id}

--- a/internal/protocolserver/openai_responses_input_test.go
+++ b/internal/protocolserver/openai_responses_input_test.go
@@ -1,0 +1,67 @@
+package protocolserver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+// decodeInput mirrors convertToResponsesParams' body → params step so the guard
+// is exercised against the same deserialization it protects.
+func decodeInput(t *testing.T, body string) ([]byte, *responses.ResponseNewParams) {
+	t.Helper()
+	processed, err := protocol.PreprocessInputData([]byte(body))
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(processed, &raw))
+	modified, err := json.Marshal(raw)
+	require.NoError(t, err)
+
+	params := &responses.ResponseNewParams{}
+	require.NoError(t, json.Unmarshal(modified, params))
+	return processed, params
+}
+
+// An input item type the pinned SDK does not model takes the entire input array
+// down with it — silently. The guard must catch that and name the item.
+func TestCheckResponsesInputSurvived_UnknownItemType(t *testing.T) {
+	processed, params := decodeInput(t, `{"model":"gpt-5.6-codex","input":[
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+		{"type":"totally_unknown_future","id":"zz_1","foo":"bar"}
+	]}`)
+
+	// Precondition: the SDK dropped everything without reporting an error.
+	require.Empty(t, params.Input.OfInputItemList)
+
+	err := checkResponsesInputSurvived(processed, params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "input[1]")
+	assert.Contains(t, err.Error(), "totally_unknown_future")
+}
+
+func TestCheckResponsesInputSurvived_SupportedItemsPass(t *testing.T) {
+	processed, params := decodeInput(t, `{"model":"gpt-5.6-codex","input":[
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+		{"type":"reasoning","id":"rs_1","summary":[],"encrypted_content":"ENC"},
+		{"type":"function_call","id":"fc_1","call_id":"call_1","name":"shell","arguments":"{}"},
+		{"type":"function_call_output","call_id":"call_1","output":"ok"},
+		{"type":"custom_tool_call","id":"ctc_1","call_id":"call_2","name":"apply_patch","input":"P"}
+	]}`)
+
+	require.Len(t, params.Input.OfInputItemList, 5)
+	assert.NoError(t, checkResponsesInputSurvived(processed, params))
+}
+
+func TestCheckResponsesInputSurvived_StringAndEmptyInput(t *testing.T) {
+	processed, params := decodeInput(t, `{"model":"gpt-5.6-codex","input":"just a string"}`)
+	assert.NoError(t, checkResponsesInputSurvived(processed, params))
+
+	processed, params = decodeInput(t, `{"model":"gpt-5.6-codex","input":[]}`)
+	assert.NoError(t, checkResponsesInputSurvived(processed, params))
+}


### PR DESCRIPTION
## Summary
Responses streams that terminate abnormally (upstream truncation, read errors, in-band errors) now emit a `response.failed` event before the legacy `error` frame. This ensures Codex and other strict consumers can diagnose the failure reason instead of reporting a generic "stream closed before response.completed".

## Key Changes

- **Responses stream failure signaling**: `HandleOpenAIResponsesStream` now calls `SendResponsesStreamFailure` on abnormal termination, emitting `response.failed` with error code and message, followed by the legacy `error` frame for backward compatibility. The response ID is carried through if already announced to the client.

- **Error detail recovery**: `describeResponsesStreamError` restores diagnostic information that the OpenAI SDK drops when aborting on in-band error events (e.g., `"error": null`), re-attaching the raw event to the error message.

- **Input validation for Responses**: `checkResponsesInputSurvived` guards against silent input array loss during SDK deserialization. When an item type the pinned SDK doesn't model appears, the entire array decodes to nothing without error — this now fails the request with a clear message naming the offending item, preventing silent conversation loss on retry loops.

- **Usage backfill safety**: The reasoning_tokens backfill now checks `IsObject()` instead of `Exists()` to avoid synthesizing incomplete usage objects from `null` values in `response.created` / `response.in_progress` events.

## Minor

- Added comprehensive test coverage for Responses stream failure paths, input validation, and error message recovery.
- Updated `.design/stream-converter-pipeline.md` with the Responses stream termination protocol and rationale.

## Notes

The `response.failed` event structure follows the protocol's own failure format: `response.error.{code,message}` with codes `upstream_truncated` (no terminal event) and `stream_failed` (read/decode error). Codex's SSE reader has a match arm for `response.failed` but not for bare `error` frames, making this change essential for error visibility in that consumer.

https://claude.ai/code/session_01ShwPKYgqy6nsZfXT5vwBoc