### PR TITLE
fix(visionproxy): anchor the latest-turn test on the last image-bearing message

### DIFF
--- a/internal/vision/visionproxy/README.md
+++ b/internal/vision/visionproxy/README.md
@@ -156,6 +156,7 @@ fail-strip does not apply; they always receive the omitted marker.
   success                 │ desc non-empty                   │  [image: …]│
                           ├──────────────────────────────────┴───────────┤
   historical image        │ messages[i] where i < lastIdx    │  historic │
+                          │ (lastIdx = latest image-bearing) │            │
                           │ (no Describe call)               │            │
                           └──────────────────────────────────┴───────────┘
   unavail  = "[image: (description unavailable)]"
@@ -166,10 +167,20 @@ fail-strip does not apply; they always receive the omitted marker.
 
 | Request shape                              | Image block source                             | Notes                                  |
 |--------------------------------------------|--------------------------------------------------|----------------------------------------|
-| `*anthropic.BetaMessageNewParams`          | `BetaImageBlockParam.Source` (Base64 \| URL)   | last message described; older stripped |
-| `*anthropic.MessageNewParams`              | `ImageBlockParam.Source` (Base64 \| URL)       | last message described; older stripped |
-| `*openai.ChatCompletionNewParams`          | `user.content[].OfImageURL.ImageURL.URL`       | last message described; older stripped |
-| `*responses.ResponseNewParams`             | `input[].content[].OfInputImage`               | last item described; older stripped    |
+| `*anthropic.BetaMessageNewParams`          | `BetaImageBlockParam.Source` (Base64 \| URL)   | latest user message described; older stripped |
+| `*anthropic.MessageNewParams`              | `ImageBlockParam.Source` (Base64 \| URL)       | latest user message described; older stripped |
+| `*openai.ChatCompletionNewParams`          | `user.content[].OfImageURL.ImageURL.URL`       | latest user/tool message described; older stripped |
+| `*responses.ResponseNewParams`             | `input[].content[].OfInputImage`               | latest user item described; older stripped    |
+
+`lastIdx` is the index of the latest message that can carry an image from the
+caller — **not** simply `len(messages)-1`. Clients append trailing messages
+that are not part of the turn: Claude Code emits a `<system-reminder>` as its
+own system-role message after every tool result, so the request answering a
+tool call arrives as `user / system / assistant(tool_use) /
+user(tool_result+image) / system`. Anchoring on the final message would make
+the image of the turn in flight test as history and replace it with the
+`omitted from history` marker, so the caller would answer about an image no
+model ever saw. See `latestImageAnchor`.
 
 Images nested inside `tool_result` content blocks are also walked (Beta and
 v1 shapes) — tool-returning agents (screenshot / read-image / MCP tools)

--- a/internal/vision/visionproxy/vision_proxy.go
+++ b/internal/vision/visionproxy/vision_proxy.go
@@ -45,6 +45,32 @@ const imageUnavailableText = "[image: (description unavailable)]"
 // message are sent through the vision upstream for description.
 const imageHistoricalText = "[image: (omitted from history)]"
 
+// latestImageAnchor reports the index the "latest turn" test should compare
+// against: the last message that can carry an image from the caller, rather
+// than the last message outright.
+//
+// Clients append trailing messages the caller never sees as part of the turn.
+// Claude Code emits a `<system-reminder>` as its own system-role message after
+// every tool result, so a request answering a tool call arrives as
+//
+//	user / system / assistant(tool_use) / user(tool_result+image) / system
+//
+// Anchoring on len-1 makes the image of the turn *in flight* test as history,
+// and it is replaced with imageHistoricalText before any model sees it — the
+// caller then answers about an image that was never described and never sent.
+//
+// canCarry reports whether the message at an index is one the caller puts
+// images in; trailing messages that fail it do not move the anchor. When no
+// message qualifies the anchor stays at len-1, preserving prior behaviour.
+func latestImageAnchor(n int, canCarry func(i int) bool) int {
+	for i := n - 1; i >= 0; i-- {
+		if canCarry(i) {
+			return i
+		}
+	}
+	return n - 1
+}
+
 // describeConcurrency bounds how many vision upstream calls run in parallel
 // for a single request. The upstream round-trip dominates proxy latency, so
 // a latest message carrying several images (multi-screenshot tool results,
@@ -213,7 +239,9 @@ func spliceOrCollect(refs []imageRef, isLast bool, ref imageRef) []imageRef {
 // .design/vision-proxy.md §6.1) — both shapes are handled.
 func collectBeta(req *anthropic.BetaMessageNewParams) []imageRef {
 	var refs []imageRef
-	lastIdx := len(req.Messages) - 1
+	lastIdx := latestImageAnchor(len(req.Messages), func(i int) bool {
+		return req.Messages[i].Role == anthropic.BetaMessageParamRoleUser
+	})
 	for mi := range req.Messages {
 		isLast := mi == lastIdx
 		blocks := req.Messages[mi].Content
@@ -258,7 +286,9 @@ func collectBeta(req *anthropic.BetaMessageNewParams) []imageRef {
 // collectV1 mirrors collectBeta for the v1 Messages API types.
 func collectV1(req *anthropic.MessageNewParams) []imageRef {
 	var refs []imageRef
-	lastIdx := len(req.Messages) - 1
+	lastIdx := latestImageAnchor(len(req.Messages), func(i int) bool {
+		return req.Messages[i].Role == anthropic.MessageParamRoleUser
+	})
 	for mi := range req.Messages {
 		isLast := mi == lastIdx
 		blocks := req.Messages[mi].Content
@@ -304,7 +334,9 @@ func collectV1(req *anthropic.MessageNewParams) []imageRef {
 // carry image_url content parts in the current SDK union.
 func collectOpenAI(req *openai.ChatCompletionNewParams) []imageRef {
 	var refs []imageRef
-	lastIdx := len(req.Messages) - 1
+	lastIdx := latestImageAnchor(len(req.Messages), func(i int) bool {
+		return req.Messages[i].OfUser != nil || req.Messages[i].OfTool != nil
+	})
 	for mi := range req.Messages {
 		um := req.Messages[mi].OfUser
 		if um == nil {
@@ -343,7 +375,16 @@ func collectOpenAI(req *openai.ChatCompletionNewParams) []imageRef {
 func collectResponses(req *responses.ResponseNewParams) []imageRef {
 	items := req.Input.OfInputItemList
 	var refs []imageRef
-	lastIdx := len(items) - 1
+	lastIdx := latestImageAnchor(len(items), func(i int) bool {
+		switch {
+		case items[i].OfMessage != nil:
+			return items[i].OfMessage.Role == responses.EasyInputMessageRoleUser
+		case items[i].OfInputMessage != nil:
+			return items[i].OfInputMessage.Role == "user"
+		default:
+			return false
+		}
+	})
 	for mi := range items {
 		var list responses.ResponseInputMessageContentListParam
 		switch {

--- a/internal/vision/visionproxy/vision_trailing_system_test.go
+++ b/internal/vision/visionproxy/vision_trailing_system_test.go
@@ -1,0 +1,167 @@
+package visionproxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+)
+
+// claudeCodeShapedBeta reproduces the message list Claude Code actually sends
+// when it returns a tool result: a `<system-reminder>` arrives as its own
+// system-role message both before the turn and, crucially, AFTER the
+// tool_result carrying the image.
+//
+//	0 user      the prompt
+//	1 system    <system-reminder>
+//	2 assistant tool_use
+//	3 user      tool_result + image   <- the turn in flight
+//	4 system    <system-reminder>
+func claudeCodeShapedBeta(b64 string) *anthropic.BetaMessageNewParams {
+	sys := func(text string) anthropic.BetaMessageParam {
+		return anthropic.BetaMessageParam{
+			Role: anthropic.BetaMessageParamRoleSystem,
+			Content: []anthropic.BetaContentBlockParamUnion{
+				{OfText: &anthropic.BetaTextBlockParam{Text: text}},
+			},
+		}
+	}
+	return &anthropic.BetaMessageNewParams{
+		Model: anthropic.Model("claude-3-5-sonnet-latest"),
+		Messages: []anthropic.BetaMessageParam{
+			{Role: anthropic.BetaMessageParamRoleUser, Content: []anthropic.BetaContentBlockParamUnion{
+				{OfText: &anthropic.BetaTextBlockParam{Text: "what registration is on the aircraft?"}},
+			}},
+			sys("<system-reminder>context</system-reminder>"),
+			{Role: anthropic.BetaMessageParamRoleAssistant, Content: []anthropic.BetaContentBlockParamUnion{
+				{OfToolUse: &anthropic.BetaToolUseBlockParam{ID: "toolu_1", Name: "Read"}},
+			}},
+			{Role: anthropic.BetaMessageParamRoleUser, Content: []anthropic.BetaContentBlockParamUnion{
+				{OfToolResult: &anthropic.BetaToolResultBlockParam{
+					ToolUseID: "toolu_1",
+					Content: []anthropic.BetaToolResultBlockParamContentUnion{
+						{OfImage: &anthropic.BetaImageBlockParam{
+							Source: anthropic.BetaImageBlockParamSourceUnion{
+								OfBase64: &anthropic.BetaBase64ImageSourceParam{
+									Data:      b64,
+									MediaType: anthropic.BetaBase64ImageSourceMediaType(tinyPNGMediaType),
+								},
+							},
+						}},
+					},
+				}},
+			}},
+			sys("<system-reminder>tokens left</system-reminder>"),
+		},
+	}
+}
+
+// TestVisionProxy_Beta_TrailingSystemMessage_StillDescribesCurrentTurn is the
+// regression guard for the failure this fix addresses: Claude Code's image
+// never reached any model because a trailing system message made the image
+// test as history and it was replaced with the "omitted from history" marker.
+func TestVisionProxy_Beta_TrailingSystemMessage_StillDescribesCurrentTurn(t *testing.T) {
+	prov := mkProvider("anthropic-vision")
+	fake := newFakeVisionClient("a V-tail aircraft, registration N40J")
+	p := mkProcessor(t, fake, prov)
+
+	req := claudeCodeShapedBeta(tinyPNGBase64)
+	svcs := []*loadbalance.Service{mkService(prov.UUID, true)}
+
+	require.NoError(t, p.Process(context.Background(), req, svcs))
+
+	require.Equal(t, 1, fake.callCount(),
+		"the image of the turn in flight must be described, not elided as history")
+	require.Equal(t, 0, countImages(req))
+
+	text := collectText(req)
+	require.Contains(t, text, "registration N40J")
+	require.NotContains(t, text, "omitted from history",
+		"a trailing system message must not turn the current turn into history")
+}
+
+// TestVisionProxy_Beta_TrailingSystem_KeepsRealHistoryElided confirms the fix
+// moves the anchor without disabling it: an image from an earlier user turn is
+// still replaced with the cheap marker rather than sent upstream.
+func TestVisionProxy_Beta_TrailingSystem_KeepsRealHistoryElided(t *testing.T) {
+	prov := mkProvider("anthropic-vision")
+	fake := newFakeVisionClient("latest description")
+	p := mkProcessor(t, fake, prov)
+
+	req := claudeCodeShapedBeta(tinyPNGBase64)
+	// Splice a genuinely historical image in as the opening user turn.
+	historical := anthropic.BetaMessageParam{
+		Role: anthropic.BetaMessageParamRoleUser,
+		Content: []anthropic.BetaContentBlockParamUnion{
+			anthropic.NewBetaImageBlock(anthropic.BetaBase64ImageSourceParam{
+				Data:      tinyPNGBase64,
+				MediaType: anthropic.BetaBase64ImageSourceMediaType(tinyPNGMediaType),
+			}),
+		},
+	}
+	req.Messages = append([]anthropic.BetaMessageParam{historical}, req.Messages...)
+
+	svcs := []*loadbalance.Service{mkService(prov.UUID, true)}
+	require.NoError(t, p.Process(context.Background(), req, svcs))
+
+	require.Equal(t, 1, fake.callCount(), "only the current turn is described")
+	require.Equal(t, 0, countImages(req))
+
+	text := collectText(req)
+	require.Contains(t, text, "latest description")
+	require.Contains(t, text, "omitted from history", "the older image stays elided")
+}
+
+// TestVisionProxy_OpenAI_TrailingSystemMessage covers the same client shape on
+// the Chat Completions ingress, where a trailing system message would
+// otherwise push the user image out of the latest slot.
+func TestVisionProxy_OpenAI_TrailingSystemMessage(t *testing.T) {
+	prov := mkProvider("anthropic-vision")
+	fake := newFakeVisionClient("chat latest desc")
+	p := mkProcessor(t, fake, prov)
+
+	req := &openai.ChatCompletionNewParams{
+		Model: "gpt-4o-mini",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			{OfUser: &openai.ChatCompletionUserMessageParam{
+				Content: openai.ChatCompletionUserMessageParamContentUnion{
+					OfArrayOfContentParts: []openai.ChatCompletionContentPartUnionParam{
+						{OfImageURL: &openai.ChatCompletionContentPartImageParam{
+							ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
+								URL: "data:" + tinyPNGMediaType + ";base64," + tinyPNGBase64,
+							},
+						}},
+					},
+				},
+			}},
+			{OfSystem: &openai.ChatCompletionSystemMessageParam{
+				Content: openai.ChatCompletionSystemMessageParamContentUnion{
+					OfString: openai.String("<system-reminder>tokens left</system-reminder>"),
+				},
+			}},
+		},
+	}
+
+	svcs := []*loadbalance.Service{mkService(prov.UUID, true)}
+	require.NoError(t, p.Process(context.Background(), req, svcs))
+
+	require.Equal(t, 1, fake.callCount(),
+		"a trailing system message must not elide the user's image")
+	require.Equal(t, 0, countImages(req))
+	require.Contains(t, collectText(req), "chat latest desc")
+}
+
+// TestLatestImageAnchor_FallsBackWhenNothingQualifies pins the guard that keeps
+// prior behaviour for message lists with no image-bearing role at all.
+func TestLatestImageAnchor_FallsBackWhenNothingQualifies(t *testing.T) {
+	require.Equal(t, 2, latestImageAnchor(3, func(int) bool { return false }),
+		"no qualifying message keeps the anchor at len-1")
+	require.Equal(t, -1, latestImageAnchor(0, func(int) bool { return false }),
+		"an empty list yields the empty-slice anchor")
+	require.Equal(t, 1, latestImageAnchor(4, func(i int) bool { return i == 1 }),
+		"the last qualifying index wins over later non-qualifying ones")
+}


### PR DESCRIPTION
## Summary

The vision proxy decides which images to describe by asking whether an image sits in the *last* message. Claude Code appends a `<system-reminder>` as its own system-role message after every tool result, so the image of the turn being answered is never last — it was replaced with the "omitted from history" marker before any model saw it, and the caller answered from nothing.

## Key Changes

- **The latest-turn test anchors on content, not position**: `lastIdx` becomes the index of the last message that can carry an image from the caller (user for the Anthropic shapes, user or tool for Chat Completions, user items for Responses) instead of `len(messages)-1`. Trailing messages that cannot carry an image no longer move the anchor, and when nothing qualifies the anchor stays at `len-1`, so behaviour is unchanged for every request whose final message is the turn.

## Notes

- Reproduced against Claude Code through a `claude_code` rule whose vision proxy is configured: a request answering a `Read` arrives as `user / system / assistant(tool_use) / user(tool_result+image) / system`, image at index 3 of 5.
- Measured end to end, asking for a registration painted on an aircraft in a photograph: **0/6 correct before, 4/4 after**. The failures were the dangerous kind — three replies invented a plausible registration rather than reporting a missing image, because the model was handed the marker text and answered around it.
- Genuine history stays elided: a test asserts an image from an earlier user turn still gets the cheap marker and costs no upstream call.
