### PR TITLE
refactor(recording): stop threading the recorder through protocol signatures — fetch from ctx

### DIFF
--- a/internal/protocolserver/anthropic_message.go
+++ b/internal/protocolserver/anthropic_message.go
@@ -11,7 +11,6 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
-	"github.com/tingly-dev/tingly-box/internal/protocolserver/recording"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -178,13 +177,12 @@ func (ph *ProtocolHandler) AnthropicMessagesV1(c *gin.Context, req *protocol.Ant
 	// Get or create the recorder for dual-stage recording. The body is the
 	// pristine request as received (post-vision-proxy, pre-pre-chain); the
 	// winning attempt's provider/model is re-bound per attempt via SetActiveService.
-	var recorder *recording.ProtocolRecorder
 	if scenarioConfig.IsRecordingEnable() {
 		bs, err := req.MarshalJSON()
 		if err != nil {
 			bs = []byte("{}")
 		}
-		recorder = ph.EnsureProtocolRecorder(c, string(scenarioType), provider, requestModel, ph.getScenarioRecordMode(scenarioType), bs)
+		ph.EnsureProtocolRecorder(c, string(scenarioType), provider, requestModel, ph.getScenarioRecordMode(scenarioType), bs)
 	}
 
 	// Snapshot a pristine template only when failover is possible; the single
@@ -212,7 +210,7 @@ func (ph *ProtocolHandler) AnthropicMessagesV1(c *gin.Context, req *protocol.Ant
 				}
 				areq = cloned
 			}
-			ph.runAnthropicV1Attempt(c, areq, responseModel, p, retryModel, rule, isStreaming, scenarioType, scenarioConfig, recorder)
+			ph.runAnthropicV1Attempt(c, areq, responseModel, p, retryModel, rule, isStreaming, scenarioType, scenarioConfig)
 		})
 }
 
@@ -221,7 +219,7 @@ func (ph *ProtocolHandler) AnthropicMessagesV1(c *gin.Context, req *protocol.Ant
 // pre-transform chain and guardrails, resolve the target API for this provider's
 // style, transform, and dispatch. Setup failures route through failAttemptSetup
 // so the orchestrator can advance to the next candidate.
-func (ph *ProtocolHandler) runAnthropicV1Attempt(c *gin.Context, req *protocol.AnthropicMessagesRequest, responseModel string, provider *typ.Provider, requestModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig, recorder *recording.ProtocolRecorder) {
+func (ph *ProtocolHandler) runAnthropicV1Attempt(c *gin.Context, req *protocol.AnthropicMessagesRequest, responseModel string, provider *typ.Provider, requestModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig) {
 	// Resolve dual endpoint: when the provider has an Anthropic-compatible
 	// dual URL configured, route there natively to avoid a transform.
 	provider = provider.ResolveStyle(protocol.APIStyleAnthropic)
@@ -267,7 +265,7 @@ func (ph *ProtocolHandler) runAnthropicV1Attempt(c *gin.Context, req *protocol.A
 	// (This also applies the custom User-Agent to the request context.)
 	ruleFlags := ResolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicV1, target, provider)
 
-	reqCtx, err := ph.TransformAnthropicV1(c, req, target, provider, isStreaming, recorder, scenarioType, RulePreBaseTransforms(ruleFlags), RulePreVendorTransforms(ruleFlags))
+	reqCtx, err := ph.TransformAnthropicV1(c, req, target, provider, isStreaming, scenarioType, RulePreBaseTransforms(ruleFlags), RulePreVendorTransforms(ruleFlags))
 	if err != nil {
 		ph.FailAttemptSetup(c, err)
 		return
@@ -277,7 +275,7 @@ func (ph *ProtocolHandler) runAnthropicV1Attempt(c *gin.Context, req *protocol.A
 	reqCtx.RequestModel = requestModel
 	reqCtx.ResponseModel = responseModel
 
-	ph.DispatchChainResult(c, reqCtx, rule, provider, isStreaming, recorder)
+	ph.DispatchChainResult(c, reqCtx, rule, provider, isStreaming)
 }
 
 // AnthropicMessagesV1Beta implements beta messages API.
@@ -305,13 +303,12 @@ func (ph *ProtocolHandler) AnthropicMessagesV1Beta(c *gin.Context, req *protocol
 	SetTrackingContext(c, rule, provider, requestModel, responseModel, isStreaming)
 
 	// Get or create the recorder for dual-stage recording (pristine request body).
-	var recorder *recording.ProtocolRecorder
 	if scenarioConfig.IsRecordingEnable() {
 		bs, err := req.MarshalJSON()
 		if err != nil {
 			bs = []byte("{}")
 		}
-		recorder = ph.EnsureProtocolRecorder(c, string(scenarioType), provider, requestModel, ph.getScenarioRecordMode(scenarioType), bs)
+		ph.EnsureProtocolRecorder(c, string(scenarioType), provider, requestModel, ph.getScenarioRecordMode(scenarioType), bs)
 	}
 
 	// Snapshot a pristine template only when failover is possible.
@@ -338,13 +335,13 @@ func (ph *ProtocolHandler) AnthropicMessagesV1Beta(c *gin.Context, req *protocol
 				}
 				areq = cloned
 			}
-			ph.runAnthropicBetaAttempt(c, areq, responseModel, p, retryModel, rule, isStreaming, scenarioType, scenarioConfig, recorder)
+			ph.runAnthropicBetaAttempt(c, areq, responseModel, p, retryModel, rule, isStreaming, scenarioType, scenarioConfig)
 		})
 }
 
 // runAnthropicBetaAttempt executes the provider-dependent half of an Anthropic
 // beta request for one failover attempt. See runAnthropicV1Attempt.
-func (ph *ProtocolHandler) runAnthropicBetaAttempt(c *gin.Context, req *protocol.AnthropicBetaMessagesRequest, responseModel string, provider *typ.Provider, requestModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig, recorder *recording.ProtocolRecorder) {
+func (ph *ProtocolHandler) runAnthropicBetaAttempt(c *gin.Context, req *protocol.AnthropicBetaMessagesRequest, responseModel string, provider *typ.Provider, requestModel string, rule *typ.Rule, isStreaming bool, scenarioType typ.RuleScenario, scenarioConfig *typ.ScenarioConfig) {
 	// Resolve dual endpoint: when the provider has an Anthropic-compatible
 	// dual URL configured, route there natively to avoid a transform.
 	provider = provider.ResolveStyle(protocol.APIStyleAnthropic)
@@ -391,7 +388,7 @@ func (ph *ProtocolHandler) runAnthropicBetaAttempt(c *gin.Context, req *protocol
 	// (This also applies the custom User-Agent to the request context.)
 	ruleFlags := ResolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeAnthropicBeta, target, provider)
 
-	reqCtx, err := ph.TransformAnthropicBeta(c, req, target, provider, isStreaming, recorder, scenarioType, RulePreBaseTransforms(ruleFlags), RulePreVendorTransforms(ruleFlags))
+	reqCtx, err := ph.TransformAnthropicBeta(c, req, target, provider, isStreaming, scenarioType, RulePreBaseTransforms(ruleFlags), RulePreVendorTransforms(ruleFlags))
 	if err != nil {
 		ph.FailAttemptSetup(c, err)
 		return
@@ -401,5 +398,5 @@ func (ph *ProtocolHandler) runAnthropicBetaAttempt(c *gin.Context, req *protocol
 	reqCtx.RequestModel = requestModel
 	reqCtx.ResponseModel = responseModel
 
-	ph.DispatchChainResult(c, reqCtx, rule, provider, isStreaming, recorder)
+	ph.DispatchChainResult(c, reqCtx, rule, provider, isStreaming)
 }

--- a/internal/protocolserver/anthropic_recording_e2e_test.go
+++ b/internal/protocolserver/anthropic_recording_e2e_test.go
@@ -86,7 +86,7 @@ func TestAnthropicV1BetaStream_Recorded(t *testing.T) {
 	// Direct call into the inner streaming handler — the function under
 	// test. If AttachRecorderHooks were dropped, the assertion below
 	// (assembled body in FinalResponse) would fail.
-	h.StreamAnthropicBeta(c, req, streamResp, string(req.Model), "proxy-stream-model", provider, recorder)
+	h.StreamAnthropicBeta(c, req, streamResp, string(req.Model), "proxy-stream-model", provider)
 
 	require.NoError(t, sink.ForceFlush(recordingtest.CtxWithTimeout(t)))
 

--- a/internal/protocolserver/error_response.go
+++ b/internal/protocolserver/error_response.go
@@ -35,7 +35,8 @@ const ProbeSyntheticRuleUUID = "probe-synthetic"
 // given description (propagating the upstream status), and recorder capture.
 // It consolidates the track/send/record triplet repeated across the protocol
 // dispatch paths.
-func (ph *ProtocolHandler) failRequest(c *gin.Context, recorder *recording.ProtocolRecorder, err error, desc string) {
+func (ph *ProtocolHandler) failRequest(c *gin.Context, err error, desc string) {
+	recorder := recording.FromGin(c)
 	ph.trackUsageFromContext(c, 0, 0, err)
 	SendErrorResponse(c, err, desc)
 	if recorder != nil {
@@ -45,7 +46,8 @@ func (ph *ProtocolHandler) failRequest(c *gin.Context, recorder *recording.Proto
 
 // failForward is failRequest with the canonical forwarding-error body
 // (stream.SendForwardingError) instead of a per-site description.
-func (ph *ProtocolHandler) failForward(c *gin.Context, recorder *recording.ProtocolRecorder, err error) {
+func (ph *ProtocolHandler) failForward(c *gin.Context, err error) {
+	recorder := recording.FromGin(c)
 	ph.trackUsageFromContext(c, 0, 0, err)
 	stream.SendForwardingError(c, err)
 	if recorder != nil {
@@ -56,7 +58,8 @@ func (ph *ProtocolHandler) failForward(c *gin.Context, recorder *recording.Proto
 // respondMCPError is the MCP-tool-call variant of failRequest: a fixed 500
 // "api_error" body (MCP loop failures are gateway-internal, so no upstream
 // status to propagate) with the message ordered as "desc: err".
-func (ph *ProtocolHandler) respondMCPError(c *gin.Context, recorder *recording.ProtocolRecorder, err error, msg string) {
+func (ph *ProtocolHandler) respondMCPError(c *gin.Context, err error, msg string) {
+	recorder := recording.FromGin(c)
 	ph.trackUsageFromContext(c, 0, 0, err)
 	c.JSON(http.StatusInternalServerError, ErrorResponse{
 		Error: ErrorDetail{

--- a/internal/protocolserver/mcp_anthropic_v1_helper.go
+++ b/internal/protocolserver/mcp_anthropic_v1_helper.go
@@ -265,8 +265,8 @@ func (ph *ProtocolHandler) DispatchGenericOpenAIChatNonStream(
 	reqCtx *transform.TransformContext,
 	rule *typ.Rule,
 	provider *typ.Provider,
-	recorder *recording.ProtocolRecorder,
 ) {
+	recorder := recording.FromGin(c)
 	req := reqCtx.Request.(*openai.ChatCompletionNewParams)
 
 	response, usage, err := ph.RunGenericOpenAIChatNonStream(c.Request.Context(), provider, req, recorder)
@@ -293,8 +293,8 @@ func (ph *ProtocolHandler) DispatchGenericOpenAIChatStream(
 	reqCtx *transform.TransformContext,
 	rule *typ.Rule,
 	provider *typ.Provider,
-	recorder *recording.ProtocolRecorder,
 ) {
+	recorder := recording.FromGin(c)
 	req := reqCtx.Request.(*openai.ChatCompletionNewParams)
 	actualModel := reqCtx.RequestModel
 	responseModel := reqCtx.ResponseModel
@@ -349,8 +349,8 @@ func (ph *ProtocolHandler) DispatchGenericAnthropicBetaNonStream(
 	reqCtx *transform.TransformContext,
 	rule *typ.Rule,
 	provider *typ.Provider,
-	recorder *recording.ProtocolRecorder,
 ) {
+	recorder := recording.FromGin(c)
 	req := reqCtx.Request.(*anthropic.BetaMessageNewParams)
 	actualModel := reqCtx.RequestModel
 
@@ -384,8 +384,8 @@ func (ph *ProtocolHandler) DispatchGenericAnthropicBetaStream(
 	reqCtx *transform.TransformContext,
 	rule *typ.Rule,
 	provider *typ.Provider,
-	recorder *recording.ProtocolRecorder,
 ) {
+	recorder := recording.FromGin(c)
 	req := reqCtx.Request.(*anthropic.BetaMessageNewParams)
 	actualModel := reqCtx.RequestModel
 	responseModel := reqCtx.ResponseModel

--- a/internal/protocolserver/mcp_stream_anthropic_to_openai.go
+++ b/internal/protocolserver/mcp_stream_anthropic_to_openai.go
@@ -24,8 +24,8 @@ func (ph *ProtocolHandler) StreamAnthropicBetaToOpenAIChatWithMCP(
 	actualModel string,
 	responseModel string,
 	disableStreamUsage bool,
-	recorder *recording.ProtocolRecorder,
 ) {
+	recorder := recording.FromGin(c)
 	for round := 0; round < 3; round++ {
 		wrapper := ph.deps.ClientPool.GetAnthropicClient(c.Request.Context(), provider, actualModel)
 		fc := forwarding.NewForwardContext(c.Request.Context(), provider)

--- a/internal/protocolserver/openai_chat.go
+++ b/internal/protocolserver/openai_chat.go
@@ -230,7 +230,7 @@ func (ph *ProtocolHandler) runOpenAIChatAttempt(c *gin.Context, req *protocol.Op
 	ruleFlags := ResolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIChat, target, provider)
 
 	// === Transform via pipeline ===
-	reqCtx, err := ph.TransformOpenAIChat(c, req, target, provider, isStreaming, nil, scenarioType, RulePreBaseTransforms(ruleFlags), RulePreVendorTransforms(ruleFlags))
+	reqCtx, err := ph.TransformOpenAIChat(c, req, target, provider, isStreaming, scenarioType, RulePreBaseTransforms(ruleFlags), RulePreVendorTransforms(ruleFlags))
 	if err != nil {
 		ph.FailAttemptSetup(c, fmt.Errorf("Transform failed: %w", err))
 		return
@@ -243,5 +243,5 @@ func (ph *ProtocolHandler) runOpenAIChatAttempt(c *gin.Context, req *protocol.Op
 	// === Dispatch via transform chain ===
 	reqCtx.RequestModel = actualModel
 	reqCtx.ResponseModel = responseModel
-	ph.DispatchChainResult(c, reqCtx, rule, provider, isStreaming, nil)
+	ph.DispatchChainResult(c, reqCtx, rule, provider, isStreaming)
 }

--- a/internal/protocolserver/openai_mcp.go
+++ b/internal/protocolserver/openai_mcp.go
@@ -20,8 +20,8 @@ func (ph *ProtocolHandler) StreamOpenAIChatToAnthropicV1WithMCP(
 	req *openai.ChatCompletionNewParams,
 	actualModel string,
 	responseModel string,
-	recorder *recording.ProtocolRecorder,
 ) {
+	recorder := recording.FromGin(c)
 	for round := 0; round < 3; round++ {
 		wrapper := ph.deps.ClientPool.GetOpenAIClient(c.Request.Context(), provider, req.Model)
 		fc := forwarding.NewForwardContext(c.Request.Context(), provider)
@@ -71,8 +71,8 @@ func (ph *ProtocolHandler) StreamOpenAIChatToAnthropicBetaWithMCP(
 	req *openai.ChatCompletionNewParams,
 	actualModel string,
 	responseModel string,
-	recorder *recording.ProtocolRecorder,
 ) {
+	recorder := recording.FromGin(c)
 	streamRec := recording.NewStreamRecorder(recorder)
 	if streamRec != nil {
 		streamRec.SetupStreamRecorderInContext(c)

--- a/internal/protocolserver/openai_responses.go
+++ b/internal/protocolserver/openai_responses.go
@@ -224,7 +224,7 @@ func (ph *ProtocolHandler) runOpenAIResponsesAttempt(c *gin.Context, req *protoc
 	// Resolve flags with scenario injection, consistent with the chat/v1/beta
 	// handlers (this also applies the custom User-Agent to the request context).
 	ruleFlags := ResolveRuleFlagsWithScenario(c, rule, scenarioType, scenarioConfig, protocol.TypeOpenAIResponses, target, provider)
-	reqCtx, err := ph.TransformOpenAIResponses(c, req, target, provider, isStreaming, nil, scenarioType, maxAllowed, RulePreBaseTransforms(ruleFlags), RulePreVendorTransforms(ruleFlags))
+	reqCtx, err := ph.TransformOpenAIResponses(c, req, target, provider, isStreaming, scenarioType, maxAllowed, RulePreBaseTransforms(ruleFlags), RulePreVendorTransforms(ruleFlags))
 	if err != nil {
 		ph.FailAttemptSetup(c, fmt.Errorf("Transform failed: %w", err))
 		return
@@ -237,7 +237,7 @@ func (ph *ProtocolHandler) runOpenAIResponsesAttempt(c *gin.Context, req *protoc
 	reqCtx.Extra["skip_usage"] = ruleFlags.SkipUsage
 
 	reqCtx.RequestModel = actualModel
-	ph.DispatchChainResult(c, reqCtx, rule, provider, isStreaming, nil)
+	ph.DispatchChainResult(c, reqCtx, rule, provider, isStreaming)
 }
 
 // convertToResponsesParams converts raw JSON to OpenAI SDK params format

--- a/internal/protocolserver/protocol_cross.go
+++ b/internal/protocolserver/protocol_cross.go
@@ -56,7 +56,7 @@ func (ph *ProtocolHandler) forwardResponsesNonstream(
 		defer cancel()
 	}
 	if err != nil {
-		ph.failForward(c, recorder, err)
+		ph.failForward(c, err)
 		return
 	}
 
@@ -193,14 +193,14 @@ func (ph *ProtocolHandler) assembleResponsesToAnthropicBeta(c *gin.Context, prox
 }
 
 // nonstreamOpenAIChatToResponses handles Chat → Responses conversion (non-streaming)
-func (ph *ProtocolHandler) nonstreamOpenAIChatToResponses(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider, recorder *recording.ProtocolRecorder) {
+func (ph *ProtocolHandler) nonstreamOpenAIChatToResponses(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider) {
 	chatReq := reqCtx.Request.(*openai.ChatCompletionNewParams)
 
 	wrapper := ph.deps.ClientPool.GetOpenAIClient(c.Request.Context(), provider, string(chatReq.Model))
 	fc := forwarding.NewForwardContext(c.Request.Context(), provider)
 	chatResp, _, err := forwarding.ForwardOpenAIChat(fc, wrapper, chatReq)
 	if err != nil {
-		ph.failRequest(c, recorder, err, "Failed to forward request")
+		ph.failRequest(c, err, "Failed to forward request")
 		return
 	}
 
@@ -210,7 +210,7 @@ func (ph *ProtocolHandler) nonstreamOpenAIChatToResponses(c *gin.Context, reqCtx
 }
 
 // streamOpenAIChatToResponses handles Chat → Responses conversion (streaming)
-func (ph *ProtocolHandler) streamOpenAIChatToResponses(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider, recorder *recording.ProtocolRecorder) {
+func (ph *ProtocolHandler) streamOpenAIChatToResponses(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider) {
 	responseModel := reqCtx.ResponseModel
 	chatReq := reqCtx.Request.(*openai.ChatCompletionNewParams)
 
@@ -221,7 +221,7 @@ func (ph *ProtocolHandler) streamOpenAIChatToResponses(c *gin.Context, reqCtx *t
 		defer cancel()
 	}
 	if err != nil {
-		ph.failRequest(c, recorder, err, "Failed to create streaming request")
+		ph.failRequest(c, err, "Failed to create streaming request")
 		return
 	}
 	hc := protocol.NewHandleContext(c, responseModel)
@@ -232,7 +232,7 @@ func (ph *ProtocolHandler) streamOpenAIChatToResponses(c *gin.Context, reqCtx *t
 // nonstreamAnthropicBetaToResponses handles a Responses-shaped client
 // request that has been normalized to Anthropic Beta and forwarded to an
 // Anthropic provider (non-streaming).
-func (ph *ProtocolHandler) nonstreamAnthropicBetaToResponses(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider, recorder *recording.ProtocolRecorder) {
+func (ph *ProtocolHandler) nonstreamAnthropicBetaToResponses(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider) {
 	anthropicReq := reqCtx.Request.(*anthropic.BetaMessageNewParams)
 
 	ctx := c.Request.Context()
@@ -243,7 +243,7 @@ func (ph *ProtocolHandler) nonstreamAnthropicBetaToResponses(c *gin.Context, req
 		defer cancel()
 	}
 	if err != nil {
-		ph.failRequest(c, recorder, err, "Failed to forward request")
+		ph.failRequest(c, err, "Failed to forward request")
 		return
 	}
 
@@ -255,7 +255,7 @@ func (ph *ProtocolHandler) nonstreamAnthropicBetaToResponses(c *gin.Context, req
 // streamAnthropicBetaToResponses handles a Responses-shaped client
 // request that has been normalized to Anthropic Beta and forwarded to an
 // Anthropic provider (streaming).
-func (ph *ProtocolHandler) streamAnthropicBetaToResponses(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider, recorder *recording.ProtocolRecorder) {
+func (ph *ProtocolHandler) streamAnthropicBetaToResponses(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider) {
 	responseModel := reqCtx.ResponseModel
 	anthropicReq := reqCtx.Request.(*anthropic.BetaMessageNewParams)
 
@@ -268,7 +268,7 @@ func (ph *ProtocolHandler) streamAnthropicBetaToResponses(c *gin.Context, reqCtx
 		defer cancel()
 	}
 	if err != nil {
-		ph.failRequest(c, recorder, err, "Failed to create streaming request")
+		ph.failRequest(c, err, "Failed to create streaming request")
 		return
 	}
 
@@ -277,7 +277,8 @@ func (ph *ProtocolHandler) streamAnthropicBetaToResponses(c *gin.Context, reqCtx
 	ph.trackUsageWithTokenUsage(c, usage, err)
 }
 
-func (ph *ProtocolHandler) streamResponsesToChat(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider, recorder *recording.ProtocolRecorder) {
+func (ph *ProtocolHandler) streamResponsesToChat(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider) {
+	recorder := recording.FromGin(c)
 	actualModel, responseModel := reqCtx.RequestModel, reqCtx.ResponseModel
 	req := reqCtx.Request.(*responses.ResponseNewParams)
 
@@ -307,7 +308,8 @@ func (ph *ProtocolHandler) streamResponsesToChat(c *gin.Context, reqCtx *transfo
 	}
 }
 
-func (ph *ProtocolHandler) nonstreamResponsesToChat(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider, recorder *recording.ProtocolRecorder) {
+func (ph *ProtocolHandler) nonstreamResponsesToChat(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider) {
+	recorder := recording.FromGin(c)
 	actualModel := reqCtx.RequestModel
 	req := reqCtx.Request.(*responses.ResponseNewParams)
 
@@ -319,7 +321,7 @@ func (ph *ProtocolHandler) nonstreamResponsesToChat(c *gin.Context, reqCtx *tran
 		defer cancel()
 	}
 	if err != nil {
-		ph.failRequest(c, recorder, err, "Failed to forward request")
+		ph.failRequest(c, err, "Failed to forward request")
 		return
 	}
 

--- a/internal/protocolserver/protocol_dispatch.go
+++ b/internal/protocolserver/protocol_dispatch.go
@@ -64,8 +64,9 @@ func ShouldUseGenericMCPForProvider(cfg *config.Config, provider *typ.Provider) 
 func (ph *ProtocolHandler) DispatchChainResult(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
-	isStreaming bool, recorder *recording.ProtocolRecorder,
+	isStreaming bool,
 ) {
+	recorder := recording.FromGin(c)
 	defer func() {
 		reqCtx.Release()
 	}()
@@ -79,19 +80,19 @@ func (ph *ProtocolHandler) DispatchChainResult(
 
 	switch reqCtx.TargetAPI {
 	case protocol.TypeOpenAIChat:
-		ph.dispatchOpenAIChat(c, reqCtx, rule, provider, isStreaming, recorder)
+		ph.dispatchOpenAIChat(c, reqCtx, rule, provider, isStreaming)
 	case protocol.TypeAnthropicV1:
 		if isStreaming {
-			ph.StreamAnthropicV1(c, reqCtx, rule, provider, recorder)
+			ph.StreamAnthropicV1(c, reqCtx, rule, provider)
 		} else {
-			ph.NonstreamAnthropicV1(c, reqCtx, rule, provider, recorder)
+			ph.NonstreamAnthropicV1(c, reqCtx, rule, provider)
 		}
 	case protocol.TypeAnthropicBeta:
-		ph.dispatchAnthropicBeta(c, reqCtx, rule, provider, isStreaming, recorder)
+		ph.dispatchAnthropicBeta(c, reqCtx, rule, provider, isStreaming)
 	case protocol.TypeOpenAIResponses:
-		ph.dispatchOpenAIResponses(c, reqCtx, rule, provider, isStreaming, recorder)
+		ph.dispatchOpenAIResponses(c, reqCtx, rule, provider, isStreaming)
 	case protocol.TypeGoogle:
-		ph.dispatchGoogle(c, reqCtx, rule, provider, isStreaming, recorder)
+		ph.dispatchGoogle(c, reqCtx, rule, provider, isStreaming)
 	default:
 		c.JSON(http.StatusBadRequest, "tingly-box: invalid api style")
 		if recorder != nil {
@@ -106,19 +107,19 @@ func (ph *ProtocolHandler) DispatchChainResult(
 func (ph *ProtocolHandler) dispatchAnthropicBeta(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
-	isStreaming bool, recorder *recording.ProtocolRecorder,
+	isStreaming bool,
 ) {
 	switch reqCtx.SourceAPI {
 	case protocol.TypeOpenAIChat:
-		ph.dispatchAnthropicBetaToOpenAIChat(c, reqCtx, rule, provider, isStreaming, recorder)
+		ph.dispatchAnthropicBetaToOpenAIChat(c, reqCtx, rule, provider, isStreaming)
 	case protocol.TypeOpenAIResponses:
 		if isStreaming {
-			ph.streamAnthropicBetaToResponses(c, reqCtx, provider, recorder)
+			ph.streamAnthropicBetaToResponses(c, reqCtx, provider)
 		} else {
-			ph.nonstreamAnthropicBetaToResponses(c, reqCtx, provider, recorder)
+			ph.nonstreamAnthropicBetaToResponses(c, reqCtx, provider)
 		}
 	default:
-		ph.passthroughAnthropicBeta(c, reqCtx, rule, provider, isStreaming, recorder)
+		ph.passthroughAnthropicBeta(c, reqCtx, rule, provider, isStreaming)
 	}
 }
 
@@ -133,7 +134,7 @@ func (ph *ProtocolHandler) dispatchAnthropicBeta(
 func (ph *ProtocolHandler) dispatchOpenAIResponses(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
-	isStreaming bool, recorder *recording.ProtocolRecorder,
+	isStreaming bool,
 ) {
 	actualModel, responseModel := reqCtx.RequestModel, reqCtx.ResponseModel
 	req := reqCtx.Request.(*responses.ResponseNewParams)
@@ -161,16 +162,16 @@ func (ph *ProtocolHandler) dispatchOpenAIResponses(
 		// Client sent Responses API, but provider needs Chat format
 		// Forward as Chat, then convert response back to Responses format
 		if isStreaming {
-			ph.streamResponsesToChat(c, reqCtx, provider, recorder)
+			ph.streamResponsesToChat(c, reqCtx, provider)
 		} else {
-			ph.nonstreamResponsesToChat(c, reqCtx, provider, recorder)
+			ph.nonstreamResponsesToChat(c, reqCtx, provider)
 		}
 	case protocol.TypeOpenAIResponses:
 		// Responses API passthrough
 		if isStreaming {
-			ph.streamOpenAIResponses(c, reqCtx, provider, recorder)
+			ph.streamOpenAIResponses(c, reqCtx, provider)
 		} else {
-			ph.nonstreamOpenAIResponses(c, reqCtx, provider, recorder)
+			ph.nonstreamOpenAIResponses(c, reqCtx, provider)
 		}
 	}
 }
@@ -283,8 +284,9 @@ func formatAppliedFlags(f typ.RuleFlags) string {
 func (ph *ProtocolHandler) dispatchAnthropicBetaToOpenAIChat(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
-	isStreaming bool, recorder *recording.ProtocolRecorder,
+	isStreaming bool,
 ) {
+	recorder := recording.FromGin(c)
 	actualModel, responseModel := reqCtx.RequestModel, reqCtx.ResponseModel
 	req := reqCtx.Request.(*anthropic.BetaMessageNewParams)
 
@@ -300,7 +302,7 @@ func (ph *ProtocolHandler) dispatchAnthropicBetaToOpenAIChat(
 		}
 
 		if HasDeclaredMCPAnthropicBetaTools(req) && ph.mcpEnabled() {
-			ph.StreamAnthropicBetaToOpenAIChatWithMCP(c, provider, req, actualModel, responseModel, disableStreamUsage, recorder)
+			ph.StreamAnthropicBetaToOpenAIChatWithMCP(c, provider, req, actualModel, responseModel, disableStreamUsage)
 			return
 		}
 
@@ -309,7 +311,7 @@ func (ph *ProtocolHandler) dispatchAnthropicBetaToOpenAIChat(
 			defer cancel()
 		}
 		if err != nil {
-			ph.failRequest(c, recorder, err, "Failed to create streaming request")
+			ph.failRequest(c, err, "Failed to create streaming request")
 			return
 		}
 
@@ -343,7 +345,7 @@ func (ph *ProtocolHandler) dispatchAnthropicBetaToOpenAIChat(
 			var genericUsage *mcp.TokenUsage
 			anthropicResp, genericUsage, err = ph.RunGenericAnthropicBetaNonStream(ctx, provider, req, recorder)
 			if err != nil {
-				ph.respondMCPError(c, recorder, err, "Failed to handle MCP tool calls")
+				ph.respondMCPError(c, err, "Failed to handle MCP tool calls")
 				return
 			}
 			if genericUsage != nil {
@@ -356,7 +358,7 @@ func (ph *ProtocolHandler) dispatchAnthropicBetaToOpenAIChat(
 				defer cancel()
 			}
 			if err != nil {
-				ph.failRequest(c, recorder, err, "Failed to forward Anthropic request")
+				ph.failRequest(c, err, "Failed to forward Anthropic request")
 				return
 			}
 			usage = usagepkg.FromAnthropicBetaMessage(anthropicResp.Usage)
@@ -388,16 +390,17 @@ func (ph *ProtocolHandler) dispatchAnthropicBetaToOpenAIChat(
 func (ph *ProtocolHandler) passthroughAnthropicBeta(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
-	isStreaming bool, recorder *recording.ProtocolRecorder,
+	isStreaming bool,
 ) {
+	recorder := recording.FromGin(c)
 	useGeneric := ph.mcpEnabled() && ph.shouldUseGenericMCPForProvider(provider)
 
 	if useGeneric {
 		if !isStreaming {
-			ph.DispatchGenericAnthropicBetaNonStream(c, reqCtx, rule, provider, recorder)
+			ph.DispatchGenericAnthropicBetaNonStream(c, reqCtx, rule, provider)
 			return
 		}
-		ph.DispatchGenericAnthropicBetaStream(c, reqCtx, rule, provider, recorder)
+		ph.DispatchGenericAnthropicBetaStream(c, reqCtx, rule, provider)
 		return
 	}
 
@@ -410,7 +413,7 @@ func (ph *ProtocolHandler) passthroughAnthropicBeta(
 		if ph.mcpEnabled() {
 			declaredMCP := HasDeclaredMCPAnthropicBetaTools(req)
 			if declaredMCP {
-				ph.DispatchGenericAnthropicBetaStream(c, reqCtx, rule, provider, recorder)
+				ph.DispatchGenericAnthropicBetaStream(c, reqCtx, rule, provider)
 				return
 			}
 		}
@@ -426,7 +429,7 @@ func (ph *ProtocolHandler) passthroughAnthropicBeta(
 			return
 		}
 
-		ph.StreamAnthropicBeta(c, req, streamResp, actualModel, responseModel, provider, recorder)
+		ph.StreamAnthropicBeta(c, req, streamResp, actualModel, responseModel, provider)
 		return
 
 	} else {
@@ -440,7 +443,7 @@ func (ph *ProtocolHandler) passthroughAnthropicBeta(
 			var usage *mcp.TokenUsage
 			anthropicResp, usage, err = ph.RunGenericAnthropicBetaNonStream(ctx, provider, req, recorder)
 			if err != nil {
-				ph.failForward(c, recorder, err)
+				ph.failForward(c, err)
 				return
 			}
 			if usage != nil {
@@ -456,7 +459,7 @@ func (ph *ProtocolHandler) passthroughAnthropicBeta(
 				defer cancel()
 			}
 			if err != nil {
-				ph.failForward(c, recorder, err)
+				ph.failForward(c, err)
 				return
 			}
 
@@ -482,8 +485,9 @@ func (ph *ProtocolHandler) passthroughAnthropicBeta(
 func (ph *ProtocolHandler) dispatchGoogle(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
-	isStreaming bool, recorder *recording.ProtocolRecorder,
+	isStreaming bool,
 ) {
+	recorder := recording.FromGin(c)
 	actualModel, responseModel := reqCtx.RequestModel, reqCtx.ResponseModel
 	googleReq := reqCtx.Request.(*protocol.GoogleRequest)
 	model, req, cfg := actualModel, googleReq.Contents, googleReq.Config
@@ -574,8 +578,9 @@ func (ph *ProtocolHandler) dispatchGoogle(
 func (ph *ProtocolHandler) dispatchOpenAIChat(
 	c *gin.Context, reqCtx *transform.TransformContext,
 	rule *typ.Rule, provider *typ.Provider,
-	isStreaming bool, recorder *recording.ProtocolRecorder,
+	isStreaming bool,
 ) {
+	recorder := recording.FromGin(c)
 	actualModel, responseModel := reqCtx.RequestModel, reqCtx.ResponseModel
 
 	req := reqCtx.Request.(*openai.ChatCompletionNewParams)
@@ -590,9 +595,9 @@ func (ph *ProtocolHandler) dispatchOpenAIChat(
 	if isStreaming {
 		switch reqCtx.SourceAPI {
 		case protocol.TypeAnthropicV1:
-			ph.StreamOpenAIChatToAnthropicV1WithMCP(c, provider, req, actualModel, responseModel, recorder)
+			ph.StreamOpenAIChatToAnthropicV1WithMCP(c, provider, req, actualModel, responseModel)
 		case protocol.TypeAnthropicBeta:
-			ph.StreamOpenAIChatToAnthropicBetaWithMCP(c, provider, req, actualModel, responseModel, recorder)
+			ph.StreamOpenAIChatToAnthropicBetaWithMCP(c, provider, req, actualModel, responseModel)
 		case protocol.TypeOpenAIChat:
 			// OpenAI passthrough: source and target are both OpenAI Chat format
 			disableStreamUsage := ShouldStripUsage(reqCtx.Extra)
@@ -601,13 +606,13 @@ func (ph *ProtocolHandler) dispatchOpenAIChat(
 			}
 
 			if HasDeclaredMCPTools(req) && ph.mcpEnabled() {
-				ph.DispatchGenericOpenAIChatStream(c, reqCtx, rule, provider, recorder)
+				ph.DispatchGenericOpenAIChatStream(c, reqCtx, rule, provider)
 				return
 			}
 
 			ph.streamOpenAIChat(c, provider, req, responseModel, disableStreamUsage)
 		case protocol.TypeOpenAIResponses:
-			ph.streamOpenAIChatToResponses(c, reqCtx, provider, recorder)
+			ph.streamOpenAIChatToResponses(c, reqCtx, provider)
 		}
 	} else {
 		switch reqCtx.SourceAPI {
@@ -616,14 +621,14 @@ func (ph *ProtocolHandler) dispatchOpenAIChat(
 			stripUsage := ShouldStripUsage(reqCtx.Extra)
 
 			if HasDeclaredMCPTools(req) && ph.mcpEnabled() {
-				ph.DispatchGenericOpenAIChatNonStream(c, reqCtx, rule, provider, recorder)
+				ph.DispatchGenericOpenAIChatNonStream(c, reqCtx, rule, provider)
 				return
 			}
 
 			ph.nonstreamOpenAIChat(c, provider, req, responseModel, stripUsage)
 			return
 		case protocol.TypeOpenAIResponses:
-			ph.nonstreamOpenAIChatToResponses(c, reqCtx, provider, recorder)
+			ph.nonstreamOpenAIChatToResponses(c, reqCtx, provider)
 			return
 		default:
 			// Forward request to provider for format conversion

--- a/internal/protocolserver/protocol_passthrough.go
+++ b/internal/protocolserver/protocol_passthrough.go
@@ -27,8 +27,8 @@ func (ph *ProtocolHandler) NonstreamAnthropicV1(
 	reqCtx *transform.TransformContext,
 	rule *typ.Rule,
 	provider *typ.Provider,
-	recorder *recording.ProtocolRecorder,
 ) {
+	recorder := recording.FromGin(c)
 	req := reqCtx.Request.(*anthropic.MessageNewParams)
 	actualModel := reqCtx.RequestModel
 
@@ -109,8 +109,8 @@ func (ph *ProtocolHandler) StreamAnthropicV1(
 	reqCtx *transform.TransformContext,
 	rule *typ.Rule,
 	provider *typ.Provider,
-	recorder *recording.ProtocolRecorder,
 ) {
+	recorder := recording.FromGin(c)
 	req := reqCtx.Request.(*anthropic.MessageNewParams)
 	actualModel := reqCtx.RequestModel
 	responseModel := reqCtx.ResponseModel
@@ -180,7 +180,8 @@ func (ph *ProtocolHandler) StreamAnthropicV1(
 // StreamAnthropicBeta processes the Anthropic beta streaming
 // response. The resolved model is passed in as actualModel rather than read from
 // the request, so the handler no longer depends on req.Model.
-func (ph *ProtocolHandler) StreamAnthropicBeta(c *gin.Context, req *anthropic.BetaMessageNewParams, streamResp *anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion], actualModel string, responseModel string, provider *typ.Provider, recorder *recording.ProtocolRecorder) {
+func (ph *ProtocolHandler) StreamAnthropicBeta(c *gin.Context, req *anthropic.BetaMessageNewParams, streamResp *anthropicstream.Stream[anthropic.BetaRawMessageStreamEventUnion], actualModel string, responseModel string, provider *typ.Provider) {
+	recorder := recording.FromGin(c)
 	hc := protocol.NewHandleContext(c, responseModel)
 
 	// Add recorder hooks if recorder is available
@@ -206,7 +207,7 @@ func (ph *ProtocolHandler) nonstreamOpenAIChat(c *gin.Context, provider *typ.Pro
 	fc := forwarding.NewForwardContext(c.Request.Context(), provider)
 	response, _, err := forwarding.ForwardOpenAIChat(fc, wrapper, req)
 	if err != nil {
-		ph.failForward(c, nil, err)
+		ph.failForward(c, err)
 		return
 	}
 
@@ -301,7 +302,8 @@ func (ph *ProtocolHandler) streamOpenAIChat(c *gin.Context, provider *typ.Provid
 }
 
 // nonstreamOpenAIResponses handles Responses API passthrough (non-streaming)
-func (ph *ProtocolHandler) nonstreamOpenAIResponses(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider, recorder *recording.ProtocolRecorder) {
+func (ph *ProtocolHandler) nonstreamOpenAIResponses(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider) {
+	recorder := recording.FromGin(c)
 	params := reqCtx.Request.(*responses.ResponseNewParams)
 
 	wrapper := ph.deps.ClientPool.GetOpenAIClient(c.Request.Context(), provider, string(params.Model))
@@ -311,7 +313,7 @@ func (ph *ProtocolHandler) nonstreamOpenAIResponses(c *gin.Context, reqCtx *tran
 		defer cancel()
 	}
 	if err != nil {
-		ph.failRequest(c, recorder, err, "Failed to forward request")
+		ph.failRequest(c, err, "Failed to forward request")
 		return
 	}
 
@@ -326,7 +328,8 @@ func (ph *ProtocolHandler) nonstreamOpenAIResponses(c *gin.Context, reqCtx *tran
 
 // streamOpenAIResponses handles Responses API passthrough (streaming)
 // Moved from openai_responses.go:421-456
-func (ph *ProtocolHandler) streamOpenAIResponses(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider, recorder *recording.ProtocolRecorder) {
+func (ph *ProtocolHandler) streamOpenAIResponses(c *gin.Context, reqCtx *transform.TransformContext, provider *typ.Provider) {
+	recorder := recording.FromGin(c)
 	responseModel := reqCtx.ResponseModel
 	params := reqCtx.Request.(*responses.ResponseNewParams)
 

--- a/internal/protocolserver/protocol_transform.go
+++ b/internal/protocolserver/protocol_transform.go
@@ -94,10 +94,11 @@ type transformSourceOptions struct {
 // TransformContext, execute, and mirror steps/errors into the recorder.
 // Generic (free function — Go methods cannot have type parameters) so the
 // compile-time RequestUnionConstraint on NewTransformContext is preserved.
-func transformRequest[T transform.RequestUnionConstraint](ph *ProtocolHandler, c *gin.Context, req T, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *recording.ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms, preVendorTransforms []transform.Transform, src transformSourceOptions) (*transform.TransformContext, error) {
+func transformRequest[T transform.RequestUnionConstraint](ph *ProtocolHandler, c *gin.Context, req T, target protocol.APIType, provider *typ.Provider, isStreaming bool, scenarioType typ.RuleScenario, preBaseTransforms, preVendorTransforms []transform.Transform, src transformSourceOptions) (*transform.TransformContext, error) {
+	protocolRecorder := recording.FromGin(c)
 	// Build transform chain with recording support. The rule-driven pre-Base and
 	// preVendor transforms are slotted into their canonical positions by the builder.
-	chain, err := ph.buildTransformChain(c, target, scenarioType, protocolRecorder, preBaseTransforms, preVendorTransforms)
+	chain, err := ph.buildTransformChain(c, target, scenarioType, preBaseTransforms, preVendorTransforms)
 	if err != nil {
 		return nil, err
 	}
@@ -156,8 +157,8 @@ func transformRequest[T transform.RequestUnionConstraint](ph *ProtocolHandler, c
 	return finalCtx, nil
 }
 
-func (ph *ProtocolHandler) TransformAnthropicBeta(c *gin.Context, req *protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *recording.ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
-	return transformRequest(ph, c, req.BetaMessageNewParams, target, provider, isStreaming, protocolRecorder, scenarioType, preBaseTransforms, preVendorTransforms, transformSourceOptions{
+func (ph *ProtocolHandler) TransformAnthropicBeta(c *gin.Context, req *protocol.AnthropicBetaMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
+	return transformRequest(ph, c, req.BetaMessageNewParams, target, provider, isStreaming, scenarioType, preBaseTransforms, preVendorTransforms, transformSourceOptions{
 		source:               protocol.TypeAnthropicBeta,
 		defaultScenarioFlags: true,
 		hasNativeAdvisor:     HasNativeAdvisorBeta(req),
@@ -165,21 +166,21 @@ func (ph *ProtocolHandler) TransformAnthropicBeta(c *gin.Context, req *protocol.
 	})
 }
 
-func (ph *ProtocolHandler) TransformAnthropicV1(c *gin.Context, req *protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *recording.ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
-	return transformRequest(ph, c, req.MessageNewParams, target, provider, isStreaming, protocolRecorder, scenarioType, preBaseTransforms, preVendorTransforms, transformSourceOptions{
+func (ph *ProtocolHandler) TransformAnthropicV1(c *gin.Context, req *protocol.AnthropicMessagesRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
+	return transformRequest(ph, c, req.MessageNewParams, target, provider, isStreaming, scenarioType, preBaseTransforms, preVendorTransforms, transformSourceOptions{
 		source:               protocol.TypeAnthropicV1,
 		defaultScenarioFlags: true,
 	})
 }
 
-func (ph *ProtocolHandler) TransformOpenAIChat(c *gin.Context, req *protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *recording.ProtocolRecorder, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
-	return transformRequest(ph, c, req.ChatCompletionNewParams, target, provider, isStreaming, protocolRecorder, scenarioType, preBaseTransforms, preVendorTransforms, transformSourceOptions{
+func (ph *ProtocolHandler) TransformOpenAIChat(c *gin.Context, req *protocol.OpenAIChatCompletionRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, scenarioType typ.RuleScenario, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
+	return transformRequest(ph, c, req.ChatCompletionNewParams, target, provider, isStreaming, scenarioType, preBaseTransforms, preVendorTransforms, transformSourceOptions{
 		source: protocol.TypeOpenAIChat,
 	})
 }
 
-func (ph *ProtocolHandler) TransformOpenAIResponses(c *gin.Context, req *protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, protocolRecorder *recording.ProtocolRecorder, scenarioType typ.RuleScenario, maxAllowed int, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
-	return transformRequest(ph, c, req.ResponseNewParams, target, provider, isStreaming, protocolRecorder, scenarioType, preBaseTransforms, preVendorTransforms, transformSourceOptions{
+func (ph *ProtocolHandler) TransformOpenAIResponses(c *gin.Context, req *protocol.ResponseCreateRequest, target protocol.APIType, provider *typ.Provider, isStreaming bool, scenarioType typ.RuleScenario, maxAllowed int, preBaseTransforms []transform.Transform, preVendorTransforms []transform.Transform) (*transform.TransformContext, error) {
+	return transformRequest(ph, c, req.ResponseNewParams, target, provider, isStreaming, scenarioType, preBaseTransforms, preVendorTransforms, transformSourceOptions{
 		source:    protocol.TypeOpenAIResponses,
 		extraOpts: []transform.TransformOption{transform.WithMaxTokens(int64(maxAllowed))},
 	})
@@ -202,7 +203,8 @@ func (ph *ProtocolHandler) TransformOpenAIResponses(c *gin.Context, req *protoco
 // the provider and must be the last mutation, so the preVendor transforms are
 // inserted after Consistency but BEFORE Vendor — this also means the StagePost
 // recording captures the truly-final, dispatched request.
-func (ph *ProtocolHandler) buildTransformChain(c *gin.Context, targetType protocol.APIType, scenarioType typ.RuleScenario, recorder *recording.ProtocolRecorder, preBase []transform.Transform, preVendor []transform.Transform) (*transform.TransformChain, error) {
+func (ph *ProtocolHandler) buildTransformChain(c *gin.Context, targetType protocol.APIType, scenarioType typ.RuleScenario, preBase []transform.Transform, preVendor []transform.Transform) (*transform.TransformChain, error) {
+	recorder := recording.FromGin(c)
 
 	recordMode := ph.getScenarioRecordMode(scenarioType)
 	shouldRecord := recorder != nil

--- a/internal/protocolserver/protocol_transform_test.go
+++ b/internal/protocolserver/protocol_transform_test.go
@@ -18,7 +18,7 @@ import (
 func chainNames(t *testing.T, preBase, preVendor []transform.Transform) []string {
 	t.Helper()
 	h := &ProtocolHandler{}
-	chain, err := h.buildTransformChain(nil, protocol.TypeOpenAIChat, typ.ScenarioGlobal, nil, preBase, preVendor)
+	chain, err := h.buildTransformChain(nil, protocol.TypeOpenAIChat, typ.ScenarioGlobal, preBase, preVendor)
 	require.NoError(t, err)
 
 	var names []string

--- a/internal/protocolserver/recording/recorder.go
+++ b/internal/protocolserver/recording/recorder.go
@@ -112,6 +112,20 @@ func getRecorderFromContext(c *gin.Context) (*ProtocolRecorder, bool) {
 	return rec, ok
 }
 
+// FromGin is the canonical way protocol code reaches the per-request
+// recorder: nil when recording is off, and every recorder method is
+// nil-safe, so callers use the result unconditionally. The recorder rides
+// the gin context (stashed once by EnsureProtocolRecorder) instead of being
+// threaded through protocol call signatures — mirroring how rule flags ride
+// the request context rather than parameter lists.
+func FromGin(c *gin.Context) *ProtocolRecorder {
+	if c == nil {
+		return nil
+	}
+	rec, _ := getRecorderFromContext(c)
+	return rec
+}
+
 func (sr *ProtocolRecorder) BindProvider(provider *typ.Provider, model string, mode obs.RecordMode) {
 	if sr == nil {
 		return

--- a/internal/server/mcp_path_matrix_e2e_test.go
+++ b/internal/server/mcp_path_matrix_e2e_test.go
@@ -289,7 +289,7 @@ func runDispatch(
 	c.Request = httptest.NewRequest(http.MethodPost, "/test", strings.NewReader("{}"))
 	protocolserver.SetTrackingContext(c, rule, provider, reqCtx.RequestModel, reqCtx.ResponseModel, streaming)
 
-	s.aiHandler.DispatchChainResult(c, reqCtx, rule, provider, streaming, nil)
+	s.aiHandler.DispatchChainResult(c, reqCtx, rule, provider, streaming)
 	return w.Code, w.Header(), w.Body.String()
 }
 

--- a/internal/server/mcp_response_hook_integration_test.go
+++ b/internal/server/mcp_response_hook_integration_test.go
@@ -704,7 +704,7 @@ func TestDispatchAnthropicToAnthropicV1_Streaming_AdvisorSSEEndToEnd(t *testing.
 	rule := &typ.Rule{}
 	protocolserver.SetTrackingContext(c, rule, provider, reqCtx.RequestModel, reqCtx.ResponseModel, true)
 
-	s.aiHandler.DispatchChainResult(c, reqCtx, rule, provider, true, nil)
+	s.aiHandler.DispatchChainResult(c, reqCtx, rule, provider, true)
 
 	require.Equal(t, 1, advisorCalls)
 	require.Equal(t, 2, workerCalls)


### PR DESCRIPTION
## Summary

The per-request recorder was threaded as an explicit parameter through ~40 protocol dispatch signatures, even though every call site handed down the same instance `EnsureProtocolRecorder` had already stashed in the gin context (or a literal `nil` on the OpenAI paths, which never create one). This pure refactor makes the context the single carrier — the same shape rule flags already use — so upcoming recording work builds on the correct form instead of extending the threading.

## Key Changes

- **Canonical accessor**: new `recording.FromGin(c)` — nil-safe (nil gin ctx included); combined with the recorder's nil-safe methods, callers use the result unconditionally.
- **De-parameterized signatures**: the `recorder *recording.ProtocolRecorder` parameter is removed from all dispatch/transform/passthrough/cross/MCP signatures; functions that use the recorder fetch it themselves.
- **Deliberate exceptions**: `RunGeneric*NonStream` leaf helpers (only `context.Context`, no gin ctx — callers fetch and pass), the recording package's own constructors, and `handlePreStreamFailure`'s narrow interface param (shared by two recorder implementations).

## Notes

- No behavior change: the gin-ctx instance and the threaded instance were always the same (or both nil); pinned by the existing recording e2e test and the full suite.

---

## 摘要

recorder 此前作为显式参数在 ~40 处协议派发签名里层层透传,而每个调用点传下去的都是 `EnsureProtocolRecorder` 早已存进 gin context 的同一实例(OpenAI 路径则是字面 `nil`,它们从不创建)。本 PR 是纯重构:让 context 成为唯一载体——与 rule flags 既有形态同构——后续录制工作在正确形态上构建,而不是继续扩散透传。

## 关键改动

- **规范取用入口**:新增 `recording.FromGin(c)`,nil 安全(含 gin ctx 为 nil);配合 recorder 方法本身 nil-safe,调用方无条件使用即可。
- **签名去参**:dispatch/transform/passthrough/cross/MCP 全部签名移除 `recorder` 参数;使用 recorder 的函数自行取用。
- **刻意保留的例外**:`RunGeneric*NonStream` 叶子 helper(只有 `context.Context`,由 gin 域调用方取好传入)、recording 包自己的构造 API、`handlePreStreamFailure` 的窄接口参数(两种 recorder 实现共用)。

## 说明

- 行为零变化:ctx 实例与透传实例始终同一(或同为 nil);由既有录制 e2e 测试与全量测试钉死。

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7tYK69i7kpVE3d5pa4Dn2)_