### PR TITLE
feat(frontend): upgrade Image Gen page to Image Playground with edit mode

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -246,8 +246,9 @@ function AppContent() {
                     <Route path="/agent/xcode" element={<UseXcodePage />} />
                     <Route path="/agent/vscode" element={<UseVSCodePage />} />
                     <Route path="/agent/embed" element={<UseEmbedPage />} />
-                    <Route path="/agent/imagegen" element={<UseImageGenPage />} />
-                    <Route path="/agent/playground" element={<Navigate to="/agent/imagegen" replace />} />
+                    <Route path="/agent/image" element={<UseImageGenPage />} />
+                    <Route path="/agent/playground" element={<Navigate to="/agent/image" replace />} />
+                    <Route path="/agent/imagegen" element={<Navigate to="/agent/image" replace />} />
                     {/* Credential routes - new unified page */}
                     <Route path="/credentials" element={<CredentialPage />} />
                     {/* Virtual Models page - peer of Model Key and Sharing */}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -55,7 +55,7 @@ export default {
       "useXcode": "Xcode",
       "useVSCode": "VS Code",
       "useEmbed": "Embedding",
-      "useImageGen": "Image Gen",
+      "useImageGen": "Image",
       "useTeam": "Team",
       "useCustom": "Custom",
       "apiKeys": "API Keys",
@@ -1540,9 +1540,9 @@ export default {
     "success": "Provider added successfully! You can now create scenarios."
   },
   "imageGenQuickStart": {
-    "title": "Image Generation Quick Start",
+    "title": "Image API Quick Start",
     "closeAriaLabel": "Close quick start",
-    "description": "Call the image generation endpoint, then decode the base64 response into an image file. The model token is available from GET /api/v1/token."
+    "description": "Call the image generation or edit endpoint, then decode the base64 response into an image file. The model token is available from GET /api/v1/token."
   },
   "templatePage": {
     "noProviders": {
@@ -1614,12 +1614,28 @@ export default {
     "model": "Model",
     "prompt": "Prompt",
     "promptPlaceholder": "Describe the image you want to generate…",
+    "editPromptPlaceholder": "Describe the change you want to make…",
     "size": "Size",
     "quality": "Quality",
     "count": "N",
     "generate": "Generate",
     "generateAnother": "Generate another · {{count}} running",
     "generatingNew": "Generating new images…",
+    "modeGenerate": "Generate",
+    "modeEdit": "Edit",
+    "editBadge": "Edited",
+    "edit": "Edit Image",
+    "editAnother": "Edit another · {{count}} running",
+    "editingNew": "Editing images…",
+    "referenceImages": "Reference images",
+    "referenceHint": "Up to {{max}} images · PNG, JPEG, or WebP",
+    "addReferenceImage": "Add image",
+    "dropReferenceImage": "Drop images here or click to browse",
+    "removeReferenceImage": "Remove reference image {{number}}",
+    "noReferenceImages": "Add at least one image to edit",
+    "useAsReference": "Edit this image",
+    "referenceLoadFailed": "Could not use this image as a reference",
+    "referenceThumbAlt": "Reference image {{number}}",
     "previewEmpty": "Your generated images will appear here",
     "previewHint": "Each generation will be kept for this session.",
     "sessionOutputs": "Session outputs",
@@ -1701,7 +1717,7 @@ export default {
     "sharingKeys": "Sharing Keys",
     "modelRules": "Model Rules",
     "embedModelRules": "Embedding Model Rules",
-    "imageGenModelRules": "Image Generation Model Rules",
+    "imageGenModelRules": "Image Model Rules",
     "tooltip": {
       "claude_code": "AI-powered CLI development agent for implementation, testing, and git operations",
       "claude_desktop": "Route Claude Desktop's third-party inference through your configured providers",
@@ -1711,7 +1727,7 @@ export default {
       "vscode": "Bring Your Own Key: Use your own API keys with VS Code Copilot through Tingly Box proxy",
       "pi": "Pi coding agent through Tingly Box proxy",
       "dsh": "DeepSeek Harness (dsh) agent harness through Tingly Box proxy",
-      "imagegen": "AI-powered image generation through Tingly Box proxy with multiple model support"
+      "imagegen": "AI-powered image generation and editing through Tingly Box proxy with multiple model support"
     },
     "vscode": {
       "installDescription": "Install the Tingly Box extension from VS Code or the Marketplace.",
@@ -1770,7 +1786,7 @@ export default {
       "openai": "Drop-in OpenAI-compatible SDK endpoint.",
       "anthropic": "Drop-in Anthropic-compatible SDK endpoint.",
       "embed": "Route embedding requests to your provider.",
-      "imagegen": "Route image generation through Tingly Box.",
+      "imagegen": "Route image generation and editing through Tingly Box.",
       "custom": "Bring your own request model name — a generic catch-all scenario. Hidden by default.",
       "team": "Shared central model deployment for your whole team. Hidden by default."
     }

--- a/frontend/src/i18n/locales/ru.ts
+++ b/frontend/src/i18n/locales/ru.ts
@@ -55,7 +55,7 @@ export default {
       "useXcode": "Xcode",
       "useVSCode": "VS Code",
       "useEmbed": "Эмбеддинги",
-      "useImageGen": "Генерация изображений",
+      "useImageGen": "Изображения",
       "useTeam": "Команда",
       "useCustom": "Свой сценарий",
       "apiKeys": "API-ключи",
@@ -1550,9 +1550,9 @@ export default {
     }
   },
   "imageGenQuickStart": {
-    "title": "Быстрый старт: генерация изображений",
+    "title": "Быстрый старт: Image API",
     "closeAriaLabel": "Закрыть быстрый старт",
-    "description": "Вызовите эндпоинт генерации изображений, затем декодируйте ответ из base64 в файл изображения. Токен модели можно получить через GET /api/v1/token."
+    "description": "Вызовите эндпоинт генерации или редактирования изображений, затем декодируйте ответ из base64 в файл изображения. Токен модели можно получить через GET /api/v1/token."
   },
   "templatePage": {
     "noProviders": {
@@ -1624,12 +1624,28 @@ export default {
     "model": "Модель",
     "prompt": "Промпт",
     "promptPlaceholder": "Опишите изображение, которое хотите получить…",
+    "editPromptPlaceholder": "Опишите, что нужно изменить…",
     "size": "Размер",
     "quality": "Качество",
     "count": "N",
     "generate": "Сгенерировать",
     "generateAnother": "Сгенерировать ещё · выполняется: {{count}}",
     "generatingNew": "Генерируем новые изображения…",
+    "modeGenerate": "Генерация",
+    "modeEdit": "Редактирование",
+    "editBadge": "Отредактировано",
+    "edit": "Редактировать изображение",
+    "editAnother": "Отредактировать ещё · выполняется: {{count}}",
+    "editingNew": "Редактируем изображения…",
+    "referenceImages": "Исходные изображения",
+    "referenceHint": "До {{max}} изображений · PNG, JPEG или WebP",
+    "addReferenceImage": "Добавить изображение",
+    "dropReferenceImage": "Перетащите изображения сюда или нажмите, чтобы выбрать",
+    "removeReferenceImage": "Удалить исходное изображение {{number}}",
+    "noReferenceImages": "Добавьте хотя бы одно изображение для редактирования",
+    "useAsReference": "Редактировать это изображение",
+    "referenceLoadFailed": "Не удалось использовать это изображение как исходное",
+    "referenceThumbAlt": "Исходное изображение {{number}}",
     "previewEmpty": "Здесь появятся сгенерированные изображения",
     "previewHint": "Каждая генерация сохраняется на время этой сессии.",
     "sessionOutputs": "Результаты сессии",
@@ -1711,7 +1727,7 @@ export default {
     "sharingKeys": "Ключи доступа",
     "modelRules": "Правила моделей",
     "embedModelRules": "Правила моделей эмбеддингов",
-    "imageGenModelRules": "Правила моделей генерации изображений",
+    "imageGenModelRules": "Правила моделей изображений",
     "tooltip": {
       "claude_code": "CLI-агент разработки на базе ИИ: реализация, тесты и операции с Git",
       "claude_desktop": "Направьте стороннюю инференцию Claude Desktop через ваших провайдеров",
@@ -1721,7 +1737,7 @@ export default {
       "vscode": "Свои ключи: используйте собственные API-ключи в VS Code Copilot через прокси Tingly Box",
       "pi": "Агент программирования Pi через прокси Tingly Box",
       "dsh": "Агентная оболочка DeepSeek Harness (dsh) через прокси Tingly Box",
-      "imagegen": "Генерация изображений через прокси Tingly Box с поддержкой нескольких моделей"
+      "imagegen": "Генерация и редактирование изображений через прокси Tingly Box с поддержкой нескольких моделей"
     },
     "vscode": {
       "installDescription": "Установите расширение Tingly Box из VS Code или Marketplace.",
@@ -1780,7 +1796,7 @@ export default {
       "openai": "Готовый эндпоинт, совместимый с OpenAI SDK.",
       "anthropic": "Готовый эндпоинт, совместимый с Anthropic SDK.",
       "embed": "Направьте запросы эмбеддингов вашему провайдеру.",
-      "imagegen": "Генерация изображений через Tingly Box.",
+      "imagegen": "Генерация и редактирование изображений через Tingly Box.",
       "custom": "Своё название модели в запросе — универсальный сценарий на все случаи. По умолчанию скрыт.",
       "team": "Общее централизованное развёртывание моделей для всей команды. По умолчанию скрыт."
     }

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -56,7 +56,7 @@ export default {
       "useXcode": "Xcode",
       "useVSCode": "VS Code",
       "useEmbed": "Embedding",
-      "useImageGen": "Image Gen",
+      "useImageGen": "Image",
       "useTeam": "Team",
       "useCustom": "Custom",
       "apiKeys": "API 密钥",
@@ -1536,9 +1536,9 @@ export default {
     }
   },
   "imageGenQuickStart": {
-    "title": "图像生成快速开始",
+    "title": "图像 API 快速开始",
     "closeAriaLabel": "关闭快速开始",
-    "description": "调用图像生成接口，然后将 base64 响应解码为图像文件。模型令牌可通过 GET /api/v1/token 获取。"
+    "description": "调用图像生成或编辑接口，然后将 base64 响应解码为图像文件。模型令牌可通过 GET /api/v1/token 获取。"
   },
   "templatePage": {
     "noProviders": {
@@ -1610,12 +1610,28 @@ export default {
     "model": "模型",
     "prompt": "提示词",
     "promptPlaceholder": "描述你想生成的图像…",
+    "editPromptPlaceholder": "描述你想做的修改…",
     "size": "尺寸",
     "quality": "质量",
     "count": "数量",
     "generate": "生成",
     "generateAnother": "再生成一批 · {{count}} 个进行中",
     "generatingNew": "正在生成新图像…",
+    "modeGenerate": "生成",
+    "modeEdit": "编辑",
+    "editBadge": "已编辑",
+    "edit": "编辑图像",
+    "editAnother": "再编辑一批 · {{count}} 个进行中",
+    "editingNew": "正在编辑图像…",
+    "referenceImages": "参考图像",
+    "referenceHint": "最多 {{max}} 张 · 支持 PNG、JPEG 或 WebP",
+    "addReferenceImage": "添加图像",
+    "dropReferenceImage": "拖拽图像到此处，或点击浏览",
+    "removeReferenceImage": "移除第 {{number}} 张参考图像",
+    "noReferenceImages": "请至少添加一张图像再进行编辑",
+    "useAsReference": "编辑这张图像",
+    "referenceLoadFailed": "无法将该图像用作参考图",
+    "referenceThumbAlt": "第 {{number}} 张参考图像",
     "previewEmpty": "生成的图像会显示在这里",
     "previewHint": "本次会话中的每次生成都会保留。",
     "sessionOutputs": "本次会话输出",
@@ -1697,7 +1713,7 @@ export default {
     "sharingKeys": "共享密钥",
     "modelRules": "模型规则",
     "embedModelRules": "向量模型规则",
-    "imageGenModelRules": "图像生成模型规则",
+    "imageGenModelRules": "图像模型规则",
     "tooltip": {
       "claude_code": "命令行 AI 开发助手，可用于编码实现、测试与 git 操作",
       "claude_desktop": "为 Claude Desktop 桌面应用提供 API 代理",
@@ -1707,7 +1723,7 @@ export default {
       "vscode": "自带密钥：通过 Tingly Box 代理，在 VS Code Copilot 中使用你自己的 API Key",
       "pi": "通过 Tingly Box 代理使用 pi 编码 Agent",
       "dsh": "通过 Tingly Box 代理使用 DeepSeek Harness (dsh) 智能体框架",
-      "imagegen": "通过 Tingly Box 代理进行 AI 图像生成，支持多种模型",
+      "imagegen": "通过 Tingly Box 代理进行 AI 图像生成与编辑，支持多种模型",
     },
     "vscode": {
       "installDescription": "从 VS Code 或应用市场安装 Tingly Box 扩展。",

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -135,7 +135,7 @@ export function useActivityItems(): ActivityItem[] {
             { id: 'openai', nav: { path: '/agent/openai', label: t('layout.nav.useOpenAI', { defaultValue: 'OpenAI' }), icon: <OpenAI size={20} /> } },
             { id: 'anthropic', nav: { path: '/agent/anthropic', label: t('layout.nav.useAnthropic', { defaultValue: 'Anthropic' }), icon: <Anthropic size={20} /> } },
             { id: 'embed', nav: { path: '/agent/embed', label: t('layout.nav.useEmbed', { defaultValue: 'Embedding' }), icon: <IconVector sx={{ fontSize: 20 }} /> } },
-            { id: 'imagegen', nav: { path: '/agent/imagegen', label: t('layout.nav.useImageGen', { defaultValue: 'Image Gen' }), icon: <IconPhoto sx={{ fontSize: 20 }} /> } },
+            { id: 'imagegen', nav: { path: '/agent/image', label: t('layout.nav.useImageGen', { defaultValue: 'Image' }), icon: <IconPhoto sx={{ fontSize: 20 }} /> } },
         ]);
 
         const scenarioChildren: NavItem[] = [];

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2415,6 +2415,41 @@ export const handlers = [
         })
     }),
 
+    // Mirrors the generations mock above but reads the standard OpenAI
+    // multipart /images/edits wire format (the openai SDK's images.edit()
+    // always multipart-encodes, regardless of upstream vendor).
+    http.post('*/tingly/imagegen/v1/images/edits', async ({ request }) => {
+        const form = await request.formData()
+        const n = Math.max(1, Math.min(10, Number(form.get('n')) || 1))
+        const sizeValue = form.get('size')
+        const size = typeof sizeValue === 'string' && sizeValue ? sizeValue : '1024x1024'
+        const [w, h] = size.split('x').map(Number)
+        const palette = ['#7c3aed', '#06b6d4', '#10b981', '#f59e0b', '#ef4444', '#3b82f6']
+        const promptText = String(form.get('prompt') ?? '').slice(0, 80).replace(/[<>&"]/g, '')
+        const model = form.get('model') ?? ''
+        const quality = form.get('quality') || 'auto'
+
+        const makeSvgDataUrl = (idx: number): string => {
+            const bg = palette[(idx + 2) % palette.length]
+            const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">`
+                + `<rect width="100%" height="100%" fill="${bg}"/>`
+                + `<text x="50%" y="45%" font-family="sans-serif" font-size="${Math.round(w / 18)}" fill="white" text-anchor="middle" font-weight="700">EDITED #${idx + 1}</text>`
+                + `<text x="50%" y="56%" font-family="sans-serif" font-size="${Math.round(w / 36)}" fill="white" fill-opacity="0.85" text-anchor="middle">${promptText}</text>`
+                + `<text x="50%" y="95%" font-family="monospace" font-size="${Math.round(w / 50)}" fill="white" fill-opacity="0.7" text-anchor="middle">${model} · ${size} · q=${quality}</text>`
+                + `</svg>`
+            const b64 = btoa(unescape(encodeURIComponent(svg)))
+            return `data:image/svg+xml;base64,${b64}`
+        }
+
+        // Simulate a small latency so the loading state is visible
+        await new Promise((r) => setTimeout(r, 600))
+
+        return HttpResponse.json({
+            created: Math.floor(Date.now() / 1000),
+            data: Array.from({ length: n }, (_, i) => ({ url: makeSvgDataUrl(i) })),
+        })
+    }),
+
     // ============================================
     // Usage Stats API (v1)
     // ============================================

--- a/frontend/src/pages/scenario/UseImageGenPage.tsx
+++ b/frontend/src/pages/scenario/UseImageGenPage.tsx
@@ -42,7 +42,7 @@ const UseImageGenPageContent: React.FC = () => {
                     titleHeadingLevel={1}
                     title={
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            <span>Image Generation API</span>
+                            <span>Image API</span>
                             <Tooltip title={t('scenarioPage.tooltip.imagegen')}>
                                 <IconButton size="small" sx={{ ml: 0.5 }}>
                                     <InfoIcon fontSize="small" sx={{ color: 'text.secondary' }} />
@@ -62,7 +62,7 @@ const UseImageGenPageContent: React.FC = () => {
                     }
                 >
                     <ProviderConfigCard
-                        title="Image Generation API"
+                        title="Image API"
                         baseUrlPath="/tingly/imagegen"
                         baseUrl={baseUrl}
                         onCopy={copyToClipboard}

--- a/frontend/src/pages/scenario/components/ImageGenPlaygroundCard.tsx
+++ b/frontend/src/pages/scenario/components/ImageGenPlaygroundCard.tsx
@@ -17,17 +17,29 @@ import {
     Select,
     Stack,
     TextField,
+    ToggleButton,
+    ToggleButtonGroup,
     Typography,
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import type { Rule } from '@/components/RoutingGraphTypes';
 import UnifiedCard from '@/components/UnifiedCard';
-import { AutoAwesome, Close, Photo, ZoomIn } from '@/components/icons';
+import { AutoAwesome, Brush, Close, Edit, FileUpload, Photo, ZoomIn } from '@/components/icons';
 import { getOpenAIClient } from '@/services/openaiClient';
 
 const IMAGE_SCENARIO = 'imagegen';
-const PLAYGROUND_PANEL_HEIGHT = 300;
+// Base panel height, plus the mode toggle row present in both modes. Edit
+// mode adds the reference-image dropzone on top of that (see
+// desktopPanelHeight below) — both panels share one height value so they
+// stay visually aligned (see the comment on the grid below).
+const PLAYGROUND_PANEL_HEIGHT = 340;
+const EDIT_REFERENCE_SECTION_HEIGHT = 108;
+// Matches the Codex-native imagegen tool's reference-image cap (see
+// .design/imageedit.md) — the common denominator across providers behind
+// this scenario.
+const MAX_EDIT_REFERENCE_IMAGES = 5;
 
+type Mode = 'generate' | 'edit';
 type Quality = 'auto' | 'high' | 'medium' | 'low' | 'standard';
 
 interface ImageResult {
@@ -35,15 +47,35 @@ interface ImageResult {
     b64_json?: string;
 }
 
+interface ReferenceImage {
+    file: File;
+    previewUrl: string;
+}
+
 interface GenerationRun {
     id: string;
+    mode: Mode;
     prompt: string;
     model: string;
     size: string;
     quality: Quality;
     images: ImageResult[];
+    // Data URLs of the reference images an edit run was built from, kept for
+    // display alongside the output — the "what did I ask for" half of the
+    // history card (edit mode only).
+    sourceImages?: string[];
     status?: 'pending' | 'completed';
 }
+
+// Reads a File into a base64 data URL, the same representation already used
+// for generated images (`data:image/png;base64,...`) so reference thumbnails
+// and outputs render through one code path.
+const fileToDataUrl = (file: File): Promise<string> => new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+});
 
 interface SelectedImage {
     src: string;
@@ -79,13 +111,16 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
 
     const [selectedModel, setSelectedModel] = useState('');
     const model = models.includes(selectedModel) ? selectedModel : (models[0] ?? '');
+    const [mode, setMode] = useState<Mode>('generate');
     const [prompt, setPrompt] = useState('');
     const [size, setSize] = useState('1024x1024');
     const [quality, setQuality] = useState<Quality>('auto');
     const [count, setCount] = useState(1);
+    const [referenceImages, setReferenceImages] = useState<ReferenceImage[]>([]);
     const [runs, setRuns] = useState<GenerationRun[]>(() => imageGenSessionRuns);
     const [selectedImage, setSelectedImage] = useState<SelectedImage | null>(null);
     const historyTrackRef = useRef<HTMLDivElement>(null);
+    const referenceFileInputRef = useRef<HTMLInputElement>(null);
     const pendingCount = runs.filter((run) => run.status === 'pending').length;
 
     const updateRuns = useCallback((updater: (currentRuns: GenerationRun[]) => GenerationRun[]) => {
@@ -102,31 +137,84 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
         return () => cancelAnimationFrame(frame);
     }, [pendingCount, runs.length]);
 
-    const handleGenerate = useCallback(async () => {
+    // Appends newly picked/dropped files (image/* only) up to the reference
+    // cap, converting each to a data URL up front so thumbnails and the
+    // eventual run history render through the same representation.
+    const handleAddReferenceImages = useCallback(async (files: FileList | File[]) => {
+        const incoming = Array.from(files).filter((file) => file.type.startsWith('image/'));
+        if (incoming.length === 0) return;
+        const accepted = incoming.slice(0, Math.max(0, MAX_EDIT_REFERENCE_IMAGES - referenceImages.length));
+        if (accepted.length === 0) return;
+        const withPreviews = await Promise.all(accepted.map(async (file) => ({
+            file,
+            previewUrl: await fileToDataUrl(file),
+        })));
+        setReferenceImages((current) => [...current, ...withPreviews].slice(0, MAX_EDIT_REFERENCE_IMAGES));
+    }, [referenceImages.length]);
+
+    const handleRemoveReferenceImage = useCallback((index: number) => {
+        setReferenceImages((current) => current.filter((_, i) => i !== index));
+    }, []);
+
+    // Hands a completed output straight back in as the next edit's source —
+    // the artifact for the next action, not just a notification that one
+    // exists. Reuses the already-rendered src as the preview (it's already a
+    // data URL/data-equivalent), so this never re-encodes the image.
+    const handleUseAsReference = useCallback(async (src: string) => {
+        try {
+            const res = await fetch(src);
+            const blob = await res.blob();
+            const file = new File([blob], `reference-${Date.now()}.png`, { type: blob.type || 'image/png' });
+            setMode('edit');
+            setReferenceImages([{ file, previewUrl: src }]);
+        } catch {
+            showNotification(
+                t('playground.referenceLoadFailed', { defaultValue: 'Could not use this image as a reference' }),
+                'error',
+            );
+        }
+    }, [showNotification, t]);
+
+    const handleSubmit = useCallback(async () => {
         if (!prompt.trim() || !model) return;
+        if (mode === 'edit' && referenceImages.length === 0) return;
         const runId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const runMode = mode;
         const generationPrompt = prompt.trim();
         const generationModel = model;
         const generationSize = size;
         const generationQuality = quality;
+        const editSources = referenceImages;
         updateRuns((currentRuns) => [...currentRuns, {
             id: runId,
+            mode: runMode,
             prompt: generationPrompt,
             model: generationModel,
             size: generationSize,
             quality: generationQuality,
             images: [],
+            sourceImages: runMode === 'edit' ? editSources.map((ref) => ref.previewUrl) : undefined,
             status: 'pending',
         }]);
         try {
             const client = await getOpenAIClient(IMAGE_SCENARIO);
-            const response = await client.images.generate({
-                model: generationModel,
-                prompt: generationPrompt,
-                n: count,
-                size: generationSize as any,
-                quality: generationQuality,
-            });
+            const editFiles = editSources.map((ref) => ref.file);
+            const response = runMode === 'edit'
+                ? await client.images.edit({
+                    image: editFiles.length === 1 ? editFiles[0] : editFiles,
+                    model: generationModel,
+                    prompt: generationPrompt,
+                    n: count,
+                    size: generationSize as any,
+                    quality: generationQuality as any,
+                })
+                : await client.images.generate({
+                    model: generationModel,
+                    prompt: generationPrompt,
+                    n: count,
+                    size: generationSize as any,
+                    quality: generationQuality,
+                });
             const images = response.data ?? [];
             updateRuns((currentRuns) => currentRuns.map((run) => (
                 run.id === runId ? { ...run, images, status: 'completed' } : run
@@ -137,10 +225,12 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
             const message = error?.error?.message || error?.message || t('playground.requestFailed', { defaultValue: 'Request failed' });
             showNotification(`${status}${message}`, 'error');
         }
-    }, [count, model, prompt, quality, showNotification, size, updateRuns]);
+    }, [count, mode, model, prompt, quality, referenceImages, showNotification, size, t, updateRuns]);
 
     const noModels = models.length === 0;
-    const desktopPanelHeight = noModels && !loadingRules ? 'auto' : PLAYGROUND_PANEL_HEIGHT;
+    const desktopPanelHeight = noModels && !loadingRules
+        ? 'auto'
+        : PLAYGROUND_PANEL_HEIGHT + (mode === 'edit' ? EDIT_REFERENCE_SECTION_HEIGHT : 0);
 
     return (
         <>
@@ -175,6 +265,131 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
                             </Alert>
                         )}
 
+                        <ToggleButtonGroup
+                            value={mode}
+                            exclusive
+                            size="small"
+                            onChange={(_, next: Mode | null) => { if (next) setMode(next); }}
+                            disabled={noModels}
+                            fullWidth
+                        >
+                            <ToggleButton value="generate">
+                                <AutoAwesome fontSize="small" sx={{ mr: 0.75 }} />
+                                {t('playground.modeGenerate', { defaultValue: 'Generate' })}
+                            </ToggleButton>
+                            <ToggleButton value="edit">
+                                <Brush fontSize="small" sx={{ mr: 0.75 }} />
+                                {t('playground.modeEdit', { defaultValue: 'Edit' })}
+                            </ToggleButton>
+                        </ToggleButtonGroup>
+
+                        {mode === 'edit' && (
+                            <Box>
+                                <Typography variant="caption" sx={{ display: 'block', mb: 0.5, color: 'text.secondary' }}>
+                                    {t('playground.referenceImages', { defaultValue: 'Reference images' })}
+                                </Typography>
+                                <Box
+                                    onClick={() => referenceFileInputRef.current?.click()}
+                                    onDragOver={(event) => event.preventDefault()}
+                                    onDrop={(event) => {
+                                        event.preventDefault();
+                                        if (event.dataTransfer.files?.length) {
+                                            void handleAddReferenceImages(event.dataTransfer.files);
+                                        }
+                                    }}
+                                    sx={{
+                                        display: 'flex',
+                                        flexWrap: 'wrap',
+                                        gap: 1,
+                                        p: 1,
+                                        border: '1px dashed',
+                                        borderColor: 'divider',
+                                        borderRadius: 1.5,
+                                        bgcolor: 'action.hover',
+                                        minHeight: 64,
+                                        alignItems: 'center',
+                                        cursor: referenceImages.length < MAX_EDIT_REFERENCE_IMAGES ? 'pointer' : 'default',
+                                    }}
+                                >
+                                    {referenceImages.length === 0 ? (
+                                        <Stack direction="row" spacing={1} sx={{ width: '100%', alignItems: 'center', justifyContent: 'center', color: 'text.secondary', py: 0.5 }}>
+                                            <FileUpload sx={{ fontSize: 20 }} />
+                                            <Typography variant="body2">
+                                                {t('playground.dropReferenceImage', { defaultValue: 'Drop images here or click to browse' })}
+                                            </Typography>
+                                        </Stack>
+                                    ) : (
+                                        <>
+                                            {referenceImages.map((ref, index) => (
+                                                <Box
+                                                    key={index}
+                                                    sx={{ position: 'relative', width: 56, height: 56, borderRadius: 1, overflow: 'hidden', flexShrink: 0 }}
+                                                >
+                                                    <Box
+                                                        component="img"
+                                                        src={ref.previewUrl}
+                                                        alt={t('playground.referenceThumbAlt', { defaultValue: 'Reference image {{number}}', number: index + 1 })}
+                                                        sx={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+                                                    />
+                                                    <IconButton
+                                                        size="small"
+                                                        onClick={(event) => { event.stopPropagation(); handleRemoveReferenceImage(index); }}
+                                                        aria-label={t('playground.removeReferenceImage', { defaultValue: 'Remove reference image {{number}}', number: index + 1 })}
+                                                        sx={{
+                                                            position: 'absolute',
+                                                            top: -6,
+                                                            right: -6,
+                                                            width: 20,
+                                                            height: 20,
+                                                            bgcolor: 'rgba(15, 23, 42, 0.7)',
+                                                            color: 'common.white',
+                                                            '&:hover': { bgcolor: 'rgba(15, 23, 42, 0.9)' },
+                                                        }}
+                                                    >
+                                                        <Close sx={{ fontSize: 14 }} />
+                                                    </IconButton>
+                                                </Box>
+                                            ))}
+                                            {referenceImages.length < MAX_EDIT_REFERENCE_IMAGES && (
+                                                <Stack
+                                                    aria-label={t('playground.addReferenceImage', { defaultValue: 'Add image' })}
+                                                    sx={{
+                                                        width: 56,
+                                                        height: 56,
+                                                        alignItems: 'center',
+                                                        justifyContent: 'center',
+                                                        borderRadius: 1,
+                                                        color: 'text.secondary',
+                                                        border: '1px solid',
+                                                        borderColor: 'divider',
+                                                    }}
+                                                >
+                                                    <FileUpload sx={{ fontSize: 20 }} />
+                                                </Stack>
+                                            )}
+                                        </>
+                                    )}
+                                </Box>
+                                <Typography variant="caption" sx={{ display: 'block', mt: 0.5, color: 'text.disabled' }}>
+                                    {t('playground.referenceHint', {
+                                        defaultValue: 'Up to {{max}} images · PNG, JPEG, or WebP',
+                                        max: MAX_EDIT_REFERENCE_IMAGES,
+                                    })}
+                                </Typography>
+                                <input
+                                    ref={referenceFileInputRef}
+                                    type="file"
+                                    accept="image/png,image/jpeg,image/webp"
+                                    multiple
+                                    hidden
+                                    onChange={(event) => {
+                                        if (event.target.files?.length) void handleAddReferenceImages(event.target.files);
+                                        event.target.value = '';
+                                    }}
+                                />
+                            </Box>
+                        )}
+
                         <FormControl size="small" fullWidth>
                             <InputLabel id="image-model-label">
                                 {t('playground.model', { defaultValue: 'Model' })}
@@ -197,9 +412,9 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
                             rows={5}
                             fullWidth
                             label={t('playground.prompt', { defaultValue: 'Prompt' })}
-                            placeholder={t('playground.promptPlaceholder', {
-                                defaultValue: 'Describe the image you want to generate…',
-                            })}
+                            placeholder={mode === 'edit'
+                                ? t('playground.editPromptPlaceholder', { defaultValue: 'Describe the change you want to make…' })
+                                : t('playground.promptPlaceholder', { defaultValue: 'Describe the image you want to generate…' })}
                             value={prompt}
                             onChange={(event) => setPrompt(event.target.value)}
                             disabled={noModels}
@@ -283,23 +498,24 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
                             variant="contained"
                             size="large"
                             fullWidth
-                            onClick={handleGenerate}
-                            disabled={noModels || !prompt.trim() || !model}
+                            onClick={handleSubmit}
+                            disabled={noModels || !prompt.trim() || !model || (mode === 'edit' && referenceImages.length === 0)}
                             startIcon={pendingCount > 0
                                 ? <CircularProgress size={18} color="inherit" />
-                                : <AutoAwesome />}
+                                : (mode === 'edit' ? <Brush /> : <AutoAwesome />)}
                             sx={{
                                 '&.Mui-disabled': {
                                     color: 'common.white',
                                 },
                             }}
                         >
-                            {pendingCount > 0
-                                ? t('playground.generateAnother', {
-                                    defaultValue: 'Generate another · {{count}} running',
-                                    count: pendingCount,
-                                })
-                                : t('playground.generate', { defaultValue: 'Generate' })}
+                            {mode === 'edit'
+                                ? (pendingCount > 0
+                                    ? t('playground.editAnother', { defaultValue: 'Edit another · {{count}} running', count: pendingCount })
+                                    : t('playground.edit', { defaultValue: 'Edit Image' }))
+                                : (pendingCount > 0
+                                    ? t('playground.generateAnother', { defaultValue: 'Generate another · {{count}} running', count: pendingCount })
+                                    : t('playground.generate', { defaultValue: 'Generate' }))}
                         </Button>
                     </Stack>
 
@@ -410,7 +626,9 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
                                                 >
                                                     <CircularProgress size={24} />
                                                     <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                                                        {t('playground.generatingNew', { defaultValue: 'Generating new images…' })}
+                                                        {run.mode === 'edit'
+                                                            ? t('playground.editingNew', { defaultValue: 'Editing images…' })
+                                                            : t('playground.generatingNew', { defaultValue: 'Generating new images…' })}
                                                     </Typography>
                                                     <Typography
                                                         variant="caption"
@@ -441,18 +659,37 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
                                             ) : (
                                             <Stack spacing={1.25} sx={{ height: '100%' }}>
                                                 <Box sx={{ minWidth: 0 }}>
-                                                    <Typography
-                                                        variant="body2"
-                                                        sx={{
-                                                            fontWeight: 500,
-                                                            display: '-webkit-box',
-                                                            WebkitLineClamp: 2,
-                                                            WebkitBoxOrient: 'vertical',
-                                                            overflow: 'hidden',
-                                                        }}
-                                                    >
-                                                        {run.prompt}
-                                                    </Typography>
+                                                    <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.75 }}>
+                                                        {run.mode === 'edit' && (
+                                                            <Typography
+                                                                component="span"
+                                                                variant="caption"
+                                                                sx={{
+                                                                    flexShrink: 0,
+                                                                    px: 0.75,
+                                                                    borderRadius: 1,
+                                                                    bgcolor: 'action.selected',
+                                                                    color: 'text.secondary',
+                                                                    fontWeight: 600,
+                                                                }}
+                                                            >
+                                                                {t('playground.editBadge', { defaultValue: 'Edited' })}
+                                                            </Typography>
+                                                        )}
+                                                        <Typography
+                                                            variant="body2"
+                                                            sx={{
+                                                                fontWeight: 500,
+                                                                minWidth: 0,
+                                                                display: '-webkit-box',
+                                                                WebkitLineClamp: 2,
+                                                                WebkitBoxOrient: 'vertical',
+                                                                overflow: 'hidden',
+                                                            }}
+                                                        >
+                                                            {run.prompt}
+                                                        </Typography>
+                                                    </Box>
                                                     <Typography
                                                         variant="caption"
                                                         sx={{
@@ -465,6 +702,27 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
                                                     >
                                                         {run.model} · {run.size} · {run.quality}
                                                     </Typography>
+                                                    {run.mode === 'edit' && run.sourceImages && run.sourceImages.length > 0 && (
+                                                        <Stack direction="row" spacing={0.5} sx={{ mt: 0.75, overflowX: 'auto' }}>
+                                                            {run.sourceImages.map((src, i) => (
+                                                                <Box
+                                                                    key={i}
+                                                                    component="img"
+                                                                    src={src}
+                                                                    alt=""
+                                                                    sx={{
+                                                                        width: 28,
+                                                                        height: 28,
+                                                                        borderRadius: 0.5,
+                                                                        objectFit: 'cover',
+                                                                        flexShrink: 0,
+                                                                        border: '1px solid',
+                                                                        borderColor: 'divider',
+                                                                    }}
+                                                                />
+                                                            ))}
+                                                        </Stack>
+                                                    )}
                                                 </Box>
                                                 <Box
                                                     sx={{
@@ -482,82 +740,101 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
                                                             ? `data:image/png;base64,${image.b64_json}`
                                                             : '');
                                                         return src ? (
-                                                            <ButtonBase
+                                                            <Box
                                                                 key={`${run.id}-${index}`}
-                                                                onClick={() => setSelectedImage({
-                                                                    src,
-                                                                    prompt: run.prompt,
-                                                                    model: run.model,
-                                                                    size: run.size,
-                                                                    quality: run.quality,
-                                                                    index,
-                                                                })}
-                                                                aria-label={t('playground.openResult', {
-                                                                    defaultValue: 'Open generated image {{number}}',
-                                                                    number: index + 1,
-                                                                })}
-                                                                sx={{
-                                                                    position: 'relative',
-                                                                    width: '100%',
-                                                                    height: '100%',
-                                                                    borderRadius: 1,
-                                                                    bgcolor: 'action.hover',
-                                                                    overflow: 'hidden',
-                                                                    '&:hover .image-preview-overlay, &:focus-visible .image-preview-overlay': {
-                                                                        opacity: 1,
-                                                                    },
-                                                                }}
+                                                                sx={{ position: 'relative', width: '100%', height: '100%', borderRadius: 1, overflow: 'hidden', bgcolor: 'action.hover' }}
                                                             >
-                                                                <Box
-                                                                    component="img"
-                                                                    src={src}
-                                                                    alt={t('playground.resultAlt', {
-                                                                        defaultValue: 'Generated image {{number}}',
+                                                                <ButtonBase
+                                                                    onClick={() => setSelectedImage({
+                                                                        src,
+                                                                        prompt: run.prompt,
+                                                                        model: run.model,
+                                                                        size: run.size,
+                                                                        quality: run.quality,
+                                                                        index,
+                                                                    })}
+                                                                    aria-label={t('playground.openResult', {
+                                                                        defaultValue: 'Open generated image {{number}}',
                                                                         number: index + 1,
                                                                     })}
                                                                     sx={{
                                                                         width: '100%',
                                                                         height: '100%',
-                                                                        maxHeight: '100%',
-                                                                        objectFit: 'contain',
                                                                         display: 'block',
-                                                                    }}
-                                                                />
-                                                                <Box
-                                                                    className="image-preview-overlay"
-                                                                    sx={{
-                                                                        position: 'absolute',
-                                                                        inset: 0,
-                                                                        display: 'flex',
-                                                                        alignItems: 'center',
-                                                                        justifyContent: 'center',
-                                                                        color: 'common.white',
-                                                                        bgcolor: 'rgba(15, 23, 42, 0.38)',
-                                                                        opacity: 0,
-                                                                        transition: 'opacity 0.16s ease-out',
+                                                                        '&:hover .image-preview-overlay, &:focus-visible .image-preview-overlay': {
+                                                                            opacity: 1,
+                                                                        },
                                                                     }}
                                                                 >
-                                                                    <ZoomIn sx={{ fontSize: 30 }} />
-                                                                </Box>
-                                                                <Box
+                                                                    <Box
+                                                                        component="img"
+                                                                        src={src}
+                                                                        alt={t('playground.resultAlt', {
+                                                                            defaultValue: 'Generated image {{number}}',
+                                                                            number: index + 1,
+                                                                        })}
+                                                                        sx={{
+                                                                            width: '100%',
+                                                                            height: '100%',
+                                                                            maxHeight: '100%',
+                                                                            objectFit: 'contain',
+                                                                            display: 'block',
+                                                                        }}
+                                                                    />
+                                                                    <Box
+                                                                        className="image-preview-overlay"
+                                                                        sx={{
+                                                                            position: 'absolute',
+                                                                            inset: 0,
+                                                                            display: 'flex',
+                                                                            alignItems: 'center',
+                                                                            justifyContent: 'center',
+                                                                            color: 'common.white',
+                                                                            bgcolor: 'rgba(15, 23, 42, 0.38)',
+                                                                            opacity: 0,
+                                                                            transition: 'opacity 0.16s ease-out',
+                                                                        }}
+                                                                    >
+                                                                        <ZoomIn sx={{ fontSize: 30 }} />
+                                                                    </Box>
+                                                                    <Box
+                                                                        sx={{
+                                                                            position: 'absolute',
+                                                                            top: 8,
+                                                                            right: 8,
+                                                                            width: 30,
+                                                                            height: 30,
+                                                                            display: 'flex',
+                                                                            alignItems: 'center',
+                                                                            justifyContent: 'center',
+                                                                            borderRadius: '50%',
+                                                                            color: 'common.white',
+                                                                            bgcolor: 'rgba(15, 23, 42, 0.58)',
+                                                                            backdropFilter: 'blur(4px)',
+                                                                        }}
+                                                                    >
+                                                                        <ZoomIn fontSize="small" />
+                                                                    </Box>
+                                                                </ButtonBase>
+                                                                <IconButton
+                                                                    size="small"
+                                                                    onClick={(event) => { event.stopPropagation(); void handleUseAsReference(src); }}
+                                                                    aria-label={t('playground.useAsReference', { defaultValue: 'Edit this image' })}
                                                                     sx={{
                                                                         position: 'absolute',
-                                                                        top: 8,
+                                                                        bottom: 8,
                                                                         right: 8,
                                                                         width: 30,
                                                                         height: 30,
-                                                                        display: 'flex',
-                                                                        alignItems: 'center',
-                                                                        justifyContent: 'center',
-                                                                        borderRadius: '50%',
                                                                         color: 'common.white',
                                                                         bgcolor: 'rgba(15, 23, 42, 0.58)',
                                                                         backdropFilter: 'blur(4px)',
+                                                                        '&:hover': { bgcolor: 'rgba(15, 23, 42, 0.78)' },
                                                                     }}
                                                                 >
-                                                                    <ZoomIn fontSize="small" />
-                                                                </Box>
-                                                            </ButtonBase>
+                                                                    <Edit fontSize="small" />
+                                                                </IconButton>
+                                                            </Box>
                                                         ) : (
                                                             <Typography key={`${run.id}-${index}`} variant="caption" sx={{
                                                                 color: "text.secondary"

--- a/frontend/src/pages/scenario/components/ImageGenQuickStartDialog.tsx
+++ b/frontend/src/pages/scenario/components/ImageGenQuickStartDialog.tsx
@@ -10,9 +10,11 @@ import {
     IconButton,
     Tab,
     Tabs,
+    ToggleButton,
+    ToggleButtonGroup,
     Typography,
 } from '@mui/material';
-import { Close } from '@/components/icons';
+import { AutoAwesome, Brush, Close } from '@/components/icons';
 import CodeBlock from '@/components/CodeBlock';
 
 interface ImageGenQuickStartDialogProps {
@@ -24,16 +26,86 @@ interface ImageGenQuickStartDialogProps {
 }
 
 type Lang = 'python' | 'typescript' | 'curl';
+type Operation = 'generate' | 'edit';
 
-const TABS: { value: Lang; label: string; filename: string }[] = [
-    { value: 'python', label: 'Python', filename: 'imagegen.py' },
-    { value: 'typescript', label: 'TypeScript', filename: 'imagegen.ts' },
-    { value: 'curl', label: 'curl', filename: 'imagegen.sh' },
+const TABS: { value: Lang; label: string }[] = [
+    { value: 'python', label: 'Python' },
+    { value: 'typescript', label: 'TypeScript' },
+    { value: 'curl', label: 'curl' },
 ];
 
-const buildSnippet = (lang: Lang, baseUrl: string, model: string): string => {
+const FILENAMES: Record<Operation, Record<Lang, string>> = {
+    generate: { python: 'imagegen.py', typescript: 'imagegen.ts', curl: 'imagegen.sh' },
+    edit: { python: 'imageedit.py', typescript: 'imageedit.ts', curl: 'imageedit.sh' },
+};
+
+const GENERATE_PROMPT = 'A cozy cabin in a snowy forest at dusk, cinematic lighting';
+const EDIT_PROMPT = 'Add a red knit hat on the subject, keep everything else unchanged';
+
+const buildSnippet = (op: Operation, lang: Lang, baseUrl: string, model: string): string => {
     const endpoint = `${baseUrl}/tingly/imagegen/v1`;
-    const prompt = 'A cozy cabin in a snowy forest at dusk, cinematic lighting';
+
+    if (op === 'edit') {
+        switch (lang) {
+            case 'python':
+                return `# pip install openai
+import base64
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="${endpoint}",
+    api_key="<TINGLY_MODEL_TOKEN>",  # GET /api/v1/token
+)
+
+resp = client.images.edit(
+    model="${model}",
+    image=open("input.png", "rb"),
+    prompt="${EDIT_PROMPT}",
+    size="1024x1024",
+    quality="auto",
+)
+
+image_b64 = resp.data[0].b64_json
+with open("output.png", "wb") as f:
+    f.write(base64.b64decode(image_b64))
+print("Saved output.png")
+`;
+            case 'typescript':
+                return `// npm i openai
+import { createReadStream, writeFileSync } from "node:fs";
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "${endpoint}",
+  apiKey: "<TINGLY_MODEL_TOKEN>", // GET /api/v1/token
+});
+
+const resp = await client.images.edit({
+  model: "${model}",
+  image: createReadStream("input.png"),
+  prompt: "${EDIT_PROMPT}",
+  size: "1024x1024",
+  quality: "auto",
+});
+
+const imageB64 = resp.data[0].b64_json!;
+writeFileSync("output.png", Buffer.from(imageB64, "base64"));
+console.log("Saved output.png");
+`;
+            case 'curl':
+                return `# requires jq; decodes the base64 payload into output.png
+curl ${endpoint}/images/edits \\
+  -H "Authorization: Bearer <TINGLY_MODEL_TOKEN>" \\
+  -F "model=${model}" \\
+  -F "image=@input.png" \\
+  -F "prompt=${EDIT_PROMPT}" \\
+  -F "size=1024x1024" \\
+  -F "quality=auto" \\
+  | jq -r '.data[0].b64_json' | base64 --decode > output.png
+`;
+        }
+    }
+
     switch (lang) {
         case 'python':
             return `# pip install openai
@@ -47,7 +119,7 @@ client = OpenAI(
 
 resp = client.images.generate(
     model="${model}",
-    prompt="${prompt}",
+    prompt="${GENERATE_PROMPT}",
     size="1024x1024",
     quality="auto",
     n=1,
@@ -70,7 +142,7 @@ const client = new OpenAI({
 
 const resp = await client.images.generate({
   model: "${model}",
-  prompt: "${prompt}",
+  prompt: "${GENERATE_PROMPT}",
   size: "1024x1024",
   quality: "auto",
   n: 1,
@@ -82,16 +154,16 @@ console.log("Saved output.png");
 `;
         case 'curl':
             return `# requires jq; decodes the base64 payload into output.png
-curl ${endpoint}/images/generations \
-  -H "Authorization: Bearer <TINGLY_MODEL_TOKEN>" \
-  -H "Content-Type: application/json" \
+curl ${endpoint}/images/generations \\
+  -H "Authorization: Bearer <TINGLY_MODEL_TOKEN>" \\
+  -H "Content-Type: application/json" \\
   -d '{
     "model": "${model}",
-    "prompt": "${prompt}",
+    "prompt": "${GENERATE_PROMPT}",
     "size": "1024x1024",
     "quality": "auto",
     "n": 1
-  }' \
+  }' \\
   | jq -r '.data[0].b64_json' | base64 --decode > output.png
 `;
     }
@@ -105,9 +177,10 @@ const ImageGenQuickStartDialog: React.FC<ImageGenQuickStartDialogProps> = ({
     onCopy,
 }) => {
     const { t } = useTranslation();
+    const [operation, setOperation] = useState<Operation>('generate');
     const [tab, setTab] = useState<Lang>('python');
-    const active = TABS.find((item) => item.value === tab)!;
-    const code = buildSnippet(tab, baseUrl, model);
+    const filename = FILENAMES[operation][tab];
+    const code = buildSnippet(operation, tab, baseUrl, model);
 
     return (
         <Dialog
@@ -136,6 +209,22 @@ const ImageGenQuickStartDialog: React.FC<ImageGenQuickStartDialogProps> = ({
                     }}>
                     {t('imageGenQuickStart.description')}
                 </Typography>
+                <ToggleButtonGroup
+                    value={operation}
+                    exclusive
+                    size="small"
+                    onChange={(_, next: Operation | null) => { if (next) setOperation(next); }}
+                    sx={{ mb: 1.5 }}
+                >
+                    <ToggleButton value="generate">
+                        <AutoAwesome fontSize="small" sx={{ mr: 0.75 }} />
+                        {t('playground.modeGenerate', { defaultValue: 'Generate' })}
+                    </ToggleButton>
+                    <ToggleButton value="edit">
+                        <Brush fontSize="small" sx={{ mr: 0.75 }} />
+                        {t('playground.modeEdit', { defaultValue: 'Edit' })}
+                    </ToggleButton>
+                </ToggleButtonGroup>
                 <Tabs
                     value={tab}
                     onChange={(_, value: Lang) => setTab(value)}
@@ -154,8 +243,8 @@ const ImageGenQuickStartDialog: React.FC<ImageGenQuickStartDialogProps> = ({
                     <CodeBlock
                         code={code}
                         language={tab === 'curl' ? 'bash' : tab}
-                        filename={active.filename}
-                        onCopy={onCopy ? (content) => onCopy(content, active.filename) : undefined}
+                        filename={filename}
+                        onCopy={onCopy ? (content) => onCopy(content, filename) : undefined}
                         maxHeight={480}
                         wrap={false}
                     />

--- a/frontend/src/pages/scenario/scenarioRegistry.tsx
+++ b/frontend/src/pages/scenario/scenarioRegistry.tsx
@@ -134,7 +134,7 @@ export const SCENARIOS: ScenarioDescriptor[] = [
         id: 'imagegen',
         labelKey: 'layout.nav.useImageGen',
         descKey: 'scenarioOverview.descriptions.imagegen',
-        path: '/agent/imagegen',
+        path: '/agent/image',
         icon: (size) => <IconPhoto sx={{ fontSize: size }} />,
         hideable: true,
     },


### PR DESCRIPTION
## Summary
Upgrades the Image Gen page into an Image Playground that switches between Generate and Edit in place, wired to the new `/images/edits` backend.

## Key Changes

- **Generate/Edit toggle**: Image Playground gets a segmented Generate/Edit control; Edit reveals a reference-image dropzone inline (no separate page/dialog).
- **Edit chaining**: Every completed output gets an "Edit this image" hover action that preloads it as the next edit's reference, so results chain instead of dead-ending.
- **Session history**: Edit runs show an "Edited" badge and the reference thumbnails they were built from.
- **Quick Start**: Dialog gains a matching Generate/Edit toggle with Python/TypeScript/curl snippets for `images.edit()`.
- **Page rename**: "Image Gen" → "Image" across nav/title/tooltips (en/zh/ru); route moved `/agent/imagegen` → `/agent/image` with redirects for the old path.

## Notes
- Stacked on `claude/codex-image-gen-edit-zxmfll` (merge that one first).
- Verified via `ui-preview` (mock mode) end to end; `pnpm build`/`lint`/`typecheck` clean, locale-parity test passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtzenncwHdbXEJthXGjMbn)_