### PR TITLE
feat(flags): add multi_enum flag type to the registry and frontend

### DIFF
--- a/frontend/src/components/RoutingGraphTypes.ts
+++ b/frontend/src/components/RoutingGraphTypes.ts
@@ -94,7 +94,7 @@ export interface RuleFlagsApi {
     extra_headers?: Record<string, string>;
 }
 
-export type FlagValueType = 'bool' | 'string' | 'enum' | 'int' | 'service_ref' | 'headers';
+export type FlagValueType = 'bool' | 'string' | 'enum' | 'int' | 'service_ref' | 'headers' | 'multi_enum';
 
 export interface FlagOption {
     value: string;

--- a/frontend/src/components/rule-card/FlagCatalogDialog.tsx
+++ b/frontend/src/components/rule-card/FlagCatalogDialog.tsx
@@ -1,12 +1,15 @@
 import {
     Box,
     Button,
+    Checkbox,
     Chip,
     Dialog,
     DialogActions,
     DialogContent,
     DialogTitle,
     FormControl,
+    FormControlLabel,
+    FormGroup,
     InputLabel,
     MenuItem,
     Select,
@@ -30,7 +33,7 @@ import type { FlagSpec, RuleFlags, VisionProxyServiceRef } from '@/components/Ro
 import type { Provider } from '@/types/provider';
 import type { ProviderSelectTabOption } from '@/components/ModelSelectDialog';
 import ModelSelectDialog from '@/components/ModelSelectDialog';
-import { getFlagValue, setFlagValue, flagDefault, enumInactive, isFlagActive, normalizeEnumForStorage, headersValue } from './flagHelpers';
+import { getFlagValue, setFlagValue, flagDefault, enumInactive, isFlagActive, normalizeEnumForStorage, headersValue, multiEnumValues, toggleMultiEnumValue } from './flagHelpers';
 import HeadersEditor from '@/components/flags/HeadersEditor';
 
 export interface FlagCatalogDialogProps {
@@ -439,6 +442,30 @@ export const FlagCatalogDialog: React.FC<FlagCatalogDialogProps> = ({
                                                             )}
                                                         </Select>
                                                     </FormControl>
+                                                )}
+                                                {spec.type === 'multi_enum' && (
+                                                    <FormGroup sx={{ mt: 0.5 }}>
+                                                        {(spec.options || []).map((opt) => {
+                                                            const selected = multiEnumValues(draft, spec.key).includes(opt.value);
+                                                            return (
+                                                                <FormControlLabel
+                                                                    key={opt.value}
+                                                                    control={
+                                                                        <Checkbox
+                                                                            size="small"
+                                                                            checked={selected}
+                                                                            onChange={() => setDraft((d) => setFlagValue(
+                                                                                d,
+                                                                                spec.key,
+                                                                                toggleMultiEnumValue(getFlagValue(d, spec.key) as string | undefined, opt.value),
+                                                                            ))}
+                                                                        />
+                                                                    }
+                                                                    label={<Typography variant="body2">{opt.label}</Typography>}
+                                                                />
+                                                            );
+                                                        })}
+                                                    </FormGroup>
                                                 )}
                                                 {spec.type === 'headers' && (
                                                     <Box sx={{ mt: 1 }}>

--- a/frontend/src/components/rule-card/flagHelpers.ts
+++ b/frontend/src/components/rule-card/flagHelpers.ts
@@ -29,6 +29,7 @@ export function flagDefault(spec: FlagSpec): unknown {
         case 'enum': return spec.options?.[0]?.value ?? '';
         case 'service_ref': return undefined;
         case 'headers': return undefined;
+        case 'multi_enum': return '';
     }
 }
 
@@ -54,6 +55,7 @@ export function isFlagActive(spec: FlagSpec, flags: RuleFlags): boolean {
             const map = value as Record<string, string> | undefined;
             return !!map && Object.keys(map).length > 0;
         }
+        case 'multi_enum': return typeof value === 'string' && value !== '';
         default: return false;
     }
 }
@@ -85,4 +87,22 @@ export function flagsToApi(flags: RuleFlags | undefined): RuleFlagsApi {
 // headersValue reads a headers-type flag as a name→value map (empty when unset).
 export function headersValue(flags: RuleFlags | undefined, key: string): Record<string, string> {
     return (getFlagValue(flags, key) as Record<string, string> | undefined) ?? {};
+}
+
+// multiEnumValues reads a multi_enum flag as the array of selected option
+// values (comma-separated string on the wire; empty array when unset).
+export function multiEnumValues(flags: RuleFlags | undefined, key: string): string[] {
+    const raw = getFlagValue(flags, key);
+    if (typeof raw !== 'string' || raw === '') return [];
+    return raw.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+// toggleMultiEnumValue flips one option inside a multi_enum selection and
+// returns the new comma-separated storage value ('' when nothing selected).
+export function toggleMultiEnumValue(current: string | undefined, option: string): string {
+    const values = (current ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+    const idx = values.indexOf(option);
+    if (idx >= 0) values.splice(idx, 1);
+    else values.push(option);
+    return values.join(',');
 }

--- a/internal/typ/flag_registry.go
+++ b/internal/typ/flag_registry.go
@@ -19,6 +19,12 @@ const (
 	// editable key/value row list (add/remove rows); an empty map is treated
 	// as inactive. Backed by a map[string]string on the flags struct.
 	FlagTypeHeaders FlagValueType = "headers"
+	// FlagTypeMultiEnum is a multi-select over the spec's Options: the stored
+	// value is a comma-separated list of the selected Option values, "" when
+	// none selected (inactive). The UI renders a checkbox group. Unlike
+	// FlagTypeEnum there is no "first option = default" rule — the empty set
+	// is the inactive state.
+	FlagTypeMultiEnum FlagValueType = "multi_enum"
 )
 
 // FlagCategory groups flags for presentation in the UI.

--- a/internal/typ/flag_registry_test.go
+++ b/internal/typ/flag_registry_test.go
@@ -74,6 +74,7 @@ func TestRuleFlagRegistry_TypesAreValid(t *testing.T) {
 		FlagTypeInt:        true,
 		FlagTypeServiceRef: true,
 		FlagTypeHeaders:    true,
+		FlagTypeMultiEnum:  true,
 	}
 	for _, spec := range RuleFlagRegistry() {
 		if !allowed[spec.Type] {
@@ -115,6 +116,35 @@ func TestRuleFlagRegistry_EnumOptions(t *testing.T) {
 		}
 	}
 }
+
+// TestRuleFlagRegistry_MultiEnumOptions asserts that every FlagTypeMultiEnum
+// spec declares at least two options with non-empty, unique, non-empty-valued
+// entries. Unlike enum there is no inactive-sentinel first option — the empty
+// set is the inactive state, so every option must carry a concrete value.
+func TestRuleFlagRegistry_MultiEnumOptions(t *testing.T) {
+	for _, spec := range RuleFlagRegistry() {
+		if spec.Type != FlagTypeMultiEnum {
+			continue
+		}
+		if len(spec.Options) < 2 {
+			t.Errorf("multi_enum flag %q has %d options, expected at least 2", spec.Key, len(spec.Options))
+		}
+		seen := map[string]bool{}
+		for i, opt := range spec.Options {
+			if opt.Value == "" {
+				t.Errorf("multi_enum flag %q option %d has empty Value", spec.Key, i)
+			}
+			if opt.Label == "" {
+				t.Errorf("multi_enum flag %q option %d has empty Label", spec.Key, i)
+			}
+			if seen[opt.Value] {
+				t.Errorf("multi_enum flag %q has duplicate option Value %q", spec.Key, opt.Value)
+			}
+			seen[opt.Value] = true
+		}
+	}
+}
+
 
 // TestRuleFlagRegistry_SharedFlagsHaveInheritanceMode verifies that every flag
 // marked Shared declares an InheritanceMode and vice versa.


### PR DESCRIPTION
> Stacked on #1656 — merge that first; this PR's diff then shows only the work below.

## Summary

The flag registry had no multi-select value type, so any flag needing "pick several of these options" had to invent per-flag UI.

## Key Changes

- **`FlagTypeMultiEnum`**: multi-select over the spec's Options, stored comma-separated; the empty set is the inactive state (no first-option-default rule, unlike enum).
- **Registry constraints**: test-enforced — ≥2 options, non-empty unique values/labels.
- **Frontend**: `FlagCatalogDialog` renders a registry-driven checkbox group; `multiEnumValues` / `toggleMultiEnumValue` helpers plus `flagDefault`/`isFlagActive` cases — no per-flag UI code.

## Notes

- No flag uses the type yet; the first consumer (recording capture points) is #1644.