### PR TITLE
bugfix(team, image): support dual-endpoint providers in image and embeddings handlers (especially for team)

### DIFF
--- a/.design/team.md
+++ b/.design/team.md
@@ -82,11 +82,9 @@ non-default Team   → rule scenario "team:<stable-team-uuid>"
 外部 URL 始终保持 `/tingly/team`；内部 scenario 由认证上下文派生，客户端不能请求
 `/tingly/team:<id>` 来选择或冒充另一个 Team。
 
-`/tingly/team[/v1]` 暴露完整的 mixin 端点集：chat/completions、responses、
-messages（含 count_tokens）、embeddings、models、images/generations 与
-images/edits。Team scenario 因此声明 `openai`、`anthropic`、`imagegen` 三种
-transport——image gen/edit 端点按 `TransportImageGen`（而非 `TransportOpenAI`）
-做 transport 判定，漏掉该声明会让 Team 下的图像生成/改图整体不可用。
+`/tingly/team[/v1]` 暴露完整的 mixin 端点集，Team scenario 因此声明
+`openai`、`anthropic`、`imagegen` 三种 transport。其中 `imagegen` 必须显式
+声明：image gen/edit 端点只按 `TransportImageGen` 判定，漏掉即整体不可用。
 
 ## 6. Request authorization flow
 

--- a/.design/team.md
+++ b/.design/team.md
@@ -82,6 +82,12 @@ non-default Team   → rule scenario "team:<stable-team-uuid>"
 外部 URL 始终保持 `/tingly/team`；内部 scenario 由认证上下文派生，客户端不能请求
 `/tingly/team:<id>` 来选择或冒充另一个 Team。
 
+`/tingly/team[/v1]` 暴露完整的 mixin 端点集：chat/completions、responses、
+messages（含 count_tokens）、embeddings、models、images/generations 与
+images/edits。Team scenario 因此声明 `openai`、`anthropic`、`imagegen` 三种
+transport——image gen/edit 端点按 `TransportImageGen`（而非 `TransportOpenAI`）
+做 transport 判定，漏掉该声明会让 Team 下的图像生成/改图整体不可用。
+
 ## 6. Request authorization flow
 
 ```text

--- a/internal/client/pool.go
+++ b/internal/client/pool.go
@@ -83,10 +83,13 @@ func (p *ClientPool) GetOpenAIClient(ctx context.Context, provider *typ.Provider
 
 	// Set finalizer for automatic cleanup when GC collects the client.
 	// This ensures idle connections are closed without requiring explicit Close() calls.
+	// Capture only the name: the closure outlives the request, and holding the
+	// provider would pin per-request ResolveStyle clones until finalization.
+	providerName := provider.Name
 	runtime.SetFinalizer(client, func(c OpenAIClientInterface) {
 		if c != nil {
 			c.Close()
-			logrus.Debugf("Auto-closed OpenAI client for provider: %s via finalizer", provider.Name)
+			logrus.Debugf("Auto-closed OpenAI client for provider: %s via finalizer", providerName)
 		}
 	})
 
@@ -126,10 +129,12 @@ func (p *ClientPool) GetAnthropicClient(ctx context.Context, provider *typ.Provi
 	}
 
 	// Set finalizer for automatic cleanup when GC collects the client.
+	// Name-only capture, same rationale as GetOpenAIClient.
+	providerName := provider.Name
 	runtime.SetFinalizer(client, func(c AnthropicClientInterface) {
 		if c != nil {
 			c.Close()
-			logrus.Debugf("Auto-closed Anthropic client for provider: %s via finalizer", provider.Name)
+			logrus.Debugf("Auto-closed Anthropic client for provider: %s via finalizer", providerName)
 		}
 	})
 
@@ -151,10 +156,12 @@ func (p *ClientPool) GetGoogleClient(ctx context.Context, provider *typ.Provider
 	}
 
 	// Set finalizer for automatic cleanup when GC collects the client.
+	// Name-only capture, same rationale as GetOpenAIClient.
+	providerName := provider.Name
 	runtime.SetFinalizer(client, func(c *GoogleClient) {
 		if c != nil {
 			c.Close()
-			logrus.Debugf("Auto-closed Google client for provider: %s via finalizer", provider.Name)
+			logrus.Debugf("Auto-closed Google client for provider: %s via finalizer", providerName)
 		}
 	})
 

--- a/internal/protocolserver/dual_provider_test.go
+++ b/internal/protocolserver/dual_provider_test.go
@@ -1,0 +1,85 @@
+package protocolserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/client"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/routing"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// newDualProviderRouter builds a real gateway stack (config, routing
+// selector, client pool, full route registration) around one dual provider
+// whose primary APIBase is a dead address and whose OpenAI-side dual URL is
+// upstreamURL: a request that reaches the upstream proves the handler
+// resolved the dual endpoint via ResolveStyle. One rule binds requestModel
+// under scenario to the provider's upstreamModel.
+func newDualProviderRouter(t *testing.T, upstreamURL string, apiStyle protocol.APIStyle, scenario typ.RuleScenario, requestModel, upstreamModel string) *gin.Engine {
+	t.Helper()
+	loadbalance.DefaultBreakerStore().Reset()
+
+	cfg, err := config.NewConfig(
+		config.WithConfigDir(t.TempDir()),
+		config.WithDisableMigration(),
+		config.WithDisableBuiltIn(),
+	)
+	require.NoError(t, err)
+	require.NoError(t, cfg.AddProvider(&typ.Provider{
+		UUID: "prov-dual", Name: "prov-dual", Enabled: true,
+		AuthType: typ.AuthTypeAPIKey, Token: "test-key",
+		APIStyle:         apiStyle,
+		APIBase:          "http://127.0.0.1:1/v1",
+		APIBaseOpenAI:    upstreamURL + "/v1",
+		APIBaseAnthropic: "http://127.0.0.1:1/anthropic",
+	}))
+	require.NoError(t, cfg.AddRule(typ.Rule{
+		Scenario: scenario, RequestModel: requestModel, Active: true,
+		Services: []*loadbalance.Service{{Provider: "prov-dual", Model: upstreamModel, Active: true}},
+	}))
+
+	hm := loadbalance.NewHealthMonitor(loadbalance.HealthMonitorConfig{ProbeEnabled: false})
+	lb := NewLoadBalancer(cfg, routing.NewHealthFilter(hm))
+	ph := NewHandler(ProtocolHandlerDeps{
+		Config:          cfg,
+		ClientPool:      client.NewClientPool(),
+		RoutingSelector: routing.NewSimpleSelector(routing.NewServiceSelector(cfg, NewAffinityStore(0), lb)),
+		LoadBalancer:    lb,
+		HealthMonitor:   hm,
+	})
+
+	engine := gin.New()
+	ph.RegisterRoutes(engine, func(c *gin.Context) { c.Next() })
+	return engine
+}
+
+// newPathRecordingUpstream serves payload as JSON for every request and
+// returns a getter for the most recent request path (mutex-guarded: the
+// server handler runs on its own goroutine).
+func newPathRecordingUpstream(t *testing.T, payload map[string]any) (*httptest.Server, func() string) {
+	t.Helper()
+	var mu sync.Mutex
+	var lastPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		lastPath = r.URL.Path
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return lastPath
+	}
+}

--- a/internal/protocolserver/openai_embeddings.go
+++ b/internal/protocolserver/openai_embeddings.go
@@ -113,6 +113,12 @@ func (ph *ProtocolHandler) HandleOpenAIEmbeddings(c *gin.Context) {
 		return
 	}
 
+	// Resolve dual endpoint: embeddings are OpenAI-protocol, so a dual
+	// provider routes to its OpenAI-side base URL — same as the image and
+	// chat/responses forwarding paths. This runs before the style check so a
+	// dual provider passes regardless of which side is its primary APIStyle.
+	provider = provider.ResolveStyle(protocol.APIStyleOpenAI)
+
 	if provider.APIStyle != protocol.APIStyleOpenAI {
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: ErrorDetail{

--- a/internal/protocolserver/openai_embeddings.go
+++ b/internal/protocolserver/openai_embeddings.go
@@ -113,10 +113,9 @@ func (ph *ProtocolHandler) HandleOpenAIEmbeddings(c *gin.Context) {
 		return
 	}
 
-	// Resolve dual endpoint: embeddings are OpenAI-protocol, so a dual
-	// provider routes to its OpenAI-side base URL — same as the image and
-	// chat/responses forwarding paths. This runs before the style check so a
-	// dual provider passes regardless of which side is its primary APIStyle.
+	// Resolve dual endpoint: when the provider has an OpenAI-compatible
+	// dual URL configured, route there natively to avoid a transform.
+	// Runs before the style check so dual providers pass either way.
 	provider = provider.ResolveStyle(protocol.APIStyleOpenAI)
 
 	if provider.APIStyle != protocol.APIStyleOpenAI {
@@ -160,30 +159,9 @@ func (ph *ProtocolHandler) HandleOpenAIEmbeddings(c *gin.Context) {
 	usage := protocol.NewTokenUsageWithCache(int(resp.Usage.PromptTokens), 0, 0)
 	ph.trackUsageWithTokenUsage(c, usage, nil)
 
-	responseJSON, err := json.Marshal(resp)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{
-			Error: ErrorDetail{
-				Message: "Failed to marshal response: " + err.Error(),
-				Type:    "api_error",
-			},
-		})
-		return
-	}
-
-	var responseMap map[string]interface{}
-	if err := json.Unmarshal(responseJSON, &responseMap); err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{
-			Error: ErrorDetail{
-				Message: "Failed to process response: " + err.Error(),
-				Type:    "api_error",
-			},
-		})
-		return
-	}
-
-	responseMap["model"] = responseModel
-	c.JSON(http.StatusOK, responseMap)
+	// Echo the caller's request model, not the routed upstream model.
+	resp.Model = responseModel
+	c.JSON(http.StatusOK, resp)
 }
 
 // isEmbeddingInputEmpty returns true if no variant of the union input is set.

--- a/internal/protocolserver/openai_embeddings_dual_test.go
+++ b/internal/protocolserver/openai_embeddings_dual_test.go
@@ -1,7 +1,6 @@
 package protocolserver
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,11 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tingly-dev/tingly-box/internal/client"
-	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
-	"github.com/tingly-dev/tingly-box/internal/routing"
-	"github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
@@ -27,51 +22,16 @@ import (
 // OpenAI-side dual URL was used).
 func TestEmbeddingsForwarding_DualProviderResolvesOpenAIEndpoint(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	loadbalance.DefaultBreakerStore().Reset()
-
-	var upstreamPaths []string
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		upstreamPaths = append(upstreamPaths, r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"object": "list",
-			"data": []map[string]any{{
-				"object": "embedding", "index": 0, "embedding": []float64{0.1, 0.2},
-			}},
-			"model": "embed-upstream-model",
-			"usage": map[string]any{"prompt_tokens": 2, "total_tokens": 2},
-		})
-	}))
-	defer upstream.Close()
-
-	cfg, err := config.NewConfig(config.WithConfigDir(t.TempDir()))
-	require.NoError(t, err)
-	require.NoError(t, cfg.AddProvider(&typ.Provider{
-		UUID: "prov-dual", Name: "prov-dual", Enabled: true,
-		AuthType: typ.AuthTypeAPIKey, Token: "test-key",
-		APIStyle:         protocol.APIStyleAnthropic,
-		APIBase:          "http://127.0.0.1:1/anthropic",
-		APIBaseOpenAI:    upstream.URL + "/v1",
-		APIBaseAnthropic: "http://127.0.0.1:1/anthropic",
-	}))
-	require.NoError(t, cfg.AddRule(typ.Rule{
-		Scenario: typ.ScenarioEmbed, RequestModel: "embed-model", Active: true,
-		Services: []*loadbalance.Service{{Provider: "prov-dual", Model: "embed-upstream-model", Active: true}},
-	}))
-
-	hm := loadbalance.NewHealthMonitor(loadbalance.HealthMonitorConfig{ProbeEnabled: false})
-	lb := NewLoadBalancer(cfg, routing.NewHealthFilter(hm))
-	selector := routing.NewSimpleSelector(routing.NewServiceSelector(cfg, NewAffinityStore(0), lb))
-	ph := NewHandler(ProtocolHandlerDeps{
-		Config:          cfg,
-		ClientPool:      client.NewClientPool(),
-		RoutingSelector: selector,
-		LoadBalancer:    lb,
-		HealthMonitor:   hm,
+	upstream, lastPath := newPathRecordingUpstream(t, map[string]any{
+		"object": "list",
+		"data": []map[string]any{{
+			"object": "embedding", "index": 0, "embedding": []float64{0.1, 0.2},
+		}},
+		"model": "embed-upstream-model",
+		"usage": map[string]any{"prompt_tokens": 2, "total_tokens": 2},
 	})
-
-	router := gin.New()
-	router.POST("/tingly/:scenario/v1/embeddings", ph.teamScopeMiddleware, ph.HandleOpenAIEmbeddings)
+	router := newDualProviderRouter(t, upstream.URL, protocol.APIStyleAnthropic,
+		typ.ScenarioEmbed, "embed-model", "embed-upstream-model")
 
 	body := `{"model": "embed-model", "input": "hello"}`
 	req := httptest.NewRequest(http.MethodPost, "/tingly/embed/v1/embeddings", strings.NewReader(body))
@@ -80,8 +40,7 @@ func TestEmbeddingsForwarding_DualProviderResolvesOpenAIEndpoint(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
-	require.NotEmpty(t, upstreamPaths, "request never reached the dual OpenAI-side upstream")
-	assert.Equal(t, "/v1/embeddings", upstreamPaths[0])
+	assert.Equal(t, "/v1/embeddings", lastPath())
 	// The response model must echo the caller's request model, not the routed one.
 	assert.Contains(t, w.Body.String(), `"model":"embed-model"`)
 }

--- a/internal/protocolserver/openai_embeddings_dual_test.go
+++ b/internal/protocolserver/openai_embeddings_dual_test.go
@@ -1,0 +1,87 @@
+package protocolserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/client"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/routing"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// TestEmbeddingsForwarding_DualProviderResolvesOpenAIEndpoint is the
+// embeddings counterpart of the image dual-endpoint regression test. The dual
+// provider is doubly adversarial: its primary APIStyle is anthropic (so the
+// handler's OpenAI-only style check would reject it without resolution) and
+// its primary APIBase is a dead address (so a served request proves the
+// OpenAI-side dual URL was used).
+func TestEmbeddingsForwarding_DualProviderResolvesOpenAIEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	loadbalance.DefaultBreakerStore().Reset()
+
+	var upstreamPaths []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamPaths = append(upstreamPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"object": "list",
+			"data": []map[string]any{{
+				"object": "embedding", "index": 0, "embedding": []float64{0.1, 0.2},
+			}},
+			"model": "embed-upstream-model",
+			"usage": map[string]any{"prompt_tokens": 2, "total_tokens": 2},
+		})
+	}))
+	defer upstream.Close()
+
+	cfg, err := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+	require.NoError(t, cfg.AddProvider(&typ.Provider{
+		UUID: "prov-dual", Name: "prov-dual", Enabled: true,
+		AuthType: typ.AuthTypeAPIKey, Token: "test-key",
+		APIStyle:         protocol.APIStyleAnthropic,
+		APIBase:          "http://127.0.0.1:1/anthropic",
+		APIBaseOpenAI:    upstream.URL + "/v1",
+		APIBaseAnthropic: "http://127.0.0.1:1/anthropic",
+	}))
+	require.NoError(t, cfg.AddRule(typ.Rule{
+		Scenario: typ.ScenarioEmbed, RequestModel: "embed-model", Active: true,
+		Services: []*loadbalance.Service{{Provider: "prov-dual", Model: "embed-upstream-model", Active: true}},
+	}))
+
+	hm := loadbalance.NewHealthMonitor(loadbalance.HealthMonitorConfig{ProbeEnabled: false})
+	lb := NewLoadBalancer(cfg, routing.NewHealthFilter(hm))
+	selector := routing.NewSimpleSelector(routing.NewServiceSelector(cfg, NewAffinityStore(0), lb))
+	ph := NewHandler(ProtocolHandlerDeps{
+		Config:          cfg,
+		ClientPool:      client.NewClientPool(),
+		RoutingSelector: selector,
+		LoadBalancer:    lb,
+		HealthMonitor:   hm,
+	})
+
+	router := gin.New()
+	router.POST("/tingly/:scenario/v1/embeddings", ph.teamScopeMiddleware, ph.HandleOpenAIEmbeddings)
+
+	body := `{"model": "embed-model", "input": "hello"}`
+	req := httptest.NewRequest(http.MethodPost, "/tingly/embed/v1/embeddings", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.NotEmpty(t, upstreamPaths, "request never reached the dual OpenAI-side upstream")
+	assert.Equal(t, "/v1/embeddings", upstreamPaths[0])
+	// The response model must echo the caller's request model, not the routed one.
+	assert.Contains(t, w.Body.String(), `"model":"embed-model"`)
+}

--- a/internal/protocolserver/openai_image.go
+++ b/internal/protocolserver/openai_image.go
@@ -121,6 +121,12 @@ func (ph *ProtocolHandler) HandleOpenAIImageGeneration(c *gin.Context) {
 		return
 	}
 
+	// Resolve dual endpoint: the images surface speaks the OpenAI protocol,
+	// so a dual provider must route to its OpenAI-side base URL — same as
+	// the chat/responses forwarding paths. OAuth providers (Codex/Kimi) are
+	// never dual and pass through unchanged.
+	provider = provider.ResolveStyle(protocol.APIStyleOpenAI)
+
 	actualModel := selectedService.Model
 	req.Model = openai.ImageModel(actualModel)
 

--- a/internal/protocolserver/openai_image.go
+++ b/internal/protocolserver/openai_image.go
@@ -27,9 +27,9 @@ import (
 // dedicated images endpoint or the Responses API — the caller chooses the
 // surface and the corresponding tingly-box route.
 //
-// Exposed via the mixin route group, so any scenario whose descriptor declares
-// TransportImageGen (or TransportOpenAI as a mixin) can reach it. The canonical
-// home is the dedicated `imagegen` scenario.
+// Exposed via the mixin route group, but gated on TransportImageGen: only
+// scenarios whose descriptor declares it can reach this endpoint. The
+// canonical home is the dedicated `imagegen` scenario.
 func (ph *ProtocolHandler) HandleOpenAIImageGeneration(c *gin.Context) {
 	scenario := c.Param("scenario")
 	scenarioType := typ.RuleScenario(scenario)
@@ -121,10 +121,8 @@ func (ph *ProtocolHandler) HandleOpenAIImageGeneration(c *gin.Context) {
 		return
 	}
 
-	// Resolve dual endpoint: the images surface speaks the OpenAI protocol,
-	// so a dual provider must route to its OpenAI-side base URL — same as
-	// the chat/responses forwarding paths. OAuth providers (Codex/Kimi) are
-	// never dual and pass through unchanged.
+	// Resolve dual endpoint: when the provider has an OpenAI-compatible
+	// dual URL configured, route there natively to avoid a transform.
 	provider = provider.ResolveStyle(protocol.APIStyleOpenAI)
 
 	actualModel := selectedService.Model

--- a/internal/protocolserver/openai_image_dual_test.go
+++ b/internal/protocolserver/openai_image_dual_test.go
@@ -1,8 +1,6 @@
 package protocolserver
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,104 +10,43 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tingly-dev/tingly-box/internal/client"
-	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
-	"github.com/tingly-dev/tingly-box/internal/routing"
-	"github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
 // TestImageForwarding_DualProviderResolvesOpenAIEndpoint proves the image
 // surfaces resolve a dual provider to its OpenAI-side base URL before
 // forwarding, exactly like the chat/responses paths do via ResolveStyle.
-//
-// The dual provider is set up adversarially: its primary APIBase points at a
-// dead address and only APIBaseOpenAI reaches the mock upstream. Without the
-// ResolveStyle call in the image handlers the request would be sent to the
-// dead primary URL and fail; with it, both generation and edit land on the
-// OpenAI-side endpoint. Routed through /tingly/team so the whole
-// team-scenario image path is exercised end to end.
+// Without that call the request would go to the dead primary APIBase and
+// fail. Routed through /tingly/team (default-team scope), so the team
+// scenario's image path is exercised through the real route chain too.
 func TestImageForwarding_DualProviderResolvesOpenAIEndpoint(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	loadbalance.DefaultBreakerStore().Reset()
-
-	var upstreamPaths []string
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		upstreamPaths = append(upstreamPaths, r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"created": 1,
-			"data":    []map[string]any{{"b64_json": base64.StdEncoding.EncodeToString(editTestPNG)}},
-			"usage":   map[string]any{"input_tokens": 1, "output_tokens": 1},
-		})
-	}))
-	defer upstream.Close()
-
-	cfg, err := config.NewConfig(config.WithConfigDir(t.TempDir()))
-	require.NoError(t, err)
-	require.NoError(t, cfg.AddProvider(&typ.Provider{
-		UUID: "prov-dual", Name: "prov-dual", Enabled: true,
-		AuthType: typ.AuthTypeAPIKey, Token: "test-key",
-		APIStyle: protocol.APIStyleOpenAI,
-		// Primary URL is a dead address on purpose: only the dual OpenAI-side
-		// URL reaches the upstream, so a hit proves ResolveStyle ran.
-		APIBase:          "http://127.0.0.1:1/v1",
-		APIBaseOpenAI:    upstream.URL + "/v1",
-		APIBaseAnthropic: "http://127.0.0.1:1/anthropic",
-	}))
-	require.NoError(t, cfg.AddRule(typ.Rule{
-		Scenario: typ.ScenarioTeam, RequestModel: "img-model", Active: true,
-		Services: []*loadbalance.Service{{Provider: "prov-dual", Model: "img-upstream-model", Active: true}},
-	}))
-
-	hm := loadbalance.NewHealthMonitor(loadbalance.HealthMonitorConfig{ProbeEnabled: false})
-	lb := NewLoadBalancer(cfg, routing.NewHealthFilter(hm))
-	selector := routing.NewSimpleSelector(routing.NewServiceSelector(cfg, NewAffinityStore(0), lb))
-	ph := NewHandler(ProtocolHandlerDeps{
-		Config:          cfg,
-		ClientPool:      client.NewClientPool(),
-		RoutingSelector: selector,
-		LoadBalancer:    lb,
-		HealthMonitor:   hm,
+	upstream, lastPath := newPathRecordingUpstream(t, map[string]any{
+		"created": 1,
+		"data":    []map[string]any{{"b64_json": editTestPNGBase64}},
+		"usage":   map[string]any{"input_tokens": 1, "output_tokens": 1},
 	})
+	router := newDualProviderRouter(t, upstream.URL, protocol.APIStyleOpenAI,
+		typ.ScenarioTeam, "img-model", "img-upstream-model")
 
-	router := gin.New()
-	router.POST("/tingly/:scenario/v1/images/generations", ph.teamScopeMiddleware, ph.HandleOpenAIImageGeneration)
-	router.POST("/tingly/:scenario/v1/images/edits", ph.teamScopeMiddleware, ph.HandleOpenAIImageEdit)
+	genBody := `{"model": "img-model", "prompt": "a cat"}`
+	editBody := `{"model": "img-model", "prompt": "a cat", "image": "` + editTestPNGBase64 + `"}`
 
-	tests := []struct {
-		name     string
-		path     string
-		body     string
-		wantPath string
-	}{
-		{
-			name:     "generation",
-			path:     "/tingly/team/v1/images/generations",
-			body:     `{"model": "img-model", "prompt": "a cat"}`,
-			wantPath: "/v1/images/generations",
-		},
-		{
-			name: "edit",
-			path: "/tingly/team/v1/images/edits",
-			body: `{"model": "img-model", "prompt": "a cat", "image": "` +
-				base64.StdEncoding.EncodeToString(editTestPNG) + `"}`,
-			wantPath: "/v1/images/edits",
-		},
+	tests := []struct{ name, path, body, wantPath string }{
+		{name: "generation", path: "/tingly/team/v1/images/generations", body: genBody, wantPath: "/v1/images/generations"},
+		{name: "edit", path: "/tingly/team/v1/images/edits", body: editBody, wantPath: "/v1/images/edits"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			upstreamPaths = nil
 			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(tt.body))
 			req.Header.Set("Content-Type", "application/json")
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)
 
 			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
-			require.NotEmpty(t, upstreamPaths, "request never reached the dual OpenAI-side upstream")
-			assert.Equal(t, tt.wantPath, upstreamPaths[0])
+			assert.Equal(t, tt.wantPath, lastPath())
 		})
 	}
 }

--- a/internal/protocolserver/openai_image_dual_test.go
+++ b/internal/protocolserver/openai_image_dual_test.go
@@ -1,0 +1,115 @@
+package protocolserver
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tingly-dev/tingly-box/internal/client"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/routing"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// TestImageForwarding_DualProviderResolvesOpenAIEndpoint proves the image
+// surfaces resolve a dual provider to its OpenAI-side base URL before
+// forwarding, exactly like the chat/responses paths do via ResolveStyle.
+//
+// The dual provider is set up adversarially: its primary APIBase points at a
+// dead address and only APIBaseOpenAI reaches the mock upstream. Without the
+// ResolveStyle call in the image handlers the request would be sent to the
+// dead primary URL and fail; with it, both generation and edit land on the
+// OpenAI-side endpoint. Routed through /tingly/team so the whole
+// team-scenario image path is exercised end to end.
+func TestImageForwarding_DualProviderResolvesOpenAIEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	loadbalance.DefaultBreakerStore().Reset()
+
+	var upstreamPaths []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamPaths = append(upstreamPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"created": 1,
+			"data":    []map[string]any{{"b64_json": base64.StdEncoding.EncodeToString(editTestPNG)}},
+			"usage":   map[string]any{"input_tokens": 1, "output_tokens": 1},
+		})
+	}))
+	defer upstream.Close()
+
+	cfg, err := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	require.NoError(t, err)
+	require.NoError(t, cfg.AddProvider(&typ.Provider{
+		UUID: "prov-dual", Name: "prov-dual", Enabled: true,
+		AuthType: typ.AuthTypeAPIKey, Token: "test-key",
+		APIStyle: protocol.APIStyleOpenAI,
+		// Primary URL is a dead address on purpose: only the dual OpenAI-side
+		// URL reaches the upstream, so a hit proves ResolveStyle ran.
+		APIBase:          "http://127.0.0.1:1/v1",
+		APIBaseOpenAI:    upstream.URL + "/v1",
+		APIBaseAnthropic: "http://127.0.0.1:1/anthropic",
+	}))
+	require.NoError(t, cfg.AddRule(typ.Rule{
+		Scenario: typ.ScenarioTeam, RequestModel: "img-model", Active: true,
+		Services: []*loadbalance.Service{{Provider: "prov-dual", Model: "img-upstream-model", Active: true}},
+	}))
+
+	hm := loadbalance.NewHealthMonitor(loadbalance.HealthMonitorConfig{ProbeEnabled: false})
+	lb := NewLoadBalancer(cfg, routing.NewHealthFilter(hm))
+	selector := routing.NewSimpleSelector(routing.NewServiceSelector(cfg, NewAffinityStore(0), lb))
+	ph := NewHandler(ProtocolHandlerDeps{
+		Config:          cfg,
+		ClientPool:      client.NewClientPool(),
+		RoutingSelector: selector,
+		LoadBalancer:    lb,
+		HealthMonitor:   hm,
+	})
+
+	router := gin.New()
+	router.POST("/tingly/:scenario/v1/images/generations", ph.teamScopeMiddleware, ph.HandleOpenAIImageGeneration)
+	router.POST("/tingly/:scenario/v1/images/edits", ph.teamScopeMiddleware, ph.HandleOpenAIImageEdit)
+
+	tests := []struct {
+		name     string
+		path     string
+		body     string
+		wantPath string
+	}{
+		{
+			name:     "generation",
+			path:     "/tingly/team/v1/images/generations",
+			body:     `{"model": "img-model", "prompt": "a cat"}`,
+			wantPath: "/v1/images/generations",
+		},
+		{
+			name: "edit",
+			path: "/tingly/team/v1/images/edits",
+			body: `{"model": "img-model", "prompt": "a cat", "image": "` +
+				base64.StdEncoding.EncodeToString(editTestPNG) + `"}`,
+			wantPath: "/v1/images/edits",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstreamPaths = nil
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+			require.NotEmpty(t, upstreamPaths, "request never reached the dual OpenAI-side upstream")
+			assert.Equal(t, tt.wantPath, upstreamPaths[0])
+		})
+	}
+}

--- a/internal/protocolserver/openai_image_edit.go
+++ b/internal/protocolserver/openai_image_edit.go
@@ -104,9 +104,8 @@ func (ph *ProtocolHandler) HandleOpenAIImageEdit(c *gin.Context) {
 		return
 	}
 
-	// Resolve dual endpoint: same rationale as HandleOpenAIImageGeneration —
-	// the images surface is OpenAI-protocol, so dual providers route to
-	// their OpenAI-side base URL.
+	// Resolve dual endpoint: when the provider has an OpenAI-compatible
+	// dual URL configured, route there natively to avoid a transform.
 	provider = provider.ResolveStyle(protocol.APIStyleOpenAI)
 
 	actualModel := selectedService.Model

--- a/internal/protocolserver/openai_image_edit.go
+++ b/internal/protocolserver/openai_image_edit.go
@@ -104,6 +104,11 @@ func (ph *ProtocolHandler) HandleOpenAIImageEdit(c *gin.Context) {
 		return
 	}
 
+	// Resolve dual endpoint: same rationale as HandleOpenAIImageGeneration —
+	// the images surface is OpenAI-protocol, so dual providers route to
+	// their OpenAI-side base URL.
+	provider = provider.ResolveStyle(protocol.APIStyleOpenAI)
+
 	actualModel := selectedService.Model
 	req.Model = openai.ImageModel(actualModel)
 

--- a/internal/protocolserver/openai_image_edit_test.go
+++ b/internal/protocolserver/openai_image_edit_test.go
@@ -22,6 +22,10 @@ import (
 
 var editTestPNG = []byte("\x89PNG\r\n\x1a\nfake-image-data")
 
+// editTestPNGBase64 is the base64 form of editTestPNG, shared by the tests
+// that inline it into JSON request bodies or mock upstream responses.
+var editTestPNGBase64 = base64.StdEncoding.EncodeToString(editTestPNG)
+
 func newEditTestContext(t *testing.T, method, contentType string, body io.Reader) *gin.Context {
 	t.Helper()
 	gin.SetMode(gin.TestMode)

--- a/internal/protocolserver/openai_image_team_test.go
+++ b/internal/protocolserver/openai_image_team_test.go
@@ -1,7 +1,6 @@
 package protocolserver
 
 import (
-	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,50 +8,31 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/tingly-dev/tingly-box/internal/constant"
 )
 
 // TestImageEndpoints_TeamScenarioPassesTransportGate is the regression test
 // for image generation/edit being unusable under the team scenario: the
 // handlers gate on TransportImageGen, which the team descriptor did not
-// declare, so /tingly/team/v1/images/* was rejected with "does not support"
-// before rule lookup ever ran. Requests must now clear the transport gate for
-// both the default team ("team") and an isolated team scope ("team:<id>")
-// and proceed to rule resolution — with no rules configured that means the
-// "not configured" error, never the transport rejection.
+// declare, so /tingly/team/v1/images/* was rejected before rule lookup ever
+// ran. An isolated team scope ("team:<id>", derived by teamScopeMiddleware
+// from the authenticated team) must clear the gate and proceed to rule
+// resolution — with no rules configured that means the "not configured"
+// error, never the transport rejection. The default-team scope is covered
+// end to end by TestImageForwarding_DualProviderResolvesOpenAIEndpoint.
 func TestImageEndpoints_TeamScenarioPassesTransportGate(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	ph := &ProtocolHandler{}
 	router := gin.New()
-	teamAuthStub := func(c *gin.Context) {
-		if teamID := c.GetHeader("X-Test-Team-ID"); teamID != "" {
-			c.Set(constant.CtxKeyTeamID, teamID)
-		}
-	}
-	router.POST("/tingly/:scenario/v1/images/generations",
-		teamAuthStub, ph.teamScopeMiddleware, ph.HandleOpenAIImageGeneration)
-	router.POST("/tingly/:scenario/v1/images/edits",
-		teamAuthStub, ph.teamScopeMiddleware, ph.HandleOpenAIImageEdit)
+	NewHandler(ProtocolHandlerDeps{}).RegisterRoutes(router, setTeamIDFromHeader)
 
 	genBody := `{"model": "img-model", "prompt": "a cat"}`
-	editBody := `{"model": "img-model", "prompt": "a cat", "image": "` +
-		base64.StdEncoding.EncodeToString(editTestPNG) + `"}`
+	editBody := `{"model": "img-model", "prompt": "a cat", "image": "` + editTestPNGBase64 + `"}`
 
-	tests := []struct {
-		name         string
-		path         string
-		body         string
-		teamID       string
-		wantGatePass bool
-	}{
-		{name: "generation default team", path: "/tingly/team/v1/images/generations", body: genBody, wantGatePass: true},
-		{name: "generation isolated team scope", path: "/tingly/team/v1/images/generations", body: genBody, teamID: "team-a", wantGatePass: true},
-		{name: "edit default team", path: "/tingly/team/v1/images/edits", body: editBody, wantGatePass: true},
-		{name: "edit isolated team scope", path: "/tingly/team/v1/images/edits", body: editBody, teamID: "team-a", wantGatePass: true},
+	tests := []struct{ name, path, body, teamID, wantErr string }{
+		{name: "generation isolated team scope", path: "/tingly/team/v1/images/generations", body: genBody, teamID: "team-a", wantErr: "not configured"},
+		{name: "edit isolated team scope", path: "/tingly/team/v1/images/edits", body: editBody, teamID: "team-a", wantErr: "not configured"},
 		// Control: a scenario without TransportImageGen still fails closed.
-		{name: "generation rejected for anthropic-only scenario", path: "/tingly/claude_code/v1/images/generations", body: genBody, wantGatePass: false},
-		{name: "edit rejected for anthropic-only scenario", path: "/tingly/claude_code/v1/images/edits", body: editBody, wantGatePass: false},
+		{name: "generation rejected for anthropic-only scenario", path: "/tingly/claude_code/v1/images/generations", body: genBody, wantErr: "does not support"},
+		{name: "edit rejected for anthropic-only scenario", path: "/tingly/claude_code/v1/images/edits", body: editBody, wantErr: "does not support"},
 	}
 
 	for _, tt := range tests {
@@ -65,13 +45,7 @@ func TestImageEndpoints_TeamScenarioPassesTransportGate(t *testing.T) {
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)
 
-			assert.Equal(t, http.StatusBadRequest, w.Code)
-			if tt.wantGatePass {
-				assert.NotContains(t, w.Body.String(), "does not support")
-				assert.Contains(t, w.Body.String(), "not configured")
-			} else {
-				assert.Contains(t, w.Body.String(), "does not support")
-			}
+			assert.Contains(t, w.Body.String(), tt.wantErr)
 		})
 	}
 }

--- a/internal/protocolserver/openai_image_team_test.go
+++ b/internal/protocolserver/openai_image_team_test.go
@@ -1,0 +1,77 @@
+package protocolserver
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tingly-dev/tingly-box/internal/constant"
+)
+
+// TestImageEndpoints_TeamScenarioPassesTransportGate is the regression test
+// for image generation/edit being unusable under the team scenario: the
+// handlers gate on TransportImageGen, which the team descriptor did not
+// declare, so /tingly/team/v1/images/* was rejected with "does not support"
+// before rule lookup ever ran. Requests must now clear the transport gate for
+// both the default team ("team") and an isolated team scope ("team:<id>")
+// and proceed to rule resolution — with no rules configured that means the
+// "not configured" error, never the transport rejection.
+func TestImageEndpoints_TeamScenarioPassesTransportGate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ph := &ProtocolHandler{}
+	router := gin.New()
+	teamAuthStub := func(c *gin.Context) {
+		if teamID := c.GetHeader("X-Test-Team-ID"); teamID != "" {
+			c.Set(constant.CtxKeyTeamID, teamID)
+		}
+	}
+	router.POST("/tingly/:scenario/v1/images/generations",
+		teamAuthStub, ph.teamScopeMiddleware, ph.HandleOpenAIImageGeneration)
+	router.POST("/tingly/:scenario/v1/images/edits",
+		teamAuthStub, ph.teamScopeMiddleware, ph.HandleOpenAIImageEdit)
+
+	genBody := `{"model": "img-model", "prompt": "a cat"}`
+	editBody := `{"model": "img-model", "prompt": "a cat", "image": "` +
+		base64.StdEncoding.EncodeToString(editTestPNG) + `"}`
+
+	tests := []struct {
+		name         string
+		path         string
+		body         string
+		teamID       string
+		wantGatePass bool
+	}{
+		{name: "generation default team", path: "/tingly/team/v1/images/generations", body: genBody, wantGatePass: true},
+		{name: "generation isolated team scope", path: "/tingly/team/v1/images/generations", body: genBody, teamID: "team-a", wantGatePass: true},
+		{name: "edit default team", path: "/tingly/team/v1/images/edits", body: editBody, wantGatePass: true},
+		{name: "edit isolated team scope", path: "/tingly/team/v1/images/edits", body: editBody, teamID: "team-a", wantGatePass: true},
+		// Control: a scenario without TransportImageGen still fails closed.
+		{name: "generation rejected for anthropic-only scenario", path: "/tingly/claude_code/v1/images/generations", body: genBody, wantGatePass: false},
+		{name: "edit rejected for anthropic-only scenario", path: "/tingly/claude_code/v1/images/edits", body: editBody, wantGatePass: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			if tt.teamID != "" {
+				req.Header.Set("X-Test-Team-ID", tt.teamID)
+			}
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			if tt.wantGatePass {
+				assert.NotContains(t, w.Body.String(), "does not support")
+				assert.Contains(t, w.Body.String(), "not configured")
+			} else {
+				assert.Contains(t, w.Body.String(), "does not support")
+			}
+		})
+	}
+}

--- a/internal/protocolserver/team_scope_test.go
+++ b/internal/protocolserver/team_scope_test.go
@@ -14,16 +14,20 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
+// setTeamIDFromHeader is a test stand-in for model auth: it injects the
+// X-Test-Team-ID header into the auth context the way sharing-key auth does.
+func setTeamIDFromHeader(c *gin.Context) {
+	if teamID := c.GetHeader("X-Test-Team-ID"); teamID != "" {
+		c.Set(constant.CtxKeyTeamID, teamID)
+	}
+}
+
 func TestTeamScopeMiddleware_DerivesRoutingScopeFromAuthContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ph := &ProtocolHandler{}
 	router := gin.New()
 	router.POST("/tingly/:scenario/messages",
-		func(c *gin.Context) {
-			if teamID := c.GetHeader("X-Test-Team-ID"); teamID != "" {
-				c.Set(constant.CtxKeyTeamID, teamID)
-			}
-		},
+		setTeamIDFromHeader,
 		ph.teamScopeMiddleware,
 		func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{
@@ -89,7 +93,7 @@ func TestTeamScopeMiddleware_SelectsOnlyAuthorizedTeamRules(t *testing.T) {
 	ph := &ProtocolHandler{deps: ProtocolHandlerDeps{Config: cfg}}
 	router := gin.New()
 	router.POST("/tingly/:scenario/messages",
-		func(c *gin.Context) { c.Set(constant.CtxKeyTeamID, c.GetHeader("X-Test-Team-ID")) },
+		setTeamIDFromHeader,
 		ph.teamScopeMiddleware,
 		func(c *gin.Context) {
 			rule, err := ph.determineRuleWithScenario(c, typ.RuleScenario(c.Param("scenario")), "shared-model")

--- a/internal/typ/scenario_registry.go
+++ b/internal/typ/scenario_registry.go
@@ -90,12 +90,14 @@ func builtinScenarioDescriptorFor(scenario RuleScenario) ScenarioDescriptor {
 			AllowDirectPathUse: true,
 		}
 	case ScenarioTeam:
-		// Centrally deployed model shared across a team. Accepts both OpenAI
-		// and Anthropic transports so any agent/client can point at
-		// /tingly/team regardless of protocol.
+		// Centrally deployed model shared across a team. Accepts OpenAI,
+		// Anthropic and ImageGen transports so any agent/client can point at
+		// /tingly/team regardless of protocol — including the image
+		// generation/edit surface (/images/generations, /images/edits), which
+		// gates on TransportImageGen rather than TransportOpenAI.
 		return ScenarioDescriptor{
 			ID:                 scenario,
-			SupportedTransport: []ScenarioTransport{TransportOpenAI, TransportAnthropic},
+			SupportedTransport: []ScenarioTransport{TransportOpenAI, TransportAnthropic, TransportImageGen},
 			AllowRuleBinding:   true,
 			AllowDirectPathUse: true,
 		}

--- a/internal/typ/scenario_registry.go
+++ b/internal/typ/scenario_registry.go
@@ -92,9 +92,9 @@ func builtinScenarioDescriptorFor(scenario RuleScenario) ScenarioDescriptor {
 	case ScenarioTeam:
 		// Centrally deployed model shared across a team. Accepts OpenAI,
 		// Anthropic and ImageGen transports so any agent/client can point at
-		// /tingly/team regardless of protocol — including the image
-		// generation/edit surface (/images/generations, /images/edits), which
-		// gates on TransportImageGen rather than TransportOpenAI.
+		// /tingly/team regardless of protocol. TransportImageGen must be
+		// explicit: the /images/* handlers gate on it alone (embeddings, by
+		// contrast, also accepts TransportOpenAI).
 		return ScenarioDescriptor{
 			ID:                 scenario,
 			SupportedTransport: []ScenarioTransport{TransportOpenAI, TransportAnthropic, TransportImageGen},

--- a/internal/typ/scenario_registry_test.go
+++ b/internal/typ/scenario_registry_test.go
@@ -145,10 +145,15 @@ func TestTeamScenarioDescriptor(t *testing.T) {
 	if !d.AllowDirectPathUse {
 		t.Error("team should allow direct path use")
 	}
-	for _, transport := range []ScenarioTransport{TransportOpenAI, TransportAnthropic} {
+	for _, transport := range []ScenarioTransport{TransportOpenAI, TransportAnthropic, TransportImageGen} {
 		if !ScenarioSupportsTransport(ScenarioTeam, transport) {
 			t.Errorf("team should support transport %q", transport)
 		}
+	}
+	// The image endpoints gate on TransportImageGen via the base descriptor,
+	// so the isolated per-team scope ("team:<id>") must resolve identically.
+	if !ScenarioSupportsTransport(ProfiledScenarioName(ScenarioTeam, "some-team-uuid"), TransportImageGen) {
+		t.Error("team:<id> scope should support transport imagegen via the base team descriptor")
 	}
 }
 

--- a/internal/typ/scenario_registry_test.go
+++ b/internal/typ/scenario_registry_test.go
@@ -150,11 +150,6 @@ func TestTeamScenarioDescriptor(t *testing.T) {
 			t.Errorf("team should support transport %q", transport)
 		}
 	}
-	// The image endpoints gate on TransportImageGen via the base descriptor,
-	// so the isolated per-team scope ("team:<id>") must resolve identically.
-	if !ScenarioSupportsTransport(ProfiledScenarioName(ScenarioTeam, "some-team-uuid"), TransportImageGen) {
-		t.Error("team:<id> scope should support transport imagegen via the base team descriptor")
-	}
 }
 
 func TestDshScenarioDescriptor(t *testing.T) {


### PR DESCRIPTION
## Summary
Image generation, image edit, and embeddings handlers now resolve dual-endpoint providers to their OpenAI-compatible URLs before forwarding, matching the behavior of chat/responses paths. This fixes requests to dual providers from failing when their primary APIStyle doesn't match the handler's expectations.

## Key Changes

- **Dual-endpoint resolution in image/embeddings handlers**: `HandleOpenAIImageGeneration`, `HandleOpenAIImageEdit`, and `HandleOpenAIEmbeddings` now call `provider.ResolveStyle(protocol.APIStyleOpenAI)` before style checks, allowing dual providers to route to their OpenAI-side URLs natively without transformation.

- **Team scenario transport gate for images**: Added `TransportImageGen` to the team scenario's supported transports, enabling `/tingly/team/v1/images/*` endpoints. Image handlers gate on `TransportImageGen` alone (not `TransportOpenAI`), so the transport must be explicitly declared.

- **Embeddings response model fidelity**: Simplified embeddings response handling to directly set `resp.Model = responseModel` instead of marshal/unmarshal round-trip, ensuring the caller's request model is echoed back (not the routed upstream model).

- **Finalizer closure safety**: Client pool finalizers now capture only `provider.Name` instead of the full provider object, preventing per-request `ResolveStyle` clones from being pinned until garbage collection.

- **Test infrastructure and coverage**: Added helper functions (`newDualProviderRouter`, `newPathRecordingUpstream`, `setTeamIDFromHeader`) and four new regression tests covering dual-provider resolution in images and embeddings, plus team scenario transport gating.

## Minor

- Extracted `editTestPNGBase64` constant for reuse across image edit tests.
- Updated `.design/team.md` to document the three transports (openai, anthropic, imagegen) now supported by the team scenario.

https://claude.ai/code/session_01GwPxMaencrRZARp372KGmi