### PR TITLE
build(npx): add tb alias to bin for global installs

### DIFF
--- a/build/npx/tingly-box-bundle/package.json
+++ b/build/npx/tingly-box-bundle/package.json
@@ -17,7 +17,8 @@
     "access": "public"
   },
   "bin": {
-    "tingly-box": "bin.js"
+    "tingly-box": "bin.js",
+    "tb": "bin.js"
   },
   "type": "module",
   "files": [

--- a/build/npx/tingly-box-gui/package.json
+++ b/build/npx/tingly-box-gui/package.json
@@ -17,7 +17,8 @@
     "access": "public"
   },
   "bin": {
-    "tingly-box": "bin.js"
+    "tingly-box": "bin.js",
+    "tb": "bin.js"
   },
   "type": "module",
   "dependencies": {

--- a/build/npx/tingly-box/package.json
+++ b/build/npx/tingly-box/package.json
@@ -17,7 +17,8 @@
     "access": "public"
   },
   "bin": {
-    "tingly-box": "bin.js"
+    "tingly-box": "bin.js",
+    "tb": "bin.js"
   },
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary
`npm install -g tingly-box` (and `-bundle`/`-gui`) now also exposes a `tb` shim alongside `tingly-box`, since typing a short command name is friendlier than the full brand name.

## Key Changes
- **Global CLI alias**: added `"tb": "bin.js"` to the `bin` field of all three npx packages (`tingly-box`, `tingly-box-bundle`, `tingly-box-gui`), so global installs get both command names for free — `npx` entry points are unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dm5MgCZFaiRPTjNt1XSxsH)_