### PR TITLE
fix(ui, credential): stop surfacing quota error text in the quota row

### DIFF
--- a/frontend/src/components/credential/QuotaInlineDisplay.tsx
+++ b/frontend/src/components/credential/QuotaInlineDisplay.tsx
@@ -3,7 +3,6 @@ import { Box, Button, Stack, IconButton, Typography, CircularProgress, Tooltip }
 import { Code as CodeIcon } from '@/components/icons';
 import { Refresh as RefreshIcon } from '@/components/icons';
 import { Info as InfoIcon } from '@/components/icons';
-import { Warning as AlertIcon } from '@/components/icons';
 import { QuotaBarItem } from './QuotaBarItem';
 import { QuotaBarRow, useQuotaBars } from './QuotaBarRow';
 import { QuotaRawResponseDialog } from './QuotaRawResponseDialog';
@@ -55,10 +54,10 @@ export function QuotaInlineDisplay({
   const hiddenWindows = windows.slice(maxInlineItems);
   const fetchedAgo = formatFetchedAgo(quota?.fetched_at);
 
-  // A provider whose quota could not be read still has something to say. It
-  // used to render nothing at all, so a failing provider simply vanished from
-  // the row and the refresh button went with it — leaving no way to retry and
-  // no reason on screen.
+  // A provider whose quota could not be read still renders its row (lastError
+  // keeps it alive below) so the refresh button survives. The error text itself
+  // is not surfaced here — Details shows the raw response when there is one;
+  // the quota area just stays empty.
   const lastError = quota?.last_error;
   if (!hasAny && !hasRawResponse && !lastError) {
     return null;
@@ -209,23 +208,6 @@ export function QuotaInlineDisplay({
             <Typography variant="caption" color="text.disabled" sx={{ whiteSpace: 'nowrap' }}>
               No quota limits reported
             </Typography>
-          )}
-          {lastError && (
-            <Tooltip title={lastError} arrow>
-              {/* Upstream reasons run long — a raw 403 envelope is a few hundred
-                  characters. The width is capped so the clipped text ends in an
-                  ellipsis inside the row instead of running past the table. */}
-              <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', minWidth: 0, maxWidth: 460 }}>
-                <AlertIcon sx={{ fontSize: 14, color: 'warning.main', flexShrink: 0 }} />
-                <Typography
-                  variant="caption"
-                  color="warning.main"
-                  sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                >
-                  {lastError}
-                </Typography>
-              </Stack>
-            </Tooltip>
           )}
         </Stack>
 

--- a/frontend/src/hooks/useProviderQuota.ts
+++ b/frontend/src/hooks/useProviderQuota.ts
@@ -150,14 +150,10 @@ export function useProviderQuota(providers: Array<{ uuid: string; name?: string 
       await fetchUIAPI(`/provider-quota/${providerUuid}/refresh`, {
         method: 'POST',
       });
-      const quota = await fetchQuota(providerUuid);
-      // The refresh endpoint answers 200 even when the upstream refused: an
-      // unreadable provider comes back as a usage record carrying last_error.
-      // Reporting only transport failures made that case look like a success
-      // that quietly rendered nothing.
-      if (quota?.last_error) {
-        notify.warning(`${providerName(providerUuid)}: ${quota.last_error}`);
-      }
+      // A refused upstream still answers 200: an unreadable provider comes
+      // back as a usage record carrying last_error. The error is not toasted —
+      // it's visible via Details on the quota row — so the refresh stays quiet.
+      await fetchQuota(providerUuid);
     } catch (error) {
       if (isMissingQuota(error)) {
         return;

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -907,18 +907,29 @@ const inThirtyDays = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000).toISOStr
 // that must not answer for the account, and a quota we cannot read at all.
 const mockQuotas: Record<string, any> = {
     // Nothing readable: the reason is recorded and no windows are invented.
-    // The credential row still renders — the reason inline, refresh still
-    // reachable — since a provider that cannot be read is exactly the one a
-    // user needs to see and retry.
+    // The credential row still renders — quota area empty, refresh still
+    // reachable — and the reason stays available via Details (raw_response).
+    // This mirrors the "upstream answered, but the answer is a refusal" case
+    // (e.g. user has no coding plan): the fetcher keeps the payload.
     'mock-provider-anthropic': {
         provider_uuid: 'mock-provider-anthropic',
         provider_name: 'Anthropic',
         provider_type: 'anthropic',
         fetched_at: now.toISOString(),
         expires_at: inOneHour,
-        last_error: 'validation failed: usage requires OAuth authentication',
+        last_error: 'user does not have an active coding plan',
         last_error_at: now.toISOString(),
+        raw_response: {
+            type: 'error',
+            error: {
+                type: 'permission_error',
+                message: 'user does not have an active coding plan',
+            },
+        },
     },
+
+    // Fetch failed outright: no payload came back, so no raw_response either —
+    // the row renders with an empty quota area and no Details button.
 
     'mock-provider-openai': {
         provider_uuid: 'mock-provider-openai',


### PR DESCRIPTION
An unreadable provider (e.g. user has no coding plan) rendered its last_error inline in the quota row and toasted the same text on every manual refresh. The error is already reachable via Details (raw response), so the quota row now stays empty for error states — the row itself still renders so the refresh button remains reachable.

Mocks cover both error paths: upstream refusal with a raw_response (Details visible) and an outright fetch failure (no Details).

Fix #1664 