### PR TITLE
fix(docker): auto-fix bind-mount ownership for quick-start

### DIFF
--- a/.github/scripts/docker-smoke-test.sh
+++ b/.github/scripts/docker-smoke-test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Regression guard for #1662: a freshly `mkdir`ed host directory bind-mounted
+# into a Tingly Box image, owned by the invoking host user (not the image's
+# non-root "tingly", UID/GID 999), must come up without a manual `chown`.
+#
+# Runs <image> against exactly that kind of directory and fails if the
+# container dies, its logs mention a permission error, or the entrypoint
+# never actually writes into the mount (memory/logs/db all nest under it,
+# see internal/config/app_config.go).
+#
+# Usage:
+#   docker-smoke-test.sh <image> <container-data-dir>
+#
+#   <image>              image tag to run, e.g. tingly-box-smoke:build
+#   <container-data-dir> bind-mount target inside the container, e.g.
+#                        /home/tingly/.tingly-box or /app/.tingly-box
+set -euo pipefail
+
+IMAGE="${1:?usage: docker-smoke-test.sh <image> <container-data-dir>}"
+DATA_DIR="${2:?usage: docker-smoke-test.sh <image> <container-data-dir>}"
+
+HOST_DIR="$(mktemp -d)"
+CONTAINER="tingly-box-smoke-$$"
+
+cleanup() {
+    docker logs "$CONTAINER" 2>&1 | tail -100 || true
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    rm -rf "$HOST_DIR"
+}
+trap cleanup EXIT
+
+echo "== host dir before run =="
+ls -ld "$HOST_DIR"
+
+# Deliberately NOT chowned — this is the exact shape of the bug: a plain
+# `mkdir` on the host, owned by whoever ran it (the CI runner user here,
+# UID/GID 999 the container's "tingly" in the reported issue).
+docker run -d --name "$CONTAINER" -p 12580:12580 \
+    -v "$HOST_DIR:$DATA_DIR" \
+    "$IMAGE"
+
+echo "== waiting for the entrypoint to fix ownership and the app to write into the mount =="
+ok=0
+for _ in $(seq 1 30); do
+    if ! docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q true; then
+        echo "FAIL: container exited early" >&2
+        break
+    fi
+    if docker logs "$CONTAINER" 2>&1 | grep -qi "permission denied"; then
+        echo "FAIL: 'permission denied' in container logs" >&2
+        break
+    fi
+    # Anything landing in the mount (config.json, memory/, logs/, db/) proves
+    # the entrypoint's chown + privilege-drop actually let the app write here.
+    if [ -n "$(ls -A "$HOST_DIR" 2>/dev/null)" ]; then
+        ok=1
+        break
+    fi
+    sleep 2
+done
+
+echo "== host dir after run =="
+ls -la "$HOST_DIR"
+
+if [ "$ok" != "1" ]; then
+    echo "FAIL: nothing was written to $HOST_DIR (bind-mounted at $DATA_DIR) within the timeout" >&2
+    exit 1
+fi
+
+echo "OK: $IMAGE wrote into a bind mount it did not own at container start"

--- a/.github/scripts/docker-smoke-test.sh
+++ b/.github/scripts/docker-smoke-test.sh
@@ -19,13 +19,27 @@ set -euo pipefail
 IMAGE="${1:?usage: docker-smoke-test.sh <image> <container-data-dir>}"
 DATA_DIR="${2:?usage: docker-smoke-test.sh <image> <container-data-dir>}"
 
+# The entrypoint's `chown -R` reassigns the bind-mounted directory itself
+# (not just its contents) to the container's "tingly" (UID/GID 999) — that's
+# the fix working as intended, but it also means the *host* user that
+# created the directory (this script, when not root) can no longer `ls` or
+# `rm` a 0700 dir it no longer owns. Use sudo for anything touching the
+# mount after the container has run, same as an operator would.
+priv() {
+    if [ "$(id -u)" != "0" ] && command -v sudo >/dev/null 2>&1; then
+        sudo "$@"
+    else
+        "$@"
+    fi
+}
+
 HOST_DIR="$(mktemp -d)"
 CONTAINER="tingly-box-smoke-$$"
 
 cleanup() {
     docker logs "$CONTAINER" 2>&1 | tail -100 || true
     docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
-    rm -rf "$HOST_DIR"
+    priv rm -rf "$HOST_DIR"
 }
 trap cleanup EXIT
 
@@ -52,7 +66,7 @@ for _ in $(seq 1 30); do
     fi
     # Anything landing in the mount (config.json, memory/, logs/, db/) proves
     # the entrypoint's chown + privilege-drop actually let the app write here.
-    if [ -n "$(ls -A "$HOST_DIR" 2>/dev/null)" ]; then
+    if [ -n "$(priv find "$HOST_DIR" -mindepth 1 -print -quit 2>/dev/null)" ]; then
         ok=1
         break
     fi
@@ -60,7 +74,7 @@ for _ in $(seq 1 30); do
 done
 
 echo "== host dir after run =="
-ls -la "$HOST_DIR"
+priv ls -la "$HOST_DIR"
 
 if [ "$ok" != "1" ]; then
     echo "FAIL: nothing was written to $HOST_DIR (bind-mounted at $DATA_DIR) within the timeout" >&2

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,59 @@
+name: Docker Bind-Mount Smoke Test
+
+# Regression guard for #1662: a freshly `mkdir`ed host directory is owned by
+# the invoking host user, not the image's non-root "tingly" user (UID/GID
+# 999), and the entrypoint in both Dockerfiles is what makes that bind mount
+# writable without a manual `chown`. Builds each image locally (no registry
+# push) and actually runs it against such a directory, so a future change to
+# build/docker/** that breaks the ownership fix fails CI instead of shipping.
+on:
+  pull_request:
+    paths:
+      - 'build/docker/**'
+      - '.github/workflows/docker-smoke-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'build/docker/**'
+      - '.github/workflows/docker-smoke-test.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test-build-image:
+    name: Smoke test docker.build.Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Build image
+        run: |
+          docker build -f build/docker/docker.build.Dockerfile -t tingly-box-smoke:build .
+
+      - name: Run against a freshly-created, unchowned bind mount
+        run: |
+          .github/scripts/docker-smoke-test.sh \
+            tingly-box-smoke:build \
+            /home/tingly/.tingly-box
+
+  smoke-test-npx-image:
+    name: Smoke test docker.npx.Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Build image
+        run: |
+          docker build -f build/docker/docker.npx.Dockerfile -t tingly-box-smoke:npx .
+
+      - name: Run against a freshly-created, unchowned bind mount
+        run: |
+          .github/scripts/docker-smoke-test.sh \
+            tingly-box-smoke:npx \
+            /app/.tingly-box

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -11,11 +11,13 @@ on:
     paths:
       - 'build/docker/**'
       - '.github/workflows/docker-smoke-test.yml'
+      - '.github/scripts/docker-smoke-test.sh'
   push:
     branches: [main]
     paths:
       - 'build/docker/**'
       - '.github/workflows/docker-smoke-test.yml'
+      - '.github/scripts/docker-smoke-test.sh'
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -22,13 +22,16 @@ frontend/dist
 frontend/node_modules
 build/linux/appimage/build
 build/windows/nsis/MicrosoftEdgeWebview2Setup.exe
+# `task cli:build` output (a single binary dropped straight into build/,
+# which otherwise holds versioned Dockerfiles/scripts/Taskfiles)
+/build/tingly-box
+/build/tingly-box.exe
 myapp/
 .tingly-box/
 bindings
 
 # IDE
 .idea
-build
 
 # Logs
 logs
@@ -100,7 +103,6 @@ __pycache__/
 *$py.class
 *.so
 .Python
-build/
 develop-eggs/
 dist/
 downloads/

--- a/README.md
+++ b/README.md
@@ -111,23 +111,7 @@ docker run -d \
   ghcr.io/tingly-dev/tingly-box
 ```
 
-**From Docker Compose (Recommend for isolated env)**
-
-```bash
-# Build and start in detached mode
-docker-compose -f build/docker/docker-compose.yml up -d
-
-# View logs
-docker-compose -f build/docker/docker-compose.yml logs -f tingly-box
-
-# Stop services
-docker-compose -f build/docker/docker-compose.yml down
-
-# Access Web UI at http://localhost:12581
-# (Note: Port 12581 is used to avoid conflict with host tingly on 12580)
-```
-
-See [Docker Guide](./docs/docker.md) for more (running as a specific host UID/GID, building for other platforms, troubleshooting).
+**From Docker Compose (recommended for isolated env), building your own image, or troubleshooting** — see the [Docker Guide](./docs/docker.md).
 
 ### Integration Guide
 

--- a/README.md
+++ b/README.md
@@ -115,17 +115,19 @@ docker run -d \
 
 ```bash
 # Build and start in detached mode
-docker-compose up -d
+docker-compose -f build/docker/docker-compose.yml up -d
 
 # View logs
-docker-compose logs -f tingly-box
+docker-compose -f build/docker/docker-compose.yml logs -f tingly-box
 
 # Stop services
-docker-compose down
+docker-compose -f build/docker/docker-compose.yml down
 
 # Access Web UI at http://localhost:12581
 # (Note: Port 12581 is used to avoid conflict with host tingly on 12580)
 ```
+
+See [Docker Guide](./docs/docker.md) for more (running as a specific host UID/GID, building for other platforms, troubleshooting).
 
 ### Integration Guide
 
@@ -282,6 +284,8 @@ Then open `http://localhost:12580` in your browser.
 ## Documentation
 
 **[User Manual](./docs/user-manual.md)** – Installation, configuration, and operational guide
+
+**[Docker Guide](./docs/docker.md)** – Building, running, and troubleshooting the Docker images
 
 **[Guardrails](./docs/guardrails.md)** – Policy-based safety checks, built-in protections, and protected credential masking
 

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -2,18 +2,17 @@ services:
   # Tingly Box Server
   tingly-box:
     build:
-      context: .
+      # Repo root: the Dockerfile COPYs build/docker/docker-entrypoint-npx.sh,
+      # so the context can't be this directory (build/docker) itself.
+      context: ../..
       dockerfile: build/docker/docker.npx.Dockerfile
     container_name: tingly-box
     ports:
       - "12581:12580"
     volumes:
-      # Mount configuration directory
+      # Mount configuration directory (config, memory, logs and db all live
+      # under this single tree, see internal/config/app_config.go)
       - ./data/.tingly-box:/app/.tingly-box
-      # Mount logs directory
-      - ./data/logs:/app/logs
-      # Mount memory directory
-      - ./data/memory:/app/memory
     environment:
       - TINGLY_PORT=12580
       - TINGLY_HOST=0.0.0.0
@@ -29,18 +28,15 @@ services:
   # Development mode - mount source and rebuild manually
   tingly-box-dev:
     build:
-      context: .
+      context: ../..
       dockerfile: build/docker/docker.npx.Dockerfile
     container_name: tingly-box-dev
     ports:
       - "12581:12580"
     volumes:
-      # Mount configuration directory
+      # Mount configuration directory (config, memory, logs and db all live
+      # under this single tree, see internal/config/app_config.go)
       - ./data/.tingly-box:/app/.tingly-box
-      # Mount logs directory
-      - ./data/logs:/app/logs
-      # Mount memory directory
-      - ./data/memory:/app/memory
     environment:
       - TINGLY_PORT=12580
       - TINGLY_HOST=0.0.0.0

--- a/build/docker/docker-entrypoint-npx.sh
+++ b/build/docker/docker-entrypoint-npx.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Fixes ownership of the bind-mounted data directory so a freshly created
+# host directory (owned by the invoking host user, not the container's
+# non-root "tingly" user) doesn't fail with permission denied on first run.
+# Only takes effect when the container is started as root (the default);
+# `docker run --user ...` is left untouched.
+set -e
+
+DATA_DIR="${TINGLY_DATA_DIR:-/app/.tingly-box}"
+
+if [ "$(id -u)" = "0" ]; then
+    mkdir -p "$DATA_DIR"
+    owner="$(stat -c '%u:%g' "$DATA_DIR")"
+    want="$(id -u tingly):$(id -g tingly)"
+    if [ "$owner" != "$want" ]; then
+        chown -R tingly:tingly "$DATA_DIR"
+    fi
+    # util-linux's setpriv is an Essential package on Debian (always present,
+    # even on -slim images) and directly execve()s the target after dropping
+    # privileges, unlike `su -c` which keeps itself resident as the parent.
+    exec setpriv --reuid=tingly --regid=tingly --init-groups "$0" "$@"
+fi
+
+exec "$@"

--- a/build/docker/docker-entrypoint-npx.sh
+++ b/build/docker/docker-entrypoint-npx.sh
@@ -6,7 +6,7 @@
 # `docker run --user ...` is left untouched.
 set -e
 
-DATA_DIR="${TINGLY_DATA_DIR:-/app/.tingly-box}"
+DATA_DIR="/app/.tingly-box"
 
 if [ "$(id -u)" = "0" ]; then
     mkdir -p "$DATA_DIR"

--- a/build/docker/docker-entrypoint.sh
+++ b/build/docker/docker-entrypoint.sh
@@ -6,7 +6,7 @@
 # `docker run --user ...` is left untouched.
 set -e
 
-DATA_DIR="${TINGLY_DATA_DIR:-/home/tingly/.tingly-box}"
+DATA_DIR="/home/tingly/.tingly-box"
 
 if [ "$(id -u)" = "0" ]; then
     mkdir -p "$DATA_DIR"

--- a/build/docker/docker-entrypoint.sh
+++ b/build/docker/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Fixes ownership of the bind-mounted data directory so a freshly created
+# host directory (owned by the invoking host user, not the container's
+# non-root "tingly" user) doesn't fail with permission denied on first run.
+# Only takes effect when the container is started as root (the default);
+# `docker run --user ...` is left untouched.
+set -e
+
+DATA_DIR="${TINGLY_DATA_DIR:-/home/tingly/.tingly-box}"
+
+if [ "$(id -u)" = "0" ]; then
+    mkdir -p "$DATA_DIR"
+    owner="$(stat -c '%u:%g' "$DATA_DIR")"
+    want="$(id -u tingly):$(id -g tingly)"
+    if [ "$owner" != "$want" ]; then
+        chown -R tingly:tingly "$DATA_DIR"
+    fi
+    exec su-exec tingly "$0" "$@"
+fi
+
+exec "$@"

--- a/build/docker/docker.build.Dockerfile
+++ b/build/docker/docker.build.Dockerfile
@@ -78,12 +78,19 @@ WORKDIR /app
 # Copy the binary from builder stage
 COPY --from=builder /app/tingly /usr/local/bin/tingly
 
-# Create necessary directories with proper permissions
-RUN mkdir -p /home/tingly/.tingly-box /app/memory /app/logs && \
+# Create the config/data directory (memory, logs and db all live under this
+# single tree, see internal/config/app_config.go) with proper permissions.
+RUN mkdir -p /home/tingly/.tingly-box && \
     chown -R tingly:tingly /app /home/tingly
 
-# Switch to non-root user
-USER tingly
+# Entrypoint fixes up ownership of a bind-mounted data directory at runtime
+# (a freshly `mkdir`ed host directory is owned by the host user, not the
+# container's UID/GID, and the non-root "tingly" user can't write into it)
+# before dropping from root down to "tingly". Deliberately does NOT switch
+# to USER tingly here, so the entrypoint still starts as root.
+COPY build/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 # Expose port
 EXPOSE 12580
@@ -105,5 +112,5 @@ CMD ["sh", "-c", "echo '======================================' && \
      rm -f /home/tingly/.tingly-box/tingly-server.pid && \
      exec tingly start --host ${TINGLY_HOST} --port ${TINGLY_PORT}"]
 
-# Volumes for persistent data
-VOLUME ["/home/tingly/.tingly-box", "/app/memory", "/app/logs"]
+# Volume for persistent data (memory, logs and db all live under this tree)
+VOLUME ["/home/tingly/.tingly-box"]

--- a/build/docker/docker.build.Dockerfile
+++ b/build/docker/docker.build.Dockerfile
@@ -99,9 +99,12 @@ EXPOSE 12580
 ENV TINGLY_PORT=12580
 ENV TINGLY_HOST=0.0.0.0
 
-# Health check
+# Health check. Runs via `docker exec`-like mechanics under the image's
+# default user, which is root now that ENTRYPOINT starts as root to chown
+# the bind mount (see docker-entrypoint.sh) — su-exec drops back to the
+# unprivileged "tingly" for this one command, matching the main process.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD tingly status || exit 1
+    CMD su-exec tingly tingly status || exit 1
 
 # Default command (server mode)
 CMD ["sh", "-c", "echo '======================================' && \

--- a/build/docker/docker.npx.Dockerfile
+++ b/build/docker/docker.npx.Dockerfile
@@ -17,9 +17,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tzdata \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user for security
+# Create non-root user for security. Home is pinned to /app (rather than
+# left to useradd's system-account default) so it unambiguously matches the
+# /app/.tingly-box path this image documents and mounts as a volume — the
+# app resolves its config dir from $HOME/.tingly-box (pkg/fs.GetUserPath).
 RUN groupadd -r tingly && \
-    useradd -r -g tingly tingly
+    useradd -r -g tingly -d /app tingly
 
 # update modules, spec version to confirm security
 RUN npm install -g npm@10.8.2
@@ -34,16 +37,26 @@ RUN chown -R tingly:tingly /usr/local/lib/node_modules /usr/local/bin /root/.npm
 # Set working directory
 WORKDIR /app
 
-# Create necessary directories with proper permissions
-RUN mkdir -p /app/.tingly-box /app/memory /app/logs && \
+# Create the config/data directory (memory, logs and db all live under this
+# single tree, see internal/config/app_config.go) with proper permissions.
+RUN mkdir -p /app/.tingly-box && \
     chown -R tingly:tingly /app
 
-RUN mkdir /home/tingly && chown -R tingly:tingly /home/tingly/
+# Entrypoint fixes up ownership of a bind-mounted data directory at runtime
+# (a freshly `mkdir`ed host directory is owned by the host user, not the
+# container's UID/GID, and the non-root "tingly" user can't write into it)
+# before dropping from root down to "tingly". Deliberately does NOT switch
+# to USER tingly here, so the entrypoint still starts as root.
+COPY build/docker/docker-entrypoint-npx.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
-# Switch to non-root user
-USER tingly
+# HOME is set here (after the npm/root install layers, so it doesn't perturb
+# root's own npm cache/config lookups) and applies to the container's
+# runtime env from this point on.
+ENV HOME=/app
 
-RUN tingly-box version
+RUN su tingly -c "tingly-box version"
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
@@ -60,5 +73,5 @@ CMD ["sh", "-c", "echo '======================================' && \
     exec pm2 logs --raw"]
 
 
-# Volumes for persistent data
-VOLUME ["/app/.tingly-box", "/app/memory", "/app/logs"]
+# Volume for persistent data (memory, logs and db all live under this tree)
+VOLUME ["/app/.tingly-box"]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -32,20 +32,18 @@ full login URL).
 ### Using Docker Compose
 
 ```bash
-cd build/docker
-
 # Start the server
-docker-compose up -d tingly-box
+docker-compose -f build/docker/docker-compose.yml up -d tingly-box
 
 # View logs
-docker-compose logs -f tingly-box
+docker-compose -f build/docker/docker-compose.yml logs -f tingly-box
 
 # Stop the server
-docker-compose down
+docker-compose -f build/docker/docker-compose.yml down
 ```
 
-Compose creates `./data/.tingly-box` for you on first `up`; no manual `mkdir`
-or `chown` is needed.
+Compose creates `build/docker/data/.tingly-box` for you on first `up`; no
+manual `mkdir` or `chown` is needed.
 
 ### Manual Docker Usage (build from source)
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,23 +4,37 @@ This guide explains how to use Tingly Box with Docker.
 
 ## Overview
 
-We provide a single Docker setup with multiple use cases:
+Two Dockerfiles live under `build/docker/`:
 
-1. **Dockerfile** - Multi-stage build using Task task runner (includes both server and CLI)
-2. **docker-compose.yml** - Complete setup with volumes for production and development
+1. **`docker.build.Dockerfile`** - Multi-stage build from source (Go + frontend). This is what the published `ghcr.io/tingly-dev/tingly-box` images are built from.
+2. **`docker.npx.Dockerfile`** - Lightweight image that installs the published `tingly-box` npm package. Used by `docker-compose.yml`.
+
+Both run as a non-root `tingly` user and both ship an entrypoint that fixes up
+ownership of the bind-mounted data directory at container start, so a plain
+`mkdir` + bind mount works without a manual `chown` on the host.
 
 ## Quick Start
 
-### Using Docker Compose (Recommended)
+### Using the published image
 
 ```bash
-# Create data directories
-mkdir -p data/{.tingly-box,logs,memory}
+mkdir tingly-data
+docker run -d \
+  --name tingly-box \
+  -p 12580:12580 \
+  -v "$(pwd)/tingly-data:/home/tingly/.tingly-box" \
+  ghcr.io/tingly-dev/tingly-box
+```
+
+Open `http://localhost:12580` in your browser (the container logs print the
+full login URL).
+
+### Using Docker Compose
+
+```bash
+cd build/docker
 
 # Start the server
-docker-compose up tingly-box
-
-# Run in detached mode
 docker-compose up -d tingly-box
 
 # View logs
@@ -30,145 +44,62 @@ docker-compose logs -f tingly-box
 docker-compose down
 ```
 
-### Manual Docker Usage
+Compose creates `./data/.tingly-box` for you on first `up`; no manual `mkdir`
+or `chown` is needed.
 
-#### 1. Build and Run Server
+### Manual Docker Usage (build from source)
 
 ```bash
 # Build the image
-docker build -t tingly-box:latest .
+docker build -f build/docker/docker.build.Dockerfile -t tingly-box:latest .
 
 # Run the server
-docker stop tingly-box && docker rm tingly-box
 docker run -d \
---name tingly-box \
--p 8080:8080 \
--v $(pwd)/data/.tingly-box:/app/.tingly-box \
--v $(pwd)/data/logs:/app/logs \
--v $(pwd)/data/memory:/app/memory \
-tingly-box:latest
-
-```
-
-#### 2. CLI Tool Usage (using same image)
-
-```bash
-# Build the image
-docker build -t tingly-box:latest .
-
-# Add a provider
-docker run -it --rm \
-  -v $(pwd)/data/.tingly-box:/app/.tingly-box \
-  tingly-box:latest add openai https://api.openai.com/v1 sk-token
-
-# List providers
-docker run -it --rm \
-  -v $(pwd)/data/.tingly-box:/app/.tingly-box \
-  tingly-box:latest list
-
-# Generate token
-docker run -it --rm \
-  -v $(pwd)/data/.tingly-box:/app/.tingly-box \
-  tingly-box:latest token
-
-# Run any other CLI command
-docker run -it --rm \
-  -v $(pwd)/data/.tingly-box:/app/.tingly-box \
-  tingly-box:latest status
-```
-
-#### 3. Development Mode
-
-For development, you can mount the source code and rebuild manually when needed:
-
-```bash
-# Run with source mounted (for development)
-docker-compose --profile dev up tingly-box-dev
-
-# Make changes to source code, then rebuild and restart:
-docker-compose exec tingly-box-dev task cli:build
-docker-compose restart tingly-box-dev
-
-# Or run manually with mounted source
-docker run -it --rm \
-  -v $(pwd):/app \
-  -v $(pwd)/data/.tingly-box:/app/.tingly-box \
-  -p 8080:8080 \
+  --name tingly-box \
+  -p 12580:12580 \
+  -v "$(pwd)/data/.tingly-box:/home/tingly/.tingly-box" \
   tingly-box:latest
+
+# CLI usage against the same data directory
+docker run -it --rm \
+  -v "$(pwd)/data/.tingly-box:/home/tingly/.tingly-box" \
+  tingly-box:latest tingly list
 ```
 
 ## Configuration
 
 ### Environment Variables
 
-- `TINGLY_PORT` - Server port (default: 8080)
-- `TINGLY_HOST` - Server host (default: 0.0.0.0)
-- `TINGLY_DEBUG` - Enable debug mode (default: false)
+- `TINGLY_PORT` - Server port (default: `12580`)
+- `TINGLY_HOST` - Server host (default: `0.0.0.0`)
+- `TINGLY_DEBUG` - Enable debug mode (npx image only, default: `false`)
 
 ### Volume Mounts
 
-- `/app/.tingly-box` - Encrypted configuration storage
-- `/app/logs` - Server logs
-- `/app/memory` - Operation history and statistics
+Config, memory, logs and the database all live under a single directory tree
+(see `internal/config/app_config.go`), so only one bind mount is needed:
 
-## Example: Complete Setup
+- `docker.build.Dockerfile`: `/home/tingly/.tingly-box`
+- `docker.npx.Dockerfile` / `docker-compose.yml`: `/app/.tingly-box`
 
-```bash
-#!/bin/bash
+### Running as a specific host UID/GID
 
-# 1. Create directories
-mkdir -p data/{.tingly-box,logs,memory}
-
-# 2. Build and start server
-docker-compose up -d tingly-box
-
-# 3. Wait for server to start
-sleep 5
-
-# 4. Add providers
-docker run -it --rm \
-  -v $(pwd)/data/.tingly-box:/app/.tingly-box \
-  tingly-box:latest add openai https://api.openai.com/v1 sk-your-token
-
-docker run -it --rm \
-  -v $(pwd)/data/.tingly-box:/app/.tingly-box \
-  tingly-box:latest add anthropic https://api.anthropic.com sk-your-token
-
-# 5. Generate token
-TOKEN=$(docker run -it --rm \
-  -v $(pwd)/data/.tingly-box:/app/.tingly-box \
-  tingly-box:latest token | grep "sk-" | head -1)
-
-# 6. Test the API
-curl -X POST http://localhost:8080/v1/chat/completions \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "gpt-3.5-turbo",
-    "messages": [{"role": "user", "content": "Hello from Docker!"}]
-  }'
-```
+The entrypoint only fixes ownership when the container starts as root (the
+default). If you explicitly run with `docker run --user <uid>:<gid>`, make
+sure that UID/GID already owns the mounted directory on the host — the
+entrypoint leaves an explicit `--user` untouched.
 
 ## Production Tips
 
 ### Security
 
-1. Use secrets for API tokens:
-```yaml
-services:
-  tingly-box:
-    environment:
-      - OPENAI_TOKEN=${OPENAI_TOKEN}
-      - ANTHROPIC_TOKEN=${ANTHROPIC_TOKEN}
-```
-
-2. Run as non-root user (included in Dockerfile)
-
-3. Use read-only volumes where possible
+1. Use secrets/env files for API tokens rather than baking them into the image.
+2. The image already runs as a non-root user by default.
+3. Use read-only volumes where possible.
 
 ### Performance
 
-1. Set memory limits:
+Set memory limits in `docker-compose.yml`:
 ```yaml
 services:
   tingly-box:
@@ -178,14 +109,11 @@ services:
           memory: 512M
 ```
 
-2. Use health checks (included in Dockerfile)
-
 ### Backup
 
-Backup the `.tingly-box` directory regularly:
+Back up the `.tingly-box` directory regularly, e.g.:
 ```bash
-docker run --rm -v tingly-config:/data -v $(pwd):/backup \
-  alpine tar czf /backup/tingly-config-backup.tar.gz -C /data .
+tar czf tingly-config-backup.tar.gz -C data .tingly-box
 ```
 
 ## Troubleshooting
@@ -193,40 +121,29 @@ docker run --rm -v tingly-config:/data -v $(pwd):/backup \
 ### Common Issues
 
 1. **Port already in use**
-   - Change the host port mapping
-   - Example: `-p 9090:8080`
+   - Change the host port mapping, e.g. `-p 12581:12580`.
 
-2. **Permission errors**
-   - Ensure proper ownership of data directories
-   - `sudo chown -R 1000:1000 data/`
+2. **Permission errors on the bind mount**
+   - The image's entrypoint chowns the mounted directory to the container's
+     `tingly` user automatically on startup as long as the container runs as
+     root (the default). If you still see `permission denied`, check
+     whether you passed `--user`, or whether the mount is on a filesystem
+     that doesn't support `chown` (e.g. some network/FUSE mounts).
 
 3. **Configuration not persisting**
-   - Check volume mounts
-   - Ensure correct paths
-
-### Debug Mode
-
-Enable debug logging:
-```bash
-docker run -d \
-  --name tingly-box-debug \
-  -p 8080:8080 \
-  -v $(pwd)/data/.tingly-box:/app/.tingly-box \
-  -e TINGLY_DEBUG=true \
-  tingly-box:latest
-
-# View debug logs
-docker logs -f tingly-box-debug
-```
+   - Check the volume mount path matches the image you're running
+     (`/home/tingly/.tingly-box` for the source-build image,
+     `/app/.tingly-box` for the npx image / Compose).
 
 ## Building for Different Platforms
 
 ```bash
 # Build for ARM64 (Apple Silicon)
-docker buildx build --platform linux/arm64 -t tingly-box:arm64 .
+docker buildx build --platform linux/arm64 -f build/docker/docker.build.Dockerfile -t tingly-box:arm64 .
 
 # Build for AMD64 (Intel/AMD)
-docker buildx build --platform linux/amd64 -t tingly-box:amd64 .
+docker buildx build --platform linux/amd64 -f build/docker/docker.build.Dockerfile -t tingly-box:amd64 .
 
 # Build multi-arch image
-docker buildx build --platform linux/amd64,linux/arm64 -t tingly-box:latest .
+docker buildx build --platform linux/amd64,linux/arm64 -f build/docker/docker.build.Dockerfile -t tingly-box:latest .
+```

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -19,16 +19,16 @@ tingly-box start
 ### Method 2: Docker
 Run as a background container:
 ```bash
-# run the prebuild image
+# run the prebuilt image
+mkdir tingly-data
 docker run -d \
   --name tingly-box \
   -p 12580:12580 \
-  -v ~/.tingly-box:/app/.tingly-box \
-  -v $(pwd)/logs:/app/logs \
-  andreasfoo/tingly-box:latest
+  -v "$(pwd)/tingly-data:/home/tingly/.tingly-box" \
+  ghcr.io/tingly-dev/tingly-box
 
-# or build for your own
-docker build -t tingly-box:latest .
+# or build for your own, see docs/docker.md
+docker build -f build/docker/docker.build.Dockerfile -t tingly-box:latest .
 ```
 
 ---

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -19,17 +19,15 @@ tingly-box start
 ### Method 2: Docker
 Run as a background container:
 ```bash
-# run the prebuilt image
 mkdir tingly-data
 docker run -d \
   --name tingly-box \
   -p 12580:12580 \
   -v "$(pwd)/tingly-data:/home/tingly/.tingly-box" \
   ghcr.io/tingly-dev/tingly-box
-
-# or build for your own, see docs/docker.md
-docker build -f build/docker/docker.build.Dockerfile -t tingly-box:latest .
 ```
+
+For Docker Compose, building your own image, or troubleshooting, see the [Docker Guide](./docker.md).
 
 ---
 


### PR DESCRIPTION
## Summary
The Docker quick-start's bind mount fails with `permission denied` because a freshly `mkdir`ed host directory is owned by the host user, not the container's non-root `tingly` (UID/GID 999). Fixes #1662.

## Key Changes

- **Bind-mount ownership**: both Dockerfiles now boot an entrypoint as root that idempotently `chown`s the mounted data directory to `tingly`, then drops privileges (`su-exec` / `setpriv`) before exec'ing the real command — no manual host-side `chown` needed.
- **`docker-compose.yml`'s build was broken**: `context: .` resolved relative to the compose file's own directory, so `dockerfile: build/docker/docker.npx.Dockerfile` pointed at a nonexistent nested path — `docker-compose build` failed outright. Fixed to resolve to the repo root, matching how CI builds the same Dockerfile.
- **CI regression guard**: added `docker-smoke-test.yml`, which builds both images and runs each against a freshly created, un-chowned bind mount on every PR touching `build/docker/**` — reproducing the exact shape of #1662 so a future change that breaks the ownership fix fails CI instead of shipping.
- **Dropped dead `/app/memory` / `/app/logs` mounts**: memory, logs and the db all live under the single `.tingly-box` config tree (`internal/config/app_config.go`); those extra volumes were never actually written to.
- **`docs/docker.md` is now the single source of truth** for Compose, custom builds, UID/GID, and troubleshooting — rewritten to match the current layout (it still described a root-level `Dockerfile` and port 8080). README and `docs/user-manual.md` link to it instead of duplicating those commands.

## Minor
- `.gitignore`'s blanket `build/` rule (leftover Python-template boilerplate) was silently swallowing new files under the versioned `build/docker/` source tree; replaced with a precise ignore for the one real build artifact that lands there.
- Removed an unused `TINGLY_DATA_DIR` env override the Go app never actually reads; `HEALTHCHECK` now explicitly drops to `tingly` via `su-exec` to restore least-privilege for that command.

## Testing
- `shellcheck` on both entrypoint scripts; `docker compose config`/`build` validated against both the pre-fix and post-fix compose files (pre-fix fails to even locate the Dockerfile).
- `docker-smoke-test.yml` builds both images for real and runs each against a fresh, un-chowned bind mount — green on actual CI, not just local simulation (Docker Hub/ghcr.io pulls are blocked in the sandbox this was authored in).
- A code-review pass flagged 3 issues: 1 refuted (checked against `su-exec`'s actual upstream source and this branch's own CI logs), 2 fixed (the dead env var, the `HEALTHCHECK` privilege drop) — re-verified green on CI after the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SazFcPLTPMzgc1eD2DSyeD)_