### PR TITLE
fix(ui): full-width cards with capped inner content; restore page bottom gap

### DIFF
--- a/frontend/src/components/PageLayout.tsx
+++ b/frontend/src/components/PageLayout.tsx
@@ -127,7 +127,12 @@ export const PageLayout: React.FC<PageLayoutProps> = ({
       sx={{
         position: "relative",
         width: '100%',
-        height: '100%',
+        // minHeight (not height): with a fixed 100% height, pages taller than
+        // the viewport overflow *out of* this box, and the scroll container's
+        // bottom padding lands mid-content — so the last row sits flush with
+        // the viewport edge when scrolled to the bottom. Letting the box grow
+        // keeps content in-flow, so the layout's bottom padding stays below it.
+        minHeight: '100%',
         display: 'flex',
         flexDirection: 'column'
       }}>

--- a/frontend/src/components/ShortcutCard.tsx
+++ b/frontend/src/components/ShortcutCard.tsx
@@ -9,7 +9,8 @@ import { isGuiMode } from '@/utils/protocol.ts';
 import { fontMono } from '@/theme/fonts';
 
 interface ShortcutCardProps {
-    maxWidth?: number | string;
+    /** Cap the card content's width; the card itself stays full-width. */
+    contentMaxWidth?: number | string;
 }
 
 /**
@@ -21,7 +22,7 @@ interface ShortcutCardProps {
  * recover a deleted shortcut, or to re-point it after an upgrade or a
  * different launch method.
  */
-export const ShortcutCard = ({ maxWidth }: ShortcutCardProps) => {
+export const ShortcutCard = ({ contentMaxWidth }: ShortcutCardProps) => {
     const { t } = useTranslation();
     const notify = useNotify();
     const [shortcutStatus, setShortcutStatus] = useState<{ exists: boolean; created: string[]; scriptPath: string } | null>(null);
@@ -76,7 +77,7 @@ export const ShortcutCard = ({ maxWidth }: ShortcutCardProps) => {
     if (!show) return null;
 
     return (
-        <UnifiedCard title={t('help.shortcut.title')} size="full" maxWidth={maxWidth}>
+        <UnifiedCard title={t('help.shortcut.title')} size="full" contentMaxWidth={contentMaxWidth}>
             <Stack spacing={1.5}>
                 <Typography variant="caption" sx={{ color: 'text.secondary' }}>
                     {t('help.shortcut.description')}

--- a/frontend/src/components/UnifiedCard.tsx
+++ b/frontend/src/components/UnifiedCard.tsx
@@ -32,13 +32,13 @@ interface UnifiedCardProps {
   // Custom height, prioritized if provided
   height?: number | string;
   /**
-   * Cap the card's width on wide viewports. Unlike `width`, the card still
-   * fills its column (`width: 100%`) and only stops growing past this value —
-   * so it remains responsive on narrow screens. Use for settings-style pages
-   * with many narrow cards that would otherwise stretch edge-to-edge. The
-   * card stays left-aligned within its column.
+   * Cap the card *content*'s width on wide viewports. The card itself stays
+   * full-width (consistent with every other card on the page), but the body
+   * stops growing past this value so text lines and form controls don't
+   * stretch uncomfortably wide. Content stays left-aligned under the title.
+   * Use for settings-style cards with narrow, row-based content.
    */
-  maxWidth?: number | string;
+  contentMaxWidth?: number | string;
   // Message support
   message?: { type: 'success' | 'error'; text: string } | null;
   onClearMessage?: () => void;
@@ -142,7 +142,7 @@ export const UnifiedCard = forwardRef<HTMLDivElement, UnifiedCardProps>(({
   variant = 'default',
   width,
   height,
-  maxWidth,
+  contentMaxWidth,
   message,
   onClearMessage,
   leftAction,
@@ -157,9 +157,6 @@ export const UnifiedCard = forwardRef<HTMLDivElement, UnifiedCardProps>(({
       id={id}
       sx={{
         ...getCardDimensions(size, width, height),
-        ...(maxWidth !== undefined && {
-          maxWidth,
-        }),
         ...cardVariants[variant],
         borderRadius: 2,
         border: '1px solid',
@@ -249,6 +246,9 @@ export const UnifiedCard = forwardRef<HTMLDivElement, UnifiedCardProps>(({
               flex: 1,
               minHeight: 0,
               position: 'relative',
+              ...(contentMaxWidth !== undefined && {
+                maxWidth: contentMaxWidth,
+              }),
             }}
           >
             {children}

--- a/frontend/src/pages/HelpPage.tsx
+++ b/frontend/src/pages/HelpPage.tsx
@@ -4,9 +4,10 @@ import { ShortcutCard } from '@/components/ShortcutCard.tsx';
 import { ProvidersCard } from '@/components/ProvidersCard.tsx';
 import { useTranslation } from 'react-i18next';
 
-// Cap the Shortcut card's width on wide viewports, matching System settings
-// cards. ProvidersCard is left uncapped — its provider grid wants the room.
-const SHORTCUT_CARD_MAX_WIDTH = 720;
+// The Shortcut card spans full width like every other card; only its content
+// is capped, matching System settings cards. ProvidersCard is left uncapped —
+// its provider grid wants the room.
+const SHORTCUT_CONTENT_MAX_WIDTH = 720;
 
 /**
  * HelpPage — the lightbulb entry in the activity bar, replacing the old
@@ -24,7 +25,7 @@ const HelpPage = () => {
     return (
         <PageLayout loading={false} title={t('help.title')} subtitle={t('help.description')}>
             <CardGrid>
-                <ShortcutCard maxWidth={SHORTCUT_CARD_MAX_WIDTH} />
+                <ShortcutCard contentMaxWidth={SHORTCUT_CONTENT_MAX_WIDTH} />
                 <ProvidersCard />
             </CardGrid>
         </PageLayout>

--- a/frontend/src/pages/prompt/CommandPage.tsx
+++ b/frontend/src/pages/prompt/CommandPage.tsx
@@ -7,7 +7,10 @@ const CommandPage = () => {
 
   return (
     <PageLayout loading={false}>
-      <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+      {/* minHeight (not height: 100%): PageLayout grows with content now, so a
+          percentage height no longer resolves — pin a viewport-based minimum
+          to keep the placeholder vertically centered. */}
+      <Box sx={{ minHeight: '60vh', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
         <Typography component="h1" variant="h4" sx={{ fontWeight: 600, mb: 2, color: 'text.primary' }}>
           Commands
         </Typography>

--- a/frontend/src/pages/system/AccessControl.tsx
+++ b/frontend/src/pages/system/AccessControl.tsx
@@ -36,7 +36,9 @@ interface TokenInfo {
     is_default: boolean;
 }
 
-const CARD_MAX_WIDTH = 720;
+// Cards span full width; only the content inside is capped so token rows and
+// descriptions don't stretch uncomfortably wide on big screens.
+const CONTENT_MAX_WIDTH = 720;
 
 // Shared shape for both the User Token and Model Token rows: masked value,
 // show/hide toggle, copy button. Behavior (what's shown, what copy does)
@@ -283,7 +285,7 @@ const AccessControl = () => {
                     User Token row's description almost verbatim and the
                     subtitle/intro paragraph above it were pure preamble, so
                     they're dropped rather than repeated a second time. */}
-                <UnifiedCard maxWidth={CARD_MAX_WIDTH} size="full">
+                <UnifiedCard contentMaxWidth={CONTENT_MAX_WIDTH} size="full">
                     <Stack spacing={2}>
                         <Box>
                             <Typography component="h1" variant="h5" sx={{
@@ -367,7 +369,7 @@ const AccessControl = () => {
                     kind of thing (a bearer credential you can view/copy/reset),
                     just scoped to different audiences (control panel vs API
                     clients), so they share one card instead of two. */}
-                <UnifiedCard maxWidth={CARD_MAX_WIDTH} size="full">
+                <UnifiedCard contentMaxWidth={CONTENT_MAX_WIDTH} size="full">
                     <Stack spacing={3}>
                         <Box>
                             <Stack direction="row" spacing={2} sx={{ alignItems: 'center', mb: 1.5 }}>

--- a/frontend/src/pages/system/ExperimentalPage.tsx
+++ b/frontend/src/pages/system/ExperimentalPage.tsx
@@ -7,7 +7,9 @@ import { Stack, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 
-const CARD_MAX_WIDTH = 720;
+// Card spans full width; only the content inside is capped so the feature
+// list doesn't stretch uncomfortably wide on big screens.
+const CONTENT_MAX_WIDTH = 720;
 
 const ExperimentalPage = () => {
     const { t } = useTranslation();
@@ -19,7 +21,7 @@ const ExperimentalPage = () => {
         <PageLayout loading={false}>
             <CardGrid>
                 <UnifiedCard
-                    maxWidth={CARD_MAX_WIDTH}
+                    contentMaxWidth={CONTENT_MAX_WIDTH}
                     title={t('system.experimentalFeatures.title')}
                     titleHeadingLevel={1}
                     size="full"

--- a/frontend/src/pages/system/System.tsx
+++ b/frontend/src/pages/system/System.tsx
@@ -20,9 +20,10 @@ import { SUPPORTED_LANGUAGES, resolveLanguage } from '@/i18n';
 // (the actual visual anchor) vertically aligned across cards.
 const LABEL_WIDTH = 140;
 
-// Cap each card's width on wide viewports (via UnifiedCard.maxWidth) so the
-// settings cards don't stretch edge-to-edge. Cards still shrink responsively.
-const CARD_MAX_WIDTH = 720;
+// Cards span the full page width (consistent with every other page); only the
+// *content* inside each card is capped (via UnifiedCard.contentMaxWidth) so
+// settings rows and inputs don't stretch uncomfortably wide on big screens.
+const CONTENT_MAX_WIDTH = 720;
 
 /**
  * SettingsRow — the shared label-column rhythm for this page.
@@ -193,7 +194,7 @@ const System = () => {
                     title={t('system.serverStatus.title')}
                     titleHeadingLevel={1}
                     size="full"
-                    maxWidth={CARD_MAX_WIDTH}
+                    contentMaxWidth={CONTENT_MAX_WIDTH}
                 >
                     <Stack spacing={1.5}>
                         <SettingsRow
@@ -301,7 +302,7 @@ const System = () => {
 
 
                 {/* Preferences — "How do I want the UI to behave?" */}
-                <UnifiedCard grid={{ xs: 12, md: 12 }} title={t('system.preferences.title')} size="full" maxWidth={CARD_MAX_WIDTH}>
+                <UnifiedCard grid={{ xs: 12, md: 12 }} title={t('system.preferences.title')} size="full" contentMaxWidth={CONTENT_MAX_WIDTH}>
                     <Stack spacing={1.5}>
                         <SettingsRow icon={<IconLanguage sx={{ fontSize: 16 }} />} label={t('system.language.title')}>
                             {SUPPORTED_LANGUAGES.map(({ code, labelKey }) => (
@@ -334,7 +335,7 @@ const System = () => {
 
                 {/* Proxy — "How does TB reach upstream?" Env-proxy policy +
                     reusable URL preset, kept on their own card. */}
-                <UnifiedCard grid={{ xs: 12, md: 12 }} title={t('system.proxy.title')} size="full" maxWidth={CARD_MAX_WIDTH}>
+                <UnifiedCard grid={{ xs: 12, md: 12 }} title={t('system.proxy.title')} size="full" contentMaxWidth={CONTENT_MAX_WIDTH}>
                     <Stack spacing={2}>
                         {/* Env-proxy policy — an honest switch, not a flip-chip.
                             The off-state is just "off" (no `common.direct`
@@ -401,7 +402,7 @@ const System = () => {
                 </UnifiedCard>
 
                 {/* About — "What is this?" */}
-                <UnifiedCard title={t('system.about.title')} size="full" maxWidth={CARD_MAX_WIDTH}>
+                <UnifiedCard title={t('system.about.title')} size="full" contentMaxWidth={CONTENT_MAX_WIDTH}>
                     <Stack spacing={1.5}>
                         <SettingsRow icon={<IconLicense sx={{ fontSize: 16, color: 'text.secondary' }} />} label={t('system.about.license')}>
                             <Typography variant="body2" sx={{ color: 'text.primary' }}>


### PR DESCRIPTION
## Summary
The 720px-capped cards on System/Help left an odd dead zone on wide viewports and broke consistency with every other page's full-width cards; separately, every page's last row sat flush against the viewport edge when scrolled to the bottom.

## Key Changes

- **Card width consistency**: `UnifiedCard.maxWidth` (whole-card cap) becomes `contentMaxWidth` — cards span full width again, only the body stops at 720px so rows and inputs don't overstretch; migrated System, Access Control, Experimental, and Help's Shortcut card.
- **Bottom breathing room**: `PageLayout` root switches `height: 100%` → `minHeight: 100%`, so tall pages grow in-flow and the layout scroll container's bottom padding stays below the content instead of landing mid-page.
- **Placeholder centering**: CommandPage relied on the old percentage-height chain; pinned with a viewport-based `minHeight`.

## Screenshots
Verified in mock mode at 1920/1280 widths: cards full-width with 720px content, and a proper gap below the last card when scrolled to the bottom (System, Help, Access Control).
