### PR TITLE
fix(ui): error notifications persist until dismissed, with copy-for-report button

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,6 +55,7 @@ const System = lazy(() => import('./pages/system/System.tsx'));
 const AccessControl = lazy(() => import('./pages/system/AccessControl.tsx'));
 const LogsPage = lazy(() => import('./pages/system/LogsPage'));
 const ExperimentalPage = lazy(() => import('./pages/system/ExperimentalPage'));
+const DevelopPage = lazy(() => import('./pages/system/DevelopPage'));
 const GuardrailsPage = lazy(() => import('./pages/GuardrailsPage'));
 const GuardrailsRulesPage = lazy(() => import('./pages/guardrails/RulesPage'));
 const GuardrailsCredentialsPage = lazy(() => import('./pages/guardrails/CredentialsPage'));
@@ -262,6 +263,7 @@ function AppContent() {
                     <Route path="/system" element={<System />} />
                     <Route path="/access-control" element={<AccessControl />} />
                     <Route path="/tingly-box-token" element={<SharingKeysPage />} />
+                    <Route path="/system/develop" element={<DevelopPage />} />
                     <Route path="/system/logs" element={<LogsPage />} />
                     <Route path="/system/experimental" element={<ExperimentalPage />} />
                     {/* Dashboard routes with time range */}

--- a/frontend/src/components/PageLayout.tsx
+++ b/frontend/src/components/PageLayout.tsx
@@ -1,5 +1,7 @@
-import { CircularProgress, Box, Alert, IconButton } from '@mui/material';
+import { CircularProgress, Box, Alert, IconButton, Tooltip } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
+import { Check, ContentCopy } from '@/components/icons';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 import PageHeader from './PageHeader';
 
 type TimerId = ReturnType<typeof setTimeout>;
@@ -68,6 +70,7 @@ export const PageLayout: React.FC<PageLayoutProps> = ({
   rightAction,
 }) => {
   const timeoutRef = useRef<TimerId | null>(null);
+  const { copied, copy } = useCopyFeedback();
 
   // Only start showing the loading state once `loading` has been true for
   // LOADING_SHOW_DELAY_MS. If the data arrives before that, nothing is
@@ -84,9 +87,16 @@ export const PageLayout: React.FC<PageLayoutProps> = ({
     return () => clearTimeout(t);
   }, [loading]);
 
-  // Auto-hide notification after specified duration
+  // Auto-hide notification after specified duration. Errors are exempt: they
+  // stay until the user explicitly closes them, so the text is always
+  // available to copy for a report.
   useEffect(() => {
-    if (notification?.open && notification.autoHideDuration && notification.autoHideDuration > 0) {
+    if (
+      notification?.open &&
+      notification.severity !== 'error' &&
+      notification.autoHideDuration &&
+      notification.autoHideDuration > 0
+    ) {
       timeoutRef.current = setTimeout(() => {
         if (notification.onClose) {
           notification.onClose();
@@ -100,7 +110,7 @@ export const PageLayout: React.FC<PageLayoutProps> = ({
         timeoutRef.current = null;
       }
     };
-  }, [notification?.open, notification?.autoHideDuration, notification?.onClose]);
+  }, [notification?.open, notification?.severity, notification?.autoHideDuration, notification?.onClose]);
 
   // Close notification on page refresh/unload
   useEffect(() => {
@@ -189,14 +199,28 @@ export const PageLayout: React.FC<PageLayoutProps> = ({
                 }
               }}
               action={
-                <IconButton
-                  aria-label="close"
-                  color="inherit"
-                  size="small"
-                  onClick={notification.onClose}
-                >
-                  ×
-                </IconButton>
+                <>
+                  {notification.severity === 'error' && notification.message && (
+                    <Tooltip title={copied ? 'Copied' : 'Copy for report'}>
+                      <IconButton
+                        aria-label="copy error"
+                        color="inherit"
+                        size="small"
+                        onClick={() => copy(notification.message ?? '')}
+                      >
+                        {copied ? <Check fontSize="small" /> : <ContentCopy fontSize="small" />}
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                  <IconButton
+                    aria-label="close"
+                    color="inherit"
+                    size="small"
+                    onClick={notification.onClose}
+                  >
+                    ×
+                  </IconButton>
+                </>
               }
             >
               {notification.customContent}
@@ -204,7 +228,33 @@ export const PageLayout: React.FC<PageLayoutProps> = ({
           ) : (
             <Alert
               severity={notification.severity || 'info'}
-              onClose={notification.onClose}
+              onClose={
+                notification.severity === 'error' ? undefined : notification.onClose
+              }
+              action={
+                notification.severity === 'error' ? (
+                  <>
+                    <Tooltip title={copied ? 'Copied' : 'Copy for report'}>
+                      <IconButton
+                        aria-label="copy error"
+                        color="inherit"
+                        size="small"
+                        onClick={() => copy(notification.message ?? '')}
+                      >
+                        {copied ? <Check fontSize="small" /> : <ContentCopy fontSize="small" />}
+                      </IconButton>
+                    </Tooltip>
+                    <IconButton
+                      aria-label="close"
+                      color="inherit"
+                      size="small"
+                      onClick={notification.onClose}
+                    >
+                      ×
+                    </IconButton>
+                  </>
+                ) : undefined
+              }
               sx={{
                 mb: 0,
                 width: '100%',

--- a/frontend/src/components/ProvidersCard.tsx
+++ b/frontend/src/components/ProvidersCard.tsx
@@ -113,7 +113,7 @@ export const ProvidersCard = () => {
 
             <Snackbar
                 open={snackbar.open}
-                autoHideDuration={4000}
+                autoHideDuration={snackbar.severity === 'error' ? null : 4000}
                 onClose={() => setSnackbar((prev) => ({ ...prev, open: false }))}
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
             >

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -6,7 +6,9 @@
  * never need to wire notification state into their own components.
  */
 import { useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from 'react';
-import { Alert, AlertTitle, Box, Collapse, Slide } from '@mui/material';
+import { Alert, AlertTitle, Box, Collapse, IconButton, Slide, Tooltip } from '@mui/material';
+import { Check, Close, ContentCopy } from '@/components/icons';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 import {
   type NotifyItem,
   dismissNotify,
@@ -23,6 +25,7 @@ function useNotifyItems(): NotifyItem[] {
 function NotificationToast({ item }: { item: NotifyItem }) {
   const [open, setOpen] = useState(false);
   const removeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { copied, copy } = useCopyFeedback();
 
   // Trigger the enter transition once mounted.
   useEffect(() => {
@@ -49,6 +52,10 @@ function NotificationToast({ item }: { item: NotifyItem }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [item.duration]);
 
+  const isError = item.severity === 'error';
+  // What lands on the clipboard when the user copies an error for a report.
+  const reportText = item.title ? `${item.title}\n${item.message}` : item.message;
+
   return (
     <Collapse in={open} appear>
       <Box sx={{ mb: 1.5 }}>
@@ -56,7 +63,31 @@ function NotificationToast({ item }: { item: NotifyItem }) {
           <Alert
             severity={item.severity}
             variant="filled"
-            onClose={handleClose}
+            onClose={isError ? undefined : handleClose}
+            action={
+              isError ? (
+                <>
+                  <Tooltip title={copied ? 'Copied' : 'Copy for report'}>
+                    <IconButton
+                      aria-label="copy error"
+                      color="inherit"
+                      size="small"
+                      onClick={() => copy(reportText)}
+                    >
+                      {copied ? <Check fontSize="small" /> : <ContentCopy fontSize="small" />}
+                    </IconButton>
+                  </Tooltip>
+                  <IconButton
+                    aria-label="close"
+                    color="inherit"
+                    size="small"
+                    onClick={handleClose}
+                  >
+                    <Close fontSize="small" />
+                  </IconButton>
+                </>
+              ) : undefined
+            }
             sx={{
               width: '100%',
               boxShadow: 6,

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -137,6 +137,7 @@ export default {
     "system": "System",
     "general": "General",
     "experimental": "Experimental",
+    "develop": "Develop",
     "logs": "Logs",
     "userRequest": "User Request",
     "skills": "Skills",

--- a/frontend/src/i18n/locales/ru.ts
+++ b/frontend/src/i18n/locales/ru.ts
@@ -137,6 +137,7 @@ export default {
     "system": "Система",
     "general": "Общие",
     "experimental": "Эксперименты",
+    "develop": "Разработка",
     "logs": "Журналы",
     "userRequest": "Запрос пользователя",
     "skills": "Навыки",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -138,6 +138,7 @@ export default {
     "system": "系统",
     "general": "通用",
     "experimental": "实验功能",
+    "develop": "开发者",
     "logs": "日志",
     "userRequest": "用户请求",
     "skills": "技能",

--- a/frontend/src/layout/useActivityItems.tsx
+++ b/frontend/src/layout/useActivityItems.tsx
@@ -31,6 +31,7 @@ import {
     Server as IconServer,
     AiAgents as IconAiAgents,
     Extension as IconExtension,
+    Code as IconCode,
 } from '@/components/icons';
 import { useFeatureFlags } from '../contexts/FeatureFlagsContext';
 import { useProfileContext } from '@/contexts/ProfileContext';
@@ -269,6 +270,7 @@ export function useActivityItems(): ActivityItem[] {
                     { path: '/system', label: t('layout.general'), icon: <IconSettings sx={{ fontSize: 20 }} /> },
                     { path: '/access-control', label: t('layout.accessControl'), icon: <IconShield sx={{ fontSize: 20 }} /> },
                     { path: '/system/experimental', label: t('layout.experimental'), icon: <IconFlask sx={{ fontSize: 20 }} /> },
+                    { path: '/system/develop', label: t('layout.develop'), icon: <IconCode sx={{ fontSize: 20 }} /> },
                     { path: '/system/logs', label: t('layout.logs'), icon: <IconFileText sx={{ fontSize: 20 }} /> },
                 ],
             },

--- a/frontend/src/pages/VirtualModelsPage.tsx
+++ b/frontend/src/pages/VirtualModelsPage.tsx
@@ -86,7 +86,7 @@ const VirtualModelsPage = () => {
             </UnifiedCard>
             <Snackbar
                 open={snackbar.open}
-                autoHideDuration={6000}
+                autoHideDuration={snackbar.severity === 'error' ? null : 6000}
                 onClose={() => setSnackbar((prev) => ({ ...prev, open: false }))}
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
             >

--- a/frontend/src/pages/system/DevelopPage.tsx
+++ b/frontend/src/pages/system/DevelopPage.tsx
@@ -1,0 +1,97 @@
+import CardGrid from '@/components/CardGrid';
+import { PageLayout } from '@/components/PageLayout';
+import UnifiedCard from '@/components/UnifiedCard';
+import { Button, Stack, Typography } from '@mui/material';
+import { useNotify } from '@/hooks/useNotify';
+
+// Card spans full width; only the content inside is capped so controls don't
+// stretch uncomfortably wide on big screens (same rhythm as System pages).
+const CONTENT_MAX_WIDTH = 720;
+
+// A realistic failure — the kind users hit and need to copy for a report.
+const ERROR_DEMO_TITLE = 'Delete API key failed';
+const ERROR_DEMO_MESSAGE =
+    'Failed to delete API key sk-proj-****7f2a: upstream returned 502 Bad Gateway (provider: OpenAI, latency: 740ms)';
+
+const DevelopPage = () => {
+    const notify = useNotify();
+
+    return (
+        <PageLayout loading={false}>
+            <CardGrid>
+                <UnifiedCard
+                    title="Develop"
+                    titleHeadingLevel={1}
+                    size="full"
+                    contentMaxWidth={CONTENT_MAX_WIDTH}
+                >
+                    <Stack spacing={2}>
+                        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                            Developer utilities for verifying frontend behaviour by hand.
+                        </Typography>
+
+                        <Stack spacing={0.5}>
+                            <Typography variant="subtitle2">Notification playground</Typography>
+                            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                                Success / info / warning toasts auto-dismiss. Errors stay on screen
+                                until explicitly closed and carry a copy button for reporting — even
+                                when the caller passes an explicit duration.
+                            </Typography>
+                            <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1, mt: 1 }}>
+                                <Button
+                                    size="small"
+                                    variant="outlined"
+                                    color="success"
+                                    onClick={() => notify.success('API key created')}
+                                >
+                                    Success
+                                </Button>
+                                <Button
+                                    size="small"
+                                    variant="outlined"
+                                    onClick={() => notify.info('Reloading provider list')}
+                                >
+                                    Info
+                                </Button>
+                                <Button
+                                    size="small"
+                                    variant="outlined"
+                                    color="warning"
+                                    onClick={() => notify.warning('Provider quota usage above 80%')}
+                                >
+                                    Warning
+                                </Button>
+                                <Button
+                                    size="small"
+                                    variant="outlined"
+                                    color="error"
+                                    onClick={() => notify.error(ERROR_DEMO_MESSAGE, { title: ERROR_DEMO_TITLE })}
+                                >
+                                    Error
+                                </Button>
+                                <Button
+                                    size="small"
+                                    variant="outlined"
+                                    color="error"
+                                    onClick={() =>
+                                        notify.error(ERROR_DEMO_MESSAGE, {
+                                            title: `${ERROR_DEMO_TITLE} (duration: 3000, must be ignored)`,
+                                            duration: 3000,
+                                        })
+                                    }
+                                >
+                                    Error + explicit duration
+                                </Button>
+                                <Button size="small" onClick={() => notify.clear()}>
+                                    Clear all
+                                </Button>
+                            </Stack>
+                        </Stack>
+                    </Stack>
+                </UnifiedCard>
+            </CardGrid>
+        </PageLayout>
+    );
+};
+
+export default DevelopPage;

--- a/frontend/src/utils/notify.ts
+++ b/frontend/src/utils/notify.ts
@@ -32,7 +32,9 @@ const DEFAULT_DURATION: Record<NotifySeverity, number> = {
   success: 3500,
   info: 3500,
   warning: 5000,
-  error: 6000,
+  // Errors must never vanish on their own: they require an explicit user
+  // action, and their text is what the user copies out to report a problem.
+  error: 0,
 };
 
 let items: NotifyItem[] = [];
@@ -65,7 +67,9 @@ export function pushNotify(
     severity,
     message,
     title: options?.title,
-    duration: options?.duration ?? DEFAULT_DURATION[severity],
+    // Enforced centrally so no caller can accidentally re-introduce a
+    // self-dismissing error toast (even with an explicit duration).
+    duration: severity === 'error' ? 0 : (options?.duration ?? DEFAULT_DURATION[severity]),
     createdAt: Date.now(),
   };
   const existingIndex = items.findIndex((i) => i.id === id);


### PR DESCRIPTION
## Summary
Error notifications used to vanish after 6s — often before the user read them, and always before they could copy the text for a bug report. 

Errors now stay on screen until explicitly closed, and carry a copy button.

## Key Changes
- **Errors never auto-dismiss**: enforced centrally in the notify store, so no caller — even one passing an explicit duration — can reintroduce a self-dismissing error toast.
- **Copy for report**: every error toast (global stack and PageLayout inline) gains a copy button next to close; clipboard gets title + message.
- **Straggler Snackbars**: ProvidersCard and VirtualModelsPage stop auto-hiding errors, matching the other pages.
- **Develop subpage**: new System → Develop page (above Logs) with a notification playground to trigger each severity by hand, including an explicit-duration error variant.
