### PR TITLE
Refactor(UI): consolidate copy-feedback/confirm-dialog duplication onto shared components

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -17,6 +17,13 @@ Every route element in `App.tsx` must be `React.lazy(() => import('./pages/...')
 
 **`vite.config.wails.ts`'s `manualChunks`/`optimizeDeps` must stay in sync with `vite.config.ts`.** They're separate config files (Rollup can't share a function across two `defineConfig` calls), so a fix applied to one doesn't propagate to the other — this has drifted before (the wails config kept forcing `recharts`/`d3` into an eager `recharts-vendor` chunk after the web config was fixed to leave them lazy). When you change one file's chunking/`optimizeDeps` logic, apply the same change to the other, or explain in a comment why they intentionally differ.
 
+## Reuse existing hooks instead of hand-rolling
+
+These get reinvented locally often enough that it's worth naming explicitly:
+
+- **Copy-to-clipboard feedback** (a "copied" flag that auto-resets after ~2s): use `hooks/useCopyFeedback.ts`, not a local `useState` + `setTimeout`. It also takes an optional `onCopied` callback for a toast, and a `reset()` for clearing the flag early (e.g. on dialog close).
+- **Toast/snackbar notifications**: use `useNotify()` (`hooks/useNotify.ts`) — it renders globally via `NotificationProvider`, so there's no local `Snackbar`/`Alert`/open-state to wire up. Don't add a component-local `Snackbar`.
+
 ## Type checking
 
 `pnpm typecheck` runs in CI (`release.yml`) as a non-blocking, `continue-on-error` step — the repo has pre-existing legacy type errors that aren't being fixed as part of unrelated changes, so this only warns instead of failing the build. Still run `pnpm typecheck` locally before opening a PR and fix anything your change introduces; don't rely on CI to catch it.

--- a/frontend/src/components/CodeBlock.tsx
+++ b/frontend/src/components/CodeBlock.tsx
@@ -1,9 +1,10 @@
 import { ContentCopy as CopyIcon, Check as CheckIcon } from '@/components/icons';
 import { Box, IconButton, Typography } from '@mui/material';
-import React, { useState } from 'react';
+import React from 'react';
 import { Highlight, themes } from 'prism-react-renderer';
 import type { Language } from 'prism-react-renderer';
 import { EMPTY_STYLE } from '@/constants/defaults';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 
 export interface CodeBlockProps {
     code: string;
@@ -56,19 +57,13 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
     headerActions,
     wrap = false,
 }) => {
-    const [copied, setCopied] = useState(false);
+    const { copied, copy } = useCopyFeedback();
 
-    const handleCopy = async () => {
+    const handleCopy = () => {
         if (onCopy) {
             onCopy(code);
         } else {
-            try {
-                await navigator.clipboard.writeText(code);
-                setCopied(true);
-                setTimeout(() => setCopied(false), 2000);
-            } catch (err) {
-                console.error('Failed to copy code:', err);
-            }
+            copy(code);
         }
     };
 

--- a/frontend/src/components/CopyIconButton.tsx
+++ b/frontend/src/components/CopyIconButton.tsx
@@ -1,0 +1,70 @@
+import { IconButton, Tooltip, type IconButtonProps, type TooltipProps } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
+import { Check, ContentCopy } from '@/components/icons';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
+
+export interface CopyIconButtonProps {
+    /** Text copied to the clipboard on click. */
+    value: string;
+    label?: string;
+    copiedLabel?: string;
+    /** sx `color` value for each state — a theme token, a CSS color, or 'inherit'. */
+    color?: string;
+    copiedColor?: string;
+    size?: IconButtonProps['size'];
+    edge?: IconButtonProps['edge'];
+    /** Icon fontSize override (px, rem, ...); omit to use the MUI 'small' preset. */
+    iconSize?: string | number;
+    tooltipPlacement?: TooltipProps['placement'];
+    tooltipArrow?: boolean;
+    'aria-label'?: string;
+    /** Merged into the IconButton's sx — for absolute positioning, hover, etc. */
+    sx?: SxProps<Theme>;
+    /** Runs once the copy actually succeeds — e.g. to also fire a toast. */
+    onCopied?: () => void;
+}
+
+/**
+ * The Tooltip + IconButton + ContentCopy⇄Check swap chrome that showed up
+ * around `useCopyFeedback` in a dozen places — byte-identical in three of
+ * them. Owns its own copy state, so it's for a standalone copy button only:
+ * when the "copied" flag must be shared with a sibling element elsewhere on
+ * the page (e.g. AccessControl's token row + its own reset-success banner),
+ * wire `useCopyFeedback` directly instead.
+ */
+export const CopyIconButton = ({
+    value,
+    label = 'Copy',
+    copiedLabel = 'Copied!',
+    color = 'text.secondary',
+    copiedColor = 'success.main',
+    size = 'small',
+    edge,
+    iconSize,
+    tooltipPlacement,
+    tooltipArrow = false,
+    'aria-label': ariaLabel,
+    sx,
+    onCopied,
+}: CopyIconButtonProps) => {
+    const { copied, copy } = useCopyFeedback();
+    const iconSx = iconSize !== undefined ? { fontSize: iconSize } : undefined;
+
+    return (
+        <Tooltip title={copied ? copiedLabel : label} placement={tooltipPlacement} arrow={tooltipArrow}>
+            <IconButton
+                size={size}
+                edge={edge}
+                aria-label={ariaLabel ?? label}
+                onClick={() => copy(value, onCopied)}
+                sx={{ color: copied ? copiedColor : color, ...sx }}
+            >
+                {copied
+                    ? <Check fontSize="small" sx={iconSx} />
+                    : <ContentCopy fontSize="small" sx={iconSx} />}
+            </IconButton>
+        </Tooltip>
+    );
+};
+
+export default CopyIconButton;

--- a/frontend/src/components/OAuthDetailDialog.tsx
+++ b/frontend/src/components/OAuthDetailDialog.tsx
@@ -1,4 +1,4 @@
-import { ContentCopy, Info, Visibility, VisibilityOff, VpnKey } from '@/components/icons';
+import { Info, Visibility, VisibilityOff, VpnKey } from '@/components/icons';
 import {
     Alert,
     Box,
@@ -17,7 +17,7 @@ import {
 import { useEffect, useState } from 'react';
 import {type Provider } from '../types/provider';
 import ProviderExportButton from '@/components/ProviderExportButton';
-import { useCopyFeedback } from '@/hooks/useCopyFeedback';
+import { CopyIconButton } from '@/components/CopyIconButton';
 
 interface OAuthEditFormData {
     name: string;
@@ -46,8 +46,6 @@ const OAuthDetailDialog = ({ open, provider, onClose, onSubmit, onNotification }
     const [submitting, setSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState<string | null>(null);
     const [visibleTokens, setVisibleTokens] = useState<Record<string, boolean>>({});
-    const { copied: copiedAccessToken, copy: copyAccessToken } = useCopyFeedback();
-    const { copied: copiedRefreshToken, copy: copyRefreshToken } = useCopyFeedback();
 
     // Update form data when provider changes
     useEffect(() => {
@@ -237,14 +235,10 @@ const OAuthDetailDialog = ({ open, provider, onClose, onSubmit, onNotification }
                                                 >
                                                     {isTokenVisible('access_token') ? <VisibilityOff fontSize="small" /> : <Visibility fontSize="small" />}
                                                 </IconButton>
-                                                <IconButton
+                                                <CopyIconButton
                                                     edge="end"
-                                                    size="small"
-                                                    onClick={() => copyAccessToken(provider.oauth_detail!.access_token)}
-                                                    title={copiedAccessToken ? 'Copied!' : 'Copy'}
-                                                >
-                                                    <ContentCopy fontSize="small" />
-                                                </IconButton>
+                                                    value={provider.oauth_detail!.access_token}
+                                                />
                                             </InputAdornment>
                                         ),
                                     },
@@ -274,14 +268,10 @@ const OAuthDetailDialog = ({ open, provider, onClose, onSubmit, onNotification }
                                                     >
                                                         {isTokenVisible('refresh_token') ? <VisibilityOff fontSize="small" /> : <Visibility fontSize="small" />}
                                                     </IconButton>
-                                                    <IconButton
+                                                    <CopyIconButton
                                                         edge="end"
-                                                        size="small"
-                                                        onClick={() => copyRefreshToken(provider.oauth_detail?.refresh_token ?? '')}
-                                                        title={copiedRefreshToken ? 'Copied!' : 'Copy'}
-                                                    >
-                                                        <ContentCopy fontSize="small" />
-                                                    </IconButton>
+                                                        value={provider.oauth_detail?.refresh_token ?? ''}
+                                                    />
                                                 </InputAdornment>
                                             ),
                                         },

--- a/frontend/src/components/OAuthDetailDialog.tsx
+++ b/frontend/src/components/OAuthDetailDialog.tsx
@@ -17,6 +17,7 @@ import {
 import { useEffect, useState } from 'react';
 import {type Provider } from '../types/provider';
 import ProviderExportButton from '@/components/ProviderExportButton';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 
 interface OAuthEditFormData {
     name: string;
@@ -45,7 +46,8 @@ const OAuthDetailDialog = ({ open, provider, onClose, onSubmit, onNotification }
     const [submitting, setSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState<string | null>(null);
     const [visibleTokens, setVisibleTokens] = useState<Record<string, boolean>>({});
-    const [copiedToken, setCopiedToken] = useState<string | null>(null);
+    const { copied: copiedAccessToken, copy: copyAccessToken } = useCopyFeedback();
+    const { copied: copiedRefreshToken, copy: copyRefreshToken } = useCopyFeedback();
 
     // Update form data when provider changes
     useEffect(() => {
@@ -76,16 +78,6 @@ const OAuthDetailDialog = ({ open, provider, onClose, onSubmit, onNotification }
 
     const toggleTokenVisibility = (tokenKey: string) => {
         setVisibleTokens(prev => ({ ...prev, [tokenKey]: !prev[tokenKey] }));
-    };
-
-    const copyToken = async (token: string, tokenKey: string) => {
-        try {
-            await navigator.clipboard.writeText(token);
-            setCopiedToken(tokenKey);
-            setTimeout(() => setCopiedToken(null), 2000);
-        } catch (err) {
-            console.error('Failed to copy:', err);
-        }
     };
 
     const maskToken = (token: string) => {
@@ -248,8 +240,8 @@ const OAuthDetailDialog = ({ open, provider, onClose, onSubmit, onNotification }
                                                 <IconButton
                                                     edge="end"
                                                     size="small"
-                                                    onClick={() => copyToken(provider.oauth_detail!.access_token, 'access_token')}
-                                                    title={copiedToken === 'access_token' ? 'Copied!' : 'Copy'}
+                                                    onClick={() => copyAccessToken(provider.oauth_detail!.access_token)}
+                                                    title={copiedAccessToken ? 'Copied!' : 'Copy'}
                                                 >
                                                     <ContentCopy fontSize="small" />
                                                 </IconButton>
@@ -285,8 +277,8 @@ const OAuthDetailDialog = ({ open, provider, onClose, onSubmit, onNotification }
                                                     <IconButton
                                                         edge="end"
                                                         size="small"
-                                                        onClick={() => copyToken(provider.oauth_detail?.refresh_token ?? '', 'refresh_token')}
-                                                        title={copiedToken === 'refresh_token' ? 'Copied!' : 'Copy'}
+                                                        onClick={() => copyRefreshToken(provider.oauth_detail?.refresh_token ?? '')}
+                                                        title={copiedRefreshToken ? 'Copied!' : 'Copy'}
                                                     >
                                                         <ContentCopy fontSize="small" />
                                                     </IconButton>

--- a/frontend/src/components/PageLayout.tsx
+++ b/frontend/src/components/PageLayout.tsx
@@ -1,7 +1,6 @@
-import { CircularProgress, Box, Alert, IconButton, Tooltip } from '@mui/material';
+import { CircularProgress, Box, Alert, IconButton } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
-import { Check, ContentCopy } from '@/components/icons';
-import { useCopyFeedback } from '@/hooks/useCopyFeedback';
+import { CopyIconButton } from '@/components/CopyIconButton';
 import PageHeader from './PageHeader';
 
 type TimerId = ReturnType<typeof setTimeout>;
@@ -70,7 +69,6 @@ export const PageLayout: React.FC<PageLayoutProps> = ({
   rightAction,
 }) => {
   const timeoutRef = useRef<TimerId | null>(null);
-  const { copied, copy } = useCopyFeedback();
 
   // Only start showing the loading state once `loading` has been true for
   // LOADING_SHOW_DELAY_MS. If the data arrives before that, nothing is
@@ -201,16 +199,14 @@ export const PageLayout: React.FC<PageLayoutProps> = ({
               action={
                 <>
                   {notification.severity === 'error' && notification.message && (
-                    <Tooltip title={copied ? 'Copied' : 'Copy for report'}>
-                      <IconButton
-                        aria-label="copy error"
-                        color="inherit"
-                        size="small"
-                        onClick={() => copy(notification.message ?? '')}
-                      >
-                        {copied ? <Check fontSize="small" /> : <ContentCopy fontSize="small" />}
-                      </IconButton>
-                    </Tooltip>
+                    <CopyIconButton
+                      value={notification.message ?? ''}
+                      label="Copy for report"
+                      copiedLabel="Copied"
+                      color="inherit"
+                      copiedColor="inherit"
+                      aria-label="copy error"
+                    />
                   )}
                   <IconButton
                     aria-label="close"
@@ -234,16 +230,14 @@ export const PageLayout: React.FC<PageLayoutProps> = ({
               action={
                 notification.severity === 'error' ? (
                   <>
-                    <Tooltip title={copied ? 'Copied' : 'Copy for report'}>
-                      <IconButton
-                        aria-label="copy error"
-                        color="inherit"
-                        size="small"
-                        onClick={() => copy(notification.message ?? '')}
-                      >
-                        {copied ? <Check fontSize="small" /> : <ContentCopy fontSize="small" />}
-                      </IconButton>
-                    </Tooltip>
+                    <CopyIconButton
+                      value={notification.message ?? ''}
+                      label="Copy for report"
+                      copiedLabel="Copied"
+                      color="inherit"
+                      copiedColor="inherit"
+                      aria-label="copy error"
+                    />
                     <IconButton
                       aria-label="close"
                       color="inherit"

--- a/frontend/src/components/ProvidersCard.tsx
+++ b/frontend/src/components/ProvidersCard.tsx
@@ -1,19 +1,18 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
-    Alert,
     Button,
     Dialog,
     DialogActions,
     DialogContent,
     DialogContentText,
     DialogTitle,
-    Snackbar,
 } from '@mui/material';
 import ConnectAIDialogs from '@/components/ConnectAIDialogs';
 import { ProviderListContent } from '@/components/ConnectProviderDialog';
 import { useProviderDialog } from '@/hooks/useProviderDialog';
+import { useNotify } from '@/hooks/useNotify.ts';
 
 /**
  * ProvidersCard — browse the provider catalog and connect one. This is what
@@ -34,24 +33,19 @@ import { useProviderDialog } from '@/hooks/useProviderDialog';
 export const ProvidersCard = () => {
     const { t } = useTranslation();
     const navigate = useNavigate();
+    const notify = useNotify();
     const [browseQuery, setBrowseQuery] = useState('');
-
-    const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' | 'info' }>({
-        open: false,
-        message: '',
-        severity: 'info',
-    });
     const [successDialogOpen, setSuccessDialogOpen] = useState(false);
 
-    const showMessage = (message: string, severity: 'success' | 'error' | 'info' = 'info') => {
-        setSnackbar({ open: true, message, severity });
-    };
+    const showNotification = useCallback((message: string, severity: 'success' | 'error') => {
+        notify[severity](message);
+    }, [notify]);
 
     // The same Connect AI flow every other surface uses: the provider list is
     // rendered inline (card content instead of a picker dialog), and every
     // card — key / custom / self-hosted / OAuth / import / paste & detect —
     // routes through the shared hook + dialog stack.
-    const connectAI = useProviderDialog(showMessage, {
+    const connectAI = useProviderDialog(showNotification, {
         onProviderAdded: () => setSuccessDialogOpen(true),
     });
 
@@ -62,7 +56,7 @@ export const ProvidersCard = () => {
 
     const handleStayHere = () => {
         setSuccessDialogOpen(false);
-        showMessage(t('onboarding.success', { defaultValue: 'Provider added successfully! You can now create scenarios.' }), 'success');
+        notify.success(t('onboarding.success', { defaultValue: 'Provider added successfully! You can now create scenarios.' }));
     };
 
     return (
@@ -104,20 +98,6 @@ export const ProvidersCard = () => {
                     </Button>
                 </DialogActions>
             </Dialog>
-
-            <Snackbar
-                open={snackbar.open}
-                autoHideDuration={snackbar.severity === 'error' ? null : 4000}
-                onClose={() => setSnackbar((prev) => ({ ...prev, open: false }))}
-                anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-            >
-                <Alert
-                    severity={snackbar.severity}
-                    onClose={() => setSnackbar((prev) => ({ ...prev, open: false }))}
-                >
-                    {snackbar.message}
-                </Alert>
-            </Snackbar>
         </>
     );
 };

--- a/frontend/src/components/ShortcutCard.tsx
+++ b/frontend/src/components/ShortcutCard.tsx
@@ -2,6 +2,7 @@ import { Check as IconCheck, Computer as IconComputer, ContentCopy as IconConten
 import { Box, Button, CircularProgress, Divider, IconButton, Paper, Stack, Tooltip, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 import { useNotify } from '@/hooks/useNotify.ts';
 import { api } from '@/services/api.ts';
 import { isGuiMode } from '@/utils/protocol.ts';
@@ -31,7 +32,7 @@ export const ShortcutCard = () => {
     const [shortcutStatus, setShortcutStatus] = useState<{ exists: boolean; created: string[]; scriptPath: string } | null>(null);
     const [shortcutCreating, setShortcutCreating] = useState(false);
     const [shortcutError, setShortcutError] = useState<string | null>(null);
-    const [copiedShortcutScript, setCopiedShortcutScript] = useState(false);
+    const { copied: copiedShortcutScript, copy: copyShortcutScript } = useCopyFeedback();
 
     useEffect(() => {
         loadShortcutStatus();
@@ -68,11 +69,7 @@ export const ShortcutCard = () => {
 
     const handleCopyShortcutScript = () => {
         if (!shortcutStatus?.scriptPath) return;
-        navigator.clipboard.writeText(shortcutStatus.scriptPath).then(() => {
-            setCopiedShortcutScript(true);
-            notify.success(t('common.copied'));
-            setTimeout(() => setCopiedShortcutScript(false), 2000);
-        });
+        copyShortcutScript(shortcutStatus.scriptPath, () => notify.success(t('common.copied')));
     };
 
     return (

--- a/frontend/src/components/ShortcutCard.tsx
+++ b/frontend/src/components/ShortcutCard.tsx
@@ -1,8 +1,8 @@
-import { Check as IconCheck, Computer as IconComputer, ContentCopy as IconContentCopy } from '@/components/icons';
-import { Box, Button, CircularProgress, Divider, IconButton, Paper, Stack, Tooltip, Typography } from '@mui/material';
+import { Check as IconCheck, Computer as IconComputer } from '@/components/icons';
+import { Box, Button, CircularProgress, Divider, Paper, Stack, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useCopyFeedback } from '@/hooks/useCopyFeedback';
+import { CopyIconButton } from '@/components/CopyIconButton';
 import { useNotify } from '@/hooks/useNotify.ts';
 import { api } from '@/services/api.ts';
 import { isGuiMode } from '@/utils/protocol.ts';
@@ -32,7 +32,6 @@ export const ShortcutCard = () => {
     const [shortcutStatus, setShortcutStatus] = useState<{ exists: boolean; created: string[]; scriptPath: string } | null>(null);
     const [shortcutCreating, setShortcutCreating] = useState(false);
     const [shortcutError, setShortcutError] = useState<string | null>(null);
-    const { copied: copiedShortcutScript, copy: copyShortcutScript } = useCopyFeedback();
 
     useEffect(() => {
         loadShortcutStatus();
@@ -65,11 +64,6 @@ export const ShortcutCard = () => {
             setShortcutError(result.error || 'Unknown error');
         }
         setShortcutCreating(false);
-    };
-
-    const handleCopyShortcutScript = () => {
-        if (!shortcutStatus?.scriptPath) return;
-        copyShortcutScript(shortcutStatus.scriptPath, () => notify.success(t('common.copied')));
     };
 
     return (
@@ -129,15 +123,16 @@ export const ShortcutCard = () => {
                                 >
                                     $ {shortcutStatus.scriptPath}
                                 </Typography>
-                                <Tooltip title={copiedShortcutScript ? t('common.copied') : t('common.copy')} placement="top" arrow>
-                                    <IconButton
-                                        size="small"
-                                        onClick={handleCopyShortcutScript}
-                                        sx={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)', color: copiedShortcutScript ? 'success.main' : 'text.secondary' }}
-                                    >
-                                        {copiedShortcutScript ? <IconCheck sx={{ fontSize: 16 }} /> : <IconContentCopy sx={{ fontSize: 16 }} />}
-                                    </IconButton>
-                                </Tooltip>
+                                <CopyIconButton
+                                    value={shortcutStatus.scriptPath}
+                                    label={t('common.copy')}
+                                    copiedLabel={t('common.copied')}
+                                    tooltipPlacement="top"
+                                    tooltipArrow
+                                    iconSize={16}
+                                    sx={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)' }}
+                                    onCopied={() => notify.success(t('common.copied'))}
+                                />
                             </Paper>
                         </Box>
                     ) : (

--- a/frontend/src/components/UpdatePanelDialog.tsx
+++ b/frontend/src/components/UpdatePanelDialog.tsx
@@ -1,12 +1,12 @@
-import { ContentCopy, Check, GitHub, AppRegistration as NPM, Refresh } from '@/components/icons';
-import { Box, Button, Dialog, DialogActions, DialogContent, Divider, IconButton, Stack, ToggleButton, ToggleButtonGroup, Typography, useTheme } from '@mui/material';
+import { GitHub, AppRegistration as NPM, Refresh } from '@/components/icons';
+import { Box, Button, Dialog, DialogActions, DialogContent, Divider, Stack, ToggleButton, ToggleButtonGroup, Typography, useTheme } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { fontMono } from '@/theme/fonts';
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useVersion } from '@/contexts/VersionContext';
-import { useCopyFeedback } from '@/hooks/useCopyFeedback';
-import { Paper, Tooltip } from '@mui/material';
+import { CopyIconButton } from '@/components/CopyIconButton';
+import { Paper } from '@mui/material';
 
 interface UpdatePanelDialogProps {
     open: boolean;
@@ -25,8 +25,6 @@ export const UpdatePanelDialog: React.FC<UpdatePanelDialogProps> = ({ open, onCl
     const theme = useTheme();
     const { currentVersion, latestVersion, checking, releaseURL, checkForUpdates, hasUpdate } = useVersion();
 
-    const { copied: copiedCommand, copy: copyCommand } = useCopyFeedback();
-    const { copied: copiedVersion, copy: copyVersion } = useCopyFeedback();
     const [selectedMethodId, setSelectedMethodId] = useState<string>('npx');
 
     const displayCurrentVersion = (currentVersion || 'Unknown').split('+')[0];
@@ -81,14 +79,6 @@ export const UpdatePanelDialog: React.FC<UpdatePanelDialogProps> = ({ open, onCl
     ] as const;
 
     const selectedMethod = updateMethods.find((m) => m.id === selectedMethodId) ?? updateMethods[0];
-
-    const handleCopy = useCallback(() => {
-        copyCommand(selectedMethod.commands.join('\n'));
-    }, [copyCommand, selectedMethod]);
-
-    const handleCopyVersion = useCallback(() => {
-        copyVersion(displayCurrentVersion);
-    }, [copyVersion, displayCurrentVersion]);
 
     const handleCheckForUpdates = useCallback(() => {
         checkForUpdates(true);
@@ -180,16 +170,14 @@ export const UpdatePanelDialog: React.FC<UpdatePanelDialogProps> = ({ open, onCl
                             t('update.currentVersion', { version: displayCurrentVersion })
                         )}
                     </Typography>
-                    <Tooltip title={copiedVersion ? t('update.copied') : t('update.copy')} placement="top" arrow>
-                        <IconButton
-                            size="small"
-                            onClick={handleCopyVersion}
-                            aria-label={t('update.copy')}
-                            sx={{ color: copiedVersion ? 'success.main' : 'text.secondary' }}
-                        >
-                            {copiedVersion ? <Check sx={{ fontSize: 16 }} /> : <ContentCopy sx={{ fontSize: 16 }} />}
-                        </IconButton>
-                    </Tooltip>
+                    <CopyIconButton
+                        value={displayCurrentVersion}
+                        label={t('update.copy')}
+                        copiedLabel={t('update.copied')}
+                        tooltipPlacement="top"
+                        tooltipArrow
+                        iconSize={16}
+                    />
                 </Box>
             </Box>
             <DialogContent sx={{ p: 0 }}>
@@ -278,30 +266,21 @@ export const UpdatePanelDialog: React.FC<UpdatePanelDialogProps> = ({ open, onCl
                                     $ {command}
                                 </Typography>
                             ))}
-                            <Tooltip
-                                title={copiedCommand ? t('update.copied') : t('update.copy')}
-                                placement="top"
-                                arrow
-                            >
-                                <IconButton
-                                    size="small"
-                                    onClick={handleCopy}
-                                    sx={{
-                                        position: 'absolute',
-                                        right: 8,
-                                        top: '50%',
-                                        transform: 'translateY(-50%)',
-                                        color: copiedCommand ? 'success.main' : 'text.secondary',
-                                        bgcolor: copiedCommand ? 'success.light' : 'transparent',
-                                        '&:hover': {
-                                            color: 'primary.main',
-                                            bgcolor: 'action.hover',
-                                        },
-                                    }}
-                                >
-                                    <ContentCopy sx={{ fontSize: 18 }} />
-                                </IconButton>
-                            </Tooltip>
+                            <CopyIconButton
+                                value={selectedMethod.commands.join('\n')}
+                                label={t('update.copy')}
+                                copiedLabel={t('update.copied')}
+                                tooltipPlacement="top"
+                                tooltipArrow
+                                iconSize={18}
+                                sx={{
+                                    position: 'absolute',
+                                    right: 8,
+                                    top: '50%',
+                                    transform: 'translateY(-50%)',
+                                    '&:hover': { color: 'primary.main', bgcolor: 'action.hover' },
+                                }}
+                            />
                         </Paper>
                     </Box>
                 </Stack>

--- a/frontend/src/components/model-select/CustomModelCard.tsx
+++ b/frontend/src/components/model-select/CustomModelCard.tsx
@@ -1,5 +1,5 @@
 import { CheckCircle, Delete as DeleteIcon, Edit as EditIcon } from '@/components/icons';
-import { Box, Card, CircularProgress, IconButton, Tooltip, Typography, Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
+import { Box, Card, CircularProgress, IconButton, Tooltip, Typography } from '@mui/material';
 import type { Theme } from '@mui/material/styles';
 import React, { useState } from 'react';
 import type { Provider } from '../../types/provider.ts';
@@ -9,6 +9,7 @@ import { ProbeDialog } from '../probe/ProbeDialog';
 import { useModelTestProbe } from '../probe/useModelTestProbe';
 import { ControlBar } from './ControlBar';
 import { getModelCardActiveColor, getModelCardStateStyles, modelCardTransition } from './cardStyles';
+import ConfirmDialog from '@/components/ConfirmDialog';
 
 interface CustomModelCardProps {
     model: string;
@@ -219,37 +220,20 @@ export default function CustomModelCard({
                 initialResult={probe.result ?? undefined}
                 onResult={probe.setResult}
             />
-            {/* Confirmation dialog for deleting custom model */}
-            <Dialog
+            <ConfirmDialog
                 open={deleteConfirmOpen}
                 onClose={handleCancelDelete}
-                aria-labelledby="delete-confirm-title"
-            >
-                <DialogTitle id="delete-confirm-title">
-                    Delete Custom Model?
-                </DialogTitle>
-                <DialogContent sx={{ pb: 2 }}>
-                    <Typography variant="body2" sx={{
-                        color: "text.secondary"
-                    }}>
+                onConfirm={handleConfirmDelete}
+                confirmColor="error"
+                confirmLabel="Delete"
+                title="Delete Custom Model?"
+                description={
+                    <>
                         Are you sure you want to delete the custom model <strong>"{model}"</strong>?
                         {isSelected && " The selection will be cleared after deletion."}
-                    </Typography>
-                </DialogContent>
-                <DialogActions sx={{ px: 3, pb: 2 }}>
-                    <Button onClick={handleCancelDelete} color="primary">
-                        Cancel
-                    </Button>
-                    <Button
-                        onClick={handleConfirmDelete}
-                        color="error"
-                        variant="contained"
-                        autoFocus
-                    >
-                        Delete
-                    </Button>
-                </DialogActions>
-            </Dialog>
+                    </>
+                }
+            />
         </>
     );
 }

--- a/frontend/src/components/probe/ProbeDialog.tsx
+++ b/frontend/src/components/probe/ProbeDialog.tsx
@@ -39,6 +39,7 @@ import {
 } from './probeConfig';
 import { ProbeControls } from './ProbeControls';
 import { useCopyFeedback } from '@/hooks/useCopyFeedback';
+import { CopyIconButton } from '@/components/CopyIconButton';
 import api from '@/services/api';
 import { ProbeDevControls } from './ProbeDialogDevControls';
 
@@ -219,7 +220,6 @@ const CollapsibleSection = memo(({ title, defaultExpanded = false, children }: C
 // artifact section (cURL, Response, Raw JSON) hands over the exact text.
 const CopyBlock = memo(({ text, maxHeight, fontSize = '0.78rem' }: { text: string; maxHeight?: number | string; fontSize?: string }) => {
     const { t } = useTranslation();
-    const { copied, copy } = useCopyFeedback();
     return (
         <Box sx={{ position: 'relative' }}>
             <Box
@@ -239,15 +239,12 @@ const CopyBlock = memo(({ text, maxHeight, fontSize = '0.78rem' }: { text: strin
             >
                 {text}
             </Box>
-            <Tooltip title={copied ? t('probe.copied') : t('probe.copy')}>
-                <IconButton
-                    size="small"
-                    onClick={() => copy(text)}
-                    sx={{ position: 'absolute', top: 4, right: 4, color: 'text.secondary' }}
-                >
-                    <CopyIcon fontSize="small" />
-                </IconButton>
-            </Tooltip>
+            <CopyIconButton
+                value={text}
+                label={t('probe.copy')}
+                copiedLabel={t('probe.copied')}
+                sx={{ position: 'absolute', top: 4, right: 4 }}
+            />
         </Box>
     );
 });

--- a/frontend/src/components/prompt/skill/SkillDetailDialog.tsx
+++ b/frontend/src/components/prompt/skill/SkillDetailDialog.tsx
@@ -23,6 +23,7 @@ import { useState, useEffect } from 'react';
 import { type Skill, type SkillLocation } from '@/types/prompt';
 import { getIdeSourceLabel } from '@/constants/ideSources';
 import { api } from '@/services/api';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 
 interface SkillDetailDialogProps {
     open: boolean;
@@ -34,7 +35,7 @@ interface SkillDetailDialogProps {
 const SkillDetailDialog = ({ open, skill, location, onClose }: SkillDetailDialogProps) => {
     const [loading, setLoading] = useState(false);
     const [content, setContent] = useState<string>('');
-    const [copied, setCopied] = useState(false);
+    const { copied, copy: copyContent, reset: resetCopied } = useCopyFeedback();
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
@@ -43,9 +44,10 @@ const SkillDetailDialog = ({ open, skill, location, onClose }: SkillDetailDialog
         }
         // Reset copied state when dialog closes
         if (!open) {
-            setCopied(false);
+            resetCopied();
             setError(null);
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [open, skill, location]);
 
     const loadSkillContent = async () => {
@@ -73,15 +75,13 @@ const SkillDetailDialog = ({ open, skill, location, onClose }: SkillDetailDialog
     };
 
     const handleCopy = () => {
-        navigator.clipboard.writeText(content);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        copyContent(content);
     };
 
     const handleClose = () => {
         setContent('');
         setError(null);
-        setCopied(false);
+        resetCopied();
         onClose();
     };
 

--- a/frontend/src/components/rule-card/dialogs.tsx
+++ b/frontend/src/components/rule-card/dialogs.tsx
@@ -1,5 +1,6 @@
 import { Alert, Box, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, TextField, Typography } from '@mui/material';
 import type { ConfigRecord } from '@/components/RoutingGraphTypes';
+import ConfirmDialog from '@/components/ConfirmDialog';
 
 // ============================================================================
 // Delete Confirmation Dialog
@@ -16,22 +17,15 @@ export interface RuleCardDeleteDialogProps {
  */
 export function RuleCardDeleteDialog({ open, onClose, onConfirm }: RuleCardDeleteDialogProps) {
     return (
-        <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-            <DialogTitle>Delete Routing Rule</DialogTitle>
-            <DialogContent>
-                <DialogContentText>
-                    Are you sure you want to delete this routing rule? This action cannot be undone.
-                </DialogContentText>
-            </DialogContent>
-            <DialogActions>
-                <Button onClick={onClose} color="primary">
-                    Cancel
-                </Button>
-                <Button onClick={onConfirm} color="error" variant="contained">
-                    Delete
-                </Button>
-            </DialogActions>
-        </Dialog>
+        <ConfirmDialog
+            open={open}
+            onClose={onClose}
+            onConfirm={onConfirm}
+            title="Delete Routing Rule"
+            description="Are you sure you want to delete this routing rule? This action cannot be undone."
+            confirmLabel="Delete"
+            confirmColor="error"
+        />
     );
 }
 

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -6,9 +6,9 @@
  * never need to wire notification state into their own components.
  */
 import { useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from 'react';
-import { Alert, AlertTitle, Box, Collapse, IconButton, Slide, Tooltip } from '@mui/material';
-import { Check, Close, ContentCopy } from '@/components/icons';
-import { useCopyFeedback } from '@/hooks/useCopyFeedback';
+import { Alert, AlertTitle, Box, Collapse, IconButton, Slide } from '@mui/material';
+import { Close } from '@/components/icons';
+import { CopyIconButton } from '@/components/CopyIconButton';
 import {
   type NotifyItem,
   dismissNotify,
@@ -25,7 +25,6 @@ function useNotifyItems(): NotifyItem[] {
 function NotificationToast({ item }: { item: NotifyItem }) {
   const [open, setOpen] = useState(false);
   const removeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const { copied, copy } = useCopyFeedback();
 
   // Trigger the enter transition once mounted.
   useEffect(() => {
@@ -67,16 +66,14 @@ function NotificationToast({ item }: { item: NotifyItem }) {
             action={
               isError ? (
                 <>
-                  <Tooltip title={copied ? 'Copied' : 'Copy for report'}>
-                    <IconButton
-                      aria-label="copy error"
-                      color="inherit"
-                      size="small"
-                      onClick={() => copy(reportText)}
-                    >
-                      {copied ? <Check fontSize="small" /> : <ContentCopy fontSize="small" />}
-                    </IconButton>
-                  </Tooltip>
+                  <CopyIconButton
+                    value={reportText}
+                    label="Copy for report"
+                    copiedLabel="Copied"
+                    color="inherit"
+                    copiedColor="inherit"
+                    aria-label="copy error"
+                  />
                   <IconButton
                     aria-label="close"
                     color="inherit"

--- a/frontend/src/hooks/useCopyFeedback.ts
+++ b/frontend/src/hooks/useCopyFeedback.ts
@@ -2,16 +2,22 @@ import { useCallback, useState } from 'react';
 
 // useCopyFeedback: copy text to the clipboard and flip a "copied" flag for a
 // couple seconds so the caller can swap a tooltip/icon to acknowledge it.
+// `onCopied` runs once the write actually succeeds — for callers that also
+// fire a toast/notification alongside the visual flip.
 export function useCopyFeedback(resetMs = 2000) {
     const [copied, setCopied] = useState(false);
     const copy = useCallback(
-        (text: string) => {
+        (text: string, onCopied?: () => void) => {
             navigator.clipboard.writeText(text).then(() => {
                 setCopied(true);
+                onCopied?.();
                 setTimeout(() => setCopied(false), resetMs);
             });
         },
         [resetMs],
     );
-    return { copied, copy };
+    // For a caller that needs to clear the flag early — e.g. a dialog
+    // resetting it on close instead of waiting out the timer.
+    const reset = useCallback(() => setCopied(false), []);
+    return { copied, copy, reset };
 }

--- a/frontend/src/pages/SharingKeysPage.tsx
+++ b/frontend/src/pages/SharingKeysPage.tsx
@@ -17,6 +17,7 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNotify } from '@/hooks/useNotify';
 import SharingKeysTable, { type SharingKey } from '@/components/SharingKeysTable';
+import ConfirmDialog from '@/components/ConfirmDialog';
 
 const SharingKeysPage = () => {
     const { t } = useTranslation();
@@ -169,37 +170,26 @@ const SharingKeysPage = () => {
                     </Button>
                 </DialogActions>
             </Dialog>
-            {/* Delete Confirm Dialog */}
-            <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)} maxWidth="sm" fullWidth>
-                <DialogTitle>
-                    <Stack direction="row" spacing={1} sx={{
-                        alignItems: "center"
-                    }}>
+            <ConfirmDialog
+                open={deleteDialogOpen}
+                onClose={() => setDeleteDialogOpen(false)}
+                onConfirm={handleDeleteToken}
+                loading={deletingToken}
+                confirmColor="error"
+                confirmLabel="Delete Token"
+                title={
+                    <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
                         <IconTrash color="error" />
                         <span>Delete Token</span>
                     </Stack>
-                </DialogTitle>
-                <DialogContent>
-                    <Typography>
+                }
+                description={
+                    <>
                         Are you sure you want to delete the token <strong>"{tokenToDelete?.display_name}"</strong>?
                         This action cannot be undone.
-                    </Typography>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={() => setDeleteDialogOpen(false)} disabled={deletingToken}>
-                        Cancel
-                    </Button>
-                    <Button
-                        variant="contained"
-                        color="error"
-                        onClick={handleDeleteToken}
-                        disabled={deletingToken}
-                        startIcon={deletingToken ? <CircularProgress size={16} /> : <IconTrash sx={{ fontSize: 18 }} />}
-                    >
-                        Delete Token
-                    </Button>
-                </DialogActions>
-            </Dialog>
+                    </>
+                }
+            />
         </PageLayout>
     );
 };

--- a/frontend/src/pages/mcp/AgentInstallCard.tsx
+++ b/frontend/src/pages/mcp/AgentInstallCard.tsx
@@ -16,6 +16,7 @@ import {
     ContentCopy as CopyIcon,
     Terminal as TerminalIcon,
 } from '@/components/icons';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -91,13 +92,11 @@ interface CodeBlockProps {
  * Includes a copy-to-clipboard button in the header.
  */
 const CodeBlock: React.FC<CodeBlockProps> = ({ filename, runtimeLabel, command }) => {
-    const [copied, setCopied] = useState(false);
+    const { copied, copy } = useCopyFeedback();
 
     const handleCopy = useCallback(() => {
-        void navigator.clipboard.writeText(command.replace(/\\\n\s*/g, ' '));
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-    }, [command]);
+        copy(command.replace(/\\\n\s*/g, ' '));
+    }, [command, copy]);
 
     return (
         <Box

--- a/frontend/src/pages/mcp/AgentInstallCard.tsx
+++ b/frontend/src/pages/mcp/AgentInstallCard.tsx
@@ -10,13 +10,12 @@
  *   <AgentInstallCard sectionNumber="02" />
  */
 
-import React, { useCallback, useState } from 'react';
-import { Alert, Box, Chip, IconButton, Tooltip, Typography } from '@mui/material';
+import React, { useState } from 'react';
+import { Alert, Box, Chip, Typography } from '@mui/material';
 import {
-    ContentCopy as CopyIcon,
     Terminal as TerminalIcon,
 } from '@/components/icons';
-import { useCopyFeedback } from '@/hooks/useCopyFeedback';
+import { CopyIconButton } from '@/components/CopyIconButton';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -92,12 +91,6 @@ interface CodeBlockProps {
  * Includes a copy-to-clipboard button in the header.
  */
 const CodeBlock: React.FC<CodeBlockProps> = ({ filename, runtimeLabel, command }) => {
-    const { copied, copy } = useCopyFeedback();
-
-    const handleCopy = useCallback(() => {
-        copy(command.replace(/\\\n\s*/g, ' '));
-    }, [command, copy]);
-
     return (
         <Box
             sx={{
@@ -140,19 +133,14 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ filename, runtimeLabel, command }
                         border: '1px solid rgb(48, 54, 61)',
                     }}
                 />
-                <Tooltip title={copied ? 'Copied!' : 'Copy'} arrow>
-                    <IconButton
-                        size="small"
-                        onClick={handleCopy}
-                        sx={{
-                            p: 0.5,
-                            color: copied ? 'rgb(16, 185, 129)' : 'rgb(125, 133, 144)',
-                            '&:hover': { color: 'rgb(201, 209, 217)' },
-                        }}
-                    >
-                        <CopyIcon sx={{ fontSize: '0.85rem' }} />
-                    </IconButton>
-                </Tooltip>
+                <CopyIconButton
+                    value={command.replace(/\\\n\s*/g, ' ')}
+                    color="rgb(125, 133, 144)"
+                    copiedColor="rgb(16, 185, 129)"
+                    iconSize="0.85rem"
+                    tooltipArrow
+                    sx={{ p: 0.5, '&:hover': { color: 'rgb(201, 209, 217)' } }}
+                />
             </Box>
 
             {/* Command text */}

--- a/frontend/src/pages/mcp/MCPLocalMode.tsx
+++ b/frontend/src/pages/mcp/MCPLocalMode.tsx
@@ -17,11 +17,12 @@ import {
 } from '@/components/icons';
 import { useEffect, useState } from 'react';
 import { useNotify } from '@/hooks/useNotify';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 
 const MCPLocalMode = () => {
     const notify = useNotify();
     const [baseUrl, setBaseUrl] = useState('');
-    const [copiedCommand, setCopiedCommand] = useState(false);
+    const { copied: copiedCommand, copy: copyCommand } = useCopyFeedback();
 
     useEffect(() => {
         const url = window.location.origin;
@@ -50,12 +51,12 @@ const MCPLocalMode = () => {
     };
 
     const handleCopy = (text: string, type: 'command' | 'config') => {
-        navigator.clipboard.writeText(text);
         if (type === 'command') {
-            setCopiedCommand(true);
-            setTimeout(() => setCopiedCommand(false), 2000);
+            copyCommand(text, () => notify.success('Copied to clipboard'));
+        } else {
+            navigator.clipboard.writeText(text);
+            notify.success('Copied to clipboard');
         }
-        notify.success('Copied to clipboard');
     };
 
     return (

--- a/frontend/src/pages/mcp/MCPLocalMode.tsx
+++ b/frontend/src/pages/mcp/MCPLocalMode.tsx
@@ -5,24 +5,21 @@ import {
     Box,
     Chip,
     Divider,
-    IconButton,
     Paper,
     Stack,
     Typography,
 } from '@mui/material';
 import {
-    ContentCopy as ContentCopyIcon,
     CheckCircle as CheckCircleIcon,
     Terminal as TerminalIcon,
 } from '@/components/icons';
+import { CopyIconButton } from '@/components/CopyIconButton';
 import { useEffect, useState } from 'react';
 import { useNotify } from '@/hooks/useNotify';
-import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 
 const MCPLocalMode = () => {
     const notify = useNotify();
     const [baseUrl, setBaseUrl] = useState('');
-    const { copied: copiedCommand, copy: copyCommand } = useCopyFeedback();
 
     useEffect(() => {
         const url = window.location.origin;
@@ -50,14 +47,7 @@ const MCPLocalMode = () => {
         }, null, 2);
     };
 
-    const handleCopy = (text: string, type: 'command' | 'config') => {
-        if (type === 'command') {
-            copyCommand(text, () => notify.success('Copied to clipboard'));
-        } else {
-            navigator.clipboard.writeText(text);
-            notify.success('Copied to clipboard');
-        }
-    };
+    const notifyCopied = () => notify.success('Copied to clipboard');
 
     return (
         <PageLayout loading={false}>
@@ -155,19 +145,12 @@ const MCPLocalMode = () => {
                                 >
                                     {getClaudeCodeCommand()}
                                 </Typography>
-                                <IconButton
-                                    size="small"
+                                <CopyIconButton
+                                    value={getClaudeCodeCommand()}
                                     aria-label="Copy Claude Code command"
-                                    onClick={() => handleCopy(getClaudeCodeCommand(), 'command')}
-                                    sx={{
-                                        position: 'absolute',
-                                        right: 8,
-                                        top: 8,
-                                    }}
-                                    color={copiedCommand ? 'success' : 'default'}
-                                >
-                                    {copiedCommand ? <CheckCircleIcon fontSize="small" /> : <ContentCopyIcon fontSize="small" />}
-                                </IconButton>
+                                    sx={{ position: 'absolute', right: 8, top: 8 }}
+                                    onCopied={notifyCopied}
+                                />
                             </Paper>
                         </Box>
 
@@ -209,18 +192,12 @@ const MCPLocalMode = () => {
                                 >
                                     {getClaudeDesktopConfig()}
                                 </Typography>
-                                <IconButton
-                                    size="small"
+                                <CopyIconButton
+                                    value={getClaudeDesktopConfig()}
                                     aria-label="Copy Claude Desktop configuration"
-                                    onClick={() => handleCopy(getClaudeDesktopConfig(), 'config')}
-                                    sx={{
-                                        position: 'absolute',
-                                        right: 8,
-                                        top: 8,
-                                    }}
-                                >
-                                    <ContentCopyIcon fontSize="small" />
-                                </IconButton>
+                                    sx={{ position: 'absolute', right: 8, top: 8 }}
+                                    onCopied={notifyCopied}
+                                />
                             </Paper>
                             <Typography
                                 variant="caption"

--- a/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
+++ b/frontend/src/pages/scenario/ClaudeCodeProfilePage.tsx
@@ -35,6 +35,7 @@ import { useTranslation } from 'react-i18next';
 import TemplatePage from './components/TemplatePage.tsx';
 import { ScenarioPageModalProvider } from '@/pages/scenario/context/ScenarioPageContext';
 import ClaudeCodeProfileOverrides, { type ClaudeCodeProfileSettingsArtifact } from './components/ClaudeCodeProfileOverrides';
+import ConfirmDialog from '@/components/ConfirmDialog';
 
 const BASE_SCENARIO = 'claude_code';
 
@@ -401,36 +402,25 @@ const ClaudeCodeProfilePageContent: React.FC = () => {
                     </DialogActions>
                 </Dialog>
 
-                {/* Delete profile confirmation dialog */}
-                <Dialog
+                <ConfirmDialog
                     open={deleteProfileOpen}
                     onClose={() => setDeleteProfileOpen(false)}
-                    maxWidth="xs"
-                    fullWidth
-                >
-                    <DialogTitle>{t('claudeCode.profile.deleteTitle')}</DialogTitle>
-                    <DialogContent sx={{ pt: 3 }}>
-                        <Typography variant="body1">
-                            {t('claudeCode.profile.deleteConfirm', { name: currentProfile?.name || profileId || '', interpolation: { escapeValue: false } })}
-                        </Typography>
-                        <Typography
-                            variant="body2"
-                            sx={{
-                                color: "text.secondary",
-                                mt: 1
-                            }}>
-                            {t('claudeCode.profile.deleteWarning')}
-                        </Typography>
-                    </DialogContent>
-                    <DialogActions sx={{ px: 3, pb: 2, gap: 1, justifyContent: 'flex-end' }}>
-                        <Button onClick={() => setDeleteProfileOpen(false)} color="inherit" disabled={isProfileMutating}>
-                            Cancel
-                        </Button>
-                        <Button onClick={handleDeleteProfile} variant="contained" color="error" disabled={isProfileMutating}>
-                            Delete
-                        </Button>
-                    </DialogActions>
-                </Dialog>
+                    onConfirm={handleDeleteProfile}
+                    loading={isProfileMutating}
+                    confirmColor="error"
+                    confirmLabel="Delete"
+                    title={t('claudeCode.profile.deleteTitle')}
+                    description={
+                        <>
+                            <Typography variant="body1">
+                                {t('claudeCode.profile.deleteConfirm', { name: currentProfile?.name || profileId || '', interpolation: { escapeValue: false } })}
+                            </Typography>
+                            <Typography variant="body2" sx={{ color: "text.secondary", mt: 1 }}>
+                                {t('claudeCode.profile.deleteWarning')}
+                            </Typography>
+                        </>
+                    }
+                />
             </CardGrid>
         </PageLayout>
     );

--- a/frontend/src/pages/scenario/UseTeamPage.tsx
+++ b/frontend/src/pages/scenario/UseTeamPage.tsx
@@ -1,6 +1,7 @@
 import CardGrid from '@/components/CardGrid.tsx';
 import UnifiedCard from '@/components/UnifiedCard.tsx';
 import ProviderConfigCard from '@/components/ProviderConfigCard.tsx';
+import ConfirmDialog from '@/components/ConfirmDialog.tsx';
 import {
     Alert, Box, Button, CircularProgress, Dialog, DialogActions,
     DialogContent, DialogTitle, FormControlLabel, IconButton, Stack, Switch,
@@ -231,18 +232,16 @@ const UseTeamPageContent: React.FC = () => {
                 </DialogActions>
             </Dialog>
 
-            <Dialog open={deleteOpen} onClose={() => setDeleteOpen(false)} maxWidth="sm" fullWidth>
-                <DialogTitle>{t('teams.deleteTeam')}</DialogTitle>
-                <DialogContent>
-                    <Typography>{t('teams.deleteConfirm', {team: currentTeam?.name})}</Typography>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={() => setDeleteOpen(false)} disabled={saving}>{t('common.cancel')}</Button>
-                    <Button variant="contained" color="error" onClick={deleteTeam} disabled={saving}>
-                        {t('teams.deleteTeam')}
-                    </Button>
-                </DialogActions>
-            </Dialog>
+            <ConfirmDialog
+                open={deleteOpen}
+                onClose={() => setDeleteOpen(false)}
+                title={t('teams.deleteTeam')}
+                description={t('teams.deleteConfirm', {team: currentTeam?.name})}
+                confirmLabel={t('teams.deleteTeam')}
+                confirmColor="error"
+                loading={saving}
+                onConfirm={deleteTeam}
+            />
         </PageLayout>
     );
 };

--- a/frontend/src/pages/scenario/components/AgentSetupCard.tsx
+++ b/frontend/src/pages/scenario/components/AgentSetupCard.tsx
@@ -21,6 +21,7 @@ import UnifiedCard from '@/components/UnifiedCard';
 import { api } from '@/services/api';
 import { SPOTLIGHT_ADD_MODEL_EVENT } from '@/components/nodes/ActionAddNode';
 import { EntryGuideDialog } from '@/components/tier/EntryGuideDialog';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 
 export interface AgentApplyResult {
     success: boolean;
@@ -148,8 +149,8 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
     const [providerCount, setProviderCount] = useState(0);
     const [providerLoading, setProviderLoading] = useState(true);
     const [applyResult, setApplyResult] = useState<AgentApplyResult | null>(null);
-    const [copied, setCopied] = useState(false);
-    const [copiedMirror, setCopiedMirror] = useState(false);
+    const { copied, copy: copyInstallCommand, reset: resetCopied } = useCopyFeedback(1500);
+    const { copied: copiedMirror, copy: copyInstallMirrorCommand, reset: resetCopiedMirror } = useCopyFeedback(1500);
     const [showGuide, setShowGuide] = useState(false);
     // Tracks which completed steps the user has manually expanded
     const [expandedDoneSteps, setExpandedDoneSteps] = useState<Set<number>>(new Set());
@@ -205,17 +206,13 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         setCollapsed(next);
     };
 
-    const handleCopy = async () => {
-        await navigator.clipboard.writeText(installCommand);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+    const handleCopy = () => {
+        copyInstallCommand(installCommand);
     };
 
-    const handleCopyMirror = async () => {
+    const handleCopyMirror = () => {
         if (!installMirrorCommand) return;
-        await navigator.clipboard.writeText(installMirrorCommand);
-        setCopiedMirror(true);
-        setTimeout(() => setCopiedMirror(false), 1500);
+        copyInstallMirrorCommand(installMirrorCommand);
     };
 
     const markInstallDone = () => {
@@ -263,8 +260,8 @@ const AgentSetupCard: React.FC<AgentSetupCardProps> = ({
         setApplyDone(false);
         setModelSkipped(false);
         setApplyResult(null);
-        setCopied(false);
-        setCopiedMirror(false);
+        resetCopied();
+        resetCopiedMirror();
     };
 
     const progressLabel = allDone ? t('agentSetup.done') : `${doneCount}/${TOTAL_STEPS}`;

--- a/frontend/src/pages/scenario/components/SharingKeysDialog.tsx
+++ b/frontend/src/pages/scenario/components/SharingKeysDialog.tsx
@@ -18,6 +18,7 @@ import { useNotify } from '@/hooks/useNotify';
 import SharingKeysTable, { type SharingKey } from '@/components/SharingKeysTable';
 import type { Team } from '@/types/team';
 import TeamKeyScopeAlert from './TeamKeyScopeAlert';
+import ConfirmDialog from '@/components/ConfirmDialog';
 
 interface SharingKeysDialogProps {
     open: boolean;
@@ -230,34 +231,21 @@ const SharingKeysDialog: React.FC<SharingKeysDialogProps> = ({ open, onClose, te
                     </Button>
                 </DialogActions>
             </Dialog>
-            {/* Delete Confirm Dialog */}
-            <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)} maxWidth="sm" fullWidth>
-                <DialogTitle>
-                    <Stack direction="row" spacing={1} sx={{
-                        alignItems: "center"
-                    }}>
+            <ConfirmDialog
+                open={deleteDialogOpen}
+                onClose={() => setDeleteDialogOpen(false)}
+                onConfirm={handleDeleteToken}
+                loading={deletingToken}
+                confirmColor="error"
+                confirmLabel={t('sharingKeys.deleteToken')}
+                title={
+                    <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
                         <IconTrash color="error" />
                         <span>{t('sharingKeys.deleteToken')}</span>
                     </Stack>
-                </DialogTitle>
-                <DialogContent>
-                    <Typography>
-                        {t('sharingKeys.deleteConfirm', { name: tokenToDelete?.display_name })}
-                    </Typography>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={() => setDeleteDialogOpen(false)} disabled={deletingToken}>{t('common.cancel')}</Button>
-                    <Button
-                        variant="contained"
-                        color="error"
-                        onClick={handleDeleteToken}
-                        disabled={deletingToken}
-                        startIcon={deletingToken ? <CircularProgress size={16} /> : <IconTrash sx={{ fontSize: 18 }} />}
-                    >
-                        {t('sharingKeys.deleteToken')}
-                    </Button>
-                </DialogActions>
-            </Dialog>
+                }
+                description={t('sharingKeys.deleteConfirm', { name: tokenToDelete?.display_name })}
+            />
         </>
     );
 };

--- a/frontend/src/pages/system/AccessControl.tsx
+++ b/frontend/src/pages/system/AccessControl.tsx
@@ -7,10 +7,6 @@ import {
     Button,
     IconButton,
     Alert,
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogActions,
     CircularProgress,
     Divider,
     Tooltip,
@@ -31,6 +27,7 @@ import { useAuth } from '@/contexts/AuthContext.tsx';
 import { PageLayout } from '@/components/PageLayout.tsx';
 import UnifiedCard from '@/components/UnifiedCard.tsx';
 import CardGrid from "@/components/CardGrid.tsx";
+import ConfirmDialog from '@/components/ConfirmDialog.tsx';
 
 interface TokenInfo {
     token: string;
@@ -440,102 +437,80 @@ const AccessControl = () => {
                     </Stack>
                 </UnifiedCard>
             </CardGrid>
-            {/* User Reset Confirmation Dialog */}
-            <Dialog open={resetUserDialogOpen} onClose={() => setResetUserDialogOpen(false)} maxWidth="sm" fullWidth>
-                <DialogTitle>
+            <ConfirmDialog
+                open={resetUserDialogOpen}
+                onClose={() => setResetUserDialogOpen(false)}
+                onConfirm={handleUserResetConfirm}
+                loading={resettingUser}
+                confirmColor="warning"
+                confirmLabel={t('accessControl.userToken.resetConfirmButton')}
+                confirmingLabel={t('accessControl.resetting')}
+                cancelLabel={t('accessControl.userToken.resetCancel')}
+                title={
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <WarningIcon color="warning" />
                         <Typography variant="h6">{t('accessControl.userToken.resetTitle')}</Typography>
                     </Box>
-                </DialogTitle>
-                <DialogContent>
-                    <Typography variant="body1" gutterBottom>
-                        {t('accessControl.userToken.resetConfirm')}
-                    </Typography>
-                    <Stack sx={{ mt: 2 }} spacing={1}>
-                        <Typography variant="body2" sx={{
-                            color: "text.secondary"
-                        }}>
-                            • {t('accessControl.userToken.resetPoints.new')}
+                }
+                description={
+                    <>
+                        <Typography variant="body1" gutterBottom>
+                            {t('accessControl.userToken.resetConfirm')}
                         </Typography>
-                        <Typography variant="body2" sx={{
-                            color: "text.secondary"
-                        }}>
-                            • {t('accessControl.userToken.resetPoints.session')}
-                        </Typography>
-                        <Typography variant="body2" sx={{
-                            color: "text.secondary"
-                        }}>
-                            • {t('accessControl.userToken.resetPoints.other')}
-                        </Typography>
-                        <Typography variant="body2" sx={{
-                            color: "text.secondary"
-                        }}>
-                            • {t('accessControl.userToken.resetPoints.stop')}
-                        </Typography>
-                    </Stack>
-                    <Alert severity="warning" sx={{ mt: 2 }}>
-                        {t('accessControl.userToken.resetWarning')}
-                    </Alert>
-                </DialogContent>
-                <DialogActions sx={{ px: 3, pb: 2 }}>
-                    <Button onClick={() => setResetUserDialogOpen(false)} disabled={resettingUser}>
-                        {t('accessControl.userToken.resetCancel')}
-                    </Button>
-                    <Button
-                        onClick={handleUserResetConfirm}
-                        variant="contained"
-                        color="warning"
-                        disabled={resettingUser}
-                        startIcon={resettingUser ? <CircularProgress size={16} /> : undefined}
-                    >
-                        {resettingUser ? t('accessControl.resetting') : t('accessControl.userToken.resetConfirmButton')}
-                    </Button>
-                </DialogActions>
-            </Dialog>
-            {/* Model Reset Confirmation Dialog */}
-            <Dialog open={resetModelDialogOpen} onClose={() => setResetModelDialogOpen(false)} maxWidth="sm" fullWidth>
-                <DialogTitle>
+                        <Stack sx={{ mt: 2 }} spacing={1}>
+                            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                                • {t('accessControl.userToken.resetPoints.new')}
+                            </Typography>
+                            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                                • {t('accessControl.userToken.resetPoints.session')}
+                            </Typography>
+                            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                                • {t('accessControl.userToken.resetPoints.other')}
+                            </Typography>
+                            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                                • {t('accessControl.userToken.resetPoints.stop')}
+                            </Typography>
+                        </Stack>
+                        <Alert severity="warning" sx={{ mt: 2 }}>
+                            {t('accessControl.userToken.resetWarning')}
+                        </Alert>
+                    </>
+                }
+            />
+            <ConfirmDialog
+                open={resetModelDialogOpen}
+                onClose={() => setResetModelDialogOpen(false)}
+                onConfirm={handleModelResetConfirm}
+                loading={resettingModel}
+                confirmColor="warning"
+                confirmLabel={t('accessControl.modelToken.resetConfirmButton')}
+                confirmingLabel={t('accessControl.resetting')}
+                cancelLabel={t('accessControl.modelToken.resetCancel')}
+                title={
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <WarningIcon color="warning" />
                         <Typography variant="h6">{t('accessControl.modelToken.resetTitle')}</Typography>
                     </Box>
-                </DialogTitle>
-                <DialogContent>
-                    <Typography variant="body1" gutterBottom>
-                        {t('accessControl.modelToken.resetConfirm')}
-                    </Typography>
-                    <Stack sx={{ mt: 2 }} spacing={1}>
-                        <Typography variant="body2" sx={{
-                            color: "text.secondary"
-                        }}>
-                            • {t('accessControl.modelToken.resetPoints.new')}
+                }
+                description={
+                    <>
+                        <Typography variant="body1" gutterBottom>
+                            {t('accessControl.modelToken.resetConfirm')}
                         </Typography>
-                        <Typography variant="body2" sx={{
-                            color: "text.secondary"
-                        }}>
-                            • {t('accessControl.modelToken.resetPoints.stop')}
-                        </Typography>
-                    </Stack>
-                    <Alert severity="warning" sx={{ mt: 2 }}>
-                        {t('accessControl.modelToken.resetWarning')}
-                    </Alert>
-                </DialogContent>
-                <DialogActions sx={{ px: 3, pb: 2 }}>
-                    <Button onClick={() => setResetModelDialogOpen(false)} disabled={resettingModel}>
-                        {t('accessControl.modelToken.resetCancel')}
-                    </Button>
-                    <Button
-                        onClick={handleModelResetConfirm}
-                        variant="contained"
-                        color="warning"
-                        disabled={resettingModel}
-                        startIcon={resettingModel ? <CircularProgress size={16} /> : undefined}
-                    >
-                        {resettingModel ? t('accessControl.resetting') : t('accessControl.modelToken.resetConfirmButton')}
-                    </Button>
-                </DialogActions>
-            </Dialog>
+                        <Stack sx={{ mt: 2 }} spacing={1}>
+                            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                                • {t('accessControl.modelToken.resetPoints.new')}
+                            </Typography>
+                            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                                • {t('accessControl.modelToken.resetPoints.stop')}
+                            </Typography>
+                        </Stack>
+                        <Alert severity="warning" sx={{ mt: 2 }}>
+                            {t('accessControl.modelToken.resetWarning')}
+                        </Alert>
+                    </>
+                }
+            />
         </PageLayout>
     );
 };

--- a/frontend/src/pages/system/AccessControl.tsx
+++ b/frontend/src/pages/system/AccessControl.tsx
@@ -25,6 +25,7 @@ import {
     Security as SecurityIcon,
 } from '@/components/icons';
 import { useTranslation } from 'react-i18next';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 import { api } from '@/services/api.ts';
 import { useAuth } from '@/contexts/AuthContext.tsx';
 import { PageLayout } from '@/components/PageLayout.tsx';
@@ -171,11 +172,12 @@ const AccessControl = () => {
     const [resetModelDialogOpen, setResetModelDialogOpen] = useState(false);
     const [userSuccessToken, setUserSuccessToken] = useState<string | null>(null);
     const [modelSuccessToken, setModelSuccessToken] = useState<string | null>(null);
-    // Which token's copy button most recently succeeded — scoped per token so
-    // copying the user token doesn't also flash "Copied!" on the model token's
-    // button (and vice versa). The row and its own reset-success banner share
-    // a key since they display the same underlying value.
-    const [copiedKey, setCopiedKey] = useState<'user' | 'model' | null>(null);
+    // Separate copy-feedback per token so copying the user token doesn't also
+    // flash "Copied!" on the model token's button (and vice versa). The row
+    // and its own reset-success banner share one flag since they display the
+    // same underlying value.
+    const { copied: copiedUser, copy: copyUserToken } = useCopyFeedback();
+    const { copied: copiedModel, copy: copyModelToken } = useCopyFeedback();
 
     // Visibility states for showing full tokens
     const [showUserToken, setShowUserToken] = useState(false);
@@ -202,18 +204,6 @@ const AccessControl = () => {
         loadModelToken();
     }, []);
 
-    const handleCopyToken = async (token: string, key: 'user' | 'model') => {
-        try {
-            await navigator.clipboard.writeText(token);
-            setCopiedKey(key);
-            // Only clear if nothing newer has claimed the "copied" flag —
-            // avoids a fast second copy of the same token having its
-            // feedback cut short by the first copy's timer.
-            setTimeout(() => setCopiedKey((current) => (current === key ? null : current)), 2000);
-        } catch (err) {
-            console.error('Failed to copy token:', err);
-        }
-    };
 
     const handleUserResetClick = () => {
         setResetUserDialogOpen(true);
@@ -341,8 +331,8 @@ const AccessControl = () => {
                         title={t('accessControl.userToken.resetSuccess')}
                         message={t('accessControl.userToken.resetSuccessMessage')}
                         token={userSuccessToken}
-                        copiedTooltip={copiedKey === 'user'}
-                        onCopy={() => handleCopyToken(userSuccessToken, 'user')}
+                        copiedTooltip={copiedUser}
+                        onCopy={() => copyUserToken(userSuccessToken)}
                         copyLabel={t('accessControl.copy')}
                         copiedLabel={t('accessControl.copied')}
                         acknowledgeLabel={t('accessControl.userToken.saved')}
@@ -356,8 +346,8 @@ const AccessControl = () => {
                         title={t('accessControl.modelToken.resetSuccess')}
                         message={t('accessControl.modelToken.resetSuccessMessage')}
                         token={modelSuccessToken}
-                        copiedTooltip={copiedKey === 'model'}
-                        onCopy={() => handleCopyToken(modelSuccessToken, 'model')}
+                        copiedTooltip={copiedModel}
+                        onCopy={() => copyModelToken(modelSuccessToken)}
                         copyLabel={t('accessControl.copy')}
                         copiedLabel={t('accessControl.copied')}
                         acknowledgeLabel={t('accessControl.modelToken.saved')}
@@ -397,8 +387,8 @@ const AccessControl = () => {
                                     displayValue={showUserToken ? displayUserToken : maskToken(displayUserToken)}
                                     revealed={showUserToken}
                                     onToggleReveal={() => setShowUserToken(!showUserToken)}
-                                    onCopy={() => handleCopyToken(displayUserToken, 'user')}
-                                    copiedTooltip={copiedKey === 'user'}
+                                    onCopy={() => copyUserToken(displayUserToken)}
+                                    copiedTooltip={copiedUser}
                                 />
                                 {!isUsingDefaultToken && !userSuccessToken && (
                                     <Typography
@@ -442,8 +432,8 @@ const AccessControl = () => {
                                     displayValue={showModelToken ? displayModelToken : maskToken(displayModelToken)}
                                     revealed={showModelToken}
                                     onToggleReveal={() => setShowModelToken(!showModelToken)}
-                                    onCopy={() => handleCopyToken(displayModelToken, 'model')}
-                                    copiedTooltip={copiedKey === 'model'}
+                                    onCopy={() => copyModelToken(displayModelToken)}
+                                    copiedTooltip={copiedModel}
                                 />
                             </Stack>
                         </Box>

--- a/frontend/src/pages/system/System.tsx
+++ b/frontend/src/pages/system/System.tsx
@@ -1,8 +1,9 @@
 import CardGrid from '@/components/CardGrid.tsx';
 import { PageLayout } from '@/components/PageLayout.tsx';
 import UnifiedCard from '@/components/UnifiedCard.tsx';
-import { Logout, Refresh as RefreshIcon, CheckCircle as IconCircleCheck, Cancel as IconCircleX, Info as IconInfoCircle, Lock as IconLock, License as IconLicense, GitHub as IconBrandGithub, Translate as IconLanguage, Brush as IconBrush, Check as IconCheck, AccessTime as IconClock, ContentCopy as IconContentCopy, Router as IconRouter } from '@/components/icons';
+import { Logout, Refresh as RefreshIcon, CheckCircle as IconCircleCheck, Cancel as IconCircleX, Info as IconInfoCircle, Lock as IconLock, License as IconLicense, GitHub as IconBrandGithub, Translate as IconLanguage, Brush as IconBrush, Check as IconCheck, AccessTime as IconClock, Router as IconRouter } from '@/components/icons';
 import { UpdatePanelDialog } from '@/components/UpdatePanelDialog';
+import { CopyIconButton } from '@/components/CopyIconButton';
 import { Box, Button, CircularProgress, Divider, IconButton, InputAdornment, Link, Stack, Switch, TextField, Tooltip, Typography, Chip, type SxProps, type Theme } from '@mui/material';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
@@ -11,7 +12,6 @@ import { useHealth } from '@/contexts/HealthContext.tsx';
 import { useVersion } from '@/contexts/VersionContext.tsx';
 import { useAuth } from '@/contexts/AuthContext.tsx';
 import { useThemeMode } from '@/contexts/ThemeContext.tsx';
-import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 import { useNotify } from '@/hooks/useNotify.ts';
 import { api } from '@/services/api.ts';
 import { getThemeOptions } from '@/theme/options.ts';
@@ -86,7 +86,6 @@ const System = () => {
     const [globalProxyUrl, setGlobalProxyUrl] = useState('');
     const [globalProxyInput, setGlobalProxyInput] = useState('');
     const [proxyUrlSaving, setProxyUrlSaving] = useState(false);
-    const { copied: copiedVersion, copy: copyVersion } = useCopyFeedback();
     const isServerStatusAvailable = Boolean(serverStatus);
     const serverStatusLabel = !isServerStatusAvailable
         ? t('system.status.unavailable')
@@ -107,10 +106,7 @@ const System = () => {
         notify.success(t('system.language.saveSuccess'));
     };
 
-    const handleCopyVersion = () => {
-        const value = (currentVersion || 'Unknown').split('+')[0];
-        copyVersion(value, () => notify.success(t('system.about.versionCopied')));
-    };
+    const displayVersion = (currentVersion || 'Unknown').split('+')[0];
 
     useEffect(() => {
         loadAllData();
@@ -246,16 +242,15 @@ const System = () => {
                             icon={<IconInfoCircle sx={{ fontSize: 16, color: 'text.secondary' }} />}
                             label={t('system.about.version')}
                             action={
-                                <Tooltip title={copiedVersion ? t('common.copied') : t('system.about.copyVersion')} placement="top" arrow>
-                                    <IconButton
-                                        size="small"
-                                        onClick={handleCopyVersion}
-                                        aria-label={t('system.about.copyVersion')}
-                                        sx={{ color: 'text.secondary' }}
-                                    >
-                                        {copiedVersion ? <IconCheck sx={{ fontSize: 16, color: 'success.main' }} /> : <IconContentCopy sx={{ fontSize: 16 }} />}
-                                    </IconButton>
-                                </Tooltip>
+                                <CopyIconButton
+                                    value={displayVersion}
+                                    label={t('system.about.copyVersion')}
+                                    copiedLabel={t('common.copied')}
+                                    iconSize={16}
+                                    tooltipPlacement="top"
+                                    tooltipArrow
+                                    onCopied={() => notify.success(t('system.about.versionCopied'))}
+                                />
                             }
                         >
                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>

--- a/frontend/src/pages/system/System.tsx
+++ b/frontend/src/pages/system/System.tsx
@@ -11,6 +11,7 @@ import { useHealth } from '@/contexts/HealthContext.tsx';
 import { useVersion } from '@/contexts/VersionContext.tsx';
 import { useAuth } from '@/contexts/AuthContext.tsx';
 import { useThemeMode } from '@/contexts/ThemeContext.tsx';
+import { useCopyFeedback } from '@/hooks/useCopyFeedback';
 import { useNotify } from '@/hooks/useNotify.ts';
 import { api } from '@/services/api.ts';
 import { getThemeOptions } from '@/theme/options.ts';
@@ -85,7 +86,7 @@ const System = () => {
     const [globalProxyUrl, setGlobalProxyUrl] = useState('');
     const [globalProxyInput, setGlobalProxyInput] = useState('');
     const [proxyUrlSaving, setProxyUrlSaving] = useState(false);
-    const [copiedVersion, setCopiedVersion] = useState(false);
+    const { copied: copiedVersion, copy: copyVersion } = useCopyFeedback();
     const isServerStatusAvailable = Boolean(serverStatus);
     const serverStatusLabel = !isServerStatusAvailable
         ? t('system.status.unavailable')
@@ -108,11 +109,7 @@ const System = () => {
 
     const handleCopyVersion = () => {
         const value = (currentVersion || 'Unknown').split('+')[0];
-        navigator.clipboard.writeText(value).then(() => {
-            setCopiedVersion(true);
-            notify.success(t('system.about.versionCopied'));
-            setTimeout(() => setCopiedVersion(false), 2000);
-        });
+        copyVersion(value, () => notify.success(t('system.about.versionCopied')));
     };
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
Follow-ups from a frontend duplication audit: consolidate hand-rolled copy-feedback state onto the existing `useCopyFeedback` hook, then adopt `ConfirmDialog` and a new `CopyIconButton` to remove the duplicated chrome built on top of it.

## Key Changes

- **Copy-feedback consolidation**: 9 files migrated from local `useState` + `setTimeout` to `useCopyFeedback` (21 call sites), including `ShortcutCard` and `System.tsx`.
- **Hook API**: extended `useCopyFeedback` with an optional `onCopied` callback (for a toast) and `reset()` (for a dialog clearing on close) — both additive.
- **CopyIconButton**: new component for the Tooltip + IconButton + ContentCopy⇄Check chrome that was hand-written at every call site (byte-identical in three); migrated 8 files / 13 call sites.
- **ConfirmDialog adoption**: 7 hand-rolled delete/reset dialogs (`AccessControl` ×2, `UseTeamPage`, `SharingKeysDialog`, `SharingKeysPage`, `ClaudeCodeProfilePage`, `rule-card/dialogs`, `CustomModelCard`) swapped for the existing, already-used `ConfirmDialog`.
- **Notification consistency**: `ProvidersCard` now uses `useNotify` instead of a local `Snackbar`/`Alert`, matching every other `useProviderDialog` consumer.
- **Docs**: added a short "reuse existing hooks" tip to `frontend/CLAUDE.md`.

## Minor
- Left ~10 clipboard/dialog call sites unchanged where they don't cleanly fit the shared shape: an `onCopy` escape hatch used by ~25 config-modal call sites (`CodeBlock`), externally-shared/resettable copy state (`AccessControl`, `AgentSetupCard`), or a custom icon/forced-open tooltip.

https://claude.ai/code/session_01SKstHBcD3WXAGWznuosYcS