### PR TITLE
fix(frontend): stop hardcoding the gateway's address in a few places

### DIFF
--- a/frontend/src/components/model-select/ModelsPanel.tsx
+++ b/frontend/src/components/model-select/ModelsPanel.tsx
@@ -28,32 +28,11 @@ import { useRecentModels } from '@/hooks/useRecentModels';
 import { useNewModels } from '@/hooks/useNewModels';
 import { useModelDescriptions } from '@/hooks/useModelDescriptions';
 import { notify } from '@/utils/notify';
+import { fetchUIAPI } from '@/services/api';
 import CustomModelCard from './CustomModelCard';
 import ModelCard from './ModelCard';
 import RecentModelsSection from './RecentModelsSection';
 import NewModelsSection from './NewModelsSection';
-
-async function fetchUIAPI(url: string, options: RequestInit = {}): Promise<any> {
-    const basePath = window.location.origin;
-    const fullUrl = `${basePath}/api/v1${url}`;
-
-    const token = localStorage.getItem('user_auth_token');
-
-    const response = await fetch(fullUrl, {
-        ...options,
-        headers: {
-            'Content-Type': 'application/json',
-            ...(token && { Authorization: `Bearer ${token}` }),
-            ...options.headers,
-        },
-    });
-
-    if (!response.ok) {
-        throw new Error(`API error: ${response.status}`);
-    }
-
-    return response.json();
-}
 
 // Convert ProviderModelData.quota to ProviderQuota type
 function convertToProviderQuota(

--- a/frontend/src/hooks/useProviderQuota.ts
+++ b/frontend/src/hooks/useProviderQuota.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNotify } from '@/hooks/useNotify';
+import { fetchUIAPI } from '@/services/api';
 import type { ProviderQuota } from '@/types/quota';
 
 interface ProviderQuotaData {
@@ -14,36 +15,9 @@ interface UseProviderQuotaOptions {
   fetchOnMount?: boolean;
 }
 
-/**
- * Helper function to fetch from API
- */
 /** 404 means the provider has no quota to show — not an error worth raising. */
 function isMissingQuota(error: unknown): boolean {
   return (error as { status?: number })?.status === 404;
-}
-
-async function fetchUIAPI(url: string, options: RequestInit = {}): Promise<any> {
-  const basePath = window.location.origin;
-  const fullUrl = `${basePath}/api/v1${url}`;
-
-  const token = localStorage.getItem('user_auth_token');
-
-  const response = await fetch(fullUrl, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(token && { Authorization: `Bearer ${token}` }),
-      ...options.headers,
-    },
-  });
-
-  if (!response.ok) {
-    // The status rides along so callers can tell "this provider has no quota"
-    // (404) from a real failure, and stay quiet about the former.
-    throw Object.assign(new Error(`API error: ${response.status}`), { status: response.status });
-  }
-
-  return response.json();
 }
 
 /**

--- a/frontend/src/pages/mcp/AgentInstallCard.tsx
+++ b/frontend/src/pages/mcp/AgentInstallCard.tsx
@@ -10,12 +10,13 @@
  *   <AgentInstallCard sectionNumber="02" />
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Alert, Box, Chip, Typography } from '@mui/material';
 import {
     Terminal as TerminalIcon,
 } from '@/components/icons';
 import { CopyIconButton } from '@/components/CopyIconButton';
+import { getApiBaseUrl } from '@/utils/protocol';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -179,39 +180,62 @@ export interface AgentInstallCardProps {
     footer?: React.ReactNode;
 }
 
-const DEFAULT_MCP_COMMAND = `claude mcp add --transport http tb "http://localhost:12580/api/v1/mcp/tb" --header "Authorization: Bearer $(cat ~/.tingly-box/config.json | jq -r '.user_token')"`;
-
-const DEFAULT_CODEX_COMMAND = `codex mcp add tb -- http http://localhost:12580/api/v1/mcp/tb \\\n  --header "Authorization: Bearer $(cat ~/.tingly-box/config.json | jq -r '.user_token')"`;
-
-const DEFAULT_OPENCODE_COMMAND = `"mcp": {\n  "http://localhost:12580/api/v1/mcp/tb": {\n    "type": "remote",\n    "url": "http://localhost:12580/api/v1/mcp/tb",\n    "oauth": false,\n    "headers": {\n      "Authorization": "Bearer {MY_API_KEY}"\n    }\n  }\n}`;
-
-const DEFAULT_RUNTIME_OPTIONS: RuntimeOptions = {
-    claude: {
-        label: 'Claude Code',
-        filename: 'register-tb.sh',
-        command: DEFAULT_MCP_COMMAND,
-    },
-    codex: {
-        label: 'Codex',
-        filename: 'register-tb.sh',
-        command: DEFAULT_CODEX_COMMAND,
-    },
-    opencode: {
-        label: 'OpenCode',
-        filename: '~/.config/opencode/opencode.json',
-        command: DEFAULT_OPENCODE_COMMAND,
-    },
+// The token is read from local config at run time (`~/.tingly-box/config.json`),
+// so these commands only need to be correct about *where* the gateway is
+// bound — which is why the endpoint is built from the resolved API base URL
+// (buildDefaultRuntimeOptions) rather than hardcoded, so it stays correct
+// when the server isn't on the default port.
+const buildDefaultRuntimeOptions = (baseUrl: string): RuntimeOptions => {
+    const endpoint = `${baseUrl}/api/v1/mcp/tb`;
+    return {
+        claude: {
+            label: 'Claude Code',
+            filename: 'register-tb.sh',
+            command: `claude mcp add --transport http tb "${endpoint}" --header "Authorization: Bearer $(cat ~/.tingly-box/config.json | jq -r '.user_token')"`,
+        },
+        codex: {
+            label: 'Codex',
+            filename: 'register-tb.sh',
+            command: `codex mcp add tb -- http ${endpoint} \\\n  --header "Authorization: Bearer $(cat ~/.tingly-box/config.json | jq -r '.user_token')"`,
+        },
+        opencode: {
+            label: 'OpenCode',
+            filename: '~/.config/opencode/opencode.json',
+            command: `"mcp": {\n  "${endpoint}": {\n    "type": "remote",\n    "url": "${endpoint}",\n    "oauth": false,\n    "headers": {\n      "Authorization": "Bearer {MY_API_KEY}"\n    }\n  }\n}`,
+        },
+    };
 };
 
+// Fallback shown before getApiBaseUrl() resolves — matches the gateway's
+// documented default port, same as every other "not yet loaded" placeholder
+// in the scenario pages.
+const DEFAULT_BASE_URL = 'http://localhost:12580';
+
 export const AgentInstallCard: React.FC<AgentInstallCardProps> = ({
-    runtimeOptions = DEFAULT_RUNTIME_OPTIONS,
+    runtimeOptions,
     sectionNumber = '01',
     heading = 'Add to agents',
     subtitle = 'Register the gateway with your coding agent. Run once per machine.',
     footer,
 }) => {
     const [runtime, setRuntime] = useState<AgentRuntime>('claude');
-    const config = runtimeOptions[runtime];
+    const [baseUrl, setBaseUrl] = useState(DEFAULT_BASE_URL);
+
+    useEffect(() => {
+        // Only needed for the default commands; an explicit runtimeOptions
+        // override means the caller already resolved its own base URL.
+        if (runtimeOptions) return;
+        let isMounted = true;
+        getApiBaseUrl().then(url => {
+            if (isMounted) setBaseUrl(url);
+        });
+        return () => {
+            isMounted = false;
+        };
+    }, [runtimeOptions]);
+
+    const resolvedOptions = runtimeOptions ?? buildDefaultRuntimeOptions(baseUrl);
+    const config = resolvedOptions[runtime];
 
     return (
         <Box>
@@ -298,7 +322,7 @@ export const AgentInstallCard: React.FC<AgentInstallCardProps> = ({
 
                     {/* Runtime pills */}
                     <RuntimeSelector
-                        options={runtimeOptions}
+                        options={resolvedOptions}
                         value={runtime}
                         onChange={setRuntime}
                     />

--- a/frontend/src/pages/mcp/MCPLocalMode.tsx
+++ b/frontend/src/pages/mcp/MCPLocalMode.tsx
@@ -16,14 +16,23 @@ import {
 import { CopyIconButton } from '@/components/CopyIconButton';
 import { useEffect, useState } from 'react';
 import { useNotify } from '@/hooks/useNotify';
+import { getApiBaseUrl } from '@/utils/protocol';
 
 const MCPLocalMode = () => {
     const notify = useNotify();
     const [baseUrl, setBaseUrl] = useState('');
 
     useEffect(() => {
-        const url = window.location.origin;
-        setBaseUrl(url);
+        let isMounted = true;
+        // getApiBaseUrl() (not window.location.origin) so this also resolves
+        // correctly in GUI/Wails mode, where the frontend's own origin does
+        // not necessarily match the backend's bound port.
+        getApiBaseUrl().then(url => {
+            if (isMounted) setBaseUrl(url);
+        });
+        return () => {
+            isMounted = false;
+        };
     }, []);
 
     const getEndpointUrl = () => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -109,6 +109,35 @@ export async function enrichBotsWithCapabilities(bots: BotSettings[]): Promise<B
     }));
 }
 
+// Raw fetch helper for tingly-box's own control-plane API (`/api/v1/...`),
+// authenticated with the browser's `user_auth_token`. Resolves the base URL
+// through getApiBaseUrl() rather than window.location.origin so it also
+// works in GUI/Wails mode, where the frontend's own origin does not
+// necessarily match the backend's port.
+export async function fetchUIAPI(url: string, options: RequestInit = {}): Promise<any> {
+    const base = await getApiBaseUrl();
+    const fullUrl = `${base}/api/v1${url}`;
+
+    const token = getUserAuthToken();
+
+    const response = await fetch(fullUrl, {
+        ...options,
+        headers: {
+            'Content-Type': 'application/json',
+            ...(token && {Authorization: `Bearer ${token}`}),
+            ...options.headers,
+        },
+    });
+
+    if (!response.ok) {
+        // The status rides along so callers can tell "this provider has no
+        // quota" (404) from a real failure, and stay quiet about the former.
+        throw Object.assign(new Error(`API error: ${response.status}`), {status: response.status});
+    }
+
+    return response.json();
+}
+
 export const api = {
     // Initialize API client
     initialize: async (): Promise<void> => {


### PR DESCRIPTION
## Summary
A few frontend spots built the tingly-box API URL by hand instead of the shared `getApiBaseUrl()`, silently showing the wrong address for non-default ports or GUI mode.

## Key Changes

- **MCP install commands**: `AgentInstallCard`'s default commands hardcoded `localhost:12580`; now built from the resolved base URL.
- **GUI-mode consistency**: `MCPLocalMode.tsx` now uses `getApiBaseUrl()` instead of `window.location.origin`.
- **Dedup**: `useProviderQuota.ts` / `ModelsPanel.tsx`'s duplicated `fetchUIAPI` consolidated into `services/api.ts`.
