### PR TITLE
docs(readme): add self-hosted model server section to integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,30 @@ This works with any tool that supports OpenAI-compatible endpoints: Cherry Studi
 </details>
 
 <details>
+<summary><strong>Self-Hosted Model Servers - vLLM / SGLang / Ollama / LM Studio / LocalAI / Jan</strong></summary>
+
+Already running your own inference server? Tingly Box connects to it like any other provider and exposes it through the same unified gateway.
+
+**Supported out of the box**
+
+- vLLM
+- SGLang
+- Ollama
+- LM Studio
+- LocalAI
+- Jan
+
+Anything else that speaks an OpenAI/Anthropic-compatible API still works via **Custom endpoint**.
+
+**Quick Setup**
+
+1. Open Web UI like `http://localhost:12580`
+2. Click **Connect AI** → pick your engine from the **Self-hosted** section (default URL and key are pre-filled)
+3. **Test Connection**, then save — it's now usable like any other provider
+
+</details>
+
+<details>
 <summary><strong>Web Management UI</strong></summary>
 
 Launch the web management interface:


### PR DESCRIPTION
## Summary
Users running self-hosted inference servers (vLLM, SGLang, etc.) had no pointer in the README telling them how to connect an already-deployed server to Tingly Box, even though the Connect AI dialog already supports it.

## Key Changes

- **README integration guide**: new collapsible section listing the six supported self-hosted engines (vLLM, SGLang, Ollama, LM Studio, LocalAI, Jan) and the Custom-endpoint fallback, with a 3-step pointer to the Connect AI → Self-hosted flow.
