### PR TITLE
fix(quota): declare the provider-quota endpoints in openapi.json

### DIFF
--- a/internal/server/module/providerquota/handler.go
+++ b/internal/server/module/providerquota/handler.go
@@ -13,34 +13,37 @@ import (
 	"github.com/tingly-dev/tingly-box/ai/quota"
 )
 
-// Manager 配额管理器接口
+// Manager is the quota manager interface.
 type Manager interface {
-	// GetQuota 获取指定供应商的配额（读库存数据，不触发上游拉取；新鲜度由后台 refresher 保证）
+	// GetQuota returns the given provider's quota (reads stored data, does not
+	// trigger an upstream fetch; freshness is guaranteed by the background refresher).
 	GetQuota(ctx context.Context, providerUUID string) (*quota.ProviderUsage, error)
-	// ListQuota 获取所有供应商的配额列表
+	// ListQuota returns the quota list for every provider.
 	ListQuota(ctx context.Context) ([]*quota.ProviderUsage, error)
-	// Refresh 刷新所有启用的供应商配额
+	// Refresh refreshes quota for every enabled provider.
 	Refresh(ctx context.Context) ([]*quota.ProviderUsage, error)
-	// RefreshProvider 刷新指定供应商的配额
+	// RefreshProvider refreshes quota for one provider.
 	RefreshProvider(ctx context.Context, providerUUID string) (*quota.ProviderUsage, error)
-	// Summary 获取配额汇总
+	// Summary returns the aggregate quota summary.
 	Summary(ctx context.Context) (*quota.Summary, error)
 	// IsProviderSupported reports whether the provider has a registered quota
 	// fetcher. Callers should skip quota fetching when this returns false.
 	IsProviderSupported(providerUUID string) bool
-	// StartAutoRefresh 启动自动刷新
+	// StartAutoRefresh starts automatic refresh.
 	StartAutoRefresh(ctx context.Context)
-	// StopAutoRefresh 停止自动刷新
+	// StopAutoRefresh stops automatic refresh.
 	StopAutoRefresh()
 }
 
-// Handler 配额 API 处理器
+// Handler is the quota API handler.
 type Handler struct {
 	manager Manager
 	logger  *logrus.Logger
 }
 
-// NewHandler 创建处理器
+// NewHandler creates the handler. manager may be nil when quota tracking is
+// not configured, or during OpenAPI schema generation — every handler method
+// checks available() first.
 func NewHandler(manager Manager, logger *logrus.Logger) *Handler {
 	return &Handler{
 		manager: manager,
@@ -48,34 +51,37 @@ func NewHandler(manager Manager, logger *logrus.Logger) *Handler {
 	}
 }
 
-// RegisterRoutes 注册路由
-func (h *Handler) RegisterRoutes(r *gin.RouterGroup) {
-	quota := r.Group("/provider-quota")
-	{
-		quota.GET("", h.ListQuota)
-		quota.POST("/batch", h.BatchGetQuota) // 批量获取指定 providers 的 quota
-		quota.GET("/:uuid", h.GetQuota)
-		quota.POST("/refresh", h.RefreshAll)
-		quota.POST("/:uuid/refresh", h.RefreshProvider)
-		quota.GET("/summary", h.Summary)
+// available reports whether quota tracking is configured, answering 503 when
+// it is not. Routes are registered unconditionally (see routes.go) so they
+// appear in openapi.json on every build; this is what keeps that safe.
+func (h *Handler) available(c *gin.Context) bool {
+	if h.manager != nil {
+		return true
 	}
+	c.JSON(http.StatusServiceUnavailable, gin.H{
+		"error": "quota tracking is not enabled on this tingly-box",
+	})
+	return false
 }
 
-// ListQuotaResponse 列表响应
+// ListQuotaResponse is the list response.
 type ListQuotaResponse struct {
 	Meta MetaData               `json:"meta"`
 	Data []*quota.ProviderUsage `json:"data"`
 }
 
-// MetaData 元数据
+// MetaData is the response metadata.
 type MetaData struct {
 	Total     int       `json:"total"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// ListQuota 获取所有供应商配额
+// ListQuota returns quota for every provider.
 // GET /api/v1/provider-quota
 func (h *Handler) ListQuota(c *gin.Context) {
+	if !h.available(c) {
+		return
+	}
 	ctx := c.Request.Context()
 
 	usages, err := h.manager.ListQuota(ctx)
@@ -96,9 +102,12 @@ func (h *Handler) ListQuota(c *gin.Context) {
 	})
 }
 
-// GetQuota 获取指定供应商配额
+// GetQuota returns quota for the given provider.
 // GET /api/v1/provider-quota/:uuid
 func (h *Handler) GetQuota(c *gin.Context) {
+	if !h.available(c) {
+		return
+	}
 	uuid := c.Param("uuid")
 	if uuid == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -129,9 +138,12 @@ func (h *Handler) GetQuota(c *gin.Context) {
 	c.JSON(http.StatusOK, usage)
 }
 
-// RefreshAll 刷新所有配额
+// RefreshAll refreshes quota for every provider.
 // POST /api/v1/provider-quota/refresh
 func (h *Handler) RefreshAll(c *gin.Context) {
+	if !h.available(c) {
+		return
+	}
 	ctx := c.Request.Context()
 
 	usages, err := h.manager.Refresh(ctx)
@@ -152,9 +164,12 @@ func (h *Handler) RefreshAll(c *gin.Context) {
 	})
 }
 
-// RefreshProvider 刷新指定供应商配额
+// RefreshProvider refreshes quota for the given provider.
 // POST /api/v1/provider-quota/:uuid/refresh
 func (h *Handler) RefreshProvider(c *gin.Context) {
+	if !h.available(c) {
+		return
+	}
 	uuid := c.Param("uuid")
 	if uuid == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -183,9 +198,12 @@ func (h *Handler) RefreshProvider(c *gin.Context) {
 	c.JSON(http.StatusOK, usage)
 }
 
-// Summary 获取配额汇总
+// Summary returns the aggregate quota summary.
 // GET /api/v1/provider-quota/summary
 func (h *Handler) Summary(c *gin.Context) {
+	if !h.available(c) {
+		return
+	}
 	ctx := c.Request.Context()
 
 	summary, err := h.manager.Summary(ctx)
@@ -200,21 +218,24 @@ func (h *Handler) Summary(c *gin.Context) {
 	c.JSON(http.StatusOK, summary)
 }
 
-// BatchGetQuotaRequest 批量获取配额请求
+// BatchGetQuotaRequest is the batch quota request.
 type BatchGetQuotaRequest struct {
-	// ProviderUUIDs 需要获取配额的供应商 UUID 列表
+	// ProviderUUIDs is the list of provider UUIDs to fetch quota for.
 	ProviderUUIDs []string `json:"provider_uuids" binding:"required"`
 }
 
-// BatchGetQuotaResponse 批量获取配额响应
+// BatchGetQuotaResponse is the batch quota response.
 type BatchGetQuotaResponse struct {
 	Data map[string]*quota.ProviderUsage `json:"data"` // key: provider_uuid, value: quota data
 }
 
-// BatchGetQuota 批量获取指定供应商的配额
+// BatchGetQuota returns quota for a specific set of providers.
 // POST /api/v1/provider-quota/batch
 // Body: { "provider_uuids": ["uuid1", "uuid2", "uuid3"] }
 func (h *Handler) BatchGetQuota(c *gin.Context) {
+	if !h.available(c) {
+		return
+	}
 	var req BatchGetQuotaRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -233,7 +254,7 @@ func (h *Handler) BatchGetQuota(c *gin.Context) {
 
 	ctx := c.Request.Context()
 
-	// 并发获取多个 provider 的 quota
+	// Fetch quota for multiple providers concurrently.
 	result := make(map[string]*quota.ProviderUsage)
 	var mu sync.Mutex
 	var wg sync.WaitGroup
@@ -245,7 +266,8 @@ func (h *Handler) BatchGetQuota(c *gin.Context) {
 			defer wg.Done()
 			usage, err := h.manager.GetQuota(ctx, providerUUID)
 			if err != nil {
-				// 如果某个 provider 没有 quota 数据（或不支持配额），不返回错误，只是跳过
+				// If a provider has no quota data (or doesn't support quota),
+				// skip it silently rather than returning an error.
 				if !errors.Is(err, quota.ErrUsageNotFound) && !errors.Is(err, quota.ErrProviderUnsupported) {
 					h.logger.WithError(err).WithField("provider_uuid", providerUUID).Warn("failed to get quota for provider")
 					errChan <- err
@@ -261,13 +283,13 @@ func (h *Handler) BatchGetQuota(c *gin.Context) {
 	wg.Wait()
 	close(errChan)
 
-	// 收集错误（如果有）
+	// Collect errors, if any.
 	var fetchErrors []error
 	for err := range errChan {
 		fetchErrors = append(fetchErrors, err)
 	}
 
-	// 如果全部失败，返回错误
+	// If everything failed, return an error.
 	if len(result) == 0 && len(fetchErrors) > 0 {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "failed to get quota for any provider",

--- a/internal/server/module/providerquota/routes.go
+++ b/internal/server/module/providerquota/routes.go
@@ -1,0 +1,51 @@
+package providerquota
+
+import (
+	"github.com/tingly-dev/tingly-box/ai/quota"
+	"github.com/tingly-dev/tingly-box/swagger"
+)
+
+// RegisterRoutes registers the provider-quota API routes with swagger
+// documentation, mirroring how every other module under internal/server/module
+// registers into apiV1. Registered unconditionally (regardless of whether a
+// quota manager is actually configured) so the routes — and their response
+// models — always appear in openapi.json and every generated client;
+// Handler.available() answers 503 at request time when there is no manager.
+func RegisterRoutes(router *swagger.RouteGroup, handler *Handler) {
+	router.GET("/provider-quota", handler.ListQuota,
+		swagger.WithTags("provider-quota"),
+		swagger.WithDescription("List cached quota for every provider that has a quota fetcher"),
+		swagger.WithResponseModel(ListQuotaResponse{}),
+	)
+
+	router.POST("/provider-quota/batch", handler.BatchGetQuota,
+		swagger.WithTags("provider-quota"),
+		swagger.WithDescription("Fetch quota for a specific set of providers in one call"),
+		swagger.WithRequestModel(BatchGetQuotaRequest{}),
+		swagger.WithResponseModel(BatchGetQuotaResponse{}),
+	)
+
+	router.GET("/provider-quota/summary", handler.Summary,
+		swagger.WithTags("provider-quota"),
+		swagger.WithDescription("Aggregate quota summary across all providers"),
+		swagger.WithResponseModel(quota.Summary{}),
+	)
+
+	router.GET("/provider-quota/:uuid", handler.GetQuota,
+		swagger.WithTags("provider-quota"),
+		swagger.WithDescription("Quota for one provider, served from cache when fresh"),
+		swagger.WithResponseModel(quota.ProviderUsage{}),
+	)
+
+	router.POST("/provider-quota/refresh", handler.RefreshAll,
+		swagger.WithTags("provider-quota"),
+		swagger.WithDescription("Force a refresh of every provider's quota from upstream"),
+		swagger.WithResponseModel(ListQuotaResponse{}),
+	)
+
+	router.POST("/provider-quota/:uuid/refresh", handler.RefreshProvider,
+		swagger.WithTags("provider-quota"),
+		swagger.WithDescription("Force a refresh of one provider's quota from upstream"),
+		swagger.WithResponseModel(quota.ProviderUsage{}),
+	)
+}

--- a/internal/server/server_control.go
+++ b/internal/server/server_control.go
@@ -229,12 +229,12 @@ func (s *Server) UseUIEndpoints(ctx context.Context) {
 	mcpHandler := mcpmodule.NewHandler(s.config, s.mcpRuntime)
 	mcpmodule.RegisterRoutes(apiV1, mcpHandler, mcpHandler.GetLocalHandler(), mcpHandler.GetTransportHandler())
 
-	// Provider quota API routes
-	if s.quotaManager != nil {
-		quotaHandler := providerQuotaModule.NewHandler(s.quotaManager, logrus.StandardLogger())
-		quotaHandler.RegisterRoutes(apiV1.Router)
-		logrus.Info("Provider quota API routes registered")
-	}
+	// Provider quota API routes — registered unconditionally (nil manager is
+	// safe; Handler.available() answers 503 per request) so the routes and
+	// their response models always appear in openapi.json regardless of
+	// whether quota tracking happens to be configured on this build.
+	quotaHandler := providerQuotaModule.NewHandler(s.quotaManager, logrus.StandardLogger())
+	providerQuotaModule.RegisterRoutes(apiV1, quotaHandler)
 
 	// Static files and templates - try embedded assets first, fallback to filesystem
 	UseWebStaticEndpoints(s.engine)

--- a/internal/server/swagger.go
+++ b/internal/server/swagger.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 	"github.com/tingly-dev/tingly-box/internal/server/config"
 	"github.com/tingly-dev/tingly-box/internal/server/module/codeximport"
 	"github.com/tingly-dev/tingly-box/internal/server/module/configapply"
@@ -13,6 +14,7 @@ import (
 	mcpmodule "github.com/tingly-dev/tingly-box/internal/server/module/mcp"
 	notifymodule "github.com/tingly-dev/tingly-box/internal/server/module/notify"
 	oauthmodule "github.com/tingly-dev/tingly-box/internal/server/module/oauth"
+	providerQuotaModule "github.com/tingly-dev/tingly-box/internal/server/module/providerquota"
 	"github.com/tingly-dev/tingly-box/internal/server/module/sharing"
 	"github.com/tingly-dev/tingly-box/internal/server/module/statusline"
 	team "github.com/tingly-dev/tingly-box/internal/server/module/team"
@@ -125,6 +127,9 @@ func registerAllAPIRoutes(engine *gin.Engine, manager *swagger.RouteManager, s *
 	sharing.RegisterRoutes(apiV1, sharing.NewHandler(nil))
 	team.RegisterRoutes(apiV1, team.NewHandler(nil))
 
-	// Provider quota API routes
-	// Note: skipped for OpenAPI generation as quotaManager is not available
+	// Provider quota API routes — nil manager; schema generation only
+	// references the handler, and available() guards every method at
+	// request time (there is no request time here).
+	quotaHandler := providerQuotaModule.NewHandler(nil, logrus.StandardLogger())
+	providerQuotaModule.RegisterRoutes(apiV1, quotaHandler)
 }

--- a/openapi.json
+++ b/openapi.json
@@ -4412,6 +4412,173 @@
         }
       }
     },
+    "/api/v1/provider-quota": {
+      "get": {
+        "tags": [
+          "provider-quota"
+        ],
+        "summary": "List cached quota for every provider that has a quota fetcher",
+        "description": "List cached quota for every provider that has a quota fetcher",
+        "operationId": "apiV1Provider-quotaGet",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListQuotaResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provider-quota/batch": {
+      "post": {
+        "tags": [
+          "provider-quota"
+        ],
+        "summary": "Fetch quota for a specific set of providers in one call",
+        "description": "Fetch quota for a specific set of providers in one call",
+        "operationId": "apiV1Provider-quotaBatchPost",
+        "requestBody": {
+          "description": "Request body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchGetQuotaRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchGetQuotaResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provider-quota/refresh": {
+      "post": {
+        "tags": [
+          "provider-quota"
+        ],
+        "summary": "Force a refresh of every provider's quota from upstream",
+        "description": "Force a refresh of every provider's quota from upstream",
+        "operationId": "apiV1Provider-quotaRefreshPost",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListQuotaResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provider-quota/summary": {
+      "get": {
+        "tags": [
+          "provider-quota"
+        ],
+        "summary": "Aggregate quota summary across all providers",
+        "description": "Aggregate quota summary across all providers",
+        "operationId": "apiV1Provider-quotaSummaryGet",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Summary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provider-quota/{uuid}": {
+      "get": {
+        "tags": [
+          "provider-quota"
+        ],
+        "summary": "Quota for one provider, served from cache when fresh",
+        "description": "Quota for one provider, served from cache when fresh",
+        "operationId": "apiV1Provider-quotaUuidGet",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "Unique identifier (UUID)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderUsage"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provider-quota/{uuid}/refresh": {
+      "post": {
+        "tags": [
+          "provider-quota"
+        ],
+        "summary": "Force a refresh of one provider's quota from upstream",
+        "description": "Force a refresh of one provider's quota from upstream",
+        "operationId": "apiV1Provider-quotaUuidRefreshPost",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "Unique identifier (UUID)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderUsage"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/requests": {
       "get": {
         "tags": [
@@ -8322,6 +8489,36 @@
           "data"
         ]
       },
+      "BatchGetQuotaRequest": {
+        "type": "object",
+        "properties": {
+          "provider_uuids": {
+            "type": "array",
+            "description": "Field provider_uuids",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "provider_uuids"
+        ]
+      },
+      "BatchGetQuotaResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "description": "Field data",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ProviderUsage"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
       "BlockedUpdateRequest": {
         "type": "object",
         "properties": {
@@ -11111,6 +11308,25 @@
           "success"
         ]
       },
+      "ListQuotaResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "description": "Field data",
+            "items": {
+              "$ref": "#/components/schemas/ProviderUsage"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/MetaData"
+          }
+        },
+        "required": [
+          "meta",
+          "data"
+        ]
+      },
       "ListResponse": {
         "type": "object",
         "properties": {
@@ -11528,6 +11744,25 @@
           "num_gc",
           "num_goroutine",
           "gc_forced"
+        ]
+      },
+      "MetaData": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field total"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Field updated_at"
+          }
+        },
+        "required": [
+          "total",
+          "updated_at"
         ]
       },
       "ModelInfo": {
@@ -14871,6 +15106,55 @@
           "status_code"
         ]
       },
+      "Summary": {
+        "type": "object",
+        "properties": {
+          "by_status": {
+            "type": "object",
+            "description": "Field by_status",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "by_type": {
+            "type": "object",
+            "description": "Field by_type",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "error_providers": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field error_providers"
+          },
+          "ok_providers": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field ok_providers"
+          },
+          "total_providers": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field total_providers"
+          },
+          "warning_providers": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Field warning_providers"
+          }
+        },
+        "required": [
+          "total_providers",
+          "ok_providers",
+          "error_providers",
+          "warning_providers",
+          "by_status",
+          "by_type"
+        ]
+      },
       "SystemLogEntry": {
         "type": "object",
         "properties": {
@@ -17198,6 +17482,10 @@
     {
       "name": "onboarding",
       "description": "Operations related to onboarding"
+    },
+    {
+      "name": "provider-quota",
+      "description": "Operations related to provider-quota"
     },
     {
       "name": "providers",


### PR DESCRIPTION
## Summary
`provider-quota`'s six endpoints were mounted with no swagger annotations, so they never reached `openapi.json` — reachable from the UI, unreachable from any generated client, in any language.

## Key Changes

- **Provider-quota API discoverability**: adds swagger declarations (`routes.go`) for all six endpoints (list, batch, summary, get, refresh-all, refresh-one), matching how every other module under `internal/server/module` registers into `apiV1`.
- **Schema-generation safety**: registration moves out of the `quotaManager != nil` gate and becomes unconditional; a new `available()` guard on the handler answers 503 per-request when there's no manager instead, so the routes (and their response models) register — and reach `openapi.json` — even during schema generation, which constructs the handler with a nil manager.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAHB6zhqMd4uR12tLmVu5C)_