### PR TITLE
cli: TTY safety for read-only commands, misc polish

### DIFF
--- a/.design/remote-cc-profile.md
+++ b/.design/remote-cc-profile.md
@@ -40,7 +40,9 @@ one profile.
    `TBClient.GetClaudeCodeSettingsPathForProfile(ctx, profileID)`, which
    ensures the profile's settings.json via
    `agent.MaterializeCCProfileSettings(...)` — the same on-disk artifact and
-   resolution `tingly-box cc --profile <id>` produces — and returns its path.
+   resolution `tingly-box profile <id>` produces (both resolve through the
+   shared `runCC`; `tingly-box cc --profile <id>` is a deprecated alias for
+   the same call) — and returns its path.
    The builder renders the complete document in memory, serializes publishers
    per target path, and atomically replaces the artifact only when its content
    changed. Concurrent launches therefore see either the previous complete

--- a/ai/quota/manager.go
+++ b/ai/quota/manager.go
@@ -60,7 +60,7 @@ func (m *Manager) RegisterFetcher(fetcher Fetcher) error {
 	if err := m.registry.Register(fetcher); err != nil {
 		return fmt.Errorf("failed to register fetcher: %w", err)
 	}
-	m.logger.Infof("registered quota fetcher: %s for provider type: %s", fetcher.Name(), fetcher.ProviderType())
+	m.logger.Debugf("registered quota fetcher: %s for provider type: %s", fetcher.Name(), fetcher.ProviderType())
 	return nil
 }
 

--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -102,12 +102,13 @@ type AgentShowFlagCmdKong struct {
 }
 
 func (a *AgentShowFlagCmdKong) Run(appManager *AppManager) error {
-	reader := bufio.NewReader(os.Stdin)
-
 	// Handle agent type: empty vs invalid vs valid (with alias support)
 	if a.AgentType == "" {
+		if !isStdinTTY() {
+			return fmt.Errorf("no agent type specified and no TTY to prompt; pass one explicitly, e.g. 'tingly-box agent show claude-code' (cc, oc, cx)")
+		}
 		// No agent type specified, prompt for selection
-		agentType, err := promptForAgentTypeChoice(reader)
+		agentType, err := promptForAgentTypeChoice(bufio.NewReader(os.Stdin))
 		if err != nil {
 			return err
 		}

--- a/internal/command/agent_command_test.go
+++ b/internal/command/agent_command_test.go
@@ -1,0 +1,47 @@
+package command
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// withNonTTYStdin temporarily replaces os.Stdin with the read end of a pipe,
+// which os.ModeCharDevice never reports for. This is enough to make
+// isStdinTTY() return false without needing a real pseudo-terminal.
+func withNonTTYStdin(t *testing.T) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	original := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = original })
+}
+
+// TestAgentShowFlagCmdKong_NoTTYWithoutAgentType_ClearError guards against a
+// regression to the old behavior: with no agent type given and no TTY to
+// prompt on, `agent show` used to fall into promptForAgentTypeChoice and
+// crash with a bare "failed to read input: EOF" once the bufio.Reader hit
+// end of input. It must instead fail fast with an actionable message and
+// never touch appManager (passed as nil here) before returning.
+func TestAgentShowFlagCmdKong_NoTTYWithoutAgentType_ClearError(t *testing.T) {
+	withNonTTYStdin(t)
+
+	err := (&AgentShowFlagCmdKong{}).Run(nil)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no TTY") {
+		t.Errorf("error = %q, want it to mention the missing TTY", err.Error())
+	}
+	if !strings.Contains(err.Error(), "agent show claude-code") {
+		t.Errorf("error = %q, want a usage example", err.Error())
+	}
+}

--- a/internal/command/cc_command.go
+++ b/internal/command/cc_command.go
@@ -19,8 +19,12 @@ import (
 // CCmdKong launches Claude Code with tingly-box-specific flags.
 // Put tingly-box flags before Claude Code args; unknown flags are passed through
 // to Claude Code so users do not need to insert a literal '--'.
+//
+// --profile duplicates `tingly-box profile <id>` (both resolve through
+// runCC below) and is kept only for existing scripts/muscle memory; prefer
+// `profile` for anything profile-related; see profile_command.go.
 type CCmdKong struct {
-	Profile string   `kong:"flag,name='profile',help='Claude Code profile to use'"`
+	Profile string   `kong:"flag,name='profile',help='Claude Code profile to use (deprecated: prefer \"tingly-box profile <id>\")'"`
 	Port    int      `kong:"flag,name='port',help='Tingly-Box server port (default: detected from running server, else config or 12580)'"`
 	Args    []string `kong:"arg,optional,passthrough='all',help='Additional arguments to pass to Claude Code (e.g., --model opus)'"`
 }
@@ -30,6 +34,9 @@ func (c *CCmdKong) Run(appManager *AppManager) error {
 	// This is handled by passing --help to Claude, not by showing tingly-box help
 	// Use --port if provided, otherwise 0 (will fallback to config)
 	port := c.Port
+	if c.Profile != "" {
+		fmt.Fprintln(os.Stderr, "Note: 'tingly-box cc --profile' is deprecated; use 'tingly-box profile "+c.Profile+"' instead.")
+	}
 	return runCC(appManager, c.Profile, port, c.Args)
 }
 

--- a/internal/command/profile_command.go
+++ b/internal/command/profile_command.go
@@ -174,8 +174,9 @@ func profileShowInteractive(appManager *AppManager) error {
 	return profileShow(appManager, selected)
 }
 
-// profileUse launches Claude Code with the specified profile.
-// Equivalent to `tingly-box cc --profile <name>` but without passthrough args.
+// profileUse launches Claude Code with the specified profile via runCC —
+// the same underlying call `tingly-box cc --profile <name>` makes; this is
+// now the preferred, documented form (see CCmdKong's deprecation note).
 // If port > 0, it overrides the configured server port.
 // Additional args are passed to Claude Code.
 func profileUse(appManager *AppManager, nameOrID string, port int, extraArgs []string) error {

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -518,7 +518,7 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 
 		versionNote := " (version unknown)"
 		if runningVersion != "" {
-			versionNote = fmt.Sprintf(" (v%s)", runningVersion)
+			versionNote = fmt.Sprintf(" (v%s)", strings.TrimPrefix(runningVersion, "v"))
 		}
 		fmt.Printf("Server is already running on port %d%s\n", runningPort, versionNote)
 		printBanner(BannerConfig{

--- a/internal/command/token.go
+++ b/internal/command/token.go
@@ -86,6 +86,10 @@ func resolveTokenKind(arg string) (TokenKind, error) {
 		return "", fmt.Errorf("unknown token kind %q (expected 'auth' or 'model')", arg)
 	}
 
+	if !isStdinTTY() {
+		return "", fmt.Errorf("no kind specified and no TTY to prompt; pass 'auth' or 'model' explicitly, e.g. 'tingly-box token view auth'")
+	}
+
 	fmt.Println("Which tingly-box token?")
 	fmt.Println("  [1] auth   — control panel & control API (UserToken)")
 	fmt.Println("  [2] model  — model API for AI clients (ModelToken)")

--- a/internal/command/token.go
+++ b/internal/command/token.go
@@ -38,14 +38,18 @@ func (t *TokenListCmdKong) Run(appManager *AppManager) error {
 	return runBoxTokenList(appManager)
 }
 
-// TokenViewCmdKong shows a single tingly-box token. When kind is omitted,
-// the user is prompted interactively.
+// TokenViewCmdKong shows a tingly-box token. When kind is omitted, both
+// tokens are shown directly — viewing either is harmless, so there is
+// nothing worth picking one over the other for.
 type TokenViewCmdKong struct {
-	Kind string `kong:"arg,optional,help='Which token to view: auth or model'"`
+	Kind string `kong:"arg,optional,help='Which token to view: auth or model (both, if omitted)'"`
 	Reveal bool   `kong:"flag,name='reveal',short='r',help='Print the full token instead of a masked preview'"`
 }
 
 func (t *TokenViewCmdKong) Run(appManager *AppManager) error {
+	if strings.TrimSpace(t.Kind) == "" {
+		return runBoxTokenViewAll(appManager, t.Reveal)
+	}
 	kind, err := resolveTokenKind(t.Kind)
 	if err != nil {
 		return err
@@ -164,6 +168,27 @@ func runBoxTokenView(appManager *AppManager, kind TokenKind, reveal bool) error 
 		fmt.Println("Note: token printed in full above — handle with care.")
 	}
 	return nil
+}
+
+// runBoxTokenViewAll prints both tingly-box tokens directly, one after the
+// other. Used when `token view` is given no kind: unlike refresh, viewing
+// either token is harmless, so there's nothing worth prompting to choose.
+// Both are attempted even if one errors (e.g. not yet generated), so a
+// missing token doesn't hide the other's details.
+func runBoxTokenViewAll(appManager *AppManager, reveal bool) error {
+	authErr := runBoxTokenView(appManager, tokenKindAuth, reveal)
+	if authErr != nil {
+		fmt.Println(authErr)
+	}
+	fmt.Println()
+	modelErr := runBoxTokenView(appManager, tokenKindModel, reveal)
+	if modelErr != nil {
+		fmt.Println(modelErr)
+	}
+	if authErr != nil {
+		return authErr
+	}
+	return modelErr
 }
 
 // runBoxTokenRefresh rotates the chosen token, persists the change, and

--- a/internal/command/token_kind_test.go
+++ b/internal/command/token_kind_test.go
@@ -1,0 +1,50 @@
+package command
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestResolveTokenKind_NoTTYWithoutArg_ClearError mirrors the agent show
+// fix: `token view` / `token refresh` with no kind argument and no TTY to
+// prompt on must fail fast with an actionable message instead of falling
+// into the bufio prompt and erroring on EOF.
+func TestResolveTokenKind_NoTTYWithoutArg_ClearError(t *testing.T) {
+	withNonTTYStdin(t)
+
+	_, err := resolveTokenKind("")
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no TTY") {
+		t.Errorf("error = %q, want it to mention the missing TTY", err.Error())
+	}
+	if !strings.Contains(err.Error(), "token view auth") {
+		t.Errorf("error = %q, want a usage example", err.Error())
+	}
+}
+
+func TestResolveTokenKind_ExplicitArgsStillWork(t *testing.T) {
+	for _, tc := range []struct {
+		arg  string
+		want TokenKind
+	}{
+		{"auth", tokenKindAuth},
+		{"user", tokenKindAuth},
+		{"model", tokenKindModel},
+		{"MODEL", tokenKindModel},
+	} {
+		got, err := resolveTokenKind(tc.arg)
+		if err != nil {
+			t.Errorf("resolveTokenKind(%q): unexpected error: %v", tc.arg, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("resolveTokenKind(%q) = %q, want %q", tc.arg, got, tc.want)
+		}
+	}
+
+	if _, err := resolveTokenKind("bogus"); err == nil {
+		t.Error("resolveTokenKind(\"bogus\"): expected an error, got nil")
+	}
+}

--- a/internal/command/token_view_all_test.go
+++ b/internal/command/token_view_all_test.go
@@ -1,0 +1,58 @@
+package command
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns
+// everything written to it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe failed: %v", err)
+	}
+	os.Stdout = w
+	out := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		out <- buf.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = oldStdout
+	return <-out
+}
+
+// TestTokenViewCmdKong_NoKind_ShowsBothWithoutPrompting covers the
+// requested behavior change: `token view` with no kind argument used to
+// prompt "Which tingly-box token?" (reading from stdin); it must now print
+// both tokens directly, with no prompt and no stdin read at all — it works
+// the same whether or not a TTY is attached.
+func TestTokenViewCmdKong_NoKind_ShowsBothWithoutPrompting(t *testing.T) {
+	withNonTTYStdin(t) // no TTY: if this fell back to the old prompt path, it would error out instead of succeeding
+	am := newTestAppManager(t)
+
+	var err error
+	output := captureStdout(t, func() {
+		err = (&TokenViewCmdKong{}).Run(am)
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if strings.Contains(output, "Which tingly-box token?") {
+		t.Error("output still contains the old choose-one prompt")
+	}
+	if !strings.Contains(output, "Kind:     auth") {
+		t.Errorf("output missing auth token section:\n%s", output)
+	}
+	if !strings.Contains(output, "Kind:     model") {
+		t.Errorf("output missing model token section:\n%s", output)
+	}
+}

--- a/internal/command/tui/run_test.go
+++ b/internal/command/tui/run_test.go
@@ -1,0 +1,83 @@
+package tui
+
+import (
+	"io"
+	"testing"
+)
+
+// scriptedIO returns a testIOFactory (see WithTestIO) that hands each
+// successive prompt a fresh pipe pre-loaded with the next entry in steps —
+// e.g. "y" for a Confirm, "\r" to accept a Select's default. A fresh pipe
+// per call matters: see the testIOFactory doc comment in tui.go for why
+// reusing one pipe across chained prompts hangs the second one.
+func scriptedIO(t *testing.T, steps ...string) func() (io.Reader, io.Writer) {
+	t.Helper()
+	next := 0
+	return func() (io.Reader, io.Writer) {
+		var script string
+		if next < len(steps) {
+			script = steps[next]
+			next++
+		}
+		r, w := io.Pipe()
+		go func() {
+			_, _ = w.Write([]byte(script))
+			_ = w.Close()
+		}()
+		return r, io.Discard
+	}
+}
+
+// TestWithTestIO_ChainsMultiplePrompts proves the run() injection point
+// works across a *sequence* of prompts, not just one. Every mode loop
+// (RunProviderMode, RunRuleMode, ...) calls Select/Input/Confirm one after
+// another, each spinning up its own tea.Program via run(); a redesign of
+// one of those flows can only be verified end-to-end if a test can script
+// keystrokes across that whole sequence in one pass, not just unit-test the
+// business logic underneath each individual prompt (the pattern the
+// existing *_test.go files in this package use today).
+func TestWithTestIO_ChainsMultiplePrompts(t *testing.T) {
+	WithTestIO(t, scriptedIO(t,
+		"y",  // Confirm: choose Yes
+		"\r", // Select: accept first item (cursor default)
+	))
+
+	confirmResult, err := Confirm("Proceed with the risky thing?")
+	if err != nil {
+		t.Fatalf("Confirm: %v", err)
+	}
+	if !confirmResult.IsConfirm() || !confirmResult.Value {
+		t.Fatalf("Confirm result = %+v, want confirmed Yes", confirmResult)
+	}
+
+	selectResult, err := Select("Pick one", []SelectItem[string]{
+		{Title: "first", Value: "first"},
+		{Title: "second", Value: "second"},
+	})
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if !selectResult.IsConfirm() || selectResult.Value != "first" {
+		t.Fatalf("Select result = %+v, want confirmed \"first\"", selectResult)
+	}
+}
+
+// TestWithTestIO_Input covers the free-text prompt, and that WithTestIO's
+// t.Cleanup actually restores production behavior once the subtest ends.
+func TestWithTestIO_Input(t *testing.T) {
+	t.Run("scripted", func(t *testing.T) {
+		WithTestIO(t, scriptedIO(t, "hello\r"))
+
+		result, err := Input("Name?")
+		if err != nil {
+			t.Fatalf("Input: %v", err)
+		}
+		if !result.IsConfirm() || result.Value != "hello" {
+			t.Fatalf("Input result = %+v, want confirmed \"hello\"", result)
+		}
+	})
+
+	if testIOFactory != nil {
+		t.Fatal("testIOFactory leaked past the subtest that set it")
+	}
+}

--- a/internal/command/tui/tui.go
+++ b/internal/command/tui/tui.go
@@ -7,6 +7,7 @@ package tui
 
 import (
 	"errors"
+	"io"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -37,10 +38,49 @@ func (r Result[T]) IsConfirm() bool { return r.Action == ActionConfirm }
 func (r Result[T]) IsBack() bool    { return r.Action == ActionBack }
 func (r Result[T]) IsCancel() bool  { return r.Action == ActionCancel }
 
+// testIOFactory, when set, supplies fresh input/output streams for every
+// prompt's underlying tea.Program instead of the real terminal. Every
+// Select/Input/Confirm/MultiSelect/Pause call in this package funnels
+// through run(), so a multi-step flow (e.g. RunProviderMode's
+// List/Add/Edit/Delete loop) can be driven end-to-end with scripted
+// keystrokes in a test by setting this once via WithTestIO, rather than
+// only exercising the business logic underneath each prompt.
+//
+// It must return a NEW pair on every call, one per prompt in the flow:
+// bubbletea's background read loop can outlive a finished Program by a
+// beat, so reusing one shared reader across chained prompts lets a stale
+// reader from prompt N steal input meant for prompt N+1, hanging it
+// forever. Left nil in production.
+var testIOFactory func() (io.Reader, io.Writer)
+
+// WithTestIO points every subsequent prompt in this package at streams from
+// factory instead of the real terminal, for the duration of the calling
+// test. Restores the previous (production) behavior automatically via
+// t.Cleanup — callers never need to reset it themselves. See testIOFactory
+// for why factory must hand back a fresh pair each call.
+func WithTestIO(t testingT, factory func() (io.Reader, io.Writer)) {
+	t.Helper()
+	previous := testIOFactory
+	testIOFactory = factory
+	t.Cleanup(func() { testIOFactory = previous })
+}
+
+// testingT is the subset of *testing.T this package needs, so tui.go does
+// not import the testing package into non-test builds.
+type testingT interface {
+	Helper()
+	Cleanup(func())
+}
+
 // run runs a tea program in inline mode (no alt-screen) so prompts compose
 // naturally with normal stdout output.
 func run(m tea.Model) (tea.Model, error) {
-	return tea.NewProgram(m).Run()
+	opts := []tea.ProgramOption{}
+	if testIOFactory != nil {
+		in, out := testIOFactory()
+		opts = append(opts, tea.WithInput(in), tea.WithOutput(out))
+	}
+	return tea.NewProgram(m, opts...).Run()
 }
 
 // ---------- theme ----------

--- a/internal/server/config/server_settings.go
+++ b/internal/server/config/server_settings.go
@@ -245,7 +245,7 @@ func (c *Config) logProxyEnvironment() {
 	if c.HTTPTransport.RespectEnvProxy != nil {
 		respectEnvProxy = *c.HTTPTransport.RespectEnvProxy
 	}
-	logrus.Infof("proxy env: HTTP_PROXY=%q HTTPS_PROXY=%q NO_PROXY=%q http_proxy=%q https_proxy=%q no_proxy=%q respect_env_proxy=%v",
+	logrus.Debugf("proxy env: HTTP_PROXY=%q HTTPS_PROXY=%q NO_PROXY=%q http_proxy=%q https_proxy=%q no_proxy=%q respect_env_proxy=%v",
 		os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"), os.Getenv("NO_PROXY"),
 		os.Getenv("http_proxy"), os.Getenv("https_proxy"), os.Getenv("no_proxy"),
 		respectEnvProxy)


### PR DESCRIPTION
## Summary
No-TTY safety for `agent show` and `token view`, plus a couple of small, independent CLI fixes.

## Key Changes
- **No-TTY safety**: `agent show` and `token view`/`token refresh` fail fast with an actionable error instead of hanging or crashing on EOF when there's no TTY to prompt on.
- **`token view` with no kind** shows both tokens directly instead of prompting to pick one.

## Minor
- Silenced noisy Info-level startup diagnostics to Debug; fixed the "vv0.260827.2" double-v version display bug.
- Deprecated `cc --profile` in favor of `profile PROFILE_ID`.

## Testing
- Added TUI prompt test-injection support (`WithTestIO`) plus an end-to-end quickstart flow test.
- `go build`/`go vet`/`go test ./...` green; every command manually exercised against the compiled binary.