### PR TITLE
cli: agent apply never prompts; -y/--yes; TTY safety

### DIFF
--- a/.design/tui.md
+++ b/.design/tui.md
@@ -287,7 +287,7 @@ provisioning flow fits in three lines, no TTY required:
 tingly-box config provider add openai https://api.openai.com $TOKEN openai
 tingly-box config rule add --scenario openai \
   --request-model gpt-4o --provider openai --model gpt-4o
-tingly-box agent apply claude-code --provider openai --model gpt-4o --force
+tingly-box agent apply claude-code --provider openai --model gpt-4o -y
 ```
 
 Three rules for CLI commands that overlap with TUI functionality:

--- a/ai/agent/info.go
+++ b/ai/agent/info.go
@@ -43,7 +43,7 @@ func ListAgentInfo() []AgentInfo {
 		{
 			Type:        AgentTypeCodex,
 			Name:        "Codex",
-			Description: "OpenAI Codex CLI (@codex)",
+			Description: "OpenAI Codex CLI",
 			ConfigFiles: []string{
 				"~/.codex/config.toml",
 				"~/.codex/auth.json",

--- a/ai/agent/parse.go
+++ b/ai/agent/parse.go
@@ -10,7 +10,8 @@ import (
 // Supported aliases:
 //   - "cc", "claude", "claude-code" -> AgentTypeClaudeCode
 //   - "oc", "opencode" -> AgentTypeOpenCode
-//   - "cx", "codex" -> AgentTypeCodex
+//   - "codex" -> AgentTypeCodex (no shorthand — unlike @cc/@oc, there's no
+//     established "@codex"-style abbreviation for it)
 //   - "dsh" -> AgentTypeDsh
 func ParseAgentType(input string) (AgentType, error) {
 	if input == "" {
@@ -24,11 +25,11 @@ func ParseAgentType(input string) (AgentType, error) {
 		return AgentTypeClaudeCode, nil
 	case "oc", "opencode", "open-code":
 		return AgentTypeOpenCode, nil
-	case "cx", "codex":
+	case "codex":
 		return AgentTypeCodex, nil
 	case "dsh":
 		return AgentTypeDsh, nil
 	default:
-		return "", fmt.Errorf("unknown agent type: %s (supported: cc/claude-code, oc/opencode, cx/codex, dsh)", input)
+		return "", fmt.Errorf("unknown agent type: %s (supported: cc/claude-code, oc/opencode, codex, dsh)", input)
 	}
 }

--- a/ai/agent/parse_test.go
+++ b/ai/agent/parse_test.go
@@ -73,12 +73,12 @@ func TestParseAgentType(t *testing.T) {
 			want:    AgentTypeOpenCode,
 			wantErr: false,
 		},
-		// Codex aliases
+		// Codex: no shorthand, unlike cc/oc
 		{
-			name:    "cx alias",
+			name:    "cx is not a valid alias",
 			input:   "cx",
-			want:    AgentTypeCodex,
-			wantErr: false,
+			want:    "",
+			wantErr: true,
 		},
 		{
 			name:    "codex full",

--- a/ai/agent/types.go
+++ b/ai/agent/types.go
@@ -47,8 +47,8 @@ type ApplyAgentRequest struct {
 	// Only applicable for AgentTypeClaudeCode
 	Unified bool
 
-	// Force skips confirmation prompts
-	Force bool
+	// Yes skips the confirmation prompt (CLI's -y/--yes)
+	Yes bool
 
 	// Preview shows what would be applied without actually applying
 	Preview bool
@@ -101,8 +101,8 @@ type RestoreAgentRequest struct {
 	// AgentType is the type of agent to restore (required)
 	AgentType AgentType
 
-	// Force skips confirmation prompts (CLI use)
-	Force bool
+	// Yes skips the confirmation prompt (CLI's -y/--yes)
+	Yes bool
 }
 
 // RestoreAgentResult represents the result of restoring agent configuration.

--- a/cli/tingly-box/main_test.go
+++ b/cli/tingly-box/main_test.go
@@ -247,11 +247,11 @@ func TestAgentApplyUnifiedDefaultIsTrue(t *testing.T) {
 // TestAgentRestoreCommandExists ensures agent restore subcommand is available.
 func TestAgentRestoreCommandExists(t *testing.T) {
 	cli, parser := newTestParser(t)
-	if _, err := parser.Parse([]string{"agent", "restore", "claude-code", "--force"}); err != nil {
+	if _, err := parser.Parse([]string{"agent", "restore", "claude-code", "-y"}); err != nil {
 		t.Fatalf("agent restore should parse: %v", err)
 	}
-	if !cli.Agent.Restore.Force {
-		t.Error("Restore.Force should be true")
+	if !cli.Agent.Restore.Yes {
+		t.Error("Restore.Yes should be true")
 	}
 }
 

--- a/internal/agent/types_test.go
+++ b/internal/agent/types_test.go
@@ -27,8 +27,8 @@ func TestParseAgentType(t *testing.T) {
 		{"open-code with dash", "open-code", AgentTypeOpenCode, false},
 		{"OC uppercase", "OC", AgentTypeOpenCode, false},
 
-		// Valid Codex aliases
-		{"cx alias", "cx", AgentTypeCodex, false},
+		// Codex: no shorthand, unlike cc/oc
+		{"cx is not a valid alias", "cx", "", true},
 		{"codex full", "codex", AgentTypeCodex, false},
 		{"CODEX uppercase", "CODEX", AgentTypeCodex, false},
 

--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -32,7 +32,7 @@ func (a *AgentListFlagCmdKong) Run(appManager *AppManager) error {
 
 // AgentApplyFlagCmdKong applies agent configuration via flags
 type AgentApplyFlagCmdKong struct {
-	AgentType  string `kong:"arg,optional,help='Agent type (cc/claude-code, oc/opencode, cx/codex)'"`
+	AgentType  string `kong:"arg,optional,help='Agent type (cc/claude-code, oc/opencode, codex)'"`
 	Provider   string `kong:"flag,name='provider',help='Provider UUID (optional, uses routing rule if not specified)'"`
 	Model      string `kong:"flag,name='model',help='Model name (optional, uses routing rule if not specified)'"`
 	Unified    bool   `kong:"flag,name='unified',default='true',help='Unified mode (claude-code only)'"`
@@ -52,15 +52,15 @@ func (a *AgentApplyFlagCmdKong) Run(appManager *AppManager) error {
 	// never prompts to choose an agent type. Picking interactively is a
 	// TUI job (`tingly-box tui`).
 	if a.AgentType == "" {
-		return fmt.Errorf("agent type required: cc (claude-code), oc (opencode), or cx (codex), e.g. 'tingly-box agent apply claude-code'; run 'tingly-box tui' to pick interactively")
+		return fmt.Errorf("agent type required: cc (claude-code), oc (opencode), or codex, e.g. 'tingly-box agent apply claude-code'; run 'tingly-box tui' to pick interactively")
 	}
 	// Parse agent type with alias support (cc, claude-code, etc.)
 	parsedType, err := agent.ParseAgentType(a.AgentType)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Available agent types:")
 		fmt.Fprintln(os.Stderr, "  cc, claude-code - Claude Code CLI agent (@cc)")
-		fmt.Fprintln(os.Stderr, "  oc, opencode   - OpenCode editor agent (@oc)")
-		fmt.Fprintln(os.Stderr, "  cx, codex      - OpenAI Codex CLI (@codex)")
+		fmt.Fprintln(os.Stderr, "  oc, opencode    - OpenCode editor agent (@oc)")
+		fmt.Fprintln(os.Stderr, "  codex           - OpenAI Codex CLI")
 		return err
 	}
 	req.AgentType = parsedType

--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -4,12 +4,10 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/tingly-dev/tingly-box/internal/agent"
-	"github.com/tingly-dev/tingly-box/internal/typ"
 	"github.com/tingly-dev/tingly-box/internal/usecase"
 )
 
@@ -50,29 +48,22 @@ func (a *AgentApplyFlagCmdKong) Run(appManager *AppManager) error {
 	req.Force = a.Force
 	req.Preview = a.Preview
 
-	// Handle agent type: empty vs invalid vs valid (with alias support)
+	// apply is a one-shot "apply the defaults" command, not a wizard — it
+	// never prompts to choose an agent type. Picking interactively is a
+	// TUI job (`tingly-box tui`).
 	if a.AgentType == "" {
-		if !isStdinTTY() {
-			return fmt.Errorf("no agent type specified and no TTY to prompt; pass one explicitly, e.g. 'tingly-box agent apply claude-code' (cc, oc, cx)")
-		}
-		// No agent type specified, prompt for selection
-		agentType, err := promptForAgentTypeChoice(bufio.NewReader(os.Stdin))
-		if err != nil {
-			return err
-		}
-		req.AgentType = agentType
-	} else {
-		// Parse agent type with alias support (cc, claude-code, etc.)
-		parsedType, err := agent.ParseAgentType(a.AgentType)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Available agent types:")
-			fmt.Fprintln(os.Stderr, "  cc, claude-code - Claude Code CLI agent (@cc)")
-			fmt.Fprintln(os.Stderr, "  oc, opencode   - OpenCode editor agent (@oc)")
-			fmt.Fprintln(os.Stderr, "  cx, codex      - OpenAI Codex CLI (@codex)")
-			return err
-		}
-		req.AgentType = parsedType
+		return fmt.Errorf("agent type required: cc (claude-code), oc (opencode), or cx (codex), e.g. 'tingly-box agent apply claude-code'; run 'tingly-box tui' to pick interactively")
 	}
+	// Parse agent type with alias support (cc, claude-code, etc.)
+	parsedType, err := agent.ParseAgentType(a.AgentType)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Available agent types:")
+		fmt.Fprintln(os.Stderr, "  cc, claude-code - Claude Code CLI agent (@cc)")
+		fmt.Fprintln(os.Stderr, "  oc, opencode   - OpenCode editor agent (@oc)")
+		fmt.Fprintln(os.Stderr, "  cx, codex      - OpenAI Codex CLI (@codex)")
+		return err
+	}
+	req.AgentType = parsedType
 
 	// Resolve provider and model from routing rules if not explicitly specified
 	if req.Provider == "" || req.Model == "" {
@@ -241,48 +232,11 @@ func promptForAgentTypeChoice(reader *bufio.Reader) (agent.AgentType, error) {
 	}
 }
 
-// promptForAgentConfig prompts user for provider and model selection
-func promptForAgentConfig(reader *bufio.Reader, appManager *AppManager, req *agent.ApplyAgentRequest) error {
-	providers := usecase.NewProviderUseCase(appManager.GetGlobalConfig()).List().Providers
-	if len(providers) == 0 {
-		return fmt.Errorf("no providers configured. Please add a provider first using 'tingly-box config provider add' / 'tb config provider add'")
-	}
-
-	// Prompt for provider if not specified
-	if req.Provider == "" {
-		provider, err := promptForAgentProviderChoice(reader, providers)
-		if err != nil {
-			return fmt.Errorf("failed to select provider: %w", err)
-		}
-		req.Provider = provider.UUID
-	}
-
-	// Fetch models for the provider. ResolveProviderModels walks the full
-	// fallback chain, so providers whose /models endpoint is unsupported
-	// (e.g. Codex) still yield their embedded template catalog.
-	globalConfig := appManager.GetGlobalConfig()
-	resolved, err := globalConfig.ResolveProviderModels(true, false, req.Provider)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: Failed to fetch models from provider: %v\n", err)
-		fmt.Fprintln(os.Stderr, "Using cached model list...")
-	}
-	models := resolved.Models
-
-	// Prompt for model if not specified
-	if req.Model == "" {
-		model, err := promptForAgentModelChoice(reader, "Select model for "+string(req.AgentType), models)
-		if err != nil {
-			return fmt.Errorf("failed to select model: %w", err)
-		}
-		req.Model = model
-	}
-
-	return nil
-}
-
-// resolveAgentConfigFromRules resolves provider and model from existing routing rules.
-// This is the preferred way for "agent apply" - use what was configured by quickstart.
-// Falls back to prompting if no rules are configured.
+// resolveAgentConfigFromRules resolves provider and model from the existing
+// routing rule for req.AgentType's scenario — the smart default apply is
+// built around: whatever's already configured (via quickstart or the TUI),
+// applied as-is, no picker. Choosing a provider/model is TUI/Web UI work;
+// apply is a one-shot "apply the defaults" command, not a wizard.
 func resolveAgentConfigFromRules(appManager *AppManager, req *agent.ApplyAgentRequest) error {
 	globalConfig := appManager.GetGlobalConfig()
 	agentUC := usecase.NewAgentUseCase(globalConfig, "localhost")
@@ -305,34 +259,15 @@ func resolveAgentConfigFromRules(appManager *AppManager, req *agent.ApplyAgentRe
 		return nil
 	}
 
-	// No rule or no usable service is configured yet. This is not fatal:
-	// `agent apply` can still write the agent's config files so the agent
-	// CLI points at tingly-box. Routing rules can be configured later via
-	// `tingly-box tui`. Only fall back to the interactive prompt when there
-	// are providers available AND we're on a TTY; otherwise just warn.
+	// No rule or no usable service is configured yet. Not fatal: apply
+	// still writes the agent's config files so the CLI points at
+	// tingly-box, just without a routing rule. Set one up via
+	// `tingly-box tui` (or the Web UI) when ready.
 	fmt.Fprintf(os.Stderr,
 		"Warning: no routing service configured for '%s' (scenario '%s').\n",
 		routing.RequestModel, routing.Scenario)
 	fmt.Fprintln(os.Stderr,
-		"Config files will still be applied. Run 'tingly-box tui' / 'tb tui' to set up routing rules later.")
-
-	providers := usecase.NewProviderUseCase(appManager.GetGlobalConfig()).List().Providers
-	if len(providers) == 0 || !isStdinTTY() {
-		// Nothing to prompt for, or stdin is non-interactive — proceed
-		// without provider/model. applyClaudeCode/applyOpenCode handles
-		// the empty case by skipping rule sync.
-		return nil
-	}
-
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Fprintln(os.Stderr, "You may optionally select a provider/model now to also create routing rules:")
-	if err := promptForAgentConfig(reader, appManager, req); err != nil {
-		// Prompt failed (e.g. user aborted) — degrade to "config files only"
-		// rather than blocking the whole apply.
-		fmt.Fprintf(os.Stderr, "Warning: skipping routing rule setup: %v\n", err)
-		req.Provider = ""
-		req.Model = ""
-	}
+		"Config files will still be applied. Run 'tingly-box tui' / 'tb tui' to set up routing rules.")
 	return nil
 }
 
@@ -344,101 +279,6 @@ func isStdinTTY() bool {
 		return false
 	}
 	return (fi.Mode() & os.ModeCharDevice) != 0
-}
-
-// promptForAgentProviderChoice prompts user to select a provider
-func promptForAgentProviderChoice(reader *bufio.Reader, providers []*typ.Provider) (*typ.Provider, error) {
-	if len(providers) == 1 {
-		return providers[0], nil
-	}
-
-	fmt.Println("\nAvailable providers:")
-	sort.Slice(providers, func(i, j int) bool {
-		return strings.ToLower(providers[i].Name) < strings.ToLower(providers[j].Name)
-	})
-	for i, p := range providers {
-		fmt.Printf("%d. %s\n", i+1, p.Name)
-	}
-
-	for {
-		fmt.Print("\nSelect provider (enter number or name): ")
-		input, err := reader.ReadString('\n')
-		if err != nil {
-			return nil, fmt.Errorf("failed to read input: %w", err)
-		}
-		input = strings.TrimSpace(input)
-
-		// Try as number
-		if choice, err := strconv.Atoi(input); err == nil {
-			if choice >= 1 && choice <= len(providers) {
-				return providers[choice-1], nil
-			}
-		}
-
-		// Try as name
-		for _, p := range providers {
-			if strings.EqualFold(p.Name, input) {
-				return p, nil
-			}
-		}
-
-		fmt.Println("Invalid selection. Please try again.")
-	}
-}
-
-// promptForAgentModelChoice prompts user to select a model
-func promptForAgentModelChoice(reader *bufio.Reader, label string, models []string) (string, error) {
-	if len(models) == 0 {
-		return promptForAgentModelInput(reader, "Enter model name: ")
-	}
-
-	fmt.Printf("\n%s:\n", label)
-	for i, model := range models {
-		fmt.Printf("%d. %s\n", i+1, model)
-	}
-	fmt.Printf("0. Enter custom model\n")
-
-	for {
-		input, err := promptForAgentModelInput(reader, "Select model (number or name): ")
-		if err != nil {
-			return "", err
-		}
-
-		if input == "0" {
-			return promptForAgentModelInput(reader, "Enter custom model name: ")
-		}
-
-		// Try as number
-		if choice, err := strconv.Atoi(input); err == nil {
-			if choice >= 1 && choice <= len(models) {
-				return models[choice-1], nil
-			}
-		}
-
-		// Check if input matches a model name
-		for _, model := range models {
-			if strings.EqualFold(model, input) {
-				return model, nil
-			}
-		}
-
-		// Use the input as custom model
-		return input, nil
-	}
-}
-
-// promptForAgentModelInput reads a single line of input
-func promptForAgentModelInput(reader *bufio.Reader, prompt string) (string, error) {
-	fmt.Print(prompt)
-	input, err := reader.ReadString('\n')
-	if err != nil {
-		return "", fmt.Errorf("failed to read input: %w", err)
-	}
-	input = strings.TrimSpace(input)
-	if input == "" {
-		return "", fmt.Errorf("input is required")
-	}
-	return input, nil
 }
 
 // confirmApply prompts user to confirm the configuration

--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -37,7 +37,7 @@ type AgentApplyFlagCmdKong struct {
 	Model      string `kong:"flag,name='model',help='Model name (optional, uses routing rule if not specified)'"`
 	Unified    bool   `kong:"flag,name='unified',default='true',help='Unified mode (claude-code only)'"`
 	StatusLine bool   `kong:"flag,name='status-line',help='Install status line integration (claude-code only)'"`
-	Force      bool   `kong:"flag,name='force',help='Skip confirmation'"`
+	Yes        bool   `kong:"flag,name='yes',short='y',help='Skip the confirmation prompt'"`
 	Preview    bool   `kong:"flag,name='preview',help='Preview without applying'"`
 }
 
@@ -45,7 +45,7 @@ func (a *AgentApplyFlagCmdKong) Run(appManager *AppManager) error {
 	var req agent.ApplyAgentRequest
 	req.Unified = a.Unified
 	req.InstallStatusLine = a.StatusLine
-	req.Force = a.Force
+	req.Force = a.Yes
 	req.Preview = a.Preview
 
 	// apply is a one-shot "apply the defaults" command, not a wizard — it
@@ -77,10 +77,10 @@ func (a *AgentApplyFlagCmdKong) Run(appManager *AppManager) error {
 		return showPreview(appManager, &req)
 	}
 
-	// Confirm if not forced
+	// Confirm unless -y/--yes was passed
 	if !req.Force {
 		if !isStdinTTY() {
-			return fmt.Errorf("no TTY to confirm; re-run with --force to apply without prompting")
+			return fmt.Errorf("no TTY to confirm; re-run with -y/--yes to apply without prompting")
 		}
 		if err := confirmApply(bufio.NewReader(os.Stdin), &req); err != nil {
 			return err
@@ -100,7 +100,7 @@ func (a *AgentShowFlagCmdKong) Run(appManager *AppManager) error {
 	// Handle agent type: empty vs invalid vs valid (with alias support)
 	if a.AgentType == "" {
 		if !isStdinTTY() {
-			return fmt.Errorf("no agent type specified and no TTY to prompt; pass one explicitly, e.g. 'tingly-box agent show claude-code' (cc, oc, cx)")
+			return fmt.Errorf("no agent type specified and no TTY to prompt; pass one explicitly, e.g. 'tingly-box agent show claude-code' (cc, oc, codex)")
 		}
 		// No agent type specified, prompt for selection
 		agentType, err := promptForAgentTypeChoice(bufio.NewReader(os.Stdin))
@@ -122,12 +122,12 @@ func (a *AgentShowFlagCmdKong) Run(appManager *AppManager) error {
 // AgentRestoreFlagCmdKong restores agent configuration from backup
 type AgentRestoreFlagCmdKong struct {
 	AgentType string `kong:"arg,optional,help='Agent type to restore'"`
-	Force     bool   `kong:"flag,name='force',help='Skip confirmation prompt'"`
+	Yes       bool   `kong:"flag,name='yes',short='y',help='Skip the confirmation prompt'"`
 }
 
 func (a *AgentRestoreFlagCmdKong) Run(appManager *AppManager) error {
 	var req agent.RestoreAgentRequest
-	req.Force = a.Force
+	req.Force = a.Yes
 
 	reader := bufio.NewReader(os.Stdin)
 

--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -50,12 +50,13 @@ func (a *AgentApplyFlagCmdKong) Run(appManager *AppManager) error {
 	req.Force = a.Force
 	req.Preview = a.Preview
 
-	reader := bufio.NewReader(os.Stdin)
-
 	// Handle agent type: empty vs invalid vs valid (with alias support)
 	if a.AgentType == "" {
+		if !isStdinTTY() {
+			return fmt.Errorf("no agent type specified and no TTY to prompt; pass one explicitly, e.g. 'tingly-box agent apply claude-code' (cc, oc, cx)")
+		}
 		// No agent type specified, prompt for selection
-		agentType, err := promptForAgentTypeChoice(reader)
+		agentType, err := promptForAgentTypeChoice(bufio.NewReader(os.Stdin))
 		if err != nil {
 			return err
 		}
@@ -87,7 +88,10 @@ func (a *AgentApplyFlagCmdKong) Run(appManager *AppManager) error {
 
 	// Confirm if not forced
 	if !req.Force {
-		if err := confirmApply(reader, &req); err != nil {
+		if !isStdinTTY() {
+			return fmt.Errorf("no TTY to confirm; re-run with --force to apply without prompting")
+		}
+		if err := confirmApply(bufio.NewReader(os.Stdin), &req); err != nil {
 			return err
 		}
 	}

--- a/internal/command/agent_command.go
+++ b/internal/command/agent_command.go
@@ -45,7 +45,7 @@ func (a *AgentApplyFlagCmdKong) Run(appManager *AppManager) error {
 	var req agent.ApplyAgentRequest
 	req.Unified = a.Unified
 	req.InstallStatusLine = a.StatusLine
-	req.Force = a.Yes
+	req.Yes = a.Yes
 	req.Preview = a.Preview
 
 	// apply is a one-shot "apply the defaults" command, not a wizard — it
@@ -78,9 +78,9 @@ func (a *AgentApplyFlagCmdKong) Run(appManager *AppManager) error {
 	}
 
 	// Confirm unless -y/--yes was passed
-	if !req.Force {
-		if !isStdinTTY() {
-			return fmt.Errorf("no TTY to confirm; re-run with -y/--yes to apply without prompting")
+	if !req.Yes {
+		if err := requireTTY("re-run with -y/--yes to apply without prompting"); err != nil {
+			return err
 		}
 		if err := confirmApply(bufio.NewReader(os.Stdin), &req); err != nil {
 			return err
@@ -99,8 +99,8 @@ type AgentShowFlagCmdKong struct {
 func (a *AgentShowFlagCmdKong) Run(appManager *AppManager) error {
 	// Handle agent type: empty vs invalid vs valid (with alias support)
 	if a.AgentType == "" {
-		if !isStdinTTY() {
-			return fmt.Errorf("no agent type specified and no TTY to prompt; pass one explicitly, e.g. 'tingly-box agent show claude-code' (cc, oc, codex)")
+		if err := requireTTY("pass the agent type explicitly, e.g. 'tingly-box agent show claude-code' (cc, oc, codex)"); err != nil {
+			return err
 		}
 		// No agent type specified, prompt for selection
 		agentType, err := promptForAgentTypeChoice(bufio.NewReader(os.Stdin))
@@ -127,14 +127,15 @@ type AgentRestoreFlagCmdKong struct {
 
 func (a *AgentRestoreFlagCmdKong) Run(appManager *AppManager) error {
 	var req agent.RestoreAgentRequest
-	req.Force = a.Yes
-
-	reader := bufio.NewReader(os.Stdin)
+	req.Yes = a.Yes
 
 	// Handle agent type: empty vs invalid vs valid (with alias support)
 	if a.AgentType == "" {
+		if err := requireTTY("pass the agent type explicitly, e.g. 'tingly-box agent restore claude-code' (cc, oc, codex)"); err != nil {
+			return err
+		}
 		// No agent type specified, prompt for selection
-		agentType, err := promptForAgentTypeChoice(reader)
+		agentType, err := promptForAgentTypeChoice(bufio.NewReader(os.Stdin))
 		if err != nil {
 			return err
 		}
@@ -153,13 +154,16 @@ func (a *AgentRestoreFlagCmdKong) Run(appManager *AppManager) error {
 		return fmt.Errorf("no info registered for agent type: %s", req.AgentType)
 	}
 
-	if !req.Force {
+	if !req.Yes {
+		if err := requireTTY("re-run with -y/--yes to restore without prompting"); err != nil {
+			return err
+		}
 		fmt.Println("\nFiles that will be restored from their most recent backup:")
 		for _, f := range info.ConfigFiles {
 			fmt.Printf("  - %s\n", f)
 		}
 		fmt.Print("\nProceed? [y/N]: ")
-		input, err := reader.ReadString('\n')
+		input, err := bufio.NewReader(os.Stdin).ReadString('\n')
 		if err != nil {
 			return err
 		}
@@ -269,16 +273,6 @@ func resolveAgentConfigFromRules(appManager *AppManager, req *agent.ApplyAgentRe
 	fmt.Fprintln(os.Stderr,
 		"Config files will still be applied. Run 'tingly-box tui' / 'tb tui' to set up routing rules.")
 	return nil
-}
-
-// isStdinTTY reports whether stdin is connected to a terminal. It is used to
-// decide whether interactive prompts are appropriate.
-func isStdinTTY() bool {
-	fi, err := os.Stdin.Stat()
-	if err != nil {
-		return false
-	}
-	return (fi.Mode() & os.ModeCharDevice) != 0
 }
 
 // confirmApply prompts user to confirm the configuration

--- a/internal/command/agent_command_test.go
+++ b/internal/command/agent_command_test.go
@@ -110,3 +110,37 @@ func TestAgentApplyFlagCmdKong_NoRoutingRule_NeverPromptsForProvider(t *testing.
 		t.Errorf("output = %q, want the config-files-only preview note", output)
 	}
 }
+
+// TestAgentRestoreFlagCmdKong_NoTTYWithoutAgentType_ClearError: `agent
+// restore` had the identical unguarded promptForAgentTypeChoice fallback
+// that show/apply were fixed for, just never covered — same bug, same
+// fix, via the shared requireTTY helper. appManager is nil: Run doesn't
+// touch it before this check.
+func TestAgentRestoreFlagCmdKong_NoTTYWithoutAgentType_ClearError(t *testing.T) {
+	withNonTTYStdin(t)
+
+	err := (&AgentRestoreFlagCmdKong{}).Run(nil)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no TTY") {
+		t.Errorf("error = %q, want it to mention the missing TTY", err.Error())
+	}
+	if !strings.Contains(err.Error(), "agent restore claude-code") {
+		t.Errorf("error = %q, want a usage example", err.Error())
+	}
+}
+
+// TestAgentRestoreFlagCmdKong_NoTTYWithoutYes_ClearError: same gap as
+// above, for restore's "Proceed? [y/N]" confirmation.
+func TestAgentRestoreFlagCmdKong_NoTTYWithoutYes_ClearError(t *testing.T) {
+	withNonTTYStdin(t)
+
+	err := (&AgentRestoreFlagCmdKong{AgentType: "claude-code"}).Run(nil)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no TTY") || !strings.Contains(err.Error(), "-y/--yes") {
+		t.Errorf("error = %q, want it to mention the missing TTY and -y/--yes", err.Error())
+	}
+}

--- a/internal/command/agent_command_test.go
+++ b/internal/command/agent_command_test.go
@@ -45,3 +45,44 @@ func TestAgentShowFlagCmdKong_NoTTYWithoutAgentType_ClearError(t *testing.T) {
 		t.Errorf("error = %q, want a usage example", err.Error())
 	}
 }
+
+// TestAgentApplyFlagCmdKong_NoTTYWithoutAgentType_ClearError is the same
+// regression guard as the show/token-view fix, for `agent apply`'s own
+// agent-type prompt.
+func TestAgentApplyFlagCmdKong_NoTTYWithoutAgentType_ClearError(t *testing.T) {
+	withNonTTYStdin(t)
+
+	err := (&AgentApplyFlagCmdKong{}).Run(nil)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no TTY") {
+		t.Errorf("error = %q, want it to mention the missing TTY", err.Error())
+	}
+	if !strings.Contains(err.Error(), "agent apply claude-code") {
+		t.Errorf("error = %q, want a usage example", err.Error())
+	}
+}
+
+// TestAgentApplyFlagCmdKong_NoTTYWithoutForce_ClearError: `apply` is meant
+// to be a one-shot "configure and go" command (unlike show/restore, it's
+// the one CLI verb genuinely worth running non-interactively often), so a
+// missing confirmation TTY must fail with a hint to pass --force rather
+// than block on a bufio read that can never succeed. Needs a real
+// AppManager: with an agent type given, Run reaches routing-rule
+// resolution (which needs a config) before the force/TTY check.
+func TestAgentApplyFlagCmdKong_NoTTYWithoutForce_ClearError(t *testing.T) {
+	withNonTTYStdin(t)
+	am := newTestAppManager(t)
+
+	var err error
+	withSilencedStdout(t, func() {
+		err = (&AgentApplyFlagCmdKong{AgentType: "claude-code"}).Run(am)
+	})
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no TTY") || !strings.Contains(err.Error(), "--force") {
+		t.Errorf("error = %q, want it to mention the missing TTY and --force", err.Error())
+	}
+}

--- a/internal/command/agent_command_test.go
+++ b/internal/command/agent_command_test.go
@@ -46,18 +46,18 @@ func TestAgentShowFlagCmdKong_NoTTYWithoutAgentType_ClearError(t *testing.T) {
 	}
 }
 
-// TestAgentApplyFlagCmdKong_NoTTYWithoutAgentType_ClearError is the same
-// regression guard as the show/token-view fix, for `agent apply`'s own
-// agent-type prompt.
-func TestAgentApplyFlagCmdKong_NoTTYWithoutAgentType_ClearError(t *testing.T) {
-	withNonTTYStdin(t)
-
+// TestAgentApplyFlagCmdKong_WithoutAgentType_ClearError: unlike agent
+// show/restore, apply never falls back to an interactive picker at all —
+// it's a one-shot "apply the defaults" command, not a wizard, so a missing
+// agent type is always a clear error, TTY or not (a TTY doesn't change
+// whether picking interactively is the right thing for apply to do).
+func TestAgentApplyFlagCmdKong_WithoutAgentType_ClearError(t *testing.T) {
 	err := (&AgentApplyFlagCmdKong{}).Run(nil)
 	if err == nil {
 		t.Fatal("expected an error, got nil")
 	}
-	if !strings.Contains(err.Error(), "no TTY") {
-		t.Errorf("error = %q, want it to mention the missing TTY", err.Error())
+	if !strings.Contains(err.Error(), "agent type required") {
+		t.Errorf("error = %q, want it to say an agent type is required", err.Error())
 	}
 	if !strings.Contains(err.Error(), "agent apply claude-code") {
 		t.Errorf("error = %q, want a usage example", err.Error())
@@ -84,5 +84,29 @@ func TestAgentApplyFlagCmdKong_NoTTYWithoutForce_ClearError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no TTY") || !strings.Contains(err.Error(), "--force") {
 		t.Errorf("error = %q, want it to mention the missing TTY and --force", err.Error())
+	}
+}
+
+// TestAgentApplyFlagCmdKong_NoRoutingRule_NeverPromptsForProvider is the
+// core regression guard for the redesign: apply is a one-shot "apply the
+// defaults" command, so with no routing rule configured it must proceed
+// with config-files-only rather than falling back to an interactive
+// provider/model picker (the old promptForAgentConfig path, now removed
+// entirely). Preview mode returns before the confirm step, so this also
+// proves the picker isn't reachable earlier in Run, without needing
+// --force or touching real Claude Code config files.
+func TestAgentApplyFlagCmdKong_NoRoutingRule_NeverPromptsForProvider(t *testing.T) {
+	withNonTTYStdin(t) // a fallback to the old picker would block reading this
+	am := newTestAppManager(t)
+
+	var err error
+	output := captureStdout(t, func() {
+		err = (&AgentApplyFlagCmdKong{AgentType: "claude-code", Preview: true}).Run(am)
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(output, "no service configured") {
+		t.Errorf("output = %q, want the config-files-only preview note", output)
 	}
 }

--- a/internal/command/agent_command_test.go
+++ b/internal/command/agent_command_test.go
@@ -64,14 +64,14 @@ func TestAgentApplyFlagCmdKong_WithoutAgentType_ClearError(t *testing.T) {
 	}
 }
 
-// TestAgentApplyFlagCmdKong_NoTTYWithoutForce_ClearError: `apply` is meant
+// TestAgentApplyFlagCmdKong_NoTTYWithoutYes_ClearError: `apply` is meant
 // to be a one-shot "configure and go" command (unlike show/restore, it's
 // the one CLI verb genuinely worth running non-interactively often), so a
-// missing confirmation TTY must fail with a hint to pass --force rather
+// missing confirmation TTY must fail with a hint to pass -y/--yes rather
 // than block on a bufio read that can never succeed. Needs a real
 // AppManager: with an agent type given, Run reaches routing-rule
-// resolution (which needs a config) before the force/TTY check.
-func TestAgentApplyFlagCmdKong_NoTTYWithoutForce_ClearError(t *testing.T) {
+// resolution (which needs a config) before the yes/TTY check.
+func TestAgentApplyFlagCmdKong_NoTTYWithoutYes_ClearError(t *testing.T) {
 	withNonTTYStdin(t)
 	am := newTestAppManager(t)
 
@@ -82,8 +82,8 @@ func TestAgentApplyFlagCmdKong_NoTTYWithoutForce_ClearError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error, got nil")
 	}
-	if !strings.Contains(err.Error(), "no TTY") || !strings.Contains(err.Error(), "--force") {
-		t.Errorf("error = %q, want it to mention the missing TTY and --force", err.Error())
+	if !strings.Contains(err.Error(), "no TTY") || !strings.Contains(err.Error(), "-y/--yes") {
+		t.Errorf("error = %q, want it to mention the missing TTY and -y/--yes", err.Error())
 	}
 }
 
@@ -94,7 +94,7 @@ func TestAgentApplyFlagCmdKong_NoTTYWithoutForce_ClearError(t *testing.T) {
 // provider/model picker (the old promptForAgentConfig path, now removed
 // entirely). Preview mode returns before the confirm step, so this also
 // proves the picker isn't reachable earlier in Run, without needing
-// --force or touching real Claude Code config files.
+// -y/--yes or touching real Claude Code config files.
 func TestAgentApplyFlagCmdKong_NoRoutingRule_NeverPromptsForProvider(t *testing.T) {
 	withNonTTYStdin(t) // a fallback to the old picker would block reading this
 	am := newTestAppManager(t)

--- a/internal/command/token.go
+++ b/internal/command/token.go
@@ -90,8 +90,8 @@ func resolveTokenKind(arg string) (TokenKind, error) {
 		return "", fmt.Errorf("unknown token kind %q (expected 'auth' or 'model')", arg)
 	}
 
-	if !isStdinTTY() {
-		return "", fmt.Errorf("no kind specified and no TTY to prompt; pass 'auth' or 'model' explicitly, e.g. 'tingly-box token view auth'")
+	if err := requireTTY("pass 'auth' or 'model' explicitly, e.g. 'tingly-box token view auth'"); err != nil {
+		return "", err
 	}
 
 	fmt.Println("Which tingly-box token?")

--- a/internal/command/tty.go
+++ b/internal/command/tty.go
@@ -1,0 +1,34 @@
+package command
+
+import (
+	"fmt"
+	"os"
+)
+
+// isStdinTTY reports whether stdin is connected to a terminal. Every
+// command that falls back to an interactive prompt when an argument is
+// omitted must check this first — a bufio.Reader blocked on a redirected
+// stdin (a script, CI, or piped input) never gets a real answer: it either
+// hangs waiting for input that will never come, or fails with a bare
+// "failed to read input: EOF" once the pipe closes.
+func isStdinTTY() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// requireTTY returns a consistent, actionable error when stdin isn't a
+// TTY, and nil when it's safe to go ahead and prompt. hint is the specific
+// way to unblock — an explicit argument to pass, or a flag that skips the
+// prompt entirely — so the "can't prompt, here's what to do instead"
+// framing lives in one place instead of being rebuilt (slightly
+// differently worded each time) at every call site that falls back to an
+// interactive read.
+func requireTTY(hint string) error {
+	if isStdinTTY() {
+		return nil
+	}
+	return fmt.Errorf("no TTY to prompt; %s", hint)
+}

--- a/internal/command/tty_test.go
+++ b/internal/command/tty_test.go
@@ -1,0 +1,26 @@
+package command
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRequireTTY covers the shared helper directly: every command's
+// "no TTY, here's how to unblock" gate goes through this one function
+// (see tty.go) instead of hand-rolling the check and message each time.
+func TestRequireTTY(t *testing.T) {
+	t.Run("no TTY", func(t *testing.T) {
+		withNonTTYStdin(t)
+
+		err := requireTTY("pass it explicitly, e.g. 'foo bar'")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "no TTY to prompt") {
+			t.Errorf("error = %q, want it to lead with the shared framing", err.Error())
+		}
+		if !strings.Contains(err.Error(), "pass it explicitly, e.g. 'foo bar'") {
+			t.Errorf("error = %q, want it to carry the caller's hint", err.Error())
+		}
+	})
+}

--- a/internal/command/tui/agent_mode.go
+++ b/internal/command/tui/agent_mode.go
@@ -133,7 +133,7 @@ func agentApply(cfg *serverconfig.Config, info agent.AgentInfo) error {
 	req := &agent.ApplyAgentRequest{
 		AgentType: info.Type,
 		Unified:   true,
-		Force:     true,
+		Yes:       true,
 	}
 
 	wireRule, err := Confirm("Also wire a routing rule (pick provider + model)?", ConfirmOptions{
@@ -236,7 +236,7 @@ func agentRestore(cfg *serverconfig.Config, info agent.AgentInfo) error {
 	}
 	res, err := usecase.NewAgentUseCase(cfg, "localhost").Restore(&agent.RestoreAgentRequest{
 		AgentType: info.Type,
-		Force:     true,
+		Yes:       true,
 	})
 	if err != nil {
 		return err

--- a/internal/command/tui/quickstart.go
+++ b/internal/command/tui/quickstart.go
@@ -728,7 +728,7 @@ func qsAgent(ctx StepContext, s quickstartState) (quickstartState, StepResult, e
 			Model:             s.model,
 			Unified:           s.ccUnified,
 			InstallStatusLine: s.ccInstallStatusLine,
-			Force:             true,
+			Yes:               true,
 		}
 		label := string(t)
 		if info, ok := agent.GetAgentInfo(t); ok {

--- a/internal/server/module/configapply/handler.go
+++ b/internal/server/module/configapply/handler.go
@@ -398,7 +398,7 @@ func (h *Handler) restoreAgent(c *gin.Context, agentType agent.AgentType) {
 
 	result, err := apply.RestoreAgent(&agent.RestoreAgentRequest{
 		AgentType: agentType,
-		Force:     true,
+		Yes:       true,
 	})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, RestoreConfigResponse{


### PR DESCRIPTION
## Summary
Redesigns `agent apply`'s prompting behavior and unifies its confirm-skip flag with `agent restore` and the rest of the CLI. Stacked on #1683.

## Key Changes
- **`agent apply` never prompts**: always a one-shot, defaults-applying command, TTY or not — no more falling into an interactive picker when a flag is missing.
- **`agent apply`/`restore` fail fast without a TTY**: actionable error instead of hanging or crashing on EOF, via a shared `requireTTY` helper; closes a gap where `restore` had no TTY guard at all.
- **Confirm-skip flag unification**: `--force` → `-y`/`--yes` on `agent apply`/`restore`, matching `restart`/`token refresh`; internal `Force` struct fields renamed to `Yes` to match.

## Minor
- Removed the fabricated "cx" alias for Codex — it had no real product basis.

## Testing
- `go build`/`go vet`/`go test ./...` green; commands manually exercised against the compiled binary.