### PR TITLE
fix(npx): GC stale versioned binary caches on every shim launch

### DIFF
--- a/.design/npm.md
+++ b/.design/npm.md
@@ -41,8 +41,8 @@ global installs overwrite each other's bin links.
 
 ## Making `npm install -g` viable again
 
-Status: A + B implemented (2026-08), effective from the next publish; C is
-still a proposal. Today the README recommends `npx` only, because
+Status: A + B implemented (2026-08), E implemented (2026-09), effective from
+the next publish; C is still a proposal. Today the README recommends `npx` only, because
 `npm update -g tingly-box` intermittently fails with `ENOTEMPTY` and leaves the
 global install broken. The rest of this doc explains the failure and lays out
 the path to re-enable global installs.
@@ -53,11 +53,14 @@ the path to re-enable global installs.
   the cli one against the real release download, the bundle one against the
   packaged zips).
 - B is `cleanupRetiredInstallDirs()` in all three `build/npx/*/bin.js`.
+- E is `cleanupStaleBinaryCaches()` in all three `build/npx/*/bin.js`.
 - `build/npx/test-shim.sh <release-tag>` codifies the verification: it builds
   the published artifact the same way CI does (pin tag, esbuild bundle) and
   runs the matrix — sweep skipped under a fresh `node_modules` mtime, exact
-  retire-shape sweep under an old one (sibling/human dirs untouched), and an
-  end-to-end download + `version` against the real release. Run it before
+  retire-shape sweep under an old one (sibling/human dirs untouched), an
+  end-to-end download + `version` against the real release, and the
+  stale-cache sweep guards (rollback kept, fresh/non-tag/file entries
+  untouched; Linux only, where `XDG_CACHE_HOME` sandboxes the cache root). Run it before
   touching the shims or the publish workflow. CI runs it too: the
   `verify-npx-shim` job in `verify-build.yml` executes it on every release
   (and on manual runs against any tag).
@@ -174,12 +177,49 @@ users run `npm update -g` at all. Invert this:
    The stale `getLatestVersion()` in `bin.js` (it fetches the download URL and
    would fail to parse) gets deleted — "what is latest" is the Go side's job.
 3. `update` also GCs old `~/.cache/tingly-box/<tag>` dirs, keeping the
-   previous one as rollback.
+   previous one as rollback — same keep policy as E, which the shim already
+   applies on every launch; `update` just makes the GC immediate instead of
+   waiting for the next shim run.
 
 After C, the npm package is a thin installer/launcher that changes rarely
 (only when shim logic changes); users update via `tb update` and never touch
 `npm update -g`. This is the same endgame as Claude Code's native installer,
 reached without leaving npm as the distribution channel.
+
+#### E. GC stale binary caches
+
+Orthogonal to the install-dir problems above: every release downloads (cli,
+gui) or extracts (bundle) its binaries into a fresh
+`~/.cache/<package>/<tag>/` dir — by design, so updates never overwrite a
+binary in place (no Windows locked-exe problem, a running daemon keeps its
+old inode) — but nothing ever removed the old tag dirs, so the cache grew by
+one full binary per release forever.
+
+`cleanupStaleBinaryCaches()` in all three `build/npx/*/bin.js` sweeps them on
+every launch, once the current tag's binary is confirmed in place. Policy and
+guards:
+
+- Keep the tag in use, plus the most recently touched *other* tag dir as
+  rollback; sweep the rest.
+- Only directories whose name is exactly a release-tag shape (`latest` or
+  `vX.Y.Z[-pre]`, the `validateTransportVersion` grammar) are candidates —
+  files (e.g. plan C's future `current` pointer) and human-made dirs never
+  match.
+- Skip any candidate touched within the last hour: a concurrent
+  version-pinned `npx tingly-box@old` may be downloading into it right now.
+  True stale dirs get swept on a later launch — eventual cleanup, same intent
+  as B.
+- Deleting a binary still running from a swept dir is safe on POSIX (the
+  inode outlives the unlink); on Windows the locked exe makes `rmSync` throw,
+  the error is swallowed, and the sweep retries on a later launch.
+- Everything in try/catch; cleanup never blocks launch. Each package sweeps
+  only its own cache root (`tingly-box`, `tingly-box-gui`,
+  `tingly-box-bundle`).
+
+Note the sweep covers *our* cache only. npm's own `_npx` / `_cacache` stores
+also accumulate one entry per `npx tingly-box@<version>` invocation, but
+those are npm's caches with npm's own eviction (`npm cache` handles them);
+the shim has no business reaching into them.
 
 #### D. README posture
 
@@ -196,5 +236,6 @@ major versions). Once C lands, the update instruction becomes `tb update`.
    (A extended to the bundle package 2026-08.)
 2. Entry-semantics split + README/user-manual flip to "npm install -g
    supported" (see `cli-entry-semantics.md`). ✅ 2026-08
-3. C behind a normal feature PR (Go `update` command + shim `current`
+3. E in the next shim release (bin.js only). ✅ 2026-09
+4. C behind a normal feature PR (Go `update` command + shim `current`
    resolution); ship shim change in the same release train as the Go command.

--- a/build/npx/test-shim.sh
+++ b/build/npx/test-shim.sh
@@ -76,6 +76,36 @@ grep -Eq "Version:[[:space:]]+$TAG" "$WORK/run.log" \
 	&& pass "T3: binary executed and reported $TAG" \
 	|| { fail "T3: version output missing:"; tail -10 "$WORK/run.log"; }
 
+# --- T4: stale version-cache sweep (Linux only: cache root is sandboxed) ----
+if [ "$(uname -s)" = "Linux" ]; then
+	echo "==> [T4] stale ~/.cache/tingly-box/<tag> dirs swept, guards respected"
+	CACHE_ROOT="$XDG_CACHE_HOME/tingly-box"
+	OLD1="$CACHE_ROOT/v0.0.1"       # oldest stale tag -> must be swept
+	OLD2="$CACHE_ROOT/v0.0.2"       # newest stale tag -> kept as rollback
+	FRESH="$CACHE_ROOT/v9.9.9"      # fresh mtime -> may be mid-download, kept
+	HUMANC="$CACHE_ROOT/backup"     # non-tag dir -> never touched
+	PTR="$CACHE_ROOT/current"       # file (future version pointer) -> kept
+	mkdir -p "$OLD1/bin" "$OLD2/bin" "$FRESH/bin" "$HUMANC"
+	echo x > "$PTR"
+	touch -t 202001010000 "$OLD1"
+	touch -t 202101010000 "$OLD2"
+	if run_shim; then pass "T4: shim ran (exit 0)"; else fail "T4: shim failed:"; tail -5 "$WORK/run.log"; fi
+	[ ! -d "$OLD1" ] && pass "T4: oldest stale tag dir swept" \
+		|| fail "T4: oldest stale tag dir NOT swept"
+	[ -d "$OLD2" ] && pass "T4: newest stale tag dir kept as rollback" \
+		|| fail "T4: rollback tag dir was deleted"
+	[ -d "$FRESH" ] && pass "T4: fresh tag dir untouched (concurrency guard)" \
+		|| fail "T4: fresh tag dir was deleted despite fresh mtime"
+	[ -d "$HUMANC" ] && pass "T4: non-tag dir untouched" \
+		|| fail "T4: non-tag dir was deleted"
+	[ -f "$PTR" ] && pass "T4: pointer file untouched" \
+		|| fail "T4: pointer file was deleted"
+	[ -d "$CACHE_ROOT/$TAG" ] && pass "T4: current tag dir kept" \
+		|| fail "T4: current tag dir was deleted"
+else
+	echo "==> [T4] skipped (non-Linux: cache root not sandboxed by XDG_CACHE_HOME)"
+fi
+
 echo
 if [ "$FAILED" -eq 0 ]; then
 	echo "🎉 All shim tests passed for $TAG"

--- a/build/npx/tingly-box-bundle/bin.js
+++ b/build/npx/tingly-box-bundle/bin.js
@@ -136,6 +136,38 @@ function cleanupRetiredInstallDirs() {
 	}
 }
 
+// Sweep stale versioned binary caches (<cacheRoot>/<tag>/) left behind by
+// earlier releases: every release extracts into its own tag dir and nothing
+// ever removed the old ones. Keeps the tag in use plus the most recently
+// touched other tag as rollback. See .design/npm.md.
+function cleanupStaleBinaryCaches(cacheRoot, keepTag) {
+	try {
+		// Exact release-tag dir shapes only ("latest" or vX.Y.Z[-pre]); files
+		// (e.g. a future `current` pointer) and human-made dirs never match.
+		const tagShape = /^(?:latest|v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/;
+		const candidates = [];
+		for (const entry of readdirSync(cacheRoot, { withFileTypes: true })) {
+			if (!entry.isDirectory() || !tagShape.test(entry.name)) continue;
+			if (entry.name === keepTag) continue;
+			const dirPath = join(cacheRoot, entry.name);
+			const mtimeMs = statSync(dirPath).mtimeMs;
+			// Fresh mtime: a concurrent launch (e.g. a version-pinned npx) may
+			// be extracting into it right now — skip, sweep on a later run.
+			if (Date.now() - mtimeMs < 60 * 60 * 1000) continue;
+			candidates.push({ dirPath, mtimeMs });
+		}
+		// Newest non-current tag survives as rollback; the rest go. A binary
+		// still running from a swept dir keeps its inode on POSIX; on Windows
+		// the locked exe makes rmSync throw and the sweep retries next launch.
+		candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+		for (const { dirPath } of candidates.slice(1)) {
+			rmSync(dirPath, { recursive: true, force: true });
+		}
+	} catch {
+		// Never block launch on cleanup.
+	}
+}
+
 // npx / `npm exec` sets npm_command=exec; a bin launched directly (e.g. from
 // `npm install -g`) does not. Entry-semantics rationale for everything below:
 // .design/cli-entry-semantics.md.
@@ -169,6 +201,9 @@ if (!existsSync(zipPath)) {
 
 // Extract binary and get path
 const binaryPath = await extractBinary(platformDir);
+
+// The binary for this tag is in place — old tag dirs are now safe to GC.
+cleanupStaleBinaryCaches(dirname(getCacheDir()), BINARY_RELEASE_BRANCH);
 
 try {
 	execFileSync(binaryPath, argsToUse, {

--- a/build/npx/tingly-box-gui/bin.js
+++ b/build/npx/tingly-box-gui/bin.js
@@ -320,6 +320,36 @@ function cleanupRetiredInstallDirs() {
 	}
 }
 
+// Sweep stale versioned app caches (<cacheRoot>/<tag>/) left behind by
+// earlier releases: every release downloads into its own tag dir and nothing
+// ever removed the old ones. Keeps the tag in use plus the most recently
+// touched other tag as rollback. See .design/npm.md.
+function cleanupStaleBinaryCaches(cacheRoot, keepTag) {
+	try {
+		// Exact release-tag dir shapes only ("latest" or vX.Y.Z[-pre]); files
+		// (e.g. a future `current` pointer) and human-made dirs never match.
+		const tagShape = /^(?:latest|v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/;
+		const candidates = [];
+		for (const entry of readdirSync(cacheRoot, { withFileTypes: true })) {
+			if (!entry.isDirectory() || !tagShape.test(entry.name)) continue;
+			if (entry.name === keepTag) continue;
+			const dirPath = join(cacheRoot, entry.name);
+			const mtimeMs = statSync(dirPath).mtimeMs;
+			// Fresh mtime: a concurrent launch (e.g. a version-pinned npx) may
+			// be downloading into it right now — skip, sweep on a later run.
+			if (Date.now() - mtimeMs < 60 * 60 * 1000) continue;
+			candidates.push({ dirPath, mtimeMs });
+		}
+		// Newest non-current tag survives as rollback; the rest go.
+		candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+		for (const { dirPath } of candidates.slice(1)) {
+			rmSync(dirPath, { recursive: true, force: true });
+		}
+	} catch {
+		// Never block launch on cleanup.
+	}
+}
+
 function formatBytes(bytes) {
 	if (bytes === 0) return "0 B";
 	const k = 1024;
@@ -389,6 +419,9 @@ function formatBytes(bytes) {
 
 		console.log(`✅ Downloaded and extracted to ${appPath}`);
 	}
+
+	// The app for this tag is in place — old tag dirs are now safe to GC.
+	cleanupStaleBinaryCaches(join(cacheDir(), "tingly-box-gui"), branchName);
 
 	console.log(`🔍 Launching app: ${appPath}`);
 

--- a/build/npx/tingly-box/bin.js
+++ b/build/npx/tingly-box/bin.js
@@ -354,6 +354,38 @@ function cleanupRetiredInstallDirs() {
 	}
 }
 
+// Sweep stale versioned binary caches (<cacheRoot>/<tag>/) left behind by
+// earlier releases: every release downloads into its own tag dir and nothing
+// ever removed the old ones. Keeps the tag in use plus the most recently
+// touched other tag as rollback. See .design/npm.md.
+function cleanupStaleBinaryCaches(cacheRoot, keepTag) {
+	try {
+		// Exact release-tag dir shapes only ("latest" or vX.Y.Z[-pre]); files
+		// (e.g. a future `current` pointer) and human-made dirs never match.
+		const tagShape = /^(?:latest|v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/;
+		const candidates = [];
+		for (const entry of readdirSync(cacheRoot, { withFileTypes: true })) {
+			if (!entry.isDirectory() || !tagShape.test(entry.name)) continue;
+			if (entry.name === keepTag) continue;
+			const dirPath = join(cacheRoot, entry.name);
+			const mtimeMs = statSync(dirPath).mtimeMs;
+			// Fresh mtime: a concurrent launch (e.g. a version-pinned npx) may
+			// be downloading into it right now — skip, sweep on a later run.
+			if (Date.now() - mtimeMs < 60 * 60 * 1000) continue;
+			candidates.push({ dirPath, mtimeMs });
+		}
+		// Newest non-current tag survives as rollback; the rest go. A binary
+		// still running from a swept dir keeps its inode on POSIX; on Windows
+		// the locked exe makes rmSync throw and the sweep retries next launch.
+		candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+		for (const { dirPath } of candidates.slice(1)) {
+			rmSync(dirPath, { recursive: true, force: true });
+		}
+	} catch {
+		// Never block launch on cleanup.
+	}
+}
+
 function formatBytes(bytes) {
 	if (bytes === 0) return "0 B";
 	const k = 1024;
@@ -407,6 +439,9 @@ function formatBytes(bytes) {
 
 		console.log(`✅ Downloaded and extracted to ${binaryPath}`);
 	}
+
+	// The binary for this tag is in place — old tag dirs are now safe to GC.
+	cleanupStaleBinaryCaches(join(cacheDir(), "tingly-box"), branchName);
 
     // Test if the binary can execute
     // Debug: Show binary location


### PR DESCRIPTION
## Summary
Every release downloads/extracts into its own `~/.cache/<package>/<tag>/` dir but nothing ever removed old tags, so the cache grew by one full binary (20–70MB) per release forever.

## Key Changes

- **Cache self-cleanup**: all three `build/npx/*/bin.js` shims sweep stale tag dirs on every launch, keeping the current tag plus the newest other tag as rollback.
- **Safety guards**: only exact release-tag dir names match; dirs touched within 1h are skipped (concurrent pinned npx may be downloading); cleanup is best-effort and never blocks launch.
- **Regression coverage**: new T4 case in `test-shim.sh` (sweep, rollback, freshness/non-tag/file guards); documented as mitigation E in `.design/npm.md`.

## Testing

- Full `test-shim.sh v0.260827.2` matrix passes (T1–T4, end-to-end against the real release).
- Manual end-to-end with real old releases: v0.260813.2 + v0.260819.0 downloaded, oldest swept, rollback binary still runs, swept version re-downloads cleanly, and a daemon running from a swept dir keeps serving HTTP (inode survives unlink).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTunqo8s7Twp2Xcw2nMDwK)_