### PR TITLE
fix(server): prioritize explicit session headers and support native client session IDs

### DIFF
--- a/internal/protocolserver/protocol_handler.go
+++ b/internal/protocolserver/protocol_handler.go
@@ -198,8 +198,8 @@ func isEnterpriseContextPresent(c *gin.Context) bool {
 
 // resolveSessionID returns the session identifier for the current request as
 // a string. It delegates to routing.ResolveSessionID which checks (in
-// priority order): Anthropic metadata.user_id > X-Tingly-Session-ID header >
-// ClientIP fallback.
+// priority order): X-Tingly-Session-ID header > native client header >
+// Anthropic metadata.user_id > ClientIP fallback.
 func resolveSessionID(c *gin.Context, req interface{}) typ.SessionID {
 	return routing.ResolveSessionID(c, req)
 }

--- a/internal/routing/context.go
+++ b/internal/routing/context.go
@@ -1,6 +1,8 @@
 package routing
 
 import (
+	"net/http"
+
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/gin-gonic/gin"
 
@@ -17,7 +19,7 @@ type SelectionContext struct {
 	Request interface{}
 
 	// SessionID is the resolved session identifier for affinity
-	// Priority: Anthropic metadata.user_id > X-Tingly-Session-ID header > ClientIP
+	// Priority: Tingly header > native client header > Anthropic metadata.user_id > ClientIP
 	SessionID typ.SessionID
 
 	// GinContext provides access to HTTP headers and client info
@@ -55,12 +57,25 @@ func NewSelectionContext(
 }
 
 // ResolveSessionID returns the best available session identifier from the request.
-// Priority: Anthropic metadata.user_id > X-Tingly-Session-ID header > ClientIP
+// Priority: X-Tingly-Session-ID header > native client header > Anthropic metadata.user_id > ClientIP.
 // The client IP is always stored in IPBackup as a fallback for rate limiting or logging.
 func ResolveSessionID(c *gin.Context, req interface{}) typ.SessionID {
 	clientIP := c.ClientIP()
 
-	// 1. Extract from Anthropic request metadata.user_id
+	// 1. The explicit Tingly header always wins, allowing callers and trusted
+	// gateways to override identifiers supplied automatically by a client.
+	if id := c.GetHeader("X-Tingly-Session-ID"); id != "" {
+		return typ.SessionID{Source: typ.SessionSourceHeader, Value: id, IPBackup: clientIP}
+	}
+
+	// 2. Native coding-agent headers. Codex uses session_id while OpenCode uses
+	// x-opencode-session.
+	if id := nativeClientSessionID(c.Request.Header); id != "" {
+		return typ.SessionID{Source: typ.SessionSourceHeader, Value: id, IPBackup: clientIP}
+	}
+
+	// 3. Extract from Anthropic request metadata.user_id only when no explicit or
+	// native client session header was provided.
 	switch r := req.(type) {
 	case *anthropic.MessageNewParams:
 		if r.Metadata.UserID.Valid() && r.Metadata.UserID.Value != "" {
@@ -74,11 +89,17 @@ func ResolveSessionID(c *gin.Context, req interface{}) typ.SessionID {
 		}
 	}
 
-	// 2. X-Tingly-Session-ID header
-	if id := c.GetHeader("X-Tingly-Session-ID"); id != "" {
-		return typ.SessionID{Source: typ.SessionSourceHeader, Value: id, IPBackup: clientIP}
-	}
-
-	// 3. Fallback: client IP (IPBackup not needed since Value is the IP)
+	// 4. Fallback: client IP (IPBackup not needed since Value is the IP)
 	return typ.SessionID{Source: typ.SessionSourceIP, Value: clientIP}
+}
+
+// nativeClientSessionID extracts session identifiers emitted by supported coding agents.
+// Header.Get is case-insensitive and also handles Codex's underscore-bearing header name.
+func nativeClientSessionID(header http.Header) string {
+	for _, name := range []string{"session_id", "x-opencode-session"} {
+		if id := header.Get(name); id != "" {
+			return id
+		}
+	}
+	return ""
 }

--- a/internal/routing/context_test.go
+++ b/internal/routing/context_test.go
@@ -1,0 +1,93 @@
+package routing
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/packages/param"
+	"github.com/gin-gonic/gin"
+
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestResolveSessionIDFromNativeClientHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name       string
+		headerName string
+		headerID   string
+	}{
+		{name: "Codex", headerName: "session_id", headerID: "codex-session-123"},
+		{name: "OpenCode", headerName: "x-opencode-session", headerID: "opencode-session-456"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+			c.Request.RemoteAddr = "192.0.2.10:1234"
+			c.Request.Header.Set(tt.headerName, tt.headerID)
+
+			got := ResolveSessionID(c, nil)
+			if got.Source != typ.SessionSourceHeader {
+				t.Fatalf("Source = %q, want %q", got.Source, typ.SessionSourceHeader)
+			}
+			if got.Value != tt.headerID {
+				t.Errorf("Value = %q, want %q", got.Value, tt.headerID)
+			}
+			if got.IPBackup != "192.0.2.10" {
+				t.Errorf("IPBackup = %q, want %q", got.IPBackup, "192.0.2.10")
+			}
+		})
+	}
+}
+
+func TestResolveSessionIDPriority(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("POST", "/v1/messages", nil)
+	c.Request.RemoteAddr = "192.0.2.10:1234"
+	c.Request.Header.Set("session_id", "codex-session")
+	c.Request.Header.Set("x-opencode-session", "opencode-session")
+	c.Request.Header.Set("X-Tingly-Session-ID", "tingly-session")
+
+	req := anthropic.MessageNewParams{
+		Metadata: anthropic.MetadataParam{
+			UserID: param.NewOpt("anthropic-session"),
+		},
+	}
+
+	got := ResolveSessionID(c, &req)
+	if got.Value != "tingly-session" {
+		t.Fatalf("Tingly header Value = %q, want %q", got.Value, "tingly-session")
+	}
+
+	c.Request.Header.Del("X-Tingly-Session-ID")
+	got = ResolveSessionID(c, &req)
+	if got.Value != "codex-session" {
+		t.Fatalf("native header Value = %q, want Codex session %q", got.Value, "codex-session")
+	}
+
+	c.Request.Header.Del("session_id")
+	c.Request.Header.Del("x-opencode-session")
+	got = ResolveSessionID(c, &req)
+	if got.Value != "anthropic-session" {
+		t.Fatalf("metadata session Value = %q, want %q", got.Value, "anthropic-session")
+	}
+}
+
+func TestResolveSessionIDFallsBackToClientIP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("POST", "/v1/responses", nil)
+	c.Request.RemoteAddr = "192.0.2.10:1234"
+
+	got := ResolveSessionID(c, nil)
+	if got.Source != typ.SessionSourceIP || got.Value != "192.0.2.10" {
+		t.Fatalf("ResolveSessionID() = %+v, want IP fallback", got)
+	}
+}


### PR DESCRIPTION
### Motivation

- Ensure an explicit gateway or caller-provided session identifier always takes precedence over client-provided metadata and IP-based fallbacks so affinity and routing behave deterministically.
- Add support for native coding-agent session headers so clients like Codex/OpenCode can supply stable session IDs for affinity.

### Description

- Change session resolution in `internal/routing/context.go` to check `X-Tingly-Session-ID` first, then native client headers (`session_id`, `x-opencode-session`), then Anthropic `metadata.user_id`, and finally fallback to client IP.
- Add `nativeClientSessionID` helper to extract coding-agent session headers and update `SelectionContext` comments to document the new priority.
- Update protocol handler documentation to reflect the new resolution order in `internal/protocolserver/protocol_handler.go`.
- Add unit tests in `internal/routing/context_test.go` covering native header extraction, header/metadata priority, and IP fallback, and adjust Anthropic `param` import path to match the repository layout.

### Testing

- Ran `go test ./internal/routing -v` and the routing package tests (including `TestResolveSessionIDFromNativeClientHeaders`, `TestResolveSessionIDPriority`, and `TestResolveSessionIDFallsBackToClientIP`) passed.
- Ensured files are `gofmt`-ed and the repository diagnostic checks (diff/check) completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9843888d0c832a974e86dd2890630b)