### PR TITLE
feat(quota): hourly request to OAuth providers to keep quota windows moving

### DIFF
--- a/.design/oauth.md
+++ b/.design/oauth.md
@@ -98,6 +98,12 @@ An upstream 401/403 is also a failover trigger (`internal/protocolserver/failove
 a broken credential on one service falls over to a sibling and is reported to the
 health monitor, instead of surfacing to the client as "Please run /login".
 
+- **Quota window nudge** — `quotawindow.Run`
+  (`internal/server/module/quotawindow/quotawindow.go`) sends one tiny model
+  request per hour to every enabled OAuth provider (direct SDK call via
+  `E2EProber`, any cached model that goes through). Subscription windows only
+  start counting on the first real request, so this keeps them moving while idle.
+
 ## Re-authentication (in place)
 
 Recovery flow for a credential that has gone **permanently** invalid — refresh token

--- a/internal/server/module/quotawindow/quotawindow.go
+++ b/internal/server/module/quotawindow/quotawindow.go
@@ -1,0 +1,63 @@
+// Package quotawindow sends one tiny model request per hour to every enabled
+// OAuth provider. Subscription quota windows (Claude Code 5h, Codex primary)
+// only start counting on the first real request, so this keeps the window
+// moving while the account is idle.
+package quotawindow
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/internal/probe"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// Send is the shape of probe.E2EProber.Probe.
+type Send func(context.Context, *probe.E2ERequest) (*probe.E2EData, error)
+
+// Run ticks hourly until ctx is done. Blocks; run it in a goroutine.
+func Run(ctx context.Context, prober *probe.E2EProber, cfg *config.Config) {
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			Tick(ctx, prober.Probe, cfg.ListProviders())
+		}
+	}
+}
+
+// Tick sends one request to each enabled OAuth provider, trying its models
+// in order until one goes through.
+func Tick(ctx context.Context, send Send, providers []*typ.Provider) {
+	for _, p := range providers {
+		if p == nil || !p.Enabled || !p.IsOAuth() {
+			continue
+		}
+		for _, model := range p.Models {
+			if ctx.Err() != nil {
+				return
+			}
+			stream := false
+			reqCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+			res, err := send(reqCtx, &probe.E2ERequest{
+				TargetType:   probe.E2ETargetProvider,
+				ProviderUUID: p.UUID,
+				Model:        model,
+				Direct:       true,
+				Stream:       &stream,
+				Message:      "Reply with the single word: ok",
+			})
+			cancel()
+			if err == nil && res != nil && res.Success {
+				break
+			}
+			logrus.WithFields(logrus.Fields{"provider": p.Name, "model": model}).
+				WithError(err).Warn("quota window request failed")
+		}
+	}
+}

--- a/internal/server/module/quotawindow/quotawindow_test.go
+++ b/internal/server/module/quotawindow/quotawindow_test.go
@@ -1,0 +1,49 @@
+package quotawindow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/internal/probe"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func TestTick(t *testing.T) {
+	oauth := func(uuid string, models ...string) *typ.Provider {
+		return &typ.Provider{UUID: uuid, Enabled: true, AuthType: typ.AuthTypeOAuth,
+			OAuthDetail: &typ.OAuthDetail{Issuer: "claude_code", AccessToken: "t"}, Models: models}
+	}
+	disabled := oauth("disabled", "m")
+	disabled.Enabled = false
+	apiKey := &typ.Provider{UUID: "key", Enabled: true, AuthType: typ.AuthTypeAPIKey, Token: "x", Models: []string{"m"}}
+
+	var got []string
+	send := func(_ context.Context, req *probe.E2ERequest) (*probe.E2EData, error) {
+		got = append(got, req.ProviderUUID+"/"+req.Model)
+		if !req.Direct || req.Stream == nil || *req.Stream {
+			t.Errorf("expected direct non-streaming request, got %+v", req)
+		}
+		if req.Model == "broken" {
+			return nil, errors.New("unavailable")
+		}
+		return &probe.E2EData{Success: true}, nil
+	}
+
+	Tick(context.Background(), send, []*typ.Provider{
+		oauth("a", "broken", "works", "never"),
+		disabled,
+		apiKey,
+		oauth("empty"),
+	})
+
+	want := []string{"a/broken", "a/works"}
+	if len(got) != len(want) {
+		t.Fatalf("requests = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("requests = %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -144,6 +144,9 @@ type Server struct {
 	// quota manager for provider quota tracking
 	quotaManager providerQuotaModule.Manager
 
+	// stops the hourly quota-window request loop
+	quotaWindowStop context.CancelFunc
+
 	// options
 	enableUI    bool
 	openBrowser bool

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/obs"
 	"github.com/tingly-dev/tingly-box/internal/server/module/codeximport"
+	"github.com/tingly-dev/tingly-box/internal/server/module/quotawindow"
 	"github.com/tingly-dev/tingly-box/internal/typ"
 	"github.com/tingly-dev/tingly-box/pkg/network"
 	"github.com/tingly-dev/tingly-box/vmodel/virtualserver"
@@ -38,6 +39,13 @@ func (s *Server) Start(port int) error {
 	if s.quotaManager != nil {
 		s.quotaManager.StartAutoRefresh(ctx)
 		log.Println("Provider quota auto-refresh started")
+	}
+
+	// Hourly tiny request to each OAuth provider keeps quota windows moving
+	if s.probeE2e != nil {
+		qctx, qcancel := context.WithCancel(context.Background())
+		s.quotaWindowStop = qcancel
+		go quotawindow.Run(qctx, s.probeE2e, s.config)
 	}
 
 	// Start configuration watcher
@@ -278,6 +286,11 @@ func (s *Server) Stop(ctx context.Context) error {
 	if s.quotaManager != nil {
 		s.quotaManager.StopAutoRefresh()
 		log.Println("Provider quota auto-refresh stopped")
+	}
+
+	if s.quotaWindowStop != nil {
+		s.quotaWindowStop()
+		s.quotaWindowStop = nil
 	}
 
 	if err := s.undoCodexImportOnStop(); err != nil {


### PR DESCRIPTION
## Summary

Subscription quota windows (Claude Code 5h, Codex primary) only start counting on the first real model request, so an idle account wastes the gap between one window ending and the user's next request. An hourly background request keeps the window moving.

## Key Changes

- **Hourly nudge**: once an hour, one tiny real model request goes to every enabled OAuth provider via the E2E probe path in direct mode (a plain client call, no TB routing).
- **Any model works**: cached models are tried in list order until one goes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJiFkVF9pmgckJDUAN5VFV