### PR TITLE
data(providers): add AMD Lemonade, refresh Codex models, re-audit dual-protocol coverage

### DIFF
--- a/internal/data/providers.json
+++ b/internal/data/providers.json
@@ -506,6 +506,13 @@
       "base_url_anthropic": null,
       "models": [
         {
+          "id": "gpt-6-astra",
+          "context": 1050000,
+          "max_output": 128000,
+          "created": "2026-09-03",
+          "note": "最新旗舰模型，代码/应用/研究综合能力最强，目前限量灰度发布，需在 config.toml 手动开启，数周内成为 Astra 默认模型"
+        },
+        {
           "id": "gpt-5.6-sol",
           "context": 1050000,
           "max_output": 128000,
@@ -524,7 +531,7 @@
           "context": 1050000,
           "max_output": 128000,
           "created": "2026-07-09",
-          "note": "平衡能力与成本，适合常规开发任务"
+          "note": "平衡能力与成本，适合常规开发任务；已取代于 2026-08-31 退役的 gpt-5.4"
         },
         {
           "id": "gpt-5.6-terra:fast",
@@ -538,29 +545,36 @@
           "context": 1050000,
           "max_output": 128000,
           "created": "2026-07-09",
-          "note": "延迟和成本最低，适合高频、相对简单的任务"
+          "note": "延迟和成本最低，适合高频、相对简单的任务；已取代于 2026-08-31 退役的 gpt-5.4-mini"
         },
         {
-          "id": "gpt-5.4",
-          "context": 272000
-        },
-        {
-          "id": "gpt-5.4-mini",
-          "context": 272000
+          "id": "gpt-5.6-luna:fast",
+          "context": 1050000,
+          "max_output": 128000,
+          "created": "2026-07-09",
+          "note": "轻量模型 · Fast 模式，请求 OpenAI 优先算力通道，速度更快但消耗更高，仅 Codex 订阅支持"
         },
         {
           "id": "gpt-5.5",
-          "context": 272000
+          "context": 272000,
+          "note": "上一代旗舰模型，ChatGPT 登录会话默认模型"
         },
         {
           "id": "gpt-5.3-codex-spark",
-          "context": 128000
+          "context": 128000,
+          "note": "纯文本研究预览模型，优化近实时编码迭代"
         }
       ],
       "supports_models_endpoint": false,
       "oauth_provider": "codex",
       "icon": "opencode",
-      "openai_endpoint_mode": "responses"
+      "openai_endpoint_mode": "responses",
+      "last_updated": "2026-09-04",
+      "sources": [
+        "https://learn.chatgpt.com/docs/models",
+        "https://openai.com/index/gpt-6-astra/",
+        "https://9to5mac.com/2026/09/03/openai-releasing-major-upgrade-to-chatgpt-and-codex-with-gpt-6-astra-details-here/"
+      ]
     },
     "googleapis-com": {
       "id": "googleapis-com",
@@ -2878,6 +2892,30 @@
       "last_updated": "2026-08-19",
       "sources": [
         "https://github.com/sgl-project/sglang/pull/18630"
+      ]
+    },
+    "lemonade": {
+      "id": "lemonade",
+      "name": "AMD Lemonade",
+      "status": "active",
+      "valid": true,
+      "vendor_family": "amd",
+      "region": "self-hosted",
+      "plan": "standard",
+      "type": "self-hosted",
+      "description": "AMD's open-source local LLM server, NPU/GPU-accelerated on Ryzen AI and Radeon",
+      "website": "https://lemonade-server.ai",
+      "base_url_openai": "http://localhost:13305/v1",
+      "base_url_anthropic": "http://localhost:13305",
+      "no_key_required": true,
+      "supports_models_endpoint": true,
+      "icon": "amd",
+      "last_updated": "2026-09-04",
+      "sources": [
+        "https://github.com/lemonade-sdk/lemonade",
+        "https://lemonade-server.ai/docs/api/openai/",
+        "https://lemonade-server.ai/docs/api/anthropic/",
+        "https://lemonade-server.ai/docs/integrations/claude-code/"
       ]
     }
   }


### PR DESCRIPTION
## Summary
Adds AMD's official local LLM server to the provider registry, refreshes Codex's model list against current OpenAI docs, and re-audits providers previously flagged single-protocol for new dual-protocol support.

## Key Changes

- **AMD provider**: Added `lemonade` — AMD's official open-source local LLM server (Ryzen AI NPU / Radeon GPU), OpenAI + Anthropic compatible on `localhost:13305`, alongside `ollama`/`vllm`/`sglang`. AMD has no distinct hosted cloud API domain of its own — its "AI Endpoint" developer perk is Fireworks AI's existing `api.fireworks.ai` (already covered by the `fireworks-ai` entry) — so no duplicate cloud entry was added.
- **Codex model list**: Added newly-released `gpt-6-astra` (limited rollout, opt-in via `config.toml`) and the missing `gpt-5.6-luna:fast`; dropped `gpt-5.4`/`gpt-5.4-mini`, retired from Codex/ChatGPT sign-in on 2026-08-31.
- **Dual-protocol re-audit**: Re-checked the 14 providers confirmed single-protocol in #1602 (OpenAI, Anthropic official, Google Gemini direct, Mistral, Groq, Together AI, Cerebras, Perplexity, Cohere, NVIDIA NIM, Hyperbolic, iFlytek Spark, Baichuan, 01.AI) against current vendor docs — no changes; none ship a native production-grade endpoint for the other wire protocol yet.

## Notes
Anthropic's own "OpenAI SDK compatibility" layer at `api.anthropic.com/v1/` exists but is explicitly documented as testing-only/non-production, so it's intentionally not recorded as a second `base_url`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRdk9feUTyFkVxwgoLtCXm)_