### PR TITLE
chore(taskfile): pass --no-daemon to dev start/restart

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,11 +57,14 @@ tasks:
     aliases:
       - http
     cmds:
-      - go run ./cli/tingly-box --verbose start --debug --port 12580 --browser=false --pprof
- 
+      # --no-daemon: start now backgrounds by default, but local dev wants the
+      # server running in the foreground so `task start`/`task dev` keep
+      # streaming logs to this terminal instead of forking and exiting.
+      - go run ./cli/tingly-box --verbose start --debug --port 12580 --browser=false --pprof --no-daemon
+
   restart:
     cmds:
-      - go run ./cli/tingly-box --verbose restart --debug --port 12580 --browser=false --pprof
+      - go run ./cli/tingly-box --verbose restart --debug --port 12580 --browser=false --pprof --no-daemon
 
   swagger:
     aliases:


### PR DESCRIPTION
## Summary
`start`/`restart` now default to `--daemon=true` (background), which made the local-dev `task start`/`task dev` fork and exit immediately instead of streaming logs in the terminal.

## Key Changes

- **Local dev foreground logs**: `task start` and `task restart` now pass `--no-daemon` explicitly, restoring the previous foreground behavior for development.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWi8FWSewYNpChpmUXmLr4)_