### PR TITLE
ci(npm): publish via Trusted Publishing, scope platform packages under @tingly-dev

### DIFF
--- a/.design/npm.md
+++ b/.design/npm.md
@@ -332,7 +332,35 @@ major versions). Once C lands, the update instruction becomes `tb update`.
    supported" (see `cli-entry-semantics.md`). ✅ 2026-08
 3. E in the next shim release (bin.js only). ✅ 2026-09
 4. F: platform packages + bundle retirement (CI + bin.js). ✅ 2026-09.
-   First publish after this needs the npm token to be allowed to create the
-   five new `tingly-box-<os>-<cpu>` packages.
+   The five `tingly-box-<os>-<cpu>` packages were first published by hand
+   (`build/npx/scripts/publish-platform-packages-manual.sh`, 2026-09) so
+   Trusted Publishing could be configured on them; see G.
 5. C behind a normal feature PR (Go `update` command + shim `current`
    resolution); ship shim change in the same release train as the Go command.
+
+## G. npm auth: Trusted Publishing (OIDC), no tokens
+
+Status: implemented 2026-09.
+
+npm revoked classic tokens (2025-11), capped granular tokens at 90 days and is
+removing the "bypass 2FA" option, so a token in a GitHub secret cannot publish
+from CI any more. `npm.yml` therefore publishes via Trusted Publishing: the
+job requests a GitHub Actions OIDC id-token (`permissions: id-token: write`)
+and npm >= 11.5.1 exchanges it for a single-publish credential. There is no
+`NPM_TOKEN` secret and no `NODE_AUTH_TOKEN` in the workflow.
+
+- **npmjs.com side.** Every package (`tingly-box`, `tingly-box-gui`, the five
+  platform packages) has one Trusted Publisher: GitHub Actions, org
+  `tingly-dev`, repo `tingly-box`, workflow `npm.yml`, environment
+  `production`. All fields are exact-match; renaming the workflow file or the
+  environment breaks publishing until the npm config is updated. Publishing
+  access on each package is set to "Require two-factor authentication and
+  disallow tokens".
+- **Provenance** is attached automatically for OIDC publishes from a public
+  repo; the explicit `--provenance` flag is kept as a no-op guard.
+- **New package names** cannot be configured for Trusted Publishing before
+  they exist, so a brand-new package is published once by hand with
+  `build/npx/scripts/publish-platform-packages-manual.sh <tag>` (curl download,
+  interactive 2FA), then configured on npmjs.com, then left to CI.
+- **Local runs** (`npm publish` from a laptop) still work with 2FA and are the
+  fallback if GitHub OIDC is unavailable.

--- a/.design/npm.md
+++ b/.design/npm.md
@@ -17,8 +17,8 @@ each GitHub release:
   zip from GitHub Releases into the same place. CI bakes the release tag into
   `BINARY_RELEASE_BRANCH` at publish time, so npm package version ↔ binary
   version are 1:1 coupled either way.
-- **`tingly-box-linux-x64`, `tingly-box-linux-arm64`, `tingly-box-darwin-x64`,
-  `tingly-box-darwin-arm64`, `tingly-box-win32-x64`** — one raw Go binary
+- **`@tingly-dev/tingly-box-linux-x64`, `-linux-arm64`, `-darwin-x64`,
+  `-darwin-arm64`, `-win32-x64`** — one raw Go binary
   each at `bin/tingly-box[.exe]`, no bins of their own, `os`/`cpu` fields
   set. Built from the release zips by
   `build/npx/scripts/build-platform-packages.sh` and published *before* the
@@ -264,7 +264,7 @@ reach, while the bundle package fetched everything from the npm registry.
 Decision: make the npm registry the binary's primary channel for the *one*
 package, the way esbuild / swc / biome / sharp do it, and retire the bundle.
 
-- **Per-platform packages** `tingly-box-<os>-<cpu>` (Node's `process.platform`
+- **Per-platform packages** `@tingly-dev/tingly-box-<os>-<cpu>` (Node's `process.platform`
   / `process.arch` names, matching their `os`/`cpu` fields) carry the raw
   binary. `shared/platform.js` is the single source of truth for the names
   and the release-zip each is built from; the build script and the publish
@@ -295,7 +295,7 @@ package, the way esbuild / swc / biome / sharp do it, and retire the bundle.
   checked against `PLATFORM_PACKAGES`), publish them, then wire and publish
   the shim. Before publishing the shim the job does what a user does:
   `npm pack` it and `npm install -g --prefix <scratch>` the tarball against
-  the real registry, asserting the binary came from `tingly-box-linux-x64`
+  the real registry, asserting the binary came from `@tingly-dev/tingly-box-linux-x64`
   and nothing was downloaded. The download fallback keeps its own smoke test.
 - **Retired:** `build/npx/tingly-box-bundle/`, its workflow leg, the
   `publish_bundle` input, the bundle entry in the web UI's update dialog,
@@ -303,7 +303,7 @@ package, the way esbuild / swc / biome / sharp do it, and retire the bundle.
   `npm-bundle` sources so existing installs' shortcuts still work; the
   package on npm should be marked with `npm deprecate` by a maintainer.
 
-Verification: `test-shim.sh` T6 builds `tingly-box-linux-x64` from the
+Verification: `test-shim.sh` T6 builds `@tingly-dev/tingly-box-linux-x64` from the
 real release zip, plants it where npm nests a global install's optional
 deps, and checks install-from-package (no download, binary in the cache
 dir, version reported), then flips the package version and checks the
@@ -332,9 +332,9 @@ major versions). Once C lands, the update instruction becomes `tb update`.
    supported" (see `cli-entry-semantics.md`). ✅ 2026-08
 3. E in the next shim release (bin.js only). ✅ 2026-09
 4. F: platform packages + bundle retirement (CI + bin.js). ✅ 2026-09.
-   The five `tingly-box-<os>-<cpu>` packages were first published by hand
-   (`build/npx/scripts/publish-platform-packages-manual.sh`, 2026-09) so
-   Trusted Publishing could be configured on them; see G.
+   The five `@tingly-dev/tingly-box-<os>-<cpu>` packages were first published
+   by hand (`build/npx/scripts/publish-platform-packages-manual.sh`, 2026-09)
+   so Trusted Publishing could be configured on them; see G.
 5. C behind a normal feature PR (Go `update` command + shim `current`
    resolution); ship shim change in the same release train as the Go command.
 
@@ -358,6 +358,13 @@ and npm >= 11.5.1 exchanges it for a single-publish credential. There is no
   disallow tokens".
 - **Provenance** is attached automatically for OIDC publishes from a public
   repo; the explicit `--provenance` flag is kept as a no-op guard.
+- **Why the platform packages are scoped.** The first attempt used unscoped
+  `tingly-box-<os>-<cpu>` names; after four of them npm's spam detection
+  rejected the fifth (`403 Package name triggered spam detection`), a rule
+  that targets batches of similar names in the public namespace. Names under
+  a scope we own (`@tingly-dev`) do not trip it. The four unscoped packages
+  that did get published (`tingly-box-{linux-x64,linux-arm64,darwin-x64,darwin-arm64}@0.260903.1`)
+  are orphaned and should be `npm deprecate`d; no shim ever referenced them.
 - **New package names** cannot be configured for Trusted Publishing before
   they exist, so a brand-new package is published once by hand with
   `build/npx/scripts/publish-platform-packages-manual.sh <tag>` (curl download,

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -41,6 +41,11 @@ on:
         type: boolean
         default: true
 
+# npm auth: Trusted Publishing (OIDC). No npm token is stored anywhere; the
+# publish jobs mint a short-lived GitHub Actions id-token and npm (>= 11.5.1)
+# exchanges it for publish rights. Each package on npmjs.com is configured
+# with this repo, workflow file "npm.yml" and environment "production"; those
+# names must stay exactly in sync. Provenance is generated automatically.
 permissions:
   contents: write
   id-token: write
@@ -176,6 +181,11 @@ jobs:
           cache: "npm"
           cache-dependency-path: build/npx/package-lock.json
 
+      - name: Check npm supports trusted publishing
+        run: |
+          npm --version
+          node -e 'const [a,b,c]=process.argv[1].split(".").map(Number); if (a<11||(a===11&&(b<5||(b===5&&c<1)))) { console.error("npm >= 11.5.1 required for OIDC trusted publishing"); process.exit(1) }' "$(npm --version)"
+
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"
@@ -218,8 +228,6 @@ jobs:
           platform/tingly-box-linux-x64/bin/tingly-box version
 
       - name: Publish platform packages to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION="${{ needs.setup.outputs.npx_version }}"
           NPM_TAG="${{ needs.setup.outputs.npm_tag }}"
@@ -320,8 +328,6 @@ jobs:
 
       - name: Publish to npm
         working-directory: ${{ env.PKG_DIR }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION="${{ needs.setup.outputs.npx_version }}"
           NPM_TAG="${{ needs.setup.outputs.npm_tag }}"
@@ -460,6 +466,11 @@ jobs:
           cache: "npm"
           cache-dependency-path: build/npx/package-lock.json
 
+      - name: Check npm supports trusted publishing
+        run: |
+          npm --version
+          node -e 'const [a,b,c]=process.argv[1].split(".").map(Number); if (a<11||(a===11&&(b<5||(b===5&&c<1)))) { console.error("npm >= 11.5.1 required for OIDC trusted publishing"); process.exit(1) }' "$(npm --version)"
+
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"
@@ -517,8 +528,6 @@ jobs:
 
       - name: Publish to npm
         working-directory: ${{ env.PKG_DIR }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION="${{ needs.setup.outputs.npx_version }}"
           NPM_TAG="${{ needs.setup.outputs.npm_tag }}"

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -26,7 +26,7 @@ on:
           - rc
         default: 'rc'
       publish_cli:
-        description: '[pkg: tingly-box + tingly-box-<os>-<cpu>] shim plus the per-platform binary packages it depends on'
+        description: '[pkg: tingly-box + @tingly-dev/tingly-box-<os>-<cpu>] shim plus the per-platform binary packages it depends on'
         required: false
         type: boolean
         default: true
@@ -150,7 +150,7 @@ jobs:
             echo "| Build Docker image | ${{ steps.set_vars.outputs.build_docker }} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # Publish the per-platform binary packages (tingly-box-linux-x64, …) and
+  # Publish the per-platform binary packages (@tingly-dev/tingly-box-linux-x64, …) and
   # then the cli shim that pins them as optionalDependencies at this exact
   # version. One job so a release needs one production approval, and the
   # platform packages exist on the registry before the shim is installed
@@ -225,7 +225,7 @@ jobs:
           echo "✅ Built $BUILT platform packages:"
           cat built.txt
           du -sh platform/*
-          platform/tingly-box-linux-x64/bin/tingly-box version
+          platform/@tingly-dev/tingly-box-linux-x64/bin/tingly-box version
 
       - name: Publish platform packages to npm
         run: |
@@ -310,19 +310,19 @@ jobs:
           VERSION="${{ needs.setup.outputs.npx_version }}"
           # Give the registry a moment to serve the platform package just published.
           for i in $(seq 1 12); do
-            if npm view "tingly-box-linux-x64@${VERSION}" version >/dev/null 2>&1; then break; fi
-            echo "waiting for tingly-box-linux-x64@${VERSION} on the registry ($i)..."
+            if npm view "@tingly-dev/tingly-box-linux-x64@${VERSION}" version >/dev/null 2>&1; then break; fi
+            echo "waiting for @tingly-dev/tingly-box-linux-x64@${VERSION} on the registry ($i)..."
             sleep 10
           done
-          npm view "tingly-box-linux-x64@${VERSION}" version
+          npm view "@tingly-dev/tingly-box-linux-x64@${VERSION}" version
           # Exactly what `npm install -g tingly-box` does, from the tarball
           # we are about to publish, into a scratch prefix.
           npm pack --pack-destination "$RUNNER_TEMP" >/dev/null
           PREFIX="$RUNNER_TEMP/prefix"
           npm install -g --prefix "$PREFIX" "$RUNNER_TEMP/tingly-box-${VERSION}.tgz"
-          ls "$PREFIX/lib/node_modules/tingly-box/node_modules"
+          ls "$PREFIX/lib/node_modules/tingly-box/node_modules/@tingly-dev"
           XDG_CACHE_HOME="$RUNNER_TEMP/cache" "$PREFIX/bin/tingly-box" version | tee install.log
-          grep -q "Installing binary from tingly-box-linux-x64@${VERSION}" install.log
+          grep -q "Installing binary from @tingly-dev/tingly-box-linux-x64@${VERSION}" install.log
           ! grep -q "Downloading" install.log
           echo "✅ Global install resolved the binary from the platform package"
 
@@ -395,7 +395,7 @@ jobs:
           \`\`\`
 
           The binary for your platform ships in a companion package
-          (\`tingly-box-linux-x64\`, \`tingly-box-darwin-arm64\`, …) that npm
+          (\`@tingly-dev/tingly-box-linux-x64\`, \`@tingly-dev/tingly-box-darwin-arm64\`, …) that npm
           installs automatically — no GitHub download, npm mirrors work.
           NOTES_EOF
 

--- a/build/npx/scripts/build-platform-packages.sh
+++ b/build/npx/scripts/build-platform-packages.sh
@@ -54,7 +54,7 @@ while IFS='|' read -r key name zip; do
   "homepage": "https://github.com/tingly-dev/tingly-box",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tingly-dev/tingly-box.git"
+    "url": "git+https://github.com/tingly-dev/tingly-box.git"
   },
   "license": "MPL-2.0",
   "author": "Tingly Dev",

--- a/build/npx/scripts/build-platform-packages.sh
+++ b/build/npx/scripts/build-platform-packages.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build the per-platform binary packages (tingly-box-linux-x64, …) that the
+# Build the per-platform binary packages (@tingly-dev/tingly-box-linux-x64, …) that the
 # `tingly-box` package pulls in as optionalDependencies. Each package is the
 # raw Go binary from the release zip plus a package.json pinned to the same
 # version as the shim. Used by .github/workflows/npm.yml and test-shim.sh.
@@ -9,7 +9,8 @@
 #   version  npm version to stamp (release tag without the leading "v")
 #   zip-dir  directory holding the release zips (tingly-box-<os>-<arch>.zip);
 #            platforms whose zip is absent are skipped with a notice
-#   out-dir  one package directory per platform is written under here
+#   out-dir  one package directory per platform is written under here, at
+#            <out-dir>/<package name> (so <out-dir>/@tingly-dev/tingly-box-linux-x64)
 # Prints the names of the packages built, one per line, on stdout.
 set -euo pipefail
 

--- a/build/npx/scripts/publish-platform-packages-manual.sh
+++ b/build/npx/scripts/publish-platform-packages-manual.sh
@@ -11,16 +11,29 @@
 # builds the packages with build-platform-packages.sh and runs `npm publish`
 # for each one; npm prompts for 2FA (browser / passkey) on every publish.
 #
-# Usage: publish-platform-packages-manual.sh <release-tag> [--dry-run]
+# Usage: publish-platform-packages-manual.sh <release-tag> [--dry-run] [--otp <code>]
 #   release-tag  e.g. v0.260903.1 (the npm version is the tag without "v")
 #   --dry-run    download + build + `npm publish --dry-run`, publish nothing
+#   --otp CODE   authenticator code to pass to npm publish (TOTP accounts).
+#                Without it npm prompts on the terminal for each package
+#                (or opens the browser for a passkey/WebAuthn account).
 #
 # Env: GITHUB_REPO (default tingly-dev/tingly-box), WORK_DIR (default ./.platform-publish)
 set -euo pipefail
 
-TAG="${1:?usage: $0 <release-tag> [--dry-run]}"
+TAG="${1:?usage: $0 <release-tag> [--dry-run] [--otp <code>]}"
+shift
 DRY_RUN=""
-[ "${2:-}" = "--dry-run" ] && DRY_RUN="--dry-run"
+OTP=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--dry-run) DRY_RUN="--dry-run" ;;
+		--otp) OTP="${2:?--otp needs a code}"; shift ;;
+		--otp=*) OTP="${1#--otp=}" ;;
+		*) echo "❌ unknown argument: $1" >&2; exit 1 ;;
+	esac
+	shift
+done
 
 if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
 	echo "❌ invalid tag '$TAG', expected e.g. v1.0.0 or v1.0.0-beta" >&2
@@ -77,14 +90,23 @@ cat "$WORK_DIR/built.txt"
 
 # ---- publish -------------------------------------------------------------
 # No --provenance: that needs the CI OIDC token and fails on a laptop.
-while read -r name; do
+# Read the list into an array first so npm keeps the terminal as stdin and
+# can prompt for the one-time password (a `while read < file` loop would
+# swallow the prompt and fail with EOTP).
+mapfile -t NAMES < "$WORK_DIR/built.txt"
+OTP_ARGS=()
+if [ -n "$OTP" ]; then
+	OTP_ARGS=(--otp "$OTP")
+	echo "⚠️  a TOTP code is valid for ~30s; if a later package fails with EOTP, rerun with a fresh code (published ones are skipped)"
+fi
+for name in "${NAMES[@]}"; do
 	if npm view "${name}@${VERSION}" version >/dev/null 2>&1; then
 		echo "ℹ️  ${name}@${VERSION} already on npm, skipping"
 		continue
 	fi
 	echo "📦 npm publish ${name}@${VERSION} ${DRY_RUN}"
-	(cd "$OUT_DIR/$name" && npm publish --access public $DRY_RUN)
-done < "$WORK_DIR/built.txt"
+	(cd "$OUT_DIR/$name" && npm publish --access public ${DRY_RUN:+"$DRY_RUN"} "${OTP_ARGS[@]}")
+done
 
 if [ -n "$DRY_RUN" ]; then
 	echo "🧪 dry run finished, nothing published"

--- a/build/npx/scripts/publish-platform-packages-manual.sh
+++ b/build/npx/scripts/publish-platform-packages-manual.sh
@@ -108,8 +108,11 @@ for name in "${NAMES[@]}"; do
 	# The registry answers 409 "Failed to save packument" while it is still
 	# processing a previous PUT for the same name (or a tombstone left by an
 	# unpublish). Wait and retry a few times before giving up.
+	# stdin/stdout must stay the terminal: npm only shows the 2FA prompt /
+	# browser auth link when both are a TTY. Only stderr is copied to a log
+	# (via process substitution) so the 409 check can read it.
 	attempt=1
-	until (cd "$OUT_DIR/$name" && npm publish --access public ${DRY_RUN:+"$DRY_RUN"} "${OTP_ARGS[@]}") 2>&1 | tee "$WORK_DIR/publish.log"; test "${PIPESTATUS[0]}" -eq 0; do
+	until (cd "$OUT_DIR/$name" && npm publish --access public ${DRY_RUN:+"$DRY_RUN"} "${OTP_ARGS[@]}" 2> >(tee "$WORK_DIR/publish.log" >&2)); do
 		if [ "$attempt" -ge 4 ] || ! grep -q "409 Conflict" "$WORK_DIR/publish.log"; then
 			echo "❌ publish of ${name}@${VERSION} failed" >&2
 			exit 1

--- a/build/npx/scripts/publish-platform-packages-manual.sh
+++ b/build/npx/scripts/publish-platform-packages-manual.sh
@@ -105,7 +105,19 @@ for name in "${NAMES[@]}"; do
 		continue
 	fi
 	echo "📦 npm publish ${name}@${VERSION} ${DRY_RUN}"
-	(cd "$OUT_DIR/$name" && npm publish --access public ${DRY_RUN:+"$DRY_RUN"} "${OTP_ARGS[@]}")
+	# The registry answers 409 "Failed to save packument" while it is still
+	# processing a previous PUT for the same name (or a tombstone left by an
+	# unpublish). Wait and retry a few times before giving up.
+	attempt=1
+	until (cd "$OUT_DIR/$name" && npm publish --access public ${DRY_RUN:+"$DRY_RUN"} "${OTP_ARGS[@]}") 2>&1 | tee "$WORK_DIR/publish.log"; test "${PIPESTATUS[0]}" -eq 0; do
+		if [ "$attempt" -ge 4 ] || ! grep -q "409 Conflict" "$WORK_DIR/publish.log"; then
+			echo "❌ publish of ${name}@${VERSION} failed" >&2
+			exit 1
+		fi
+		echo "⏳ 409 from the registry, retrying in 60s (attempt $attempt/3)…"
+		sleep 60
+		attempt=$((attempt + 1))
+	done
 done
 
 if [ -n "$DRY_RUN" ]; then

--- a/build/npx/scripts/publish-platform-packages-manual.sh
+++ b/build/npx/scripts/publish-platform-packages-manual.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# One-off manual publish of the per-platform binary packages
+# (tingly-box-linux-x64, …) from a maintainer's machine.
+#
+# Needed once per package that does not exist on npm yet: a Trusted Publisher
+# (OIDC) can only be configured on an existing package, so the first version
+# has to be published with an interactive 2FA login. After that
+# .github/workflows/npm.yml publishes every version via OIDC.
+#
+# Downloads the release zips straight from GitHub Releases with curl (no gh),
+# builds the packages with build-platform-packages.sh and runs `npm publish`
+# for each one; npm prompts for 2FA (browser / passkey) on every publish.
+#
+# Usage: publish-platform-packages-manual.sh <release-tag> [--dry-run]
+#   release-tag  e.g. v0.260903.1 (the npm version is the tag without "v")
+#   --dry-run    download + build + `npm publish --dry-run`, publish nothing
+#
+# Env: GITHUB_REPO (default tingly-dev/tingly-box), WORK_DIR (default ./.platform-publish)
+set -euo pipefail
+
+TAG="${1:?usage: $0 <release-tag> [--dry-run]}"
+DRY_RUN=""
+[ "${2:-}" = "--dry-run" ] && DRY_RUN="--dry-run"
+
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+	echo "❌ invalid tag '$TAG', expected e.g. v1.0.0 or v1.0.0-beta" >&2
+	exit 1
+fi
+VERSION="${TAG#v}"
+REPO="${GITHUB_REPO:-tingly-dev/tingly-box}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NPX_DIR="$(dirname "$SCRIPT_DIR")"
+WORK_DIR="${WORK_DIR:-$PWD/.platform-publish}"
+ZIP_DIR="$WORK_DIR/zips"
+OUT_DIR="$WORK_DIR/platform"
+
+for tool in curl unzip node npm; do
+	command -v "$tool" >/dev/null || { echo "❌ $tool is required" >&2; exit 1; }
+done
+
+if [ -z "$DRY_RUN" ]; then
+	if ! npm whoami >/dev/null 2>&1; then
+		echo "❌ not logged in to npm. Run 'npm login' first (passkey/WebAuthn 2FA)." >&2
+		exit 1
+	fi
+	echo "👤 publishing as $(npm whoami) to $(npm config get registry)"
+fi
+
+# ---- download release zips (curl, follows the GitHub CDN redirect) ---------
+mkdir -p "$ZIP_DIR"
+ZIPS="$(node -e '
+import("'"$NPX_DIR"'/shared/platform.js").then(m => {
+  for (const { zip } of Object.values(m.PLATFORM_PACKAGES)) console.log(zip);
+});')"
+while read -r zip; do
+	url="https://github.com/$REPO/releases/download/$TAG/$zip"
+	if [ -s "$ZIP_DIR/$zip" ]; then
+		echo "ℹ️  $zip already downloaded"
+		continue
+	fi
+	echo "📥 $url"
+	curl -fL --retry 3 --retry-delay 2 -o "$ZIP_DIR/$zip.part" "$url"
+	mv "$ZIP_DIR/$zip.part" "$ZIP_DIR/$zip"
+done <<< "$ZIPS"
+ls -lh "$ZIP_DIR"
+
+# ---- build ---------------------------------------------------------------
+"$SCRIPT_DIR/build-platform-packages.sh" "$VERSION" "$ZIP_DIR" "$OUT_DIR" > "$WORK_DIR/built.txt"
+EXPECTED="$(printf '%s\n' "$ZIPS" | wc -l | tr -d ' ')"
+BUILT="$(wc -l < "$WORK_DIR/built.txt" | tr -d ' ')"
+if [ "$BUILT" -ne "$EXPECTED" ]; then
+	echo "❌ built $BUILT packages, expected $EXPECTED (a release zip is missing)" >&2
+	exit 1
+fi
+echo "✅ built $BUILT packages:"
+cat "$WORK_DIR/built.txt"
+
+# ---- publish -------------------------------------------------------------
+# No --provenance: that needs the CI OIDC token and fails on a laptop.
+while read -r name; do
+	if npm view "${name}@${VERSION}" version >/dev/null 2>&1; then
+		echo "ℹ️  ${name}@${VERSION} already on npm, skipping"
+		continue
+	fi
+	echo "📦 npm publish ${name}@${VERSION} ${DRY_RUN}"
+	(cd "$OUT_DIR/$name" && npm publish --access public $DRY_RUN)
+done < "$WORK_DIR/built.txt"
+
+if [ -n "$DRY_RUN" ]; then
+	echo "🧪 dry run finished, nothing published"
+else
+	echo "✅ done. Next: configure a Trusted Publisher on npmjs.com for each package"
+	echo "   (repo $REPO, workflow npm.yml, environment production)."
+fi

--- a/build/npx/scripts/publish-platform-packages-manual.sh
+++ b/build/npx/scripts/publish-platform-packages-manual.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # One-off manual publish of the per-platform binary packages
-# (tingly-box-linux-x64, …) from a maintainer's machine.
+# (@tingly-dev/tingly-box-linux-x64, …) from a maintainer's machine.
 #
 # Needed once per package that does not exist on npm yet: a Trusted Publisher
 # (OIDC) can only be configured on an existing package, so the first version

--- a/build/npx/shared/platform.js
+++ b/build/npx/shared/platform.js
@@ -1,5 +1,5 @@
 // Platform binary packages: `tingly-box` declares one optionalDependency per
-// supported platform (tingly-box-linux-x64, …); npm installs only the one
+// supported platform (@tingly-dev/tingly-box-linux-x64, …); npm installs only the one
 // whose os/cpu match and skips the rest silently. Each carries the raw Go
 // binary at bin/tingly-box[.exe], so an install needs nothing but the npm
 // registry (mirrors included) — no GitHub download. The cli shim resolves it
@@ -9,7 +9,9 @@
 //
 // scripts/build-platform-packages.sh and the publish workflow read this map
 // (via `node -e`) to build and wire the packages, so it is the single source
-// of truth for names and the release-zip mapping.
+// of truth for names and the release-zip mapping. Names are scoped under
+// @tingly-dev: npm's spam detection blocks batches of similar unscoped
+// names, a scope we own does not trip it (.design/npm.md, "G").
 
 import { createRequire } from "module";
 import { existsSync } from "fs";
@@ -18,11 +20,11 @@ import { dirname, join } from "path";
 // key: `${process.platform}-${process.arch}` → { name, zip }
 // zip: the release asset name (release.yml) the package is built from.
 export const PLATFORM_PACKAGES = {
-	"linux-x64": { name: "tingly-box-linux-x64", zip: "tingly-box-linux-amd64.zip" },
-	"linux-arm64": { name: "tingly-box-linux-arm64", zip: "tingly-box-linux-arm64.zip" },
-	"darwin-x64": { name: "tingly-box-darwin-x64", zip: "tingly-box-macos-amd64.zip" },
-	"darwin-arm64": { name: "tingly-box-darwin-arm64", zip: "tingly-box-macos-arm64.zip" },
-	"win32-x64": { name: "tingly-box-win32-x64", zip: "tingly-box-windows-amd64.zip" },
+	"linux-x64": { name: "@tingly-dev/tingly-box-linux-x64", zip: "tingly-box-linux-amd64.zip" },
+	"linux-arm64": { name: "@tingly-dev/tingly-box-linux-arm64", zip: "tingly-box-linux-arm64.zip" },
+	"darwin-x64": { name: "@tingly-dev/tingly-box-darwin-x64", zip: "tingly-box-macos-amd64.zip" },
+	"darwin-arm64": { name: "@tingly-dev/tingly-box-darwin-arm64", zip: "tingly-box-macos-arm64.zip" },
+	"win32-x64": { name: "@tingly-dev/tingly-box-win32-x64", zip: "tingly-box-windows-amd64.zip" },
 };
 
 export function platformPackageName() {

--- a/build/npx/test-shim.sh
+++ b/build/npx/test-shim.sh
@@ -145,7 +145,7 @@ grep -q "Stack:" "$WORK/fail.log" \
 	|| pass "T5: no stack trace in the failure output"
 
 # --- T6: platform package (the npm install path) is used, no download ------
-# Build tingly-box-linux-x64 from the release zip like the publish workflow,
+# Build @tingly-dev/tingly-box-linux-x64 from the release zip like the publish workflow,
 # plant it where npm nests optional deps of a global install, and check the
 # shim installs from it into the versioned cache without touching GitHub.
 if [ "$(uname -s)" = "Linux" ] && [ "$(uname -m)" = "x86_64" ]; then
@@ -156,15 +156,15 @@ if [ "$(uname -s)" = "Linux" ] && [ "$(uname -m)" = "x86_64" ]; then
 	"$SCRIPT_DIR/scripts/build-platform-packages.sh" "$VERSION" "$WORK/zips" "$WORK/platform" >/dev/null 2>&1 \
 		&& pass "T6: platform package built from the release zip" \
 		|| fail "T6: build-platform-packages.sh failed"
-	mkdir -p "$NM/tingly-box/node_modules"
-	cp -r "$WORK/platform/tingly-box-linux-x64" "$NM/tingly-box/node_modules/"
+	mkdir -p "$NM/tingly-box/node_modules/@tingly-dev"
+	cp -r "$WORK/platform/@tingly-dev/tingly-box-linux-x64" "$NM/tingly-box/node_modules/@tingly-dev/"
 	rm -rf "$XDG_CACHE_HOME/tingly-box/$TAG"
 	if node "$NM/tingly-box/bin.js" version > "$WORK/pkg.log" 2>&1; then
 		pass "T6: shim ran (exit 0)"
 	else
 		fail "T6: shim failed:"; tail -5 "$WORK/pkg.log"
 	fi
-	grep -q "Installing binary from tingly-box-linux-x64@$VERSION" "$WORK/pkg.log" \
+	grep -q "Installing binary from @tingly-dev/tingly-box-linux-x64@$VERSION" "$WORK/pkg.log" \
 		&& ! grep -q "Downloading" "$WORK/pkg.log" \
 		&& pass "T6: binary came from the platform package, nothing downloaded" \
 		|| { fail "T6: expected the platform package path:"; head -5 "$WORK/pkg.log"; }
@@ -175,7 +175,7 @@ if [ "$(uname -s)" = "Linux" ] && [ "$(uname -m)" = "x86_64" ]; then
 		&& pass "T6: binary copied into the versioned cache dir" \
 		|| fail "T6: cache copy missing"
 	# Version mismatch (partial upgrade) must fall back to the release download.
-	sed -i 's/"version": "[^"]*"/"version": "0.0.1"/' "$NM/tingly-box/node_modules/tingly-box-linux-x64/package.json"
+	sed -i 's/"version": "[^"]*"/"version": "0.0.1"/' "$NM/tingly-box/node_modules/@tingly-dev/tingly-box-linux-x64/package.json"
 	node "$NM/tingly-box/bin.js" version > "$WORK/mismatch.log" 2>&1 || true
 	grep -q "does not match tingly-box@$VERSION" "$WORK/mismatch.log" \
 		&& ! grep -q "Installing binary from" "$WORK/mismatch.log" \

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -193,7 +193,7 @@ This is a manual workflow that publishes npm packages based on an existing GitHu
 | Package | Description | Install Command |
 |---------|-------------|-----------------|
 | `tingly-box` | CLI shim; pulls the platform package below as an optional dependency, falls back to the GitHub release download | `npx tingly-box@version` |
-| `tingly-box-<os>-<cpu>` | Binary for one platform (`linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`, `win32-x64`); published before `tingly-box` at the same version | installed automatically |
+| `@tingly-dev/tingly-box-<os>-<cpu>` | Binary for one platform (`linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`, `win32-x64`); published before `tingly-box` at the same version | installed automatically |
 | `tingly-box-gui` | GUI package (desktop app) | `npx tingly-box-gui@version start` |
 
 `tingly-box-bundle` (binaries zipped inside one ~70MB package) is retired:

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -21,8 +21,8 @@ npm install -g tingly-box
 tb start    # background by default; pass --no-daemon for foreground
 ```
 
-The binary for your platform is an npm package too (`tingly-box-linux-x64`,
-`tingly-box-darwin-arm64`, …), installed automatically alongside
+The binary for your platform is an npm package too (`@tingly-dev/tingly-box-linux-x64`,
+`@tingly-dev/tingly-box-darwin-arm64`, …), installed automatically alongside
 `tingly-box`. Nothing is fetched from GitHub, so an npm mirror registry
 (`--registry=https://registry.npmmirror.com`) is all a restricted network
 needs.


### PR DESCRIPTION
## Summary
npm is retiring token-based publishing that bypasses 2FA, so CI could no longer publish with `NPM_TOKEN`; the workflow now publishes through GitHub OIDC, and the platform packages moved under `@tingly-dev` after npm's spam detection rejected the fifth unscoped name.

## Key Changes

- **Token-free publishing**: `npm.yml` drops `NODE_AUTH_TOKEN` from all publish steps and relies on the `id-token` it already requests, guarded by an npm ≥ 11.5.1 check.
- **Scoped platform packages**: `tingly-box-<os>-<cpu>` becomes `@tingly-dev/tingly-box-<os>-<cpu>` in `shared/platform.js`; build dirs, CI smoke test, and `test-shim.sh` T6 follow the nested layout.
- **First-publish path for new names**: `publish-platform-packages-manual.sh` downloads release zips with curl (no gh), builds, and publishes interactively with 2FA, retrying on 409.

## Notes

- npmjs.com must carry a Trusted Publisher (repo `tingly-dev/tingly-box`, workflow `npm.yml`, environment `production`) on all seven packages; the `NPM_TOKEN` secret can be deleted after merge.
- The four orphaned unscoped packages at `0.260903.1` should be `npm deprecate`d; no published shim references them.

## Testing

- `build/npx/test-shim.sh v0.260903.1` passes, including T6 through the scoped package.
- A CI-style `npm install -g` of a packed shim against the real registry pulled `@tingly-dev/tingly-box-linux-x64@0.260903.1` and ran the binary without a download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UTf8E97AU3Qzhq1EDKWWUV