### PR TITLE
cli: restart without confirmation; simplify access banner title

### DIFF
--- a/.design/cli-entry-semantics.md
+++ b/.design/cli-entry-semantics.md
@@ -14,13 +14,15 @@ requests, which for an LLM gateway can be minutes-long streams.
 ## Decision
 
 Split the entry semantics by how the process was invoked; server lifecycle
-changes are either explicitly requested or explicitly confirmed.
+changes are always explicitly requested — by a lifecycle verb (`start`,
+`stop`, `restart`) or by a bare `npx` invocation, never by a casual run of an
+installed bin.
 
 **Bare invocation:**
 
 - **`npx tingly-box` / `npm exec`** (shim detects `npm_command=exec`): keeps
-  the historical run-now behavior as `restart --daemon -y` — the npx
-  invocation is itself the consent a bare `restart` would prompt for.
+  the historical run-now behavior as `restart --daemon` (the shim still
+  passes `-y`, now a hidden no-op kept for compatibility).
 - **Installed CLI** (global `npm install -g` bin run directly, or the raw Go
   binary): shows **help**. An installed CLI is a toolbox (like `git`,
   `docker`); the server is started deliberately with `tingly-box start`.
@@ -58,7 +60,7 @@ which one the user typed.
   recorded server version differs from this launcher (typical right after
   `npm install -g`), one extra hint line says so and points to
   `tingly-box restart`. `start` is purely informational when the server is
-  up; all interactive confirmation lives in `restart`.
+  up; interrupting a running server is what `restart` / `stop` are for.
 
   The running version comes from `<configDir>/tingly-server.version`
   (`pkg/lock.VersionFile`), a runtime artifact written next to the port file
@@ -69,13 +71,15 @@ which one the user typed.
   started by a build predating the file reads as "unknown" and simply gets
   the generic restart hint.
 
-**`restart`:** confirms before interrupting. When the server is running, a
-bare `restart` asks ("In-flight AI requests will be interrupted. [y/N]",
-default No); `-y`/`--yes` proceeds directly (what npx passes); without a TTY
-and without `-y` it leaves the server untouched and says to re-run with
-`-y`. When the server is not running there is nothing to interrupt, so it
-starts without asking — which keeps unattended first-boots (e.g. the Docker
-npx image's pm2 wrapper) working. `restart` inherits daemon-by-default.
+**`restart`:** acts immediately, no second confirmation. Typing the verb is
+already the intent — exactly like `stop`, which has never asked — and a
+`[y/N]` prompt on top of it was inconsistent (`stop` kills in-flight requests
+without asking) and broke unattended use (without a TTY the old code refused
+to act and told the user to re-run with `-y`). The in-flight-requests cost
+is documented instead of gated. `-y`/`--yes` is still accepted as a hidden
+no-op so existing invocations (the npx shim, the Docker npx image's pm2
+wrapper, user scripts) keep working. When the server is not running,
+`restart` simply starts it. `restart` inherits daemon-by-default.
 
 **`stop`:** remains the explicit, immediate lifecycle verb.
 

--- a/.design/npm.md
+++ b/.design/npm.md
@@ -49,8 +49,8 @@ which is what `test-shim.sh` T6 does).
 
 No-args behavior is split by invocation (see `cli-entry-semantics.md`): under
 npx / `npm exec` (`npm_command=exec`) the shim keeps the historical run-now
-behavior as `restart --daemon -y` (the invocation is the consent a bare
-`restart` prompts for); run as an installed bin (global install) it passes
+behavior as `restart --daemon -y` (`-y` is a compatibility no-op — `restart`
+no longer prompts); run as an installed bin (global install) it passes
 `--help` instead — server lifecycle is explicit (`tingly-box start`, which
 daemonizes by default) so a casual `tingly-box` can't kill in-flight AI
 requests. `--source` follows the same split (`npx`/`npm`) with unified

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm install -g tingly-box@latest   # --registry=<mirror> works here too
 tb start   # tb = tingly-box; runs in the background (--no-daemon for foreground)
 tb open    # open the web UI
 
-# update: reinstall, then restart to apply (asks first; -y skips)
+# update: reinstall, then restart to apply
 npm install -g tingly-box@latest
 tb restart
 ```

--- a/build/npx/shared/entry.js
+++ b/build/npx/shared/entry.js
@@ -4,9 +4,9 @@
 
 export const IS_NPX = process.env.npm_command === "exec";
 
-// Bare npx invocation = "run it now" (restart into the background, -y being
-// the consent a bare `restart` would otherwise prompt for); a bare installed
-// bin shows help.
+// Bare npx invocation = "run it now" (restart into the background; -y is a
+// compatibility no-op — `restart` no longer prompts); a bare installed bin
+// shows help.
 export const DEFAULT_ARGS = IS_NPX ? ["restart", "--daemon", "-y"] : ["--help"];
 
 // Records how this process was launched; also decides which npm package a

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -29,9 +29,9 @@ needs.
 
 `tingly-box` and `tb` are the same CLI; running it with no arguments shows
 help. To update a global install: `npm install -g tingly-box@latest`, then
-`tb restart` to switch the running server to the new version — `restart`
-asks for confirmation while the server is running (a restart interrupts
-in-flight AI requests); pass `-y` to skip the prompt in scripts.
+`tb restart` to switch the running server to the new version. `restart` acts
+immediately — like `stop`, the command itself is the intent — so be aware it
+interrupts any in-flight AI requests.
 
 
 ### Method 2: Docker

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -86,7 +86,10 @@ func (s *StatusCmdKong) Run(appManager *AppManager) error {
 // RestartCmdKong is the Kong version of restart command
 type RestartCmdKong struct {
 	StartCmdKong
-	Yes bool `kong:"flag,name='yes',short='y',help='Restart without asking for confirmation'"`
+	// Kept as a hidden no-op: `restart` no longer asks for confirmation (the
+	// verb itself is the intent), but the npx entrypoint, the Docker pm2
+	// wrapper and user scripts still pass -y.
+	Yes bool `kong:"flag,name='yes',short='y',hidden"`
 }
 
 func (r *RestartCmdKong) Run(appManager *AppManager, source LaunchSource) error {
@@ -105,23 +108,10 @@ func (r *RestartCmdKong) Run(appManager *AppManager, source LaunchSource) error 
 		runningPort = appManager.GetRuntimeServerPort()
 	}
 
-	// Restarting a running server interrupts in-flight AI requests, so a bare
-	// `restart` confirms first; -y (what the npx entrypoint passes — there the
-	// invocation itself expresses "run it now") proceeds directly. When the
-	// server isn't running there is nothing to interrupt and no question to
-	// ask. Without a terminal and without -y, leave the server untouched.
-	if wasRunning && !r.Yes {
-		if !isStdinTTY() {
-			fmt.Printf("Server is running on port %d — a restart would interrupt in-flight AI requests.\n", runningPort)
-			fmt.Println("Re-run with -y ('tingly-box restart -y' / 'tb restart -y') to restart without prompting.")
-			return nil
-		}
-		if !promptYesNo("Restart the server? In-flight AI requests will be interrupted.") {
-			fmt.Println("\nKeeping the running server untouched.")
-			return nil
-		}
-	}
-
+	// Typing `restart` already expresses the intent, so there is no second
+	// confirmation — the command stops the running server (interrupting any
+	// in-flight AI requests) and starts it again.
+	//
 	// A real restart continues on the port the server is actually running on,
 	// not the config default. That port may have come from `--port` at start
 	// time and is intentionally never persisted, so without this a bare
@@ -361,6 +351,7 @@ func printBanner(cfg BannerConfig) {
 	urlStyle := lipgloss.NewStyle().Foreground(success)
 	tokenStyle := lipgloss.NewStyle().Foreground(highlight)
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(primary)
+	versionStyle := lipgloss.NewStyle().Foreground(muted)
 
 	var lines []string
 	addLine := func(label, value string, valueStyle lipgloss.Style) {
@@ -380,11 +371,15 @@ func printBanner(cfg BannerConfig) {
 		addLine("Login Token", cfg.GlobalConfig.GetUserToken(), tokenStyle)
 	}
 
-	// Build title with product name and version
-	titleText := titleStyle.Render(fmt.Sprintf("Tingly Box - %s — Access Information", BuildVersion))
+	// Title: product name on one line, version on the next — nothing else.
+	titleText := titleStyle.Render("Tingly-Box")
+	versionText := versionStyle.Render(formatVersion(BuildVersion))
 
-	// Compute visual width for centering the title
+	// Compute visual width for centering the title lines
 	maxWidth := lipgloss.Width(titleText)
+	if w := lipgloss.Width(versionText); w > maxWidth {
+		maxWidth = w
+	}
 	for _, line := range lines {
 		if w := lipgloss.Width(line); w > maxWidth {
 			maxWidth = w
@@ -392,7 +387,8 @@ func printBanner(cfg BannerConfig) {
 	}
 
 	title := lipgloss.PlaceHorizontal(maxWidth, lipgloss.Center, titleText)
-	allLines := append([]string{title, ""}, lines...)
+	version := lipgloss.PlaceHorizontal(maxWidth, lipgloss.Center, versionText)
+	allLines := append([]string{title, version, ""}, lines...)
 
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
@@ -406,6 +402,19 @@ func printBanner(cfg BannerConfig) {
 	if cfg.IsDaemon {
 		fmt.Println("Server is running in background. Use 'tingly-box stop' / 'tb stop' to stop.")
 	}
+}
+
+// formatVersion renders a build version for display: release builds get a
+// "v" prefix ("v1.4.2"), while non-release markers such as "dev" are shown
+// as-is.
+func formatVersion(v string) string {
+	if v == "" || v == "dev" || strings.HasPrefix(v, "v") {
+		return v
+	}
+	if v[0] >= '0' && v[0] <= '9' {
+		return "v" + v
+	}
+	return v
 }
 
 // openBrowserURL opens the given URL in the default browser
@@ -433,16 +442,6 @@ func doStopServer(appManager *AppManager) error {
 
 	fmt.Println("Server stopped successfully")
 	return nil
-}
-
-// promptYesNo asks a [y/N] question on stdin, defaulting to no on anything
-// but an explicit yes (including EOF from a detached stdin).
-func promptYesNo(question string) bool {
-	fmt.Print(question + " [y/N]: ")
-	var response string
-	fmt.Scanln(&response)
-	response = strings.ToLower(strings.TrimSpace(response))
-	return response == "y" || response == "yes"
 }
 
 // startServer handles the server starting logic

--- a/internal/command/server.go
+++ b/internal/command/server.go
@@ -404,14 +404,10 @@ func printBanner(cfg BannerConfig) {
 	}
 }
 
-// formatVersion renders a build version for display: release builds get a
-// "v" prefix ("v1.4.2"), while non-release markers such as "dev" are shown
-// as-is.
+// formatVersion renders a build version for display: a bare release number
+// ("1.4.2") gets a "v" prefix; anything else ("dev", "v1.4.2") is shown as-is.
 func formatVersion(v string) string {
-	if v == "" || v == "dev" || strings.HasPrefix(v, "v") {
-		return v
-	}
-	if v[0] >= '0' && v[0] <= '9' {
+	if v != "" && v[0] >= '0' && v[0] <= '9' {
 		return "v" + v
 	}
 	return v
@@ -517,7 +513,7 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 
 		versionNote := " (version unknown)"
 		if runningVersion != "" {
-			versionNote = fmt.Sprintf(" (v%s)", strings.TrimPrefix(runningVersion, "v"))
+			versionNote = fmt.Sprintf(" (%s)", formatVersion(runningVersion))
 		}
 		fmt.Printf("Server is already running on port %d%s\n", runningPort, versionNote)
 		printBanner(BannerConfig{
@@ -528,7 +524,7 @@ func startServerWithHook(appManager *AppManager, opts options.StartServerOptions
 			IsDaemon:     false,
 		})
 		if runningVersion != "" && runningVersion != BuildVersion {
-			fmt.Printf("This launcher is v%s — run 'tingly-box restart' / 'tb restart' to switch the running server to it.\n", BuildVersion)
+			fmt.Printf("This launcher is %s — run 'tingly-box restart' / 'tb restart' to switch the running server to it.\n", formatVersion(BuildVersion))
 		} else {
 			fmt.Println("Use 'tingly-box restart' / 'tb restart' to restart the server")
 		}

--- a/internal/command/token.go
+++ b/internal/command/token.go
@@ -312,3 +312,13 @@ func maskTokenPreview(t string) string {
 	}
 	return t[:6] + "…" + t[len(t)-4:]
 }
+
+// promptYesNo asks a [y/N] question on stdin, defaulting to no on anything
+// but an explicit yes (including EOF from a detached stdin).
+func promptYesNo(question string) bool {
+	fmt.Print(question + " [y/N]: ")
+	var response string
+	fmt.Scanln(&response)
+	response = strings.ToLower(strings.TrimSpace(response))
+	return response == "y" || response == "yes"
+}


### PR DESCRIPTION
## Summary
`restart` asked `[y/N]` while `stop` never did, and without a TTY it refused to act; the verb is already the intent, so it now proceeds directly.

## Key Changes

- **Restart lifecycle**: no second confirmation; `-y` kept as a hidden no-op so the npx shim, Docker pm2 wrapper and scripts keep working.
- **Access banner**: title is now two centered lines, `Tingly-Box` and the version (`v1.4.2` / `dev`), dropping "Access Information".
- **Docs**: README, user manual and `.design` entry-semantics notes updated to match.