### PR TITLE
ci: map docker moving tag to npm dist-tag (latest vs rc)

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -11,6 +11,13 @@ inputs:
   version:
     description: 'Version tag for the image'
     required: true
+  channel_tag:
+    description: >-
+      Moving alias to additionally apply (e.g. "latest" for a stable release,
+      "rc" for a pre-release). Empty applies only the version tag. Must mirror
+      the npm dist-tag: only a `latest` npm publish may move docker `latest`.
+    required: false
+    default: ''
   dockerfile:
     description: 'Path to Dockerfile'
     required: false
@@ -53,7 +60,7 @@ runs:
         images: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}
         tags: |
           type=raw,value=${{ inputs.version }}
-          type=raw,value=latest
+          type=raw,value=${{ inputs.channel_tag }},enable=${{ inputs.channel_tag != '' }}
 
     - name: Build and push Docker image
       id: build
@@ -76,6 +83,7 @@ runs:
         ## Docker Image Published :rocket:
 
         **Tag:** `${{ inputs.version }}`
+        **Channel tag:** `${{ inputs.channel_tag || '(none)' }}`
         **Image:** `${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}:${{ inputs.version }}`
 
         ### Pull Command

--- a/.github/workflows/docker-npx.yml
+++ b/.github/workflows/docker-npx.yml
@@ -27,11 +27,13 @@ jobs:
         with:
           release_tag: ${{ github.event.inputs.release_tag }}
 
+      # Same mapping as npm.yml: stable → latest, pre-release (v1.2.3-rc1) → rc.
       - name: Build and push Docker image
         uses: ./.github/actions/docker-build-push
         with:
           image_name: tingly-box
           version: ${{ steps.validate.outputs.tag }}
+          channel_tag: ${{ steps.validate.outputs.is_prerelease == 'true' && 'rc' || 'latest' }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_args: |
             TINGLY_VERSION=${{ steps.validate.outputs.npm_version }}

--- a/.github/workflows/docker-source.yml
+++ b/.github/workflows/docker-source.yml
@@ -55,6 +55,8 @@ jobs:
             exit 1
           fi
 
+      # Source builds are ad-hoc: only the requested tag is applied, never a
+      # moving alias such as `latest` or `rc` (those follow npm publishes).
       - name: Build and push Docker image
         uses: ./.github/actions/docker-build-push
         with:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -148,6 +148,7 @@ jobs:
             echo "| Publish CLI (\`tingly-box\` + platform packages) | ${{ steps.set_vars.outputs.publish_cli }} |"
             echo "| Publish GUI (\`tingly-box-gui\`) | ${{ steps.set_vars.outputs.publish_gui }} |"
             echo "| Build Docker image | ${{ steps.set_vars.outputs.build_docker }} |"
+            echo "| Docker moving tag | \`${{ steps.set_vars.outputs.npm_tag }}\` (mirrors npm dist-tag) |"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Publish the per-platform binary packages (@tingly-dev/tingly-box-linux-x64, …) and
@@ -427,11 +428,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      # The docker moving tag mirrors the npm dist-tag: a `latest` npm publish
+      # moves docker `latest`, an `rc` publish moves docker `rc` only.
       - name: Build and push Docker image
         uses: ./.github/actions/docker-build-push
         with:
           image_name: tingly-box
           version: ${{ needs.setup.outputs.release_tag }}
+          channel_tag: ${{ needs.setup.outputs.npm_tag }}
           github_token: ${{ github.token }}
           build_args: |
             TINGLY_VERSION=${{ needs.setup.outputs.npx_version }}

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -29,6 +29,11 @@ docker run -d \
 Open `http://localhost:12580` in your browser (the container logs print the
 full login URL).
 
+Image tags mirror the npm dist-tags: `latest` tracks the newest stable
+release, `rc` tracks the newest pre-release (e.g. `v1.2.3-rc1`), and every
+release is also available under its exact version tag (`v1.2.3`). Pre-releases
+never move `latest`.
+
 ### Using Docker Compose
 
 ```bash


### PR DESCRIPTION
## Summary
The docker build action always applied `latest`, so an rc npm publish (or an ad-hoc source build) overwrote the stable docker `latest` tag.

## Key Changes

- **Release channel fidelity**: new `channel_tag` input on `docker-build-push`; npm `latest` → docker `latest`, npm `rc` → docker `rc`.
- **Manual image build**: `docker-npx.yml` infers the channel from the tag (pre-release → `rc`).
- **Source builds**: `docker-source.yml` applies only the requested tag, no moving alias.
