### PR TITLE
npx: ship the release zip in platform packages, publish concurrently

### DIFF
--- a/.design/npm.md
+++ b/.design/npm.md
@@ -352,7 +352,9 @@ and npm >= 11.5.1 exchanges it for a single-publish credential. There is no
 - **npmjs.com side.** Every package (`tingly-box`, `tingly-box-gui`, the five
   platform packages) has one Trusted Publisher: GitHub Actions, org
   `tingly-dev`, repo `tingly-box`, workflow `npm.yml`, environment
-  `production`. All fields are exact-match; renaming the workflow file or the
+  `production`, with Allowed actions including `npm publish` (configs created
+  after 2026-09-03 default to stage publish only, which makes `npm publish`
+  fail with a generic "package not found"). All fields are exact-match; renaming the workflow file or the
   environment breaks publishing until the npm config is updated. Publishing
   access on each package is set to "Require two-factor authentication and
   disallow tokens".

--- a/.design/npm.md
+++ b/.design/npm.md
@@ -18,11 +18,10 @@ each GitHub release:
   `BINARY_RELEASE_BRANCH` at publish time, so npm package version ↔ binary
   version are 1:1 coupled either way.
 - **`@tingly-dev/tingly-box-linux-x64`, `-linux-arm64`, `-darwin-x64`,
-  `-darwin-arm64`, `-win32-x64`** — one raw Go binary
-  each at `bin/tingly-box[.exe]`, no bins of their own, `os`/`cpu` fields
-  set. Built from the release zips by
-  `build/npx/scripts/build-platform-packages.sh` and published *before* the
-  shim at the same version. Not meant to be installed directly.
+  `-darwin-arm64`, `-win32-x64`** — the release zip, unchanged, at
+  `bin/tingly-box-<os>-<arch>.zip`; no bins of their own, `os`/`cpu` fields
+  set. Built by `build/npx/scripts/build-platform-packages.sh` and published
+  *before* the shim at the same version. Not meant to be installed directly.
 - **`tingly-box-gui`** — shim variant for the desktop UI, published on demand;
   download-only (no platform packages).
 
@@ -265,24 +264,29 @@ Decision: make the npm registry the binary's primary channel for the *one*
 package, the way esbuild / swc / biome / sharp do it, and retire the bundle.
 
 - **Per-platform packages** `@tingly-dev/tingly-box-<os>-<cpu>` (Node's `process.platform`
-  / `process.arch` names, matching their `os`/`cpu` fields) carry the raw
-  binary. `shared/platform.js` is the single source of truth for the names
-  and the release-zip each is built from; the build script and the publish
-  workflow read it with `node -e`. Sizes match the zips (~20–30 MB each);
-  a user downloads exactly one.
+  / `process.arch` names, matching their `os`/`cpu` fields) carry the
+  release zip itself. `shared/platform.js` is the single source of truth
+  for the names and the zip each one holds; the build script and the
+  publish workflow read it with `node -e`. A user downloads exactly one
+  (~20–30 MB). The zip stays compressed in `node_modules`: the npm tarball
+  is gzip already, so shipping the raw binary saved nothing on the wire
+  but cost ~110 MB on disk per install for the non-UPX macOS/Windows
+  builds (2026-09, first cut shipped the raw binary).
 - **Exact-version pins.** CI sets `optionalDependencies.<name> = <version>`
   on the shim at publish time, and the shim uses a platform package only if
   `version === own version` (`shared/platform.js` + `resolveBinarySource()`
   in `bin.js`). A partial upgrade can't pair an old binary with a new shim;
   the mismatch falls through to the download with a warning.
-- **Copy to the versioned cache, don't exec in `node_modules`.** The shim
-  copies the binary into `~/.cache/tingly-box/v<ver>/bin/` (temp file +
-  rename) and runs it from there, so every invariant the download path
-  already had still holds: a running daemon keeps its inode while
-  `npm install -g` retires the package dir (on Windows npm could not even
-  remove a locked exe from under a running server), the stale-cache sweep
-  (E) sees one layout, and shortcut relaunch / `--transport-version` are
-  unchanged. Cost: one ~20 MB copy per version.
+- **Extract into the versioned cache, don't exec in `node_modules`.** The
+  shim extracts the packaged zip into `~/.cache/tingly-box/v<ver>/bin/`
+  with the same `extractZipBuffer` the download path uses (only the source
+  differs: local file vs GitHub) and runs it from there, so every invariant
+  the download path already had still holds: a running daemon keeps its
+  inode while `npm install -g` retires the package dir (on Windows npm
+  could not even remove a locked exe from under a running server), the
+  stale-cache sweep (E) sees one layout, and shortcut relaunch /
+  `--transport-version` are unchanged. Cost: one extraction (~1–2 s) per
+  version.
 - **Download stays as the fallback.** `--no-optional`, a mirror that hasn't
   synced the platform package yet, an unsupported platform, or an explicit
   `--transport-version` all take the GitHub path exactly as before. When the

--- a/.design/npm.md
+++ b/.design/npm.md
@@ -292,8 +292,14 @@ package, the way esbuild / swc / biome / sharp do it, and retire the bundle.
   all means the package is absent, so that is the fix, before retry/proxy.
 - **Publish order.** One `publish-cli` job (one production approval per
   release): build all five platform packages from the release zips (count
-  checked against `PLATFORM_PACKAGES`), publish them, then wire and publish
-  the shim. Before publishing the shim the job does what a user does:
+  checked against `PLATFORM_PACKAGES`), publish all five concurrently
+  (background processes in one step, so the single approval is kept; a
+  matrix job per platform would need a second approval for the shim job),
+  then wire and publish the shim. A version already on the registry is a
+  skip, not a failure, and the registry's own "previously published"
+  rejection counts as "already there" because `npm view` on the read
+  replicas can lag a publish by minutes. Before publishing the shim the job
+  does what a user does:
   `npm pack` it and `npm install -g --prefix <scratch>` the tarball against
   the real registry, asserting the binary came from `@tingly-dev/tingly-box-linux-x64`
   and nothing was downloaded. The download fallback keeps its own smoke test.

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -213,6 +213,18 @@ jobs:
               FAIL=1
             fi
           done
+          # Control probes: packages known to use Trusted Publishing from
+          # other repos. Their (expected) rejection message shows what the
+          # registry says for "config exists but does not match this token".
+          for pkg in npm sigstore; do
+            body=$(curl -sS -o /dev/stdout -w '\n%{http_code}' -X POST \
+              -H "Authorization: Bearer $ID_TOKEN" \
+              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$pkg")
+            echo "ℹ️  control $pkg: HTTP ${body##*$'\n'}: $(printf '%s' "${body%$'\n'*}" | jq -r '.message // .error // .' 2>/dev/null)"
+          done
+          # npm's own exchange attempt, verbose (dry-run still runs the OIDC step).
+          echo "npm CLI oidc log:"
+          (cd "$PKG_DIR" && npm publish --dry-run --loglevel verbose 2>&1 | grep -iE "oidc|exchange" || true)
           [ "$FAIL" -eq 0 ] || { echo "Fix the Trusted Publisher config on npmjs.com (repo, workflow filename npm.yml, environment production)"; exit 1; }
 
       - name: Configure Git
@@ -529,6 +541,18 @@ jobs:
               FAIL=1
             fi
           done
+          # Control probes: packages known to use Trusted Publishing from
+          # other repos. Their (expected) rejection message shows what the
+          # registry says for "config exists but does not match this token".
+          for pkg in npm sigstore; do
+            body=$(curl -sS -o /dev/stdout -w '\n%{http_code}' -X POST \
+              -H "Authorization: Bearer $ID_TOKEN" \
+              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$pkg")
+            echo "ℹ️  control $pkg: HTTP ${body##*$'\n'}: $(printf '%s' "${body%$'\n'*}" | jq -r '.message // .error // .' 2>/dev/null)"
+          done
+          # npm's own exchange attempt, verbose (dry-run still runs the OIDC step).
+          echo "npm CLI oidc log:"
+          (cd "$PKG_DIR" && npm publish --dry-run --loglevel verbose 2>&1 | grep -iE "oidc|exchange" || true)
           [ "$FAIL" -eq 0 ] || { echo "Fix the Trusted Publisher config on npmjs.com (repo, workflow filename npm.yml, environment production)"; exit 1; }
 
       - name: Configure Git

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -192,35 +192,7 @@ jobs:
       # registry's reason is visible in the log. Fails the job early.
       - name: Verify npm OIDC trusted-publisher exchange
         env:
-          PACKAGES: ${{ env.PKG_NAME }}
-        run: |
-          ID_TOKEN=$(curl -sSf -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" | jq -r .value)
-          echo "id-token claims npm matches against:"
-          node -e 'const c=JSON.parse(Buffer.from(process.argv[1].split(".")[1],"base64url")); console.log(JSON.stringify({repository:c.repository,repository_owner:c.repository_owner,workflow_ref:c.workflow_ref,job_workflow_ref:c.job_workflow_ref,environment:c.environment,event_name:c.event_name,ref:c.ref},null,2))' "$ID_TOKEN"
-          FAIL=0
-          for pkg in $PACKAGES; do
-            escaped=$(printf '%s' "$pkg" | sed 's|/|%2F|')
-            body=$(curl -sS -o /dev/stdout -w '\n%{http_code}' -X POST \
-              -H "Authorization: Bearer $ID_TOKEN" \
-              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$escaped")
-            code=${body##*$'\n'}
-            resp=${body%$'\n'*}
-            if [ "$code" = "200" ]; then
-              echo "✅ $pkg: exchange OK"
-            else
-              echo "❌ $pkg: exchange HTTP $code: $(printf '%s' "$resp" | jq -r '.message // .error // .' 2>/dev/null || printf '%s' "$resp")"
-              FAIL=1
-            fi
-          done
-          [ "$FAIL" -eq 0 ] || { echo "Fix the Trusted Publisher config on npmjs.com (repo, workflow filename npm.yml, environment production)"; exit 1; }
-
-      # npm silently falls back to token auth (and then fails with E404) when
-      # the OIDC exchange is rejected; do the same exchange here first so the
-      # registry's reason is visible in the log. Fails the job early.
-      - name: Verify npm OIDC trusted-publisher exchange
-        env:
-          PACKAGES: ${{ env.PKG_NAME }} @tingly-dev/tingly-box-linux-x64
+          PACKAGES: ${{ env.PKG_NAME }} @tingly-dev/tingly-box-linux-x64 @tingly-dev/tingly-box-linux-arm64 @tingly-dev/tingly-box-darwin-x64 @tingly-dev/tingly-box-darwin-arm64 @tingly-dev/tingly-box-win32-x64
         run: |
           ID_TOKEN=$(curl -sSf -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" | jq -r .value)
@@ -530,6 +502,34 @@ jobs:
         run: |
           npm --version
           node -e 'const [a,b,c]=process.argv[1].split(".").map(Number); if (a<11||(a===11&&(b<5||(b===5&&c<1)))) { console.error("npm >= 11.5.1 required for OIDC trusted publishing"); process.exit(1) }' "$(npm --version)"
+
+      # npm silently falls back to token auth (and then fails with E404) when
+      # the OIDC exchange is rejected; do the same exchange here first so the
+      # registry's reason is visible in the log. Fails the job early.
+      - name: Verify npm OIDC trusted-publisher exchange
+        env:
+          PACKAGES: ${{ env.PKG_NAME }}
+        run: |
+          ID_TOKEN=$(curl -sSf -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" | jq -r .value)
+          echo "id-token claims npm matches against:"
+          node -e 'const c=JSON.parse(Buffer.from(process.argv[1].split(".")[1],"base64url")); console.log(JSON.stringify({repository:c.repository,repository_owner:c.repository_owner,workflow_ref:c.workflow_ref,job_workflow_ref:c.job_workflow_ref,environment:c.environment,event_name:c.event_name,ref:c.ref},null,2))' "$ID_TOKEN"
+          FAIL=0
+          for pkg in $PACKAGES; do
+            escaped=$(printf '%s' "$pkg" | sed 's|/|%2F|')
+            body=$(curl -sS -o /dev/stdout -w '\n%{http_code}' -X POST \
+              -H "Authorization: Bearer $ID_TOKEN" \
+              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$escaped")
+            code=${body##*$'\n'}
+            resp=${body%$'\n'*}
+            if [ "$code" = "200" ]; then
+              echo "✅ $pkg: exchange OK"
+            else
+              echo "❌ $pkg: exchange HTTP $code: $(printf '%s' "$resp" | jq -r '.message // .error // .' 2>/dev/null || printf '%s' "$resp")"
+              FAIL=1
+            fi
+          done
+          [ "$FAIL" -eq 0 ] || { echo "Fix the Trusted Publisher config on npmjs.com (repo, workflow filename npm.yml, environment production)"; exit 1; }
 
       - name: Configure Git
         run: |

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -213,18 +213,6 @@ jobs:
               FAIL=1
             fi
           done
-          # Control probes: packages known to use Trusted Publishing from
-          # other repos. Their (expected) rejection message shows what the
-          # registry says for "config exists but does not match this token".
-          for pkg in npm sigstore; do
-            body=$(curl -sS -o /dev/stdout -w '\n%{http_code}' -X POST \
-              -H "Authorization: Bearer $ID_TOKEN" \
-              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$pkg")
-            echo "ℹ️  control $pkg: HTTP ${body##*$'\n'}: $(printf '%s' "${body%$'\n'*}" | jq -r '.message // .error // .' 2>/dev/null)"
-          done
-          # npm's own exchange attempt, verbose (dry-run still runs the OIDC step).
-          echo "npm CLI oidc log:"
-          (cd "$PKG_DIR" && npm publish --dry-run --loglevel verbose 2>&1 | grep -iE "oidc|exchange" || true)
           [ "$FAIL" -eq 0 ] || {
             echo "The registry has no Trusted Publisher on that package that matches this run AND allows 'npm publish'."
             echo "Check on npmjs.com (package Settings -> Trusted Publisher): org tingly-dev, repo tingly-box, workflow npm.yml,"
@@ -274,18 +262,44 @@ jobs:
           du -sh platform/*
           platform/@tingly-dev/tingly-box-linux-x64/bin/tingly-box version
 
+      # All five uploads run concurrently (one job, so still one production
+      # approval). A version that is already on the registry is a skip, not a
+      # failure: `npm view` can lag behind a publish by minutes on the read
+      # replicas, so the registry's own "previously published" rejection is
+      # treated as "already there" too. Per-package logs keep output readable.
       - name: Publish platform packages to npm
         run: |
           VERSION="${{ needs.setup.outputs.npx_version }}"
           NPM_TAG="${{ needs.setup.outputs.npm_tag }}"
-          while read -r name; do
+          mkdir -p publish-logs
+          publish_one() {
+            local name="$1" log="publish-logs/$(echo "$1" | tr '/@' '__').log"
             if npm view "${name}@${VERSION}" version >/dev/null 2>&1; then
-              echo "ℹ️ ${name}@${VERSION} already exists on npm. Skipping publish."
-              continue
+              echo "skip" > "$log.status"; return 0
             fi
+            if (cd "platform/$name" && npm publish --provenance --access public --tag "$NPM_TAG") > "$log" 2>&1; then
+              echo "ok" > "$log.status"
+            elif grep -qiE "previously published|cannot publish over|EPUBLISHCONFLICT|already exists" "$log"; then
+              echo "skip" > "$log.status"
+            else
+              echo "fail" > "$log.status"
+            fi
+          }
+          while read -r name; do
             echo "📦 Publishing ${name}@${VERSION} (tag: ${NPM_TAG})..."
-            (cd "platform/$name" && npm publish --provenance --access public --tag "$NPM_TAG")
+            publish_one "$name" &
           done < built.txt
+          wait
+          FAILED=0
+          while read -r name; do
+            log="publish-logs/$(echo "$name" | tr '/@' '__').log"
+            case "$(cat "$log.status" 2>/dev/null)" in
+              ok)   echo "✅ ${name}@${VERSION} published" ;;
+              skip) echo "ℹ️  ${name}@${VERSION} already on npm, skipped" ;;
+              *)    echo "❌ ${name}@${VERSION} failed:"; sed 's/^/    /' "$log"; FAILED=1 ;;
+            esac
+          done < built.txt
+          [ "$FAILED" -eq 0 ]
 
       # ---- cli shim ----------------------------------------------------
       - name: Update NPX package.json with new version
@@ -356,7 +370,7 @@ jobs:
         run: |
           VERSION="${{ needs.setup.outputs.npx_version }}"
           # Give the registry a moment to serve the platform package just published.
-          for i in $(seq 1 12); do
+          for i in $(seq 1 30); do
             if npm view "@tingly-dev/tingly-box-linux-x64@${VERSION}" version >/dev/null 2>&1; then break; fi
             echo "waiting for @tingly-dev/tingly-box-linux-x64@${VERSION} on the registry ($i)..."
             sleep 10
@@ -383,8 +397,13 @@ jobs:
 
           if npm view "$PKG_NAME@${VERSION}" version >/dev/null 2>&1; then
             echo "ℹ️ $PKG_NAME@${VERSION} already exists on npm. Skipping publish."
+          elif npm publish --provenance --access public --tag "$NPM_TAG" 2>&1 | tee publish.log; test "${PIPESTATUS[0]}" -eq 0; then
+            echo "✅ $PKG_NAME@${VERSION} published"
+          elif grep -qiE "previously published|cannot publish over|EPUBLISHCONFLICT" publish.log; then
+            # `npm view` lags behind the registry; the registry itself says it is there.
+            echo "ℹ️ $PKG_NAME@${VERSION} already on npm (registry rejected the re-publish). Skipping."
           else
-            npm publish --provenance --access public --tag "$NPM_TAG"
+            exit 1
           fi
 
   # Append NPX install info to the existing version release (no extra tag/release)
@@ -547,18 +566,6 @@ jobs:
               FAIL=1
             fi
           done
-          # Control probes: packages known to use Trusted Publishing from
-          # other repos. Their (expected) rejection message shows what the
-          # registry says for "config exists but does not match this token".
-          for pkg in npm sigstore; do
-            body=$(curl -sS -o /dev/stdout -w '\n%{http_code}' -X POST \
-              -H "Authorization: Bearer $ID_TOKEN" \
-              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$pkg")
-            echo "ℹ️  control $pkg: HTTP ${body##*$'\n'}: $(printf '%s' "${body%$'\n'*}" | jq -r '.message // .error // .' 2>/dev/null)"
-          done
-          # npm's own exchange attempt, verbose (dry-run still runs the OIDC step).
-          echo "npm CLI oidc log:"
-          (cd "$PKG_DIR" && npm publish --dry-run --loglevel verbose 2>&1 | grep -iE "oidc|exchange" || true)
           [ "$FAIL" -eq 0 ] || {
             echo "The registry has no Trusted Publisher on that package that matches this run AND allows 'npm publish'."
             echo "Check on npmjs.com (package Settings -> Trusted Publisher): org tingly-dev, repo tingly-box, workflow npm.yml,"
@@ -632,8 +639,13 @@ jobs:
 
           if npm view "$PKG_NAME@${VERSION}" version >/dev/null 2>&1; then
             echo "ℹ️ $PKG_NAME@${VERSION} already exists on npm. Skipping publish."
+          elif npm publish --provenance --access public --tag "$NPM_TAG" 2>&1 | tee publish.log; test "${PIPESTATUS[0]}" -eq 0; then
+            echo "✅ $PKG_NAME@${VERSION} published"
+          elif grep -qiE "previously published|cannot publish over|EPUBLISHCONFLICT" publish.log; then
+            # `npm view` lags behind the registry; the registry itself says it is there.
+            echo "ℹ️ $PKG_NAME@${VERSION} already on npm (registry rejected the re-publish). Skipping."
           else
-            npm publish --provenance --access public --tag "$NPM_TAG"
+            exit 1
           fi
 
       - name: Append GUI NPX info to release notes

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -259,8 +259,10 @@ jobs:
           fi
           echo "✅ Built $BUILT platform packages:"
           cat built.txt
-          du -sh platform/*
-          platform/@tingly-dev/tingly-box-linux-x64/bin/tingly-box version
+          du -sh platform/@tingly-dev/*
+          # The package carries the release zip; run the binary out of it once.
+          unzip -q -o platform/@tingly-dev/tingly-box-linux-x64/bin/tingly-box-linux-amd64.zip tingly-box -d "$RUNNER_TEMP/sanity"
+          "$RUNNER_TEMP/sanity/tingly-box" version
 
       # All five uploads run concurrently (one job, so still one production
       # approval). A version that is already on the registry is a skip, not a

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -187,6 +187,62 @@ jobs:
           npm --version
           node -e 'const [a,b,c]=process.argv[1].split(".").map(Number); if (a<11||(a===11&&(b<5||(b===5&&c<1)))) { console.error("npm >= 11.5.1 required for OIDC trusted publishing"); process.exit(1) }' "$(npm --version)"
 
+      # npm silently falls back to token auth (and then fails with E404) when
+      # the OIDC exchange is rejected; do the same exchange here first so the
+      # registry's reason is visible in the log. Fails the job early.
+      - name: Verify npm OIDC trusted-publisher exchange
+        env:
+          PACKAGES: ${{ env.PKG_NAME }}
+        run: |
+          ID_TOKEN=$(curl -sSf -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" | jq -r .value)
+          echo "id-token claims npm matches against:"
+          node -e 'const c=JSON.parse(Buffer.from(process.argv[1].split(".")[1],"base64url")); console.log(JSON.stringify({repository:c.repository,repository_owner:c.repository_owner,workflow_ref:c.workflow_ref,job_workflow_ref:c.job_workflow_ref,environment:c.environment,event_name:c.event_name,ref:c.ref},null,2))' "$ID_TOKEN"
+          FAIL=0
+          for pkg in $PACKAGES; do
+            escaped=$(printf '%s' "$pkg" | sed 's|/|%2F|')
+            body=$(curl -sS -o /dev/stdout -w '\n%{http_code}' -X POST \
+              -H "Authorization: Bearer $ID_TOKEN" \
+              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$escaped")
+            code=${body##*$'\n'}
+            resp=${body%$'\n'*}
+            if [ "$code" = "200" ]; then
+              echo "✅ $pkg: exchange OK"
+            else
+              echo "❌ $pkg: exchange HTTP $code: $(printf '%s' "$resp" | jq -r '.message // .error // .' 2>/dev/null || printf '%s' "$resp")"
+              FAIL=1
+            fi
+          done
+          [ "$FAIL" -eq 0 ] || { echo "Fix the Trusted Publisher config on npmjs.com (repo, workflow filename npm.yml, environment production)"; exit 1; }
+
+      # npm silently falls back to token auth (and then fails with E404) when
+      # the OIDC exchange is rejected; do the same exchange here first so the
+      # registry's reason is visible in the log. Fails the job early.
+      - name: Verify npm OIDC trusted-publisher exchange
+        env:
+          PACKAGES: ${{ env.PKG_NAME }} @tingly-dev/tingly-box-linux-x64
+        run: |
+          ID_TOKEN=$(curl -sSf -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" | jq -r .value)
+          echo "id-token claims npm matches against:"
+          node -e 'const c=JSON.parse(Buffer.from(process.argv[1].split(".")[1],"base64url")); console.log(JSON.stringify({repository:c.repository,repository_owner:c.repository_owner,workflow_ref:c.workflow_ref,job_workflow_ref:c.job_workflow_ref,environment:c.environment,event_name:c.event_name,ref:c.ref},null,2))' "$ID_TOKEN"
+          FAIL=0
+          for pkg in $PACKAGES; do
+            escaped=$(printf '%s' "$pkg" | sed 's|/|%2F|')
+            body=$(curl -sS -o /dev/stdout -w '\n%{http_code}' -X POST \
+              -H "Authorization: Bearer $ID_TOKEN" \
+              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$escaped")
+            code=${body##*$'\n'}
+            resp=${body%$'\n'*}
+            if [ "$code" = "200" ]; then
+              echo "✅ $pkg: exchange OK"
+            else
+              echo "❌ $pkg: exchange HTTP $code: $(printf '%s' "$resp" | jq -r '.message // .error // .' 2>/dev/null || printf '%s' "$resp")"
+              FAIL=1
+            fi
+          done
+          [ "$FAIL" -eq 0 ] || { echo "Fix the Trusted Publisher config on npmjs.com (repo, workflow filename npm.yml, environment production)"; exit 1; }
+
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -225,7 +225,13 @@ jobs:
           # npm's own exchange attempt, verbose (dry-run still runs the OIDC step).
           echo "npm CLI oidc log:"
           (cd "$PKG_DIR" && npm publish --dry-run --loglevel verbose 2>&1 | grep -iE "oidc|exchange" || true)
-          [ "$FAIL" -eq 0 ] || { echo "Fix the Trusted Publisher config on npmjs.com (repo, workflow filename npm.yml, environment production)"; exit 1; }
+          [ "$FAIL" -eq 0 ] || {
+            echo "The registry has no Trusted Publisher on that package that matches this run AND allows 'npm publish'."
+            echo "Check on npmjs.com (package Settings -> Trusted Publisher): org tingly-dev, repo tingly-box, workflow npm.yml,"
+            echo "environment production, and Allowed actions includes 'npm publish' (configs created after 2026-09-03 default"
+            echo "to stage publish only). Or: npm trust list <pkg> / npm trust github <pkg> --repo tingly-dev/tingly-box --file npm.yml --env production --allow-publish"
+            exit 1
+          }
 
       - name: Configure Git
         run: |
@@ -553,7 +559,13 @@ jobs:
           # npm's own exchange attempt, verbose (dry-run still runs the OIDC step).
           echo "npm CLI oidc log:"
           (cd "$PKG_DIR" && npm publish --dry-run --loglevel verbose 2>&1 | grep -iE "oidc|exchange" || true)
-          [ "$FAIL" -eq 0 ] || { echo "Fix the Trusted Publisher config on npmjs.com (repo, workflow filename npm.yml, environment production)"; exit 1; }
+          [ "$FAIL" -eq 0 ] || {
+            echo "The registry has no Trusted Publisher on that package that matches this run AND allows 'npm publish'."
+            echo "Check on npmjs.com (package Settings -> Trusted Publisher): org tingly-dev, repo tingly-box, workflow npm.yml,"
+            echo "environment production, and Allowed actions includes 'npm publish' (configs created after 2026-09-03 default"
+            echo "to stage publish only). Or: npm trust list <pkg> / npm trust github <pkg> --repo tingly-dev/tingly-box --file npm.yml --env production --allow-publish"
+            exit 1
+          }
 
       - name: Configure Git
         run: |

--- a/build/npx/scripts/build-platform-packages.sh
+++ b/build/npx/scripts/build-platform-packages.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Build the per-platform binary packages (@tingly-dev/tingly-box-linux-x64, …) that the
 # `tingly-box` package pulls in as optionalDependencies. Each package is the
-# raw Go binary from the release zip plus a package.json pinned to the same
-# version as the shim. Used by .github/workflows/npm.yml and test-shim.sh.
+# release zip itself (bin/<zip>, unchanged) plus a package.json pinned to the
+# same version as the shim; the shim extracts it into its versioned cache on
+# first run. Used by .github/workflows/npm.yml and test-shim.sh.
 # Design: .design/npm.md ("F. Platform packages").
 #
 # Usage: build-platform-packages.sh <version> <zip-dir> <out-dir>
@@ -39,19 +40,20 @@ while IFS='|' read -r key name zip; do
 	fi
 	binary="tingly-box"
 	[ "$os" = "win32" ] && binary="tingly-box.exe"
+	# Sanity: the zip must hold the binary at its top level (what the shim extracts).
+	unzip -l "$zip_path" | awk '{print $NF}' | grep -qx "$binary" \
+		|| { echo "$zip does not contain $binary at its top level" >&2; exit 1; }
 
 	pkg_dir="$OUT_DIR/$name"
 	rm -rf "$pkg_dir"
 	mkdir -p "$pkg_dir/bin"
-	# The release zip holds the binary at its top level; extract just that.
-	unzip -q -o -j "$zip_path" "$binary" -d "$pkg_dir/bin"
-	[ "$os" = "win32" ] || chmod 755 "$pkg_dir/bin/$binary"
+	cp "$zip_path" "$pkg_dir/bin/$zip"
 
 	cat > "$pkg_dir/package.json" <<JSON
 {
   "name": "$name",
   "version": "$VERSION",
-  "description": "tingly-box binary for $os-$cpu. Installed automatically as an optional dependency of the tingly-box package; not meant to be installed directly.",
+  "description": "tingly-box binary for $os-$cpu (release zip). Installed automatically as an optional dependency of the tingly-box package; not meant to be installed directly.",
   "homepage": "https://github.com/tingly-dev/tingly-box",
   "repository": {
     "type": "git",
@@ -76,14 +78,15 @@ JSON
 	cat > "$pkg_dir/README.md" <<MD
 # $name
 
-The tingly-box binary for $os-$cpu. This package is pulled in automatically
-by the [\`tingly-box\`](https://www.npmjs.com/package/tingly-box) package as
-an optional dependency; install that one instead:
+The tingly-box binary for $os-$cpu, as the release zip. This package is pulled
+in automatically by the [\`tingly-box\`](https://www.npmjs.com/package/tingly-box)
+package as an optional dependency and extracted on first run; install that
+one instead:
 
 \`\`\`bash
 npm install -g tingly-box
 \`\`\`
 MD
-	echo "built $name@$VERSION ($(du -h "$pkg_dir/bin/$binary" | cut -f1))" >&2
+	echo "built $name@$VERSION ($(du -h "$pkg_dir/bin/$zip" | cut -f1))" >&2
 	echo "$name"
 done <<< "$PLATFORMS"

--- a/build/npx/shared/download.js
+++ b/build/npx/shared/download.js
@@ -1,7 +1,8 @@
-// Release-zip download + extraction shared by the cli and gui shims
-// (the bundle shim extracts from packaged zips and has its own path).
+// Release-zip download + extraction shared by the cli and gui shims. The
+// cli shim also extracts the same zip from the platform package npm
+// installed next to it (extractZipFile), so both sources share one path.
 
-import { chmodSync, createWriteStream, existsSync, mkdirSync, statSync } from "fs";
+import { chmodSync, createWriteStream, existsSync, mkdirSync, readFileSync, statSync } from "fs";
 import { join } from "path";
 import { Readable } from "stream";
 import { ProxyAgent } from "undici";
@@ -84,7 +85,25 @@ export async function downloadAndExtractZip(url, extractDir, { hints = [] } = {}
 		}
 	}
 	const zipBuffer = Buffer.concat(chunks);
+	await extractZipBuffer(zipBuffer, extractDir);
+}
 
+// Extract a release zip that is already on disk (the platform package's
+// bin/<zip>) into extractDir.
+export async function extractZipFile(zipPath, extractDir) {
+	let zipBuffer;
+	try {
+		zipBuffer = readFileSync(zipPath);
+	} catch (error) {
+		console.error(`\n❌ Failed to read ${zipPath}: ${error.message}`);
+		process.exit(1);
+	}
+	await extractZipBuffer(zipBuffer, extractDir);
+}
+
+// Extract every file of a zip buffer into extractDir, keeping unix modes
+// (binaries stay executable). Exits the process on failure.
+export async function extractZipBuffer(zipBuffer, extractDir) {
 	// Extract ZIP from buffer using unzipper
 	try {
 		console.log(`\n📦 Extracting ZIP to ${extractDir}...`);

--- a/build/npx/shared/platform.js
+++ b/build/npx/shared/platform.js
@@ -1,9 +1,11 @@
 // Platform binary packages: `tingly-box` declares one optionalDependency per
 // supported platform (@tingly-dev/tingly-box-linux-x64, …); npm installs only the one
-// whose os/cpu match and skips the rest silently. Each carries the raw Go
-// binary at bin/tingly-box[.exe], so an install needs nothing but the npm
-// registry (mirrors included) — no GitHub download. The cli shim resolves it
-// from here and falls back to the release download when it is missing (e.g.
+// whose os/cpu match and skips the rest silently. Each carries the release
+// zip (bin/tingly-box-<os>-<arch>.zip, the same asset the download path
+// fetches from GitHub), so an install needs nothing but the npm registry
+// (mirrors included) — no GitHub download — and node_modules holds ~30 MB
+// instead of the ~110 MB raw binary. The cli shim resolves it from here and
+// falls back to the release download when it is missing (e.g.
 // `--no-optional`, a registry mirror that hasn't synced the platform package
 // yet, or a dev checkout). Rationale: .design/npm.md ("F. Platform packages").
 //
@@ -36,20 +38,19 @@ export function platformPackageName() {
 // from `fromUrl` (the calling shim's import.meta.url), so it finds the
 // package wherever npm put it: nested under the global install, hoisted in
 // npx's cache, or a dev checkout's node_modules. Returns
-// { name, version, binaryPath } or null when not installed / incomplete.
+// { name, version, zipPath } or null when not installed / incomplete.
 // Never throws — the caller treats null as "use the download path".
 export function findPlatformPackage(fromUrl) {
-	const name = platformPackageName();
-	if (!name) return null;
+	const entry = PLATFORM_PACKAGES[`${process.platform}-${process.arch}`];
+	if (!entry) return null;
 	try {
 		// Distinct identifier from the `require` the esbuild banner defines.
 		const resolver = createRequire(fromUrl);
-		const pkgJsonPath = resolver.resolve(`${name}/package.json`);
+		const pkgJsonPath = resolver.resolve(`${entry.name}/package.json`);
 		const pkg = resolver(pkgJsonPath);
-		const binaryName = "tingly-box" + (process.platform === "win32" ? ".exe" : "");
-		const binaryPath = join(dirname(pkgJsonPath), "bin", binaryName);
-		if (!existsSync(binaryPath)) return null;
-		return { name, version: pkg.version, binaryPath };
+		const zipPath = join(dirname(pkgJsonPath), "bin", entry.zip);
+		if (!existsSync(zipPath)) return null;
+		return { name: entry.name, version: pkg.version, zipPath };
 	} catch {
 		return null;
 	}

--- a/build/npx/tingly-box/bin.js
+++ b/build/npx/tingly-box/bin.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-import { chmodSync, copyFileSync, existsSync, mkdirSync, renameSync, rmSync } from "fs";
+import { existsSync, mkdirSync } from "fs";
 import { createRequire } from "module";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { cacheDir } from "../shared/cachedir.js";
 import { cleanupRetiredInstallDirs, cleanupStaleBinaryCaches } from "../shared/cleanup.js";
-import { downloadAndExtractZip } from "../shared/download.js";
+import { downloadAndExtractZip, extractZipFile } from "../shared/download.js";
 import { DEFAULT_ARGS, downloadFailureHints, sourceArgs } from "../shared/entry.js";
 import { execBinary } from "../shared/exec.js";
 import { findPlatformPackage, platformPackageName } from "../shared/platform.js";
@@ -50,32 +50,16 @@ function resolveBinarySource() {
 	return { kind: "download", tag: VERSION, hints: [] };
 }
 
-// Copy the platform package's binary into the versioned cache dir, writing a
-// temp file and renaming so the final path only ever holds a complete
-// binary. The cache copy — rather than exec'ing inside node_modules — keeps
-// the invariants the download path already has: a running daemon keeps its
-// inode while `npm install -g` retires the package dir (on Windows npm
-// could not even remove a locked exe), and the stale-cache sweep, shortcut
-// relaunch and `--transport-version` all keep one layout.
-function installFromPackage(local, binaryPath) {
+// Extract the platform package's release zip into the versioned cache dir
+// — the same extraction the download path does, just from a local file.
+// Running from the cache rather than from node_modules keeps the invariants
+// the download path already has: a running daemon keeps its inode while
+// `npm install -g` retires the package dir (on Windows npm could not even
+// remove a locked exe), and the stale-cache sweep, shortcut relaunch and
+// `--transport-version` all keep one layout.
+async function installFromPackage(local, extractDir) {
 	console.log(`📦 Installing binary from ${local.name}@${local.version}...`);
-	const tmpPath = `${binaryPath}.tmp-${process.pid}`;
-	try {
-		copyFileSync(local.binaryPath, tmpPath);
-		if (process.platform !== "win32") {
-			chmodSync(tmpPath, 0o755);
-		}
-		try {
-			renameSync(tmpPath, binaryPath);
-		} catch {
-			rmSync(binaryPath, { force: true });
-			renameSync(tmpPath, binaryPath);
-		}
-	} catch (e) {
-		rmSync(tmpPath, { force: true });
-		console.error(`❌ Failed to install binary from ${local.name}: ${e.message}`);
-		process.exit(1);
-	}
+	await extractZipFile(local.zipPath, extractDir);
 }
 
 async function getPlatformArchAndBinary() {
@@ -146,7 +130,11 @@ async function getPlatformArchAndBinary() {
 	// download and extract the release ZIP
 	if (!existsSync(binaryPath)) {
 		if (source.kind === "package") {
-			installFromPackage(source.local, binaryPath);
+			await installFromPackage(source.local, tinglyBinDir);
+			if (!existsSync(binaryPath)) {
+				console.error(`❌ ${source.local.name} did not contain ${binaryPath}`);
+				process.exit(1);
+			}
 			console.log(`✅ Installed to ${binaryPath}`);
 		} else {
 			await downloadAndExtractZip(downloadUrl, tinglyBinDir, { hints: source.hints });


### PR DESCRIPTION
## Summary
The first OIDC release left a ~110 MB raw binary in `node_modules` for no wire savings and spent most of its time on sequential uploads; this fixes both and makes a rejected trusted-publisher exchange visible instead of a generic E404.

## Key Changes

- **Platform packages carry the release zip**: unpacked size drops from ~110 MB to ~30 MB, tarball size unchanged; the shim extracts it into the versioned cache via the same path as the GitHub download.
- **Concurrent platform uploads**: five publishes run in one job, keeping the single production approval.
- **Already-published is a skip**: the registry's "previously published" rejection is treated as done, since `npm view` can lag a publish by minutes.
- **OIDC pre-check**: fails early with the registry's reason and the token claims when no trusted publisher matches.

## Notes

- Zip layout takes effect from the next release; `0.260910.0-rc1` is unaffected since the shim only uses a platform package of its own version.
- `test-shim.sh v0.260903.1` passes; a local `npm install -g` against the zip layout extracted from the package with no download.