### PR TITLE
fix(opencode): stamp x-opencode-session on OpenCode Zen requests

### DIFF
--- a/.design/opencode-session.md
+++ b/.design/opencode-session.md
@@ -1,0 +1,103 @@
+# OpenCode Zen session header
+
+OpenCode Zen (`opencode.ai/zen/…`, both the pay-as-you-go `/zen/v1` and the Go
+subscription `/zen/go/v1`) rejects any request that arrives without a
+conversation identifier:
+
+```json
+{
+  "type": "MissingSessionID",
+  "message": "Error from provider (Console Go): Request is missing x-opencode-session and cannot be routed efficiently."
+}
+```
+
+Every request through Tingly-Box hit this (#1713). The client's own
+`x-opencode-session` never reaches the upstream — the SDK builds a fresh
+outbound request from the transformed params, so inbound headers are not
+forwarded — which is why the failure was total rather than
+client-dependent.
+
+## Where the header is stamped
+
+`OpenCodeClient` (`internal/client/opencode_client.go`), dispatched from
+`ClientPool.GetOpenAIClient` next to the Codex, Kimi and Azure branches — one
+vendor, one client, the same shape every other vendor handshake follows. Its
+`openCodeRoundTripper` carries the single wire concern. Zen's Anthropic-style
+base (`/zen/go` alongside `/zen/go/v1`) needs the same header, so
+`GetAnthropicClient` dispatches to `NewOpenCodeAnthropicClient`, which reuses
+the same layer; nothing else about the generic Anthropic client changes, so it
+is not wrapped in a vendor type.
+
+Dispatch is on the provider's API base (`IsOpenCodeZen`: host + `/zen` path
+prefix through `ops.SplitProviderHostPath`) — the same host-match discipline
+the request-side vendor transforms use, so a relay that merely mentions the
+host in its path is not mistaken for Zen.
+
+One difference from the OAuth vendor clients: Codex and Kimi replace the
+transport outright, which deliberately drops the rule-flag layer so their
+pinned handshake UA stays decisive. Zen providers are plain `api_key`
+providers, where `extra_headers` and the UA precedence are supported features,
+so `openCodeTransport` splices the vendor layer in *underneath* the generic
+provider chain instead of replacing it. The layer also fills an **absent**
+header only, so a session pinned through the rule's `extra_headers` wins on
+both counts.
+
+## What the value is
+
+The hashed form of the request's resolved session
+(`typ.GetSessionID`: Tingly header > native client header >
+Anthropic `metadata.user_id` > client IP), which is the per-conversation
+identity the gateway already uses for provider affinity.
+
+Two properties matter, and Zen's own docs are explicit that this is what the
+header is for (backend affinity, and with it prompt-cache warmth):
+
+- **Stable per conversation.** One constant for all conversations would clear
+  the 400 while collapsing every conversation onto one affinity scope; a fresh
+  value per request would clear it while defeating cache reuse entirely.
+- **Opaque.** The resolved session falls back to the client IP, and can be a
+  user id carried in Anthropic metadata — neither is something to hand an
+  upstream verbatim, hence the SHA-256.
+
+A request with no resolved session (nothing put one in the context) gets a
+random value rather than a shared constant: it still reaches the upstream, and
+unrelated conversations stay off one scope. Every dispatch path sets the
+session, so this is the probe/diagnostic case, not the request path.
+
+## Diagnostics
+
+The probe path goes through `ClientPool`, so probes get the header like any
+other request. `probe.BuildCurl`'s **direct** command deliberately does not:
+a direct call failing where the through-TB one succeeds is the diagnostic —
+it is what shows the user the gateway is the part supplying the session.
+
+## Verified against the live upstream
+
+`internal/client/opencode_e2e_test.go` (skipped unless `OPENCODE_API_KEY` is
+set) drives the real Go-subscription endpoint through `ClientPool`. All three
+confirmed on 2026-09-08 against `https://opencode.ai/zen/go`:
+
+| path | without the header | with it |
+| --- | --- | --- |
+| Chat Completions | 400 `MissingSessionID` | 200 |
+| Chat Completions, streaming | — | 200, SSE chunks |
+| Anthropic `/v1/messages` | 400 `MissingSessionID` | 200 |
+
+So the Anthropic shape needing the header is measured, not assumed. What is
+*not* measured is the pay-as-you-go `/zen/v1`: the gate covers it because the
+header is harmless where it is not required, while missing it is a hard 400.
+
+Two things the e2e test's own setup documents, both independent of this fix:
+
+- The transport pool never inherits `HTTP(S)_PROXY` from the environment (see
+  `NewOpenAIClient`), so the test takes `OPENCODE_PROXY_URL` and sets it as
+  the provider's `proxy_url`, the way a user would.
+- Not every Zen model answers on the Anthropic shape — `glm-5.3-flash` 500s
+  there with or without the session header — hence
+  `OPENCODE_ANTHROPIC_MODEL`.
+
+## Not covered
+
+The quota fetcher's `GET /zen/go/v1/usage` (`ai/quota/fetcher/opencode.go`)
+uses its own HTTP client and needs no session — usage is account-scoped, not
+conversation-scoped.

--- a/internal/client/opencode_client.go
+++ b/internal/client/opencode_client.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// guard
+var _ OpenAIClientInterface = (*OpenCodeClient)(nil)
+
+// OpenCodeClient wraps OpenAIClient for OpenCode Zen. It embeds OpenAIClient
+// to inherit the standard OpenAI API surface — Zen speaks plain
+// OpenAI-compatible Chat Completions, and the only vendor requirement is the
+// handshake header openCodeRoundTripper stamps.
+//
+// OpenCode Zen requirements:
+//   - Every request must carry x-opencode-session, a stable per-conversation
+//     identifier, or the upstream answers 400 MissingSessionID (#1713)
+//
+// Unlike the OAuth vendor clients (Codex, Kimi), the transport keeps the
+// generic provider chain underneath: Zen providers are plain api_key
+// providers, so the rule flags that gate on api_key — extra_headers — and the
+// UA precedence must keep applying. The vendor layer is mounted below that
+// chain and only fills a header nothing else supplied.
+type OpenCodeClient struct {
+	*OpenAIClient
+}
+
+// NewOpenCodeClient creates an OpenCode Zen client over the standard provider
+// transport chain with the vendor session layer underneath.
+func NewOpenCodeClient(provider *typ.Provider, model string, sessionID typ.SessionID) (*OpenCodeClient, error) {
+	if !IsOpenCodeZen(provider.APIBase) {
+		return nil, fmt.Errorf("opencode client can only work for OpenCode Zen providers, got API base %q", provider.APIBase)
+	}
+
+	base, err := newOpenAIClientWithTransport(provider, provider.APIBase, openCodeTransport(provider, model, sessionID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create base OpenAI client: %w", err)
+	}
+
+	return &OpenCodeClient{OpenAIClient: base}, nil
+}
+
+// NewOpenCodeAnthropicClient is the Anthropic-shape counterpart: OpenCode Zen
+// publishes an Anthropic-style base too ("/zen/go" alongside "/zen/go/v1"),
+// and the session header is required there just the same. No behavior of the
+// generic Anthropic client changes, so this returns it directly rather than
+// wrapping it in a vendor type.
+func NewOpenCodeAnthropicClient(provider *typ.Provider, model string, sessionID typ.SessionID) (*AnthropicClient, error) {
+	if !IsOpenCodeZen(provider.APIBase) {
+		return nil, fmt.Errorf("opencode client can only work for OpenCode Zen providers, got API base %q", provider.APIBase)
+	}
+	return newAnthropicClientWithTransport(provider, provider.APIBase, openCodeTransport(provider, model, sessionID))
+}
+
+// openCodeTransport builds the chain both shapes share: pooled session-bound
+// base (provider proxy_url honored, env proxy not inherited), the vendor
+// session layer, then the generic provider chain (rule flags, advisor
+// loopback stamp, logging) on top — the same chain
+// NewOpenAIClient/anthropicTransport assemble, with the vendor layer spliced
+// in at the bottom so the rule flags above it stay decisive.
+func openCodeTransport(provider *typ.Provider, model string, sessionID typ.SessionID) http.RoundTripper {
+	base := GetGlobalTransportPool().GetTransport(provider.UUID, model, provider.ProxyURL, ai.Issuer(""), sessionID)
+	return providerTransportChain(&openCodeRoundTripper{RoundTripper: base}, provider)
+}

--- a/internal/client/opencode_client_test.go
+++ b/internal/client/opencode_client_test.go
@@ -1,0 +1,224 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+func openCodeProvider() *typ.Provider {
+	return &typ.Provider{
+		UUID:     "opencode-1",
+		AuthType: ai.AuthTypeAPIKey,
+		Token:    "sk-x",
+		APIBase:  "https://opencode.ai/zen/go/v1",
+	}
+}
+
+func sessionCtx(value string) context.Context {
+	return typ.WithSessionID(context.Background(), typ.SessionID{
+		Source: typ.SessionSourceHeader,
+		Value:  value,
+	})
+}
+
+func TestIsOpenCodeZen(t *testing.T) {
+	tests := []struct {
+		apiBase string
+		want    bool
+	}{
+		{"https://opencode.ai/zen/go/v1", true},
+		{"https://opencode.ai/zen/v1", true},
+		{"https://opencode.ai/zen/go", true}, // Anthropic-style base
+		{"opencode.ai/zen/go/v1", true},      // stored without a scheme
+		{"https://opencode.ai/v1", false},
+		{"https://api.openai.com/v1", false},
+		// A relay that merely mentions the host in its path is not OpenCode.
+		{"https://gateway.example.com/relay/opencode.ai/zen/v1", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsOpenCodeZen(tt.apiBase); got != tt.want {
+			t.Errorf("IsOpenCodeZen(%q) = %v, want %v", tt.apiBase, got, tt.want)
+		}
+	}
+}
+
+func TestNewOpenCodeClient_RejectsForeignProvider(t *testing.T) {
+	provider := openCodeProvider()
+	provider.APIBase = "https://api.openai.com/v1"
+
+	if _, err := NewOpenCodeClient(provider, "gpt-5", typ.SessionID{}); err == nil {
+		t.Fatal("expected an error for a non-OpenCode provider")
+	}
+	if _, err := NewOpenCodeAnthropicClient(provider, "claude-sonnet-5", typ.SessionID{}); err == nil {
+		t.Fatal("expected an error for a non-OpenCode provider (Anthropic shape)")
+	}
+}
+
+// ── the vendor layer ────────────────────────────────────────────────────────
+
+func TestOpenCodeRoundTripper_StampsHeaderFromContextSession(t *testing.T) {
+	cap := &captureTransport{}
+	wrapped := &openCodeRoundTripper{RoundTripper: cap}
+
+	req := newReq(t, sessionCtx("conversation-a"), "")
+	if _, err := wrapped.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+
+	got := cap.lastReq.Header.Get(OpenCodeSessionHeader)
+	if got == "" {
+		t.Fatal("no x-opencode-session header on the outbound request")
+	}
+	if got == "conversation-a" {
+		t.Error("session value forwarded verbatim; it must be hashed so IPs and user ids never reach the upstream")
+	}
+	// Clone-before-mutate: the caller's request stays untouched.
+	if req.Header.Get(OpenCodeSessionHeader) != "" {
+		t.Error("original request was mutated")
+	}
+}
+
+func TestOpenCodeRoundTripper_StableAcrossRequestsOfOneConversation(t *testing.T) {
+	cap := &captureTransport{}
+	wrapped := &openCodeRoundTripper{RoundTripper: cap}
+
+	values := make([]string, 0, 2)
+	for range 2 {
+		if _, err := wrapped.RoundTrip(newReq(t, sessionCtx("conversation-a"), "")); err != nil {
+			t.Fatalf("RoundTrip: %v", err)
+		}
+		values = append(values, cap.lastReq.Header.Get(OpenCodeSessionHeader))
+	}
+	if values[0] != values[1] {
+		t.Errorf("session header changed between requests of one conversation: %q vs %q", values[0], values[1])
+	}
+
+	if _, err := wrapped.RoundTrip(newReq(t, sessionCtx("conversation-b"), "")); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if other := cap.lastReq.Header.Get(OpenCodeSessionHeader); other == values[0] {
+		t.Error("two conversations collapsed onto one session value")
+	}
+}
+
+func TestOpenCodeRoundTripper_MintsValueWhenNoSessionResolved(t *testing.T) {
+	cap := &captureTransport{}
+	wrapped := &openCodeRoundTripper{RoundTripper: cap}
+
+	if _, err := wrapped.RoundTrip(newReq(t, context.Background(), "")); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	first := cap.lastReq.Header.Get(OpenCodeSessionHeader)
+	if first == "" {
+		t.Fatal("session-less request went out without the header; the upstream would 400")
+	}
+
+	if _, err := wrapped.RoundTrip(newReq(t, context.Background(), "")); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if second := cap.lastReq.Header.Get(OpenCodeSessionHeader); second == first {
+		t.Error("session-less requests share one value; unrelated conversations must not collapse onto one affinity scope")
+	}
+}
+
+// TestOpenCodeClient_RuleExtraHeaderWins proves the vendor layer sits *below*
+// the rule-flag layer: OpenCode providers are api_key providers, so a session
+// pinned through the rule's extra_headers is still decisive.
+func TestOpenCodeClient_RuleExtraHeaderWins(t *testing.T) {
+	cap := &captureTransport{}
+	provider := openCodeProvider()
+	chain := providerTransportChain(&openCodeRoundTripper{RoundTripper: cap}, provider)
+
+	ctx := typ.WithRuleFlags(sessionCtx("conversation-a"), typ.RuleFlags{
+		ExtraHeaders: map[string]string{OpenCodeSessionHeader: "pinned-by-rule"},
+	})
+	if _, err := chain.RoundTrip(newReq(t, ctx, "")); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if got := cap.lastReq.Header.Get(OpenCodeSessionHeader); got != "pinned-by-rule" {
+		t.Errorf("session header = %q, want the rule-configured value", got)
+	}
+}
+
+// TestOpenCodeClient_ChatCompletionSucceeds reproduces #1713 against a
+// stand-in for OpenCode Zen: the upstream rejects any request without
+// x-opencode-session exactly as the real one does, so this fails with the
+// reported 400 MissingSessionID unless the client supplies the header.
+func TestOpenCodeClient_ChatCompletionSucceeds(t *testing.T) {
+	var gotSession string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSession = r.Header.Get(OpenCodeSessionHeader)
+		if gotSession == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]any{
+				"type":    "MissingSessionID",
+				"message": "Error from provider (Console Go): Request is missing x-opencode-session and cannot be routed efficiently.",
+			})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id": "chatcmpl-1", "object": "chat.completion", "created": 1, "model": "gpt-luna",
+			"choices": []map[string]any{{
+				"index": 0, "finish_reason": "stop",
+				"message": map[string]any{"role": "assistant", "content": "ok"},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	provider := openCodeProvider()
+	// The client is gated on the provider's API base (OpenCode Zen) while the
+	// request is dispatched at the local stand-in.
+	base, err := newOpenAIClientWithTransport(provider, server.URL, openCodeTransport(provider, "gpt-luna", typ.SessionID{}))
+	if err != nil {
+		t.Fatalf("newOpenAIClientWithTransport: %v", err)
+	}
+	oc := &OpenCodeClient{OpenAIClient: base}
+
+	resp, err := oc.ChatCompletionsNew(sessionCtx("conversation-a"), openai.ChatCompletionNewParams{
+		Model:    "gpt-luna",
+		Messages: []openai.ChatCompletionMessageParamUnion{openai.UserMessage("say ok")},
+	})
+	if err != nil {
+		t.Fatalf("chat completion through OpenCode Zen: %v", err)
+	}
+	if gotSession == "" {
+		t.Fatal("upstream saw no x-opencode-session")
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("choices = %d, want 1", len(resp.Choices))
+	}
+}
+
+// TestClientPool_DispatchesOpenCodeProviders guards the wiring: without the
+// pool branch the vendor layer is never mounted and every Zen request 400s,
+// which is exactly the shape of #1713.
+func TestClientPool_DispatchesOpenCodeProviders(t *testing.T) {
+	pool := NewClientPool()
+	ctx := sessionCtx("conversation-a")
+
+	if _, ok := pool.GetOpenAIClient(ctx, openCodeProvider(), "gpt-luna").(*OpenCodeClient); !ok {
+		t.Error("OpenAI-shape Zen provider did not dispatch to the OpenCode client")
+	}
+
+	anthropicBase := openCodeProvider()
+	anthropicBase.APIBase = "https://opencode.ai/zen/go"
+	if pool.GetAnthropicClient(ctx, anthropicBase, "claude-sonnet-5") == nil {
+		t.Error("Anthropic-shape Zen provider produced no client")
+	}
+
+	other := openCodeProvider()
+	other.APIBase = "https://api.openai.com/v1"
+	if _, ok := pool.GetOpenAIClient(ctx, other, "gpt-5").(*OpenCodeClient); ok {
+		t.Error("a non-OpenCode provider was routed through the OpenCode client")
+	}
+}

--- a/internal/client/opencode_e2e_test.go
+++ b/internal/client/opencode_e2e_test.go
@@ -1,0 +1,136 @@
+package client
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/stretchr/testify/require"
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// TestE2E_OpenCodeSession drives the real OpenCode Zen upstream through the
+// dispatch path a request takes (ClientPool → OpenCodeClient → the vendor
+// layer), proving the session header the upstream requires actually reaches
+// it (#1713).
+//
+// Prerequisites:
+//   - OPENCODE_API_KEY: a Zen API key
+//   - OPENCODE_API_BASE (optional): defaults to the Go subscription base
+//   - OPENCODE_MODEL (optional): defaults to a cheap model
+//   - OPENCODE_PROXY_URL (optional): provider proxy. The transport pool never
+//     inherits HTTP(S)_PROXY from the environment (see NewOpenAIClient), so a
+//     sandbox that only reaches the internet through a proxy must configure it
+//     here, as a provider would.
+//
+// Run with: go test -v ./internal/client -run TestE2E_OpenCodeSession
+func TestE2E_OpenCodeSession(t *testing.T) {
+	apiKey := os.Getenv("OPENCODE_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENCODE_API_KEY not set, skipping e2e test")
+	}
+
+	apiBase := os.Getenv("OPENCODE_API_BASE")
+	if apiBase == "" {
+		apiBase = "https://opencode.ai/zen/go/v1"
+	}
+	model := os.Getenv("OPENCODE_MODEL")
+	if model == "" {
+		model = "glm-5.3-flash"
+	}
+
+	provider := &typ.Provider{
+		UUID:     "opencode-e2e-test",
+		Name:     "opencode-e2e-test",
+		AuthType: ai.AuthTypeAPIKey,
+		Token:    apiKey,
+		APIBase:  apiBase,
+		ProxyURL: os.Getenv("OPENCODE_PROXY_URL"),
+		Enabled:  true,
+	}
+
+	ctx := typ.WithSessionID(context.Background(), typ.SessionID{
+		Source: typ.SessionSourceHeader,
+		Value:  "e2e-conversation-a",
+	})
+
+	// The pool must hand back the vendor client; without that branch the
+	// header is never stamped and the upstream answers 400 MissingSessionID.
+	c := NewClientPool().GetOpenAIClient(ctx, provider, model)
+	require.NotNil(t, c)
+	require.IsType(t, &OpenCodeClient{}, c)
+
+	resp, err := c.ChatCompletionsNew(ctx, openai.ChatCompletionNewParams{
+		Model:     openai.ChatModel(model),
+		MaxTokens: openai.Int(8),
+		Messages:  []openai.ChatCompletionMessageParamUnion{openai.UserMessage("say ok")},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Choices)
+	t.Logf("chat: id=%s model=%s tokens=%d", resp.ID, resp.Model, resp.Usage.TotalTokens)
+
+	// #1713 was reported on a streaming request; SSE takes the same transport,
+	// but assert it rather than reason about it.
+	stream := c.ChatCompletionsNewStreaming(ctx, openai.ChatCompletionNewParams{
+		Model:     openai.ChatModel(model),
+		MaxTokens: openai.Int(8),
+		Messages:  []openai.ChatCompletionMessageParamUnion{openai.UserMessage("say ok")},
+	})
+	defer stream.Close()
+	var chunks int
+	for stream.Next() {
+		chunks++
+	}
+	require.NoError(t, stream.Err())
+	require.Positive(t, chunks, "no SSE chunks arrived")
+	t.Logf("stream: %d chunks", chunks)
+}
+
+// TestE2E_OpenCodeSessionAnthropicShape covers Zen's Anthropic-style base,
+// which rejects a session-less request exactly like the OpenAI-style one.
+//
+// OPENCODE_ANTHROPIC_MODEL selects the model; not every Zen model answers on
+// this shape (glm-5.3-flash 500s upstream regardless of the session header).
+func TestE2E_OpenCodeSessionAnthropicShape(t *testing.T) {
+	apiKey := os.Getenv("OPENCODE_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENCODE_API_KEY not set, skipping e2e test")
+	}
+
+	model := os.Getenv("OPENCODE_ANTHROPIC_MODEL")
+	if model == "" {
+		model = "kimi-k3"
+	}
+
+	provider := &typ.Provider{
+		UUID:     "opencode-e2e-test-anthropic",
+		Name:     "opencode-e2e-test-anthropic",
+		AuthType: ai.AuthTypeAPIKey,
+		Token:    apiKey,
+		APIBase:  "https://opencode.ai/zen/go",
+		ProxyURL: os.Getenv("OPENCODE_PROXY_URL"),
+		Enabled:  true,
+	}
+
+	ctx := typ.WithSessionID(context.Background(), typ.SessionID{
+		Source: typ.SessionSourceHeader,
+		Value:  "e2e-conversation-b",
+	})
+
+	c := NewClientPool().GetAnthropicClient(ctx, provider, model)
+	require.NotNil(t, c)
+
+	resp, err := c.MessagesNew(ctx, &anthropic.MessageNewParams{
+		Model:     anthropic.Model(model),
+		MaxTokens: 8,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("say ok")),
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Content)
+	t.Logf("messages: id=%s model=%s tokens=%d", resp.ID, resp.Model, resp.Usage.OutputTokens)
+}

--- a/internal/client/opencode_round_tripper.go
+++ b/internal/client/opencode_round_tripper.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/tingly-dev/tingly-box/internal/protocol/ops"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// OpenCodeSessionHeader is the conversation identifier OpenCode Zen requires
+// on every request. Without it the upstream rejects the call with HTTP 400
+// `MissingSessionID` ("Request is missing x-opencode-session and cannot be
+// routed efficiently"), so the gateway must supply one on the
+// Tingly-Box → OpenCode hop; the client's own header never survives, because
+// the SDK builds a fresh outbound request (#1713).
+const OpenCodeSessionHeader = "x-opencode-session"
+
+// openCodeSessionPrefix marks a value as minted by Tingly-Box. Purely for
+// legibility in upstream logs — the value itself is opaque.
+const openCodeSessionPrefix = "tb-"
+
+// openCodeRoundTripper is the OpenCode Zen vendor layer: it stamps the
+// conversation identifier the upstream requires. Same shape as the Codex and
+// Kimi round-trippers — one vendor handshake concern, applied by the vendor's
+// own client constructor rather than by the generic chain.
+//
+// It fills an absent header only, so a value pinned through the rule's
+// extra_headers still wins (the rule-flag layer sits above it).
+type openCodeRoundTripper struct {
+	http.RoundTripper
+}
+
+// IsOpenCodeZen reports whether apiBase points at OpenCode Zen. Both products
+// live on the same host and both route through the session header: "/zen/v1"
+// (pay-as-you-go) and "/zen/go/v1" (the Go subscription), plus their
+// Anthropic-style bases without the "/v1" suffix.
+//
+// Matching goes through ops.SplitProviderHostPath for the same reason the
+// request-side vendor transforms do: a relay whose URL merely mentions the
+// host in its path is not OpenCode.
+func IsOpenCodeZen(apiBase string) bool {
+	host, path := ops.SplitProviderHostPath(apiBase)
+	return host == "opencode.ai" && strings.HasPrefix(path, "/zen")
+}
+
+func (t *openCodeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	inner := t.RoundTripper
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	if req.Header.Get(OpenCodeSessionHeader) != "" {
+		return inner.RoundTrip(req)
+	}
+
+	// Clone before mutating so a retry never races on shared headers.
+	req = req.Clone(req.Context())
+	req.Header.Set(OpenCodeSessionHeader, openCodeSessionValue(typ.GetSessionID(req.Context())))
+	return inner.RoundTrip(req)
+}
+
+// openCodeSessionValue turns the request's resolved session into an opaque,
+// stable per-conversation token.
+//
+// Stability is the point: Zen uses the header for backend affinity, and with
+// it prompt-cache warmth. One constant for every conversation would clear the
+// 400 while collapsing them onto one affinity scope; a fresh value per
+// request would clear it while defeating cache reuse entirely.
+//
+// The hash matters too: the resolved session falls back to the client IP, and
+// can be a user id carried in Anthropic metadata — neither is something to
+// hand an upstream verbatim.
+//
+// A request with no resolved session gets a random value rather than a shared
+// constant: it still reaches the upstream, and unrelated conversations stay
+// off one scope. Every dispatch path puts the session in the context, so this
+// is the probe/diagnostic case, not the request path.
+func openCodeSessionValue(session typ.SessionID) string {
+	if session.Value == "" {
+		return openCodeSessionPrefix + uuid.NewString()
+	}
+	sum := sha256.Sum256([]byte(session.Value))
+	return openCodeSessionPrefix + hex.EncodeToString(sum[:16])
+}

--- a/internal/client/pool.go
+++ b/internal/client/pool.go
@@ -79,6 +79,14 @@ func (p *ClientPool) GetOpenAIClient(ctx context.Context, provider *typ.Provider
 			logrus.WithContext(ctx).Errorf("Failed to create vmodel client for provider %s: %v", provider.Name, err)
 			return nil
 		}
+	} else if IsOpenCodeZen(provider.APIBase) {
+		// OpenCode Zen: plain api_key provider, but every request needs the
+		// vendor session header (#1713).
+		client, err = NewOpenCodeClient(provider, model, sessionID)
+		if err != nil {
+			logrus.WithContext(ctx).Errorf("Failed to create OpenCode client for provider %s: %v", provider.Name, err)
+			return nil
+		}
 	} else if provider.AuthType == typ.AuthTypeAzureKey {
 		// GPT / o-series on Azure OpenAI (api-key auth).
 		client, err = NewAzureClient(provider, model, sessionID)
@@ -133,6 +141,10 @@ func (p *ClientPool) GetAnthropicClient(ctx context.Context, provider *typ.Provi
 	case provider.AuthType == typ.AuthTypeGCPVertex:
 		// Claude on GCP Vertex AI (service-account OAuth2).
 		client, err = NewVertexAnthropicClient(provider, model, sessionID)
+	case IsOpenCodeZen(provider.APIBase):
+		// OpenCode Zen's Anthropic-style base needs the same vendor session
+		// header as its OpenAI-style one (#1713).
+		client, err = NewOpenCodeAnthropicClient(provider, model, sessionID)
 	default:
 		client, err = NewAnthropicClient(provider, model, sessionID)
 	}


### PR DESCRIPTION
## Summary

OpenCode Zen rejects any request without a conversation identifier, so every request through the gateway returned 400 `MissingSessionID` — the client's own `x-opencode-session` never survived the hop, because the SDK builds a fresh outbound request from the transformed params.

## Key Changes

- **OpenCode Zen requests**: the gateway now supplies the session header, in the OpenAI and Anthropic shapes alike.
- **Vendor client**: `OpenCodeClient` dispatched from `ClientPool` on the provider's API base, the shape Codex/Kimi/Azure already follow.
- **Rule flags preserved**: unlike the OAuth vendor clients, the chain keeps `extra_headers` and UA precedence — Zen providers are plain `api_key` providers, and a session pinned through a rule still wins.
- **Session identity**: hashed from the request's resolved session — stable per conversation for upstream affinity and cache warmth, without handing the upstream a client IP.

## Notes

- Verified live against `/zen/go` through `ClientPool` (`opencode_e2e_test.go`, skipped without `OPENCODE_API_KEY`): chat, streaming chat, and Anthropic `/v1/messages` each 400 without the header, 200 with it.
- Pay-as-you-go `/zen/v1` is covered by the same gate but unmeasured: a superfluous header is harmless, a missing one is a hard 400.

Fixes #1713