### PR TITLE
feat(routing): learn per-model OpenAI endpoints on relays that mix them

### DIFF
--- a/.design/openai-endpoint-routing.md
+++ b/.design/openai-endpoint-routing.md
@@ -14,13 +14,20 @@ OpenAI 兼容生态里有两种 endpoint 形态：
 | `/v1/chat/completions` | 几乎所有 OpenAI-compat 厂商（Qwen、Deepseek、Mistral、GLM、MiniMax、xAI、本地 vLLM/llama.cpp 等）+ OpenAI 官方 |
 | `/v1/responses` | 仅 OpenAI 官方（gpt-5、o-series 等）+ Codex |
 
-Provider 实际能力组合**只有三种**：
+Provider 实际能力组合有四种：
 
 | 类型 | 例子 | Chat | Responses |
 |---|---|:---:|:---:|
 | Chat-only | Qwen / Deepseek / Mistral / 本地模型 / 绝大多数厂商 | ✅ | ❌ |
 | Responses-only | Codex | ❌ | ✅ |
 | Both | OpenAI 官方 | ✅ | ✅ |
+| Per-model | OpenCode Zen | 看模型 | 看模型 |
+
+前三种是 provider 级事实。**第四种不是**：它是多厂商中转，两个 endpoint 都
+真实存在，但每个模型只认其中一个——这不是 "both"（both 的含义是"同一个模型
+两条路都能走，所以 mirror 入站永远安全"），而是混合。实测 `/zen/go` 35 个
+模型：32 个 chat-only，`gpt-5.6-luna` / `grok-4.5` / `grok-4.6` 只认
+Responses，`deepseek-v4-flash-vision-exp` 两个都行。
 
 Gateway 收到客户端的 request 时（无论入站协议是 OpenAI Chat / OpenAI Responses / Anthropic Messages 经转换后等价的 OpenAI 形态），**必须知道**：上游用哪一个？
 
@@ -69,10 +76,11 @@ const (
     EndpointModeChat      OpenAIEndpointMode = "chat"       // 绝大多数厂商
     EndpointModeResponses OpenAIEndpointMode = "responses"  // Codex
     EndpointModeBoth      OpenAIEndpointMode = "both"       // OpenAI 官方
+    EndpointModePerModel  OpenAIEndpointMode = "per_model"  // OpenCode Zen 这类中转
 )
 ```
 
-三种状态 1:1 映射上文表格的三类 provider。
+四种状态 1:1 映射上文表格的四类 provider。`per_model` 的运行时行为见 §8。
 
 ---
 
@@ -159,6 +167,8 @@ Provider 未声明或显式声明 `EndpointModeUnknown` 时按 Chat 处理。Rul
 | 无 | `"responses"` | Responses | Codex |
 | 无 | `"both"` (chat 入站) | Chat | mirror |
 | 无 | `"both"` (responses 入站) | Responses | mirror |
+| 无 | `"per_model"`，该模型已学到 | 学到的那个 | 见 §8 |
+| 无 | `"per_model"`，未学到 | **Chat** | 猜安全默认，不 mirror |
 | `=chat` | 任意 | Chat | override 生效 |
 | `=responses` | 任意 | Responses | override 生效 |
 
@@ -191,6 +201,7 @@ Template 是用户实例化 provider 的预设入口。Template 里的 `openai_e
 |---|---|
 | `openai-com` | `"both"` |
 | `codex` | `"responses"` |
+| `opencode-ai` / `opencode-go` | `"per_model"` |
 | 其他（Qwen / Deepseek / GLM / ...）| 未设（= `""` / unknown，resolver 按 Chat 处理）|
 
 用户**不在 provider 编辑 UI 里改 mode**——它从 template 来。后续若发现某个 Chat-only template 应该是 `"both"`，在 `providers.json` 修，新装机生效；存量 provider 需手动 edit config.json 或重建 provider。
@@ -216,20 +227,95 @@ Template 是用户实例化 provider 的预设入口。Template 里的 `openai_e
 
 ---
 
-## 8. 关键文件
+## 8. `per_model`：反应式学习
+
+多厂商中转（OpenCode Zen）的格式归属是**按模型**的，而 provider 级 mode 表达
+不了。模型名是轮换的代号（luna / omen-alpha / muse-spark），维护一张静态模型
+表是伪精确——今天对，下个月就漏。所以 `per_model` 声明的不是"哪个模型走哪
+边"，而是"**这个上游的归属按模型分，请在运行时学**"。
+
+### 8.1 行为
+
+1. **初猜 Chat**，不 mirror 入站。实测分布 32/35 是 chat-only，而且 Anthropic
+   入站在本网关里算作 Responses 入站（§7），mirror 会让最常见的
+   Claude Code + kimi/glm 组合白付一次失败往返。
+2. 失败且**像 endpoint 不匹配**时，换另一个 endpoint 在**同一个 service** 上
+   重试一次。
+3. 重试成功 → 把 `(provider UUID, model) → endpoint` 写进内存缓存，TTL 8 小时。
+
+命中缓存的后续请求第一次就走对，零额外往返。
+
+### 8.2 为什么这次不是 Adaptive 的老路
+
+§2.1 那套失败的根因是**默认全局开启的乐观假设**，不是"运行时学习"这件事本身。
+逐条对照：
+
+| | 旧 AdaptiveProbe | `per_model` |
+|---|---|---|
+| 触发 | cold-start 主动探两个 endpoint | 真实请求失败之后 |
+| 代价 | 首请求阻塞 10s + 烧 token | 最多一次额外往返 |
+| 范围 | 所有 provider | 仅显式声明 `per_model` 的 |
+| 缓存 | 失败也写，被限流/临时 5xx 污染 | 只写被 2xx 验证过的结果 |
+| 持久化 | — | 只在内存，重启重学 |
+| 可诊断 | 黑盒 | `endpoint_learning_retry` / `endpoint_learned` 两条日志 |
+
+**声明式门控是关键**：没声明 `per_model` 的 provider 连判定函数都进不去，行为
+逐字节不变。这也是为什么不能靠"识别错误再重试"来通吃——见 8.3。
+
+不落盘是刻意的：这是运行时观测，不是用户配置。写进 config.json 会让一个上游
+的临时状态看起来像用户选过的设置，正是当年 Adaptive 最难排查的地方。
+
+### 8.3 判定条件：为什么必须容忍裸 5xx
+
+同一个原因，Zen 按模型背后的厂商给三种回答（2026-09-08 实测 `/zen/go`）：
+
+```
+grok-4.6      401  "Model grok-4.6 is not supported for format oa-compat"
+grok-4.5      500  "Upstream request failed: Endpoint is unavailable."
+gpt-5.6-luna  500  "Internal server error"
+```
+
+第三种不带任何标记。要修 luna（也就是最初的用户报告）就必须接受"裸 5xx 也算
+疑似"。这条单独看是危险的——普通上游 5xx 会被误判——**只有在 mode 门控之下才
+安全**：没声明的 provider 永远不会走到这个判定。
+
+4xx 反过来要求显式标记：没有标记的 401 是凭证问题、400 是请求格式问题，换个
+endpoint 都不会变好。
+
+### 8.4 护栏
+
+- 每个请求最多一次 endpoint 重试；重试仍失败则交回正常 failover。
+- 重试发生在**失败被记账之前**：不消耗 failover tier，不算 breaker 失败，不上报
+  健康状态——service 没病，是 endpoint 猜错了。
+- 只在首字节之前重试。复用既有的 `firstChunkGate`：单 service 的规则平时绕过
+  gate，`per_model` 是唯一的例外（要缓冲才能重试），代价是这类 provider 的单
+  service 请求也走一次缓冲。
+- **冷却只管失败**。重试成功 → 写入 8 小时学习结果并清掉冷却，之后直接用学到的
+  endpoint，根本不会再产生需要重试的失败；重试也失败 → 什么都不学，1 分钟内不再
+  花第二次往返。最坏额外流量因此有上界：**每个 (provider, model) 每分钟至多 1 次
+  额外请求**，且仅在持续失败时。
+- 冷却 1 分钟**远短于 8 小时 TTL**，两者管的不是一回事：学到的是被验证过的事实，
+  值得留；学失败通常只说明上游当时有病，钉死 8 小时会让一个真正 responses-only
+  的模型在故障恢复后继续坏着。
+- 冷却在**发起重试之前**打点，不是之后：重试挂起或 panic 也必须挡住后续，否则坏
+  上游会变成热循环。
+
+## 9. 关键文件
 
 - `ai/provider.go` —— `OpenAIEndpointMode` 类型 + 常量 + `Provider.OpenAIEndpointMode` 字段
 - `internal/data/provider_template.go` —— `ProviderTemplate.OpenAIEndpointMode`（plain string）
 - `internal/data/providers.json` —— 出厂 template 的 mode 声明
-- `internal/server/endpoint_resolution.go` —— `ResolveOpenAIEndpoint` 纯函数
-- `internal/server/endpoint_override.go` —— `EndpointOverride` 枚举与 `ParseEndpointOverride`
-- `internal/server/openai_responses.go` —— Responses 入站的路由调用点
+- `internal/protocolserver/protocol_endpoint.go` —— `ResolveOpenAIEndpoint` 纯函数、`EndpointOverride` 枚举与 `ParseEndpointOverride`
+- `internal/protocolserver/endpoint_learning.go` —— `per_model` 的请求内接线：`ResolveOpenAIEndpointForRequest`、不匹配判定、重试
+- `internal/protocolserver/endpoint_memory.go` —— 学习结果的内存 TTL 存储
+- `internal/protocolserver/failover_dispatch.go` —— gate 与编排器，endpoint 重试挂在这里
+- `internal/protocolserver/openai_responses.go` —— Responses 入站的路由调用点
 - `internal/server/module/oauth/handler.go`、`internal/command/oauth.go` —— Codex OAuth 实例化打 mode
 - `internal/server/config/migration_codex_endpoint_mode.go` —— 存量 Codex backfill 迁移
 
 ---
 
-## 9. 升级与兼容性
+## 10. 升级与兼容性
 
 PR #976 引入此设计。涉及行为变更的两个点：
 
@@ -238,9 +324,26 @@ PR #976 引入此设计。涉及行为变更的两个点：
 
 后续若新增 provider 类型，原则不变：默认 Chat，需要 Responses 就显式声明。
 
+`per_model` 是后加的第四种（见 §8），纯增量：不属于这一类的 provider 行为不变。
+
+**没有迁移，也不需要。** 因为一个先前就存在的缺口：
+`ProviderTemplate.OpenAIEndpointMode` 只有 OAuth 路径（Codex）会拷到 Provider
+上，走正常 API 从 template 建的 provider 拿到的是零值——`openai-com` 的
+`"both"` 同样从来没生效过。所以声明式这条路对 opencode 是走不通的：改
+`providers.json` 对新建 provider 无效，加启动迁移则对**运行时新加的 provider**
+无效（要等下次重启）。
+
+改成在用到的地方推导：`EffectiveEndpointMode()` 在 provider 未声明 mode 且
+API base 命中 OpenCode Zen 时返回 `per_model`，复用 OpenCode client 已有的
+host 判定。存量的、新建的、手工加的，一律立即生效，不写 DB、不依赖重启。
+
+`providers.json` 里那两行声明保留——它是这个事实的书面形式，等哪天有人把
+template → provider 的拷贝补上，它就自动接管兜底逻辑。**修那个缺口才是这里
+真正的深层修复**，但它会连带改变 `openai-com` 的行为，不该混在本次改动里。
+
 ---
 
-## 10. 不在本文档范围
+## 11. 不在本文档范围
 
 - Anthropic / Google provider 的路由（走各自原生 endpoint，不进 OpenAI resolver）
 - Smart routing / load balance 选哪个 service（在 endpoint 选择之前）

--- a/.design/openai-endpoint-routing.md
+++ b/.design/openai-endpoint-routing.md
@@ -241,9 +241,22 @@ Template 是用户实例化 provider 的预设入口。Template 里的 `openai_e
    Claude Code + kimi/glm 组合白付一次失败往返。
 2. 失败且**像 endpoint 不匹配**时，换另一个 endpoint 在**同一个 service** 上
    重试一次。
-3. 重试成功 → 把 `(provider UUID, model) → endpoint` 写进内存缓存，TTL 8 小时。
+3. 重试成功 → 把 `service (provider UUID + model) → endpoint` 写进内存缓存，
+   TTL 8 小时。key 用 `loadbalance.FormatServiceID`，和熔断器 / 用量统计同一把
+   钥匙，日志里能对上；时间走 `internal/clock`，和 breaker / affinity 一起被
+   模拟器推进。
 
 命中缓存的后续请求第一次就走对，零额外往返。
+
+**缓冲只持续到学会为止。** 重试要成立，需要两样东西：响应缓冲（`firstChunkGate`）
+和请求快照（handler 里的 pristine template，一次 marshal + unmarshal）。对 Claude
+Code 这种上百 KB 的请求体，后者不是小钱。所以 `DispatchMayRetry` 在已经学到答案
+时返回 false——没有第二次尝试，也就不必为它付费。
+
+代价是学到的映射一旦失效（上游把某个模型换了格式），没有缓冲就没法当场重试。
+`forgetStaleEndpoint` 补上这半：学过的 endpoint 上再遇 5xx 就把映射丢掉，这一次
+请求照常失败，**下一次**重新进入学习路径。用一次失败换掉了稳态下每请求一次的
+JSON 往返。
 
 ### 8.2 为什么这次不是 Adaptive 的老路
 
@@ -284,12 +297,19 @@ endpoint 都不会变好。
 
 ### 8.4 护栏
 
-- 每个请求最多一次 endpoint 重试；重试仍失败则交回正常 failover。
+- 每个请求最多一次 endpoint 重试；重试仍失败则交回正常 failover，且**失败的重试
+  不会掩盖原始状态**——第一次失败若是可 failover 的，健康的 sibling 仍然拿得到
+  这一轮。
 - 重试发生在**失败被记账之前**：不消耗 failover tier，不算 breaker 失败，不上报
   健康状态——service 没病，是 endpoint 猜错了。
-- 只在首字节之前重试。复用既有的 `firstChunkGate`：单 service 的规则平时绕过
-  gate，`per_model` 是唯一的例外（要缓冲才能重试），代价是这类 provider 的单
-  service 请求也走一次缓冲。
+- 只在首字节之前重试。复用既有的 `firstChunkGate` 而不是自己再套一层——
+  `CommitFirstChunkIfGate` 是对 `*firstChunkGate` 的类型断言，嵌套会断掉首字节
+  信号链，把流式响应憋到请求结束。
+- 「这个请求会不会被尝试第二次」由 `DispatchMayRetry` 一处回答，dispatch 循环
+  （装不装 gate）和四个 handler（做不做请求快照）共用它。两边一旦说法不一致，
+  重试就会拿着被第一次尝试改过的请求对象重新走一遍转换。
+- 规则里 `openai_endpoint_override` 钉死过的 endpoint 不重试；网关自己的失败
+  （transform / 目标解析，`FailAttemptSetup` 写的 500）也不算上游判决。
 - **冷却只管失败**。重试成功 → 写入 8 小时学习结果并清掉冷却，之后直接用学到的
   endpoint，根本不会再产生需要重试的失败；重试也失败 → 什么都不学，1 分钟内不再
   花第二次往返。最坏额外流量因此有上界：**每个 (provider, model) 每分钟至多 1 次

--- a/ai/provider.go
+++ b/ai/provider.go
@@ -246,6 +246,21 @@ const (
 	// client's incoming API so native semantics (reasoning blocks,
 	// previous_response_id continuity, etc.) survive the round trip.
 	EndpointModeBoth OpenAIEndpointMode = "both"
+
+	// EndpointModePerModel means the upstream exposes both endpoints but each
+	// model answers on only one of them — a relay whose catalog mixes vendors
+	// (OpenCode Zen: most models on Chat, a few only on Responses). It is not
+	// EndpointModeBoth: "both" says one model can be reached either way, so
+	// mirroring the client's protocol is always safe, while here mirroring is
+	// a coin flip.
+	//
+	// Which model needs which endpoint cannot be declared statically — the
+	// catalog is codenamed and rotates — so this mode, and only this mode,
+	// enables the learning fallback in the dispatch loop: start on Chat, and
+	// on a format rejection retry once on Responses and remember the answer.
+	// Every other mode stays fully deterministic, with no extra round-trip
+	// ever.
+	EndpointModePerModel OpenAIEndpointMode = "per_model"
 )
 
 // OpenAIEndpointModeForIssuer returns the OpenAIEndpointMode that an OAuth

--- a/internal/data/provider_template.go
+++ b/internal/data/provider_template.go
@@ -127,7 +127,8 @@ type ProviderTemplate struct {
 	// OpenAIEndpointMode declares which OpenAI endpoints providers instantiated
 	// from this template expose. Plain string at this layer; cast to the typed
 	// ai.OpenAIEndpointMode when assigned to a Provider. Values: "" (Chat,
-	// default), "responses" (Codex-style), "both" (OpenAI proper).
+	// default), "responses" (Codex-style), "both" (OpenAI proper),
+	// "per_model" (a relay whose models differ, e.g. OpenCode Zen).
 	OpenAIEndpointMode string `json:"openai_endpoint_mode,omitempty"`
 }
 

--- a/internal/data/providers.json
+++ b/internal/data/providers.json
@@ -2644,6 +2644,7 @@
       "pricing_doc": "https://opencode.ai/docs/providers/",
       "base_url_openai": "https://opencode.ai/zen/v1",
       "base_url_anthropic": "https://opencode.ai/zen",
+      "openai_endpoint_mode": "per_model",
       "models": [
         {
           "id": "qwen3.7-max"
@@ -2713,6 +2714,7 @@
       "pricing_doc": "https://opencode.ai/docs/providers/",
       "base_url_openai": "https://opencode.ai/zen/go/v1",
       "base_url_anthropic": "https://opencode.ai/zen/go",
+      "openai_endpoint_mode": "per_model",
       "models": [
         {
           "id": "kimi-k3"

--- a/internal/db/provider_store.go
+++ b/internal/db/provider_store.go
@@ -39,7 +39,7 @@ type ProviderRecord struct {
 	APIBaseAnthropic string `gorm:"column:api_base_anthropic"`
 
 	// OpenAIEndpointMode declares which OpenAI endpoints this provider exposes
-	// ("", "chat", "responses", "both"). See ai.OpenAIEndpointMode.
+	// ("", "chat", "responses", "both", "per_model"). See ai.OpenAIEndpointMode.
 	OpenAIEndpointMode string `gorm:"column:openai_endpoint_mode"`
 
 	// Credential fields - stored with provider as a unit

--- a/internal/protocolserver/anthropic_message.go
+++ b/internal/protocolserver/anthropic_message.go
@@ -187,7 +187,10 @@ func (ph *ProtocolHandler) AnthropicMessagesV1(c *gin.Context, req *protocol.Ant
 
 	// Snapshot a pristine template only when failover is possible; the single
 	// service case reuses the original request with no clone overhead.
-	multi := len(rule.GetActiveServices()) > 1
+	// "Possible" includes the endpoint-learning retry, which re-enters this
+	// pipeline as a second attempt on the *same* service: without a snapshot it
+	// would re-transform the request object the first attempt already mutated.
+	multi := len(rule.GetActiveServices()) > 1 || endpointLearningEnabled(provider)
 	var template []byte
 	if multi {
 		bs, err := req.MarshalJSON()
@@ -253,7 +256,7 @@ func (ph *ProtocolHandler) runAnthropicV1Attempt(c *gin.Context, req *protocol.A
 	case protocol.APIStyleGoogle:
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
-		resolvedTarget, routeErr := ResolveOpenAIEndpoint(provider, ResolveRuleFlags(c, rule), IncomingAPIResponses)
+		resolvedTarget, routeErr := ResolveOpenAIEndpointForRequest(c, provider, requestModel, ResolveRuleFlags(c, rule), IncomingAPIResponses)
 		if routeErr != nil {
 			ph.FailAttemptSetup(c, routeErr)
 			return
@@ -312,7 +315,10 @@ func (ph *ProtocolHandler) AnthropicMessagesV1Beta(c *gin.Context, req *protocol
 	}
 
 	// Snapshot a pristine template only when failover is possible.
-	multi := len(rule.GetActiveServices()) > 1
+	// "Possible" includes the endpoint-learning retry, which re-enters this
+	// pipeline as a second attempt on the *same* service: without a snapshot it
+	// would re-transform the request object the first attempt already mutated.
+	multi := len(rule.GetActiveServices()) > 1 || endpointLearningEnabled(provider)
 	var template []byte
 	if multi {
 		bs, err := req.MarshalJSON()
@@ -376,7 +382,7 @@ func (ph *ProtocolHandler) runAnthropicBetaAttempt(c *gin.Context, req *protocol
 	case protocol.APIStyleGoogle:
 		target = protocol.TypeGoogle
 	case protocol.APIStyleOpenAI:
-		resolvedTarget, routeErr := ResolveOpenAIEndpoint(provider, ResolveRuleFlags(c, rule), IncomingAPIResponses)
+		resolvedTarget, routeErr := ResolveOpenAIEndpointForRequest(c, provider, requestModel, ResolveRuleFlags(c, rule), IncomingAPIResponses)
 		if routeErr != nil {
 			ph.FailAttemptSetup(c, routeErr)
 			return

--- a/internal/protocolserver/anthropic_message.go
+++ b/internal/protocolserver/anthropic_message.go
@@ -187,10 +187,7 @@ func (ph *ProtocolHandler) AnthropicMessagesV1(c *gin.Context, req *protocol.Ant
 
 	// Snapshot a pristine template only when failover is possible; the single
 	// service case reuses the original request with no clone overhead.
-	// "Possible" includes the endpoint-learning retry, which re-enters this
-	// pipeline as a second attempt on the *same* service: without a snapshot it
-	// would re-transform the request object the first attempt already mutated.
-	multi := len(rule.GetActiveServices()) > 1 || endpointLearningEnabled(provider)
+	multi := DispatchMayRetry(rule, provider, requestModel)
 	var template []byte
 	if multi {
 		bs, err := req.MarshalJSON()
@@ -315,10 +312,7 @@ func (ph *ProtocolHandler) AnthropicMessagesV1Beta(c *gin.Context, req *protocol
 	}
 
 	// Snapshot a pristine template only when failover is possible.
-	// "Possible" includes the endpoint-learning retry, which re-enters this
-	// pipeline as a second attempt on the *same* service: without a snapshot it
-	// would re-transform the request object the first attempt already mutated.
-	multi := len(rule.GetActiveServices()) > 1 || endpointLearningEnabled(provider)
+	multi := DispatchMayRetry(rule, provider, requestModel)
 	var template []byte
 	if multi {
 		bs, err := req.MarshalJSON()

--- a/internal/protocolserver/endpoint_learning.go
+++ b/internal/protocolserver/endpoint_learning.go
@@ -1,0 +1,301 @@
+package protocolserver
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/client"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// Request-scoped plumbing between the endpoint resolution done inside an
+// attempt and the dispatch loop that owns the retry decision.
+//
+//   - ctxKeyResolvedEndpoint: what the attempt actually used, so the loop can
+//     compute the alternative without re-deriving it.
+//   - ctxKeyForcedEndpoint: the loop's instruction for the retry attempt.
+//
+// The gin context is the same channel the rest of the per-request routing
+// state travels on (rule flags, tracking); a parameter would have to thread
+// through every transform signature to reach the same place.
+const (
+	ctxKeyResolvedEndpoint = "tingly_resolved_openai_endpoint"
+	ctxKeyForcedEndpoint   = "tingly_forced_openai_endpoint"
+	// ctxKeyEndpointPinned marks a resolution that came from the rule's
+	// openai_endpoint_override. A pinned endpoint is the caller's explicit
+	// choice and is never second-guessed by learning.
+	ctxKeyEndpointPinned = "tingly_openai_endpoint_pinned"
+	// ctxKeySetupFailed marks an attempt that failed inside the gateway
+	// (target resolution, transform) rather than at the upstream.
+	ctxKeySetupFailed = "tingly_attempt_setup_failed"
+)
+
+// EffectiveEndpointMode is the provider's declared OpenAIEndpointMode, with one
+// host-derived fallback: an OpenCode Zen provider carrying no declaration is
+// treated as per-model.
+//
+// The fallback exists because the declaration cannot reach these providers.
+// ProviderTemplate.OpenAIEndpointMode is only ever copied onto a Provider by
+// the OAuth path (Codex); a provider created from a template through the normal
+// API keeps the zero value — which is why openai-com's "both" has never taken
+// effect either. Rather than add a startup migration that still leaves a
+// provider added at runtime broken until the next restart, derive the fact
+// where it is used, from the same host match the OpenCode client already
+// relies on.
+//
+// Pure: reads provider fields only.
+func EffectiveEndpointMode(provider *typ.Provider) ai.OpenAIEndpointMode {
+	if provider == nil {
+		return ai.EndpointModeUnknown
+	}
+	if provider.OpenAIEndpointMode != ai.EndpointModeUnknown {
+		return provider.OpenAIEndpointMode
+	}
+	for _, base := range []string{provider.APIBase, provider.APIBaseOpenAI, provider.APIBaseAnthropic} {
+		if base != "" && client.IsOpenCodeZen(base) {
+			return ai.EndpointModePerModel
+		}
+	}
+	return ai.EndpointModeUnknown
+}
+
+// ResolveOpenAIEndpointForRequest wraps the pure resolver with the two pieces
+// of request state it deliberately does not read: the endpoint the dispatch
+// loop is forcing for a learning retry, and what has already been learned for
+// this provider+model. It also records the decision for the loop.
+//
+// Every handler resolves through here so no dispatch path can silently opt
+// out of learning — or of being retried.
+func ResolveOpenAIEndpointForRequest(
+	c *gin.Context,
+	provider *typ.Provider,
+	model string,
+	flags typ.RuleFlags,
+	incoming IncomingAPIType,
+) (protocol.APIType, error) {
+	if forced, ok := forcedEndpoint(c); ok {
+		c.Set(ctxKeyResolvedEndpoint, forced)
+		return forced, nil
+	}
+
+	// A rule that pins the endpoint owns the decision; record that so the
+	// learning retry stands down instead of overruling it.
+	c.Set(ctxKeyEndpointPinned, ParseEndpointOverride(flags.OpenAIEndpointOverride) != OverrideAuto)
+
+	var learned protocol.APIType
+	if endpointLearningEnabled(provider) {
+		learned = defaultEndpointMemory.Lookup(provider.UUID, model)
+	}
+
+	target, err := ResolveOpenAIEndpoint(provider, flags, incoming, learned)
+	if err != nil {
+		return "", err
+	}
+	c.Set(ctxKeyResolvedEndpoint, target)
+	return target, nil
+}
+
+// endpointLearningEnabled reports whether this provider opted into the
+// learning fallback by declaring EndpointModePerModel. Everything downstream
+// — installing the buffer for a single-service rule, spending an extra
+// round-trip, writing to the memory — is gated on this one declaration, which
+// is what keeps the blast radius at "providers whose upstream is known to be
+// per-model" instead of "every provider", the flaw that sank the old
+// AdaptiveProbe.
+func endpointLearningEnabled(provider *typ.Provider) bool {
+	return EffectiveEndpointMode(provider) == ai.EndpointModePerModel
+}
+
+// ResetEndpointDecision clears the per-attempt decision state. The dispatch
+// loop calls it before every attempt: a later attempt may land on a provider
+// of another API style that never resolves an OpenAI endpoint at all, and a
+// stale value there would let the retry fire on someone else's failure.
+func ResetEndpointDecision(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	c.Set(ctxKeyResolvedEndpoint, protocol.APIType(""))
+	c.Set(ctxKeyEndpointPinned, false)
+	c.Set(ctxKeySetupFailed, false)
+}
+
+// MarkAttemptSetupFailed records that the gateway itself failed the attempt
+// before reaching the upstream. Such a failure is written as a 500, which the
+// mismatch matcher would otherwise read as "maybe the wrong endpoint" and pay
+// a pointless round-trip for.
+func MarkAttemptSetupFailed(c *gin.Context) {
+	if c != nil {
+		c.Set(ctxKeySetupFailed, true)
+	}
+}
+
+func boolFromContext(c *gin.Context, key string) bool {
+	if c == nil {
+		return false
+	}
+	v, ok := c.Get(key)
+	if !ok {
+		return false
+	}
+	b, _ := v.(bool)
+	return b
+}
+
+func forcedEndpoint(c *gin.Context) (protocol.APIType, bool) {
+	if c == nil {
+		return "", false
+	}
+	v, ok := c.Get(ctxKeyForcedEndpoint)
+	if !ok {
+		return "", false
+	}
+	ep, ok := v.(protocol.APIType)
+	return ep, ok && ep != ""
+}
+
+func resolvedEndpoint(c *gin.Context) protocol.APIType {
+	if c == nil {
+		return ""
+	}
+	if v, ok := c.Get(ctxKeyResolvedEndpoint); ok {
+		if ep, ok := v.(protocol.APIType); ok {
+			return ep
+		}
+	}
+	return ""
+}
+
+// endpointMismatchMarkers are the upstream rejections that mean "this model
+// does not speak this endpoint". OpenCode Zen answers the same condition three
+// different ways depending on which backend vendor is behind the model, so
+// text matching is unavoidable — measured 2026-09-08 on /zen/go:
+//
+//	grok-4.6     → 401 "Model grok-4.6 is not supported for format oa-compat"
+//	grok-4.5     → 500 "Upstream request failed: Endpoint is unavailable."
+//	gpt-5.6-luna → 500 "Internal server error"
+//
+// The last one carries no marker at all, which is why looksLikeEndpointMismatch
+// also accepts a bare 5xx. That is safe only because the whole path is gated on
+// EndpointModePerModel: a provider that has not declared per-model variance
+// never reaches this test, so an ordinary upstream 500 is never retried on a
+// different endpoint.
+var endpointMismatchMarkers = []string{
+	"not supported for format",
+	"endpoint is unavailable",
+	"unsupported endpoint",
+}
+
+// looksLikeEndpointMismatch reports whether a buffered attempt failure is
+// plausibly "wrong endpoint for this model".
+//
+// 4xx needs an explicit marker: a 401 without one is a credential problem and
+// a 400 without one is a malformed request, and neither gets better on the
+// other endpoint. 5xx is accepted bare, per the luna case above.
+func looksLikeEndpointMismatch(status int, body []byte) bool {
+	if status >= 500 {
+		return true
+	}
+	if status != 400 && status != 401 && status != 404 {
+		return false
+	}
+	lower := strings.ToLower(string(body))
+	for _, marker := range endpointMismatchMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// retryOnAlternateEndpoint gives a failed attempt on a per-model provider one
+// second chance on the other OpenAI endpoint, and remembers the answer when
+// it works. Returns whether a retry actually ran (the caller then re-reads
+// the gate).
+//
+// It is the whole of the "adaptive" behavior, and every guard here is one of
+// the ways the old AdaptiveProbe went wrong:
+//
+//   - Reactive, never proactive: this runs after a real request already
+//     failed at the upstream. A failure the gateway produced itself, or an
+//     endpoint the rule pinned, is not second-guessed.
+//   - Gated on the provider's declared mode, so no other upstream can ever
+//     pay for it.
+//   - Pre-commit only: a stream that has put bytes on the wire cannot be
+//     retried, and is not.
+//   - One retry, then normal failover takes over.
+//   - Cooldown on failure, so a sick upstream cannot turn into a hot loop:
+//     one extra request per (provider, model) per minute, at worst. Success
+//     is not throttled at all — it is remembered, and a remembered mapping
+//     produces no failure to retry.
+//   - Only the success is remembered.
+func (ph *ProtocolHandler) retryOnAlternateEndpoint(
+	c *gin.Context,
+	gate *firstChunkGate,
+	provider *typ.Provider,
+	model string,
+	status int,
+	attemptNo int,
+	attempt dispatchAttempt,
+) bool {
+	if !endpointLearningEnabled(provider) || gate.Committed() {
+		return false
+	}
+	if _, forced := forcedEndpoint(c); forced {
+		return false // already the retry
+	}
+	if boolFromContext(c, ctxKeyEndpointPinned) {
+		return false // the rule chose this endpoint explicitly
+	}
+	if boolFromContext(c, ctxKeySetupFailed) {
+		return false // our own failure, not the upstream's verdict
+	}
+	used := resolvedEndpoint(c)
+	alternate := alternateEndpoint(used)
+	if alternate == "" {
+		return false // not an OpenAI-shaped attempt
+	}
+	if !looksLikeEndpointMismatch(status, gate.BufferedBody()) {
+		return false
+	}
+	if !defaultEndpointMemory.ShouldRetry(provider.UUID, model) {
+		return false
+	}
+	defaultEndpointMemory.MarkRetry(provider.UUID, model)
+
+	logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+		"stage":    "endpoint_learning_retry",
+		"provider": provider.UUID,
+		"model":    model,
+		"attempt":  attemptNo,
+		"status":   status,
+		"from":     used,
+		"to":       alternate,
+	}).Infof("[endpoint] %s/%s failed on %s, retrying on %s", provider.UUID, model, used, alternate)
+
+	gate.Discard()
+	c.Set(ctxKeyForcedEndpoint, alternate)
+	defer c.Set(ctxKeyForcedEndpoint, protocol.APIType(""))
+
+	attempt(provider, model)
+
+	if gate.Committed() || isSuccessStatus(gate.Status()) {
+		defaultEndpointMemory.Remember(provider.UUID, model, alternate)
+		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+			"stage":    "endpoint_learned",
+			"provider": provider.UUID,
+			"model":    model,
+			"endpoint": alternate,
+			"ttl":      endpointMemoryTTL.String(),
+		}).Infof("[endpoint] learned %s/%s speaks %s", provider.UUID, model, alternate)
+	}
+	return true
+}
+
+// isSuccessStatus treats a buffered 2xx as success. A gate that was never
+// written (status 0) is not success: the attempt produced nothing.
+func isSuccessStatus(status int) bool {
+	return status >= 200 && status < 300
+}

--- a/internal/protocolserver/endpoint_learning.go
+++ b/internal/protocolserver/endpoint_learning.go
@@ -1,7 +1,7 @@
 package protocolserver
 
 import (
-	"strings"
+	"bytes"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -11,27 +11,68 @@ import (
 	"github.com/tingly-dev/tingly-box/internal/typ"
 )
 
-// Request-scoped plumbing between the endpoint resolution done inside an
-// attempt and the dispatch loop that owns the retry decision.
+// ctxKeyEndpointDecision carries the endpointDecision below. One key rather
+// than one per field: these values are facets of a single decision with a
+// single lifetime, and the dispatch loop resets them together.
+const ctxKeyEndpointDecision = "tingly_endpoint_decision"
+
+// endpointDecision is the per-attempt contract between endpoint resolution
+// (inside the attempt) and the dispatch loop that owns the retry decision.
 //
-//   - ctxKeyResolvedEndpoint: what the attempt actually used, so the loop can
-//     compute the alternative without re-deriving it.
-//   - ctxKeyForcedEndpoint: the loop's instruction for the retry attempt.
-//
-// The gin context is the same channel the rest of the per-request routing
-// state travels on (rule flags, tracking); a parameter would have to thread
-// through every transform signature to reach the same place.
-const (
-	ctxKeyResolvedEndpoint = "tingly_resolved_openai_endpoint"
-	ctxKeyForcedEndpoint   = "tingly_forced_openai_endpoint"
-	// ctxKeyEndpointPinned marks a resolution that came from the rule's
-	// openai_endpoint_override. A pinned endpoint is the caller's explicit
-	// choice and is never second-guessed by learning.
-	ctxKeyEndpointPinned = "tingly_openai_endpoint_pinned"
-	// ctxKeySetupFailed marks an attempt that failed inside the gateway
-	// (target resolution, transform) rather than at the upstream.
-	ctxKeySetupFailed = "tingly_attempt_setup_failed"
-)
+// The gin context is the channel because dispatchAttempt is
+// func(provider, model): widening that signature to carry an outcome would
+// reach every handler closure and FailAttemptSetup. That is the deeper fix if
+// this contract ever grows again.
+type endpointDecision struct {
+	// resolved is the endpoint the current attempt used; forced is the one
+	// the loop is making it use for a learning retry.
+	resolved, forced protocol.APIType
+	// pinned marks a resolution the rule's openai_endpoint_override dictated.
+	// setupFailed marks an attempt the gateway failed itself, before the
+	// upstream saw it. Neither is a verdict on the endpoint.
+	pinned, setupFailed bool
+	// mode caches EffectiveEndpointMode for modeProvider. Resolution, the
+	// snapshot decision and the retry check all ask for it within one attempt,
+	// and deriving it parses URLs.
+	mode         ai.OpenAIEndpointMode
+	modeProvider string
+}
+
+// endpointDecisionFor returns the request's decision, creating it on first use.
+func endpointDecisionFor(c *gin.Context) *endpointDecision {
+	if c == nil {
+		return &endpointDecision{}
+	}
+	if v, ok := c.Get(ctxKeyEndpointDecision); ok {
+		if d, ok := v.(*endpointDecision); ok {
+			return d
+		}
+	}
+	d := &endpointDecision{}
+	c.Set(ctxKeyEndpointDecision, d)
+	return d
+}
+
+// reset clears everything scoped to one attempt. forced survives: the loop
+// sets it for the retry attempt it is about to run.
+func (d *endpointDecision) reset() {
+	d.resolved = ""
+	d.pinned = false
+	d.setupFailed = false
+}
+
+// effectiveMode is EffectiveEndpointMode memoized for the attempt's provider.
+func (d *endpointDecision) effectiveMode(provider *typ.Provider) ai.OpenAIEndpointMode {
+	uuid := ""
+	if provider != nil {
+		uuid = provider.UUID
+	}
+	if d.modeProvider != uuid || d.mode == "" {
+		d.mode = EffectiveEndpointMode(provider)
+		d.modeProvider = uuid
+	}
+	return d.mode
+}
 
 // EffectiveEndpointMode is the provider's declared OpenAIEndpointMode, with one
 // host-derived fallback: an OpenCode Zen provider carrying no declaration is
@@ -41,10 +82,13 @@ const (
 // ProviderTemplate.OpenAIEndpointMode is only ever copied onto a Provider by
 // the OAuth path (Codex); a provider created from a template through the normal
 // API keeps the zero value — which is why openai-com's "both" has never taken
-// effect either. Rather than add a startup migration that still leaves a
-// provider added at runtime broken until the next restart, derive the fact
-// where it is used, from the same host match the OpenCode client already
-// relies on.
+// effect either.
+//
+// This is a stopgap, and the deeper fix is named in
+// .design/openai-endpoint-routing.md §10: serve the template's declaration
+// lazily at request time, the way TemplateManager already serves max_tokens
+// and web-search capability, which would retire the host match here and repair
+// "both" at the same time.
 //
 // Pure: reads provider fields only.
 func EffectiveEndpointMode(provider *typ.Provider) ai.OpenAIEndpointMode {
@@ -62,13 +106,13 @@ func EffectiveEndpointMode(provider *typ.Provider) ai.OpenAIEndpointMode {
 	return ai.EndpointModeUnknown
 }
 
-// ResolveOpenAIEndpointForRequest wraps the pure resolver with the two pieces
-// of request state it deliberately does not read: the endpoint the dispatch
-// loop is forcing for a learning retry, and what has already been learned for
-// this provider+model. It also records the decision for the loop.
+// ResolveOpenAIEndpointForRequest wraps the pure resolver with the request
+// state it deliberately does not read: the endpoint the dispatch loop is
+// forcing for a learning retry, and what has already been learned for this
+// service. It also records the decision for the loop.
 //
-// Every handler resolves through here so no dispatch path can silently opt
-// out of learning — or of being retried.
+// Every handler resolves through here so no dispatch path can silently opt out
+// of learning — or of being retried.
 func ResolveOpenAIEndpointForRequest(
 	c *gin.Context,
 	provider *typ.Provider,
@@ -76,96 +120,76 @@ func ResolveOpenAIEndpointForRequest(
 	flags typ.RuleFlags,
 	incoming IncomingAPIType,
 ) (protocol.APIType, error) {
-	if forced, ok := forcedEndpoint(c); ok {
-		c.Set(ctxKeyResolvedEndpoint, forced)
-		return forced, nil
+	d := endpointDecisionFor(c)
+	if d.forced != "" {
+		d.resolved = d.forced
+		return d.forced, nil
 	}
 
 	// A rule that pins the endpoint owns the decision; record that so the
 	// learning retry stands down instead of overruling it.
-	c.Set(ctxKeyEndpointPinned, ParseEndpointOverride(flags.OpenAIEndpointOverride) != OverrideAuto)
+	d.pinned = ParseEndpointOverride(flags.OpenAIEndpointOverride) != OverrideAuto
 
 	var learned protocol.APIType
-	if endpointLearningEnabled(provider) {
-		learned = defaultEndpointMemory.Lookup(provider.UUID, model)
+	if d.effectiveMode(provider) == ai.EndpointModePerModel {
+		learned = defaultEndpointMemory.Lookup(endpointMemoryKey(provider.UUID, model))
 	}
 
 	target, err := ResolveOpenAIEndpoint(provider, flags, incoming, learned)
 	if err != nil {
 		return "", err
 	}
-	c.Set(ctxKeyResolvedEndpoint, target)
+	d.resolved = target
 	return target, nil
 }
 
-// endpointLearningEnabled reports whether this provider opted into the
-// learning fallback by declaring EndpointModePerModel. Everything downstream
-// — installing the buffer for a single-service rule, spending an extra
-// round-trip, writing to the memory — is gated on this one declaration, which
-// is what keeps the blast radius at "providers whose upstream is known to be
-// per-model" instead of "every provider", the flaw that sank the old
-// AdaptiveProbe.
-func endpointLearningEnabled(provider *typ.Provider) bool {
-	return EffectiveEndpointMode(provider) == ai.EndpointModePerModel
-}
-
-// ResetEndpointDecision clears the per-attempt decision state. The dispatch
-// loop calls it before every attempt: a later attempt may land on a provider
-// of another API style that never resolves an OpenAI endpoint at all, and a
-// stale value there would let the retry fire on someone else's failure.
-func ResetEndpointDecision(c *gin.Context) {
-	if c == nil {
-		return
+// DispatchMayRetry reports whether `attempt` can run more than once for this
+// request — because the rule has a fallback tier, or because endpoint learning
+// may retry the same service on the other endpoint.
+//
+// It states one invariant in one place for the two consumers that must agree:
+// the dispatch loop (which installs the response buffer) and the handlers
+// (which snapshot a pristine request). If they disagree, a second attempt
+// re-transforms the request object the first one already mutated.
+//
+// Once an endpoint is learned there is nothing left to retry, so the cost of
+// buffering and snapshotting is paid only until the answer is known — see
+// forgetStaleEndpoint for how a mapping that stops working gets re-learned.
+func DispatchMayRetry(rule *typ.Rule, provider *typ.Provider, model string) bool {
+	if rule != nil && len(rule.GetActiveServices()) > 1 {
+		return true
 	}
-	c.Set(ctxKeyResolvedEndpoint, protocol.APIType(""))
-	c.Set(ctxKeyEndpointPinned, false)
-	c.Set(ctxKeySetupFailed, false)
+	if EffectiveEndpointMode(provider) != ai.EndpointModePerModel {
+		return false
+	}
+	return defaultEndpointMemory.Lookup(endpointMemoryKey(provider.UUID, model)) == ""
 }
 
 // MarkAttemptSetupFailed records that the gateway itself failed the attempt
 // before reaching the upstream. Such a failure is written as a 500, which the
-// mismatch matcher would otherwise read as "maybe the wrong endpoint" and pay
-// a pointless round-trip for.
+// mismatch matcher would otherwise read as "maybe the wrong endpoint".
 func MarkAttemptSetupFailed(c *gin.Context) {
-	if c != nil {
-		c.Set(ctxKeySetupFailed, true)
-	}
+	endpointDecisionFor(c).setupFailed = true
 }
 
-func boolFromContext(c *gin.Context, key string) bool {
-	if c == nil {
-		return false
+// forgetStaleEndpoint drops a learned mapping after the endpoint it names
+// failed with a server error. Without this, a model the upstream moves between
+// formats stays broken for the rest of the TTL: the learned value routes every
+// request to the dead endpoint, and DispatchMayRetry — seeing an answer
+// already known — installs no buffer to retry with. Forgetting costs one
+// failed request and lets the next one re-learn.
+func forgetStaleEndpoint(c *gin.Context, provider *typ.Provider, model string, status int) {
+	if status < 500 || endpointDecisionFor(c).effectiveMode(provider) != ai.EndpointModePerModel {
+		return
 	}
-	v, ok := c.Get(key)
-	if !ok {
-		return false
+	serviceID := endpointMemoryKey(provider.UUID, model)
+	if defaultEndpointMemory.Lookup(serviceID) == "" {
+		return
 	}
-	b, _ := v.(bool)
-	return b
-}
-
-func forcedEndpoint(c *gin.Context) (protocol.APIType, bool) {
-	if c == nil {
-		return "", false
-	}
-	v, ok := c.Get(ctxKeyForcedEndpoint)
-	if !ok {
-		return "", false
-	}
-	ep, ok := v.(protocol.APIType)
-	return ep, ok && ep != ""
-}
-
-func resolvedEndpoint(c *gin.Context) protocol.APIType {
-	if c == nil {
-		return ""
-	}
-	if v, ok := c.Get(ctxKeyResolvedEndpoint); ok {
-		if ep, ok := v.(protocol.APIType); ok {
-			return ep
-		}
-	}
-	return ""
+	defaultEndpointMemory.Forget(serviceID)
+	logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
+		"stage": "endpoint_forgotten", "provider": provider.UUID, "model": model, "status": status,
+	}).Infof("[endpoint] %s/%s failed on its learned endpoint; will re-learn", provider.UUID, model)
 }
 
 // endpointMismatchMarkers are the upstream rejections that mean "this model
@@ -179,14 +203,18 @@ func resolvedEndpoint(c *gin.Context) protocol.APIType {
 //
 // The last one carries no marker at all, which is why looksLikeEndpointMismatch
 // also accepts a bare 5xx. That is safe only because the whole path is gated on
-// EndpointModePerModel: a provider that has not declared per-model variance
-// never reaches this test, so an ordinary upstream 500 is never retried on a
-// different endpoint.
-var endpointMismatchMarkers = []string{
-	"not supported for format",
-	"endpoint is unavailable",
-	"unsupported endpoint",
+// EndpointModePerModel: a provider whose format does not vary by model never
+// reaches this test, so an ordinary upstream 500 is never retried elsewhere.
+var endpointMismatchMarkers = [][]byte{
+	[]byte("not supported for format"),
+	[]byte("endpoint is unavailable"),
+	[]byte("unsupported endpoint"),
 }
+
+// endpointMismatchScanLimit caps how much of a failure body is scanned. The
+// markers sit in the first JSON object; a relay echoing a request back would
+// otherwise be lowercased in full.
+const endpointMismatchScanLimit = 4096
 
 // looksLikeEndpointMismatch reports whether a buffered attempt failure is
 // plausibly "wrong endpoint for this model".
@@ -201,9 +229,12 @@ func looksLikeEndpointMismatch(status int, body []byte) bool {
 	if status != 400 && status != 401 && status != 404 {
 		return false
 	}
-	lower := strings.ToLower(string(body))
+	if len(body) > endpointMismatchScanLimit {
+		body = body[:endpointMismatchScanLimit]
+	}
+	lower := bytes.ToLower(body)
 	for _, marker := range endpointMismatchMarkers {
-		if strings.Contains(lower, marker) {
+		if bytes.Contains(lower, marker) {
 			return true
 		}
 	}
@@ -211,26 +242,15 @@ func looksLikeEndpointMismatch(status int, body []byte) bool {
 }
 
 // retryOnAlternateEndpoint gives a failed attempt on a per-model provider one
-// second chance on the other OpenAI endpoint, and remembers the answer when
-// it works. Returns whether a retry actually ran (the caller then re-reads
-// the gate).
+// second chance on the other OpenAI endpoint, remembers the answer when it
+// works, and returns the status the dispatch loop should judge.
 //
-// It is the whole of the "adaptive" behavior, and every guard here is one of
-// the ways the old AdaptiveProbe went wrong:
-//
-//   - Reactive, never proactive: this runs after a real request already
-//     failed at the upstream. A failure the gateway produced itself, or an
-//     endpoint the rule pinned, is not second-guessed.
-//   - Gated on the provider's declared mode, so no other upstream can ever
-//     pay for it.
-//   - Pre-commit only: a stream that has put bytes on the wire cannot be
-//     retried, and is not.
-//   - One retry, then normal failover takes over.
-//   - Cooldown on failure, so a sick upstream cannot turn into a hot loop:
-//     one extra request per (provider, model) per minute, at worst. Success
-//     is not throttled at all — it is remembered, and a remembered mapping
-//     produces no failure to retry.
-//   - Only the success is remembered.
+// It is the whole of the "adaptive" behavior. Two properties keep it from
+// repeating the AdaptiveProbe (PR #976) mistakes: it is reactive — it runs
+// only after a real request already failed at the upstream, so there is no
+// cold-start probe and no synthetic token spend — and it is gated on the
+// provider's mode, so no other upstream can pay for it. The remaining guards
+// are inline below.
 func (ph *ProtocolHandler) retryOnAlternateEndpoint(
 	c *gin.Context,
 	gate *firstChunkGate,
@@ -239,59 +259,61 @@ func (ph *ProtocolHandler) retryOnAlternateEndpoint(
 	status int,
 	attemptNo int,
 	attempt dispatchAttempt,
-) bool {
-	if !endpointLearningEnabled(provider) || gate.Committed() {
-		return false
+) int {
+	d := endpointDecisionFor(c)
+	if d.effectiveMode(provider) != ai.EndpointModePerModel || gate.Committed() {
+		return status
 	}
-	if _, forced := forcedEndpoint(c); forced {
-		return false // already the retry
+	if d.forced != "" {
+		return status // already the retry
 	}
-	if boolFromContext(c, ctxKeyEndpointPinned) {
-		return false // the rule chose this endpoint explicitly
+	if d.pinned {
+		return status // the rule chose this endpoint explicitly
 	}
-	if boolFromContext(c, ctxKeySetupFailed) {
-		return false // our own failure, not the upstream's verdict
+	if d.setupFailed {
+		return status // our own failure, not the upstream's verdict
 	}
-	used := resolvedEndpoint(c)
-	alternate := alternateEndpoint(used)
+	alternate := alternateEndpoint(d.resolved)
 	if alternate == "" {
-		return false // not an OpenAI-shaped attempt
+		return status // not an OpenAI-shaped attempt
 	}
 	if !looksLikeEndpointMismatch(status, gate.BufferedBody()) {
-		return false
+		return status
 	}
-	if !defaultEndpointMemory.ShouldRetry(provider.UUID, model) {
-		return false
+	serviceID := endpointMemoryKey(provider.UUID, model)
+	if !defaultEndpointMemory.ShouldRetry(serviceID) {
+		return status
 	}
-	defaultEndpointMemory.MarkRetry(provider.UUID, model)
+	defaultEndpointMemory.MarkRetry(serviceID)
 
 	logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-		"stage":    "endpoint_learning_retry",
-		"provider": provider.UUID,
-		"model":    model,
-		"attempt":  attemptNo,
-		"status":   status,
-		"from":     used,
-		"to":       alternate,
-	}).Infof("[endpoint] %s/%s failed on %s, retrying on %s", provider.UUID, model, used, alternate)
+		"stage": "endpoint_learning_retry", "provider": provider.UUID, "model": model,
+		"attempt": attemptNo, "status": status, "from": d.resolved, "to": alternate,
+	}).Infof("[endpoint] %s/%s failed on %s, retrying on %s", provider.UUID, model, d.resolved, alternate)
 
 	gate.Discard()
-	c.Set(ctxKeyForcedEndpoint, alternate)
-	defer c.Set(ctxKeyForcedEndpoint, protocol.APIType(""))
+	d.forced = alternate
+	defer func() { d.forced = "" }()
 
 	attempt(provider, model)
 
-	if gate.Committed() || isSuccessStatus(gate.Status()) {
-		defaultEndpointMemory.Remember(provider.UUID, model, alternate)
+	retried := gate.Status()
+	if gate.Committed() || isSuccessStatus(retried) {
+		defaultEndpointMemory.Remember(serviceID, alternate)
 		logrus.WithContext(c.Request.Context()).WithFields(logrus.Fields{
-			"stage":    "endpoint_learned",
-			"provider": provider.UUID,
-			"model":    model,
-			"endpoint": alternate,
-			"ttl":      endpointMemoryTTL.String(),
+			"stage": "endpoint_learned", "provider": provider.UUID, "model": model,
+			"endpoint": alternate, "ttl": endpointMemoryTTL.String(),
 		}).Infof("[endpoint] learned %s/%s speaks %s", provider.UUID, model, alternate)
+		return retried
 	}
-	return true
+
+	// A terminal status from the retry must not mask a retryable original:
+	// the first failure had earned this service a fallback to a healthy
+	// sibling, and the second endpoint's verdict does not take that away.
+	if isRetryableStatus(retried) || !isRetryableStatus(status) {
+		return retried
+	}
+	return status
 }
 
 // isSuccessStatus treats a buffered 2xx as success. A gate that was never

--- a/internal/protocolserver/endpoint_learning_e2e_test.go
+++ b/internal/protocolserver/endpoint_learning_e2e_test.go
@@ -1,0 +1,123 @@
+package protocolserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/client"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// TestE2E_OpenCodePerModelEndpoints drives the real OpenCode Zen upstream to
+// prove the two facts the per_model mode is built on, rather than trusting a
+// stand-in for them:
+//
+//   - a Responses-only model (gpt-5.6-luna) really is rejected on
+//     /chat/completions and really answers on /responses;
+//   - a Chat-only model (kimi-k3) is the mirror image.
+//
+// Prerequisites: OPENCODE_API_KEY, and OPENCODE_PROXY_URL where the network
+// only leaves through a proxy (the transport pool never inherits HTTP(S)_PROXY).
+//
+// Run with: go test -v ./internal/protocolserver -run TestE2E_OpenCodePerModel
+func TestE2E_OpenCodePerModelEndpoints(t *testing.T) {
+	apiKey := os.Getenv("OPENCODE_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENCODE_API_KEY not set, skipping e2e test")
+	}
+
+	provider := &typ.Provider{
+		UUID:               "opencode-e2e-endpoint",
+		Name:               "OpenCode Go",
+		AuthType:           ai.AuthTypeAPIKey,
+		Token:              apiKey,
+		APIBase:            "https://opencode.ai/zen/go/v1",
+		ProxyURL:           os.Getenv("OPENCODE_PROXY_URL"),
+		APIStyle:           protocol.APIStyleOpenAI,
+		OpenAIEndpointMode: ai.EndpointModePerModel,
+		Enabled:            true,
+	}
+
+	tests := []struct {
+		model     string
+		chatOK    bool
+		responses bool
+	}{
+		{model: "gpt-5.6-luna", chatOK: false, responses: true},
+		{model: "kimi-k3", chatOK: true, responses: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			gotChat, chatBody := postChat(t, provider, tt.model)
+			gotResponses, responsesBody := postResponses(t, provider, tt.model)
+			t.Logf("%s: chat=%d responses=%d", tt.model, gotChat, gotResponses)
+
+			if (gotChat == http.StatusOK) != tt.chatOK {
+				t.Errorf("chat status %d, want ok=%v", gotChat, tt.chatOK)
+			}
+			if (gotResponses == http.StatusOK) != tt.responses {
+				t.Errorf("responses status %d, want ok=%v", gotResponses, tt.responses)
+			}
+			// The rejection must be one the learning path recognizes, or the
+			// retry would never fire for this model.
+			if !tt.chatOK && !looksLikeEndpointMismatch(gotChat, chatBody) {
+				t.Errorf("chat rejection %d/%s is not recognized as an endpoint mismatch", gotChat, chatBody)
+			}
+			if !tt.responses && !looksLikeEndpointMismatch(gotResponses, responsesBody) {
+				t.Errorf("responses rejection %d/%s is not recognized as an endpoint mismatch", gotResponses, responsesBody)
+			}
+		})
+	}
+}
+
+func postChat(t *testing.T, provider *typ.Provider, model string) (int, []byte) {
+	t.Helper()
+	body := `{"model":"` + model + `","max_tokens":4,"messages":[{"role":"user","content":"hi"}]}`
+	return postUpstream(t, provider, "/chat/completions", body)
+}
+
+func postResponses(t *testing.T, provider *typ.Provider, model string) (int, []byte) {
+	t.Helper()
+	body := `{"model":"` + model + `","max_output_tokens":16,"input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}]}`
+	return postUpstream(t, provider, "/responses", body)
+}
+
+// postUpstream sends one request over the same client transport chain a
+// dispatch attempt would use, so the session header and proxy handling match
+// the real path.
+func postUpstream(t *testing.T, provider *typ.Provider, path, body string) (int, []byte) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/tingly/openai"+path, strings.NewReader(body))
+
+	oc := client.NewClientPool().GetOpenAIClient(c.Request.Context(), provider, "")
+	if oc == nil {
+		t.Fatal("no client for provider")
+	}
+	req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodPost,
+		strings.TrimSuffix(provider.APIBase, "/")+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+provider.GetAccessToken())
+
+	resp, err := oc.(*client.OpenCodeClient).HttpClient.Do(req)
+	if err != nil {
+		t.Fatalf("upstream: %v", err)
+	}
+	defer resp.Body.Close()
+	var payload map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&payload)
+	raw, _ := json.Marshal(payload)
+	return resp.StatusCode, raw
+}

--- a/internal/protocolserver/endpoint_learning_test.go
+++ b/internal/protocolserver/endpoint_learning_test.go
@@ -1,0 +1,490 @@
+package protocolserver
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+	"github.com/tingly-dev/tingly-box/internal/routing"
+	"github.com/tingly-dev/tingly-box/internal/server/config"
+	"github.com/tingly-dev/tingly-box/internal/typ"
+)
+
+// ── the store ───────────────────────────────────────────────────────────────
+
+func TestEndpointMemory_LookupRememberExpiry(t *testing.T) {
+	now := time.Now()
+	m := newEndpointMemory()
+	m.now = func() time.Time { return now }
+
+	if got := m.Lookup("p1", "luna"); got != "" {
+		t.Fatalf("empty store returned %q", got)
+	}
+
+	m.Remember("p1", "luna", protocol.TypeOpenAIResponses)
+	if got := m.Lookup("p1", "luna"); got != protocol.TypeOpenAIResponses {
+		t.Errorf("learned value = %q, want responses", got)
+	}
+	// Keyed per model, not per provider.
+	if got := m.Lookup("p1", "kimi-k3"); got != "" {
+		t.Errorf("another model on the same provider returned %q", got)
+	}
+
+	now = now.Add(endpointMemoryTTL + time.Second)
+	if got := m.Lookup("p1", "luna"); got != "" {
+		t.Errorf("expired entry still returned %q", got)
+	}
+}
+
+func TestEndpointMemory_FailedRetryCooldown(t *testing.T) {
+	now := time.Now()
+	m := newEndpointMemory()
+	m.now = func() time.Time { return now }
+
+	if !m.ShouldRetry("p1", "luna") {
+		t.Fatal("first retry must be allowed")
+	}
+	m.MarkRetry("p1", "luna")
+	if m.ShouldRetry("p1", "luna") {
+		t.Error("a second retry inside the cooldown must be refused")
+	}
+
+	now = now.Add(endpointRetryCooldown + time.Second)
+	if !m.ShouldRetry("p1", "luna") {
+		t.Error("retry must be allowed again after the cooldown")
+	}
+
+	// The cooldown gates failures only: a success clears it outright, and the
+	// learned mapping then means no failure arises to retry in the first place.
+	m.MarkRetry("p1", "luna")
+	m.Remember("p1", "luna", protocol.TypeOpenAIResponses)
+	if !m.ShouldRetry("p1", "luna") {
+		t.Error("remembering an answer must clear the cooldown")
+	}
+}
+
+// ── the signature ───────────────────────────────────────────────────────────
+
+// TestLooksLikeEndpointMismatch pins the three shapes OpenCode Zen actually
+// returns for one condition, and the failures that must NOT be mistaken for it.
+func TestLooksLikeEndpointMismatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{"grok-4.6: explicit format rejection", 401,
+			`{"error":{"type":"ModelError","message":"Model grok-4.6 is not supported for format oa-compat"}}`, true},
+		{"grok-4.5: marker inside a 500", 500,
+			`{"error":{"message":"Upstream request failed: Endpoint is unavailable."}}`, true},
+		{"gpt-5.6-luna: bare 500", 500,
+			`{"type":"error","error":{"message":"Internal server error"}}`, true},
+		{"bad credential", 401,
+			`{"error":{"type":"AuthError","message":"Missing API key."}}`, false},
+		{"malformed request", 400,
+			`{"error":{"message":"messages: field required"}}`, false},
+		{"rate limited", 429,
+			`{"error":{"message":"slow down"}}`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := looksLikeEndpointMismatch(tt.status, []byte(tt.body)); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAlternateEndpoint(t *testing.T) {
+	if got := alternateEndpoint(protocol.TypeOpenAIChat); got != protocol.TypeOpenAIResponses {
+		t.Errorf("chat → %q", got)
+	}
+	if got := alternateEndpoint(protocol.TypeOpenAIResponses); got != protocol.TypeOpenAIChat {
+		t.Errorf("responses → %q", got)
+	}
+	if got := alternateEndpoint(protocol.TypeAnthropicV1); got != "" {
+		t.Errorf("non-OpenAI target → %q, want empty", got)
+	}
+}
+
+// ── the loop ────────────────────────────────────────────────────────────────
+
+// perModelFailoverHandler builds a handler with the deps failover selection
+// needs (config-backed provider lookup, load balancer, health monitor), plus a
+// two-tier rule: the per-model Zen service first, a sibling behind it.
+func perModelFailoverHandler(t *testing.T, zen *typ.Provider, sibling *typ.Provider, zenModel, siblingModel string) (*ProtocolHandler, *typ.Rule) {
+	t.Helper()
+	cfg, err := config.NewConfig(config.WithConfigDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+	for _, p := range []*typ.Provider{zen, sibling} {
+		p.Enabled = true
+		if err := cfg.AddProvider(p); err != nil {
+			t.Fatalf("AddProvider(%s): %v", p.UUID, err)
+		}
+	}
+	hm := loadbalance.NewHealthMonitor(loadbalance.HealthMonitorConfig{ProbeEnabled: false})
+	lb := NewLoadBalancer(cfg, routing.NewHealthFilter(hm))
+	ph := NewHandler(ProtocolHandlerDeps{Config: cfg, LoadBalancer: lb, HealthMonitor: hm})
+
+	rule := &typ.Rule{
+		UUID: "r-permodel", Scenario: typ.ScenarioOpenAI, Active: true,
+		LBTactic: typ.Tactic{
+			Type:   loadbalance.TacticTier,
+			Params: &typ.TierParams{WithinTierTactic: loadbalance.TacticRandom},
+		},
+		Services: []*loadbalance.Service{
+			{Provider: zen.UUID, Model: zenModel, Active: true, Tier: 0},
+			{Provider: sibling.UUID, Model: siblingModel, Active: true, Tier: 1},
+		},
+	}
+	return ph, rule
+}
+
+func perModelProvider() *typ.Provider {
+	return &typ.Provider{
+		UUID:               "p-opencode",
+		Name:               "OpenCode Go",
+		APIStyle:           protocol.APIStyleOpenAI,
+		APIBase:            "https://opencode.ai/zen/go/v1",
+		OpenAIEndpointMode: ai.EndpointModePerModel,
+	}
+}
+
+func singleServiceRule(provider *typ.Provider, model string) *typ.Rule {
+	return &typ.Rule{
+		UUID:     "r1",
+		Scenario: typ.ScenarioOpenAI,
+		Active:   true,
+		Services: []*loadbalance.Service{{Provider: provider.UUID, Model: model, Active: true}},
+	}
+}
+
+func testGinContext() (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	return c, rec
+}
+
+// TestDispatch_PerModel_LearnsResponsesOnlyModel is the #1595 shape: a
+// single-service rule on a per-model provider whose model only answers on
+// Responses. The first attempt guesses Chat and is rejected; the loop must
+// retry the same service on Responses, serve that answer, and remember it so
+// the next request pays no extra round-trip.
+func TestDispatch_PerModel_LearnsResponsesOnlyModel(t *testing.T) {
+	defaultEndpointMemory = newEndpointMemory()
+	provider := perModelProvider()
+	rule := singleServiceRule(provider, "gpt-5.6-luna")
+	c, rec := testGinContext()
+	ph := &ProtocolHandler{}
+
+	var used []protocol.APIType
+	attempt := func(p *typ.Provider, model string) {
+		target, err := ResolveOpenAIEndpointForRequest(c, p, model, typ.RuleFlags{}, IncomingAPIChat)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		used = append(used, target)
+		if target == protocol.TypeOpenAIChat {
+			// what Zen answers for luna on /chat/completions
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"message": "Internal server error"}})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"id": "resp_1"})
+	}
+
+	ph.DispatchWithPriorityFailover(c, rule, provider, "gpt-5.6-luna", attempt)
+
+	if len(used) != 2 {
+		t.Fatalf("attempts = %v, want one guess plus one learning retry", used)
+	}
+	if used[0] != protocol.TypeOpenAIChat || used[1] != protocol.TypeOpenAIResponses {
+		t.Errorf("attempt endpoints = %v, want [chat responses]", used)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("client saw %d, want the retry's 200", rec.Code)
+	}
+	if got := defaultEndpointMemory.Lookup(provider.UUID, "gpt-5.6-luna"); got != protocol.TypeOpenAIResponses {
+		t.Errorf("learned = %q, want responses", got)
+	}
+}
+
+// TestDispatch_PerModel_UsesLearnedEndpointWithoutRetry proves the learning is
+// worth having: once known, the right endpoint is used on the first attempt.
+func TestDispatch_PerModel_UsesLearnedEndpointWithoutRetry(t *testing.T) {
+	defaultEndpointMemory = newEndpointMemory()
+	provider := perModelProvider()
+	defaultEndpointMemory.Remember(provider.UUID, "gpt-5.6-luna", protocol.TypeOpenAIResponses)
+	rule := singleServiceRule(provider, "gpt-5.6-luna")
+	c, rec := testGinContext()
+	ph := &ProtocolHandler{}
+
+	var used []protocol.APIType
+	ph.DispatchWithPriorityFailover(c, rule, provider, "gpt-5.6-luna", func(p *typ.Provider, model string) {
+		target, _ := ResolveOpenAIEndpointForRequest(c, p, model, typ.RuleFlags{}, IncomingAPIChat)
+		used = append(used, target)
+		c.JSON(http.StatusOK, gin.H{"id": "resp_1"})
+	})
+
+	if len(used) != 1 || used[0] != protocol.TypeOpenAIResponses {
+		t.Errorf("attempt endpoints = %v, want a single responses attempt", used)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("client saw %d", rec.Code)
+	}
+}
+
+// TestDispatch_PerModel_DoesNotRetryCredentialFailures keeps the fallback
+// narrow: a 401 that is a credential problem carries no format marker and
+// must not spend a round-trip on the other endpoint.
+func TestDispatch_PerModel_DoesNotRetryCredentialFailures(t *testing.T) {
+	defaultEndpointMemory = newEndpointMemory()
+	provider := perModelProvider()
+	rule := singleServiceRule(provider, "kimi-k3")
+	c, _ := testGinContext()
+	ph := &ProtocolHandler{}
+
+	attempts := 0
+	ph.DispatchWithPriorityFailover(c, rule, provider, "kimi-k3", func(p *typ.Provider, model string) {
+		attempts++
+		_, _ = ResolveOpenAIEndpointForRequest(c, p, model, typ.RuleFlags{}, IncomingAPIChat)
+		c.JSON(http.StatusUnauthorized, gin.H{"error": gin.H{"type": "AuthError", "message": "Missing API key."}})
+	})
+
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (no endpoint retry for a credential failure)", attempts)
+	}
+	if got := defaultEndpointMemory.Lookup(provider.UUID, "kimi-k3"); got != "" {
+		t.Errorf("nothing should have been learned, got %q", got)
+	}
+}
+
+// TestDispatch_OtherModes_NeverRetryEndpoints is the containment guarantee:
+// a provider that has not declared per-model variance behaves exactly as
+// before — one attempt, no buffering for a single-service rule, no learning.
+func TestDispatch_OtherModes_NeverRetryEndpoints(t *testing.T) {
+	defaultEndpointMemory = newEndpointMemory()
+	provider := perModelProvider()
+	provider.OpenAIEndpointMode = ai.EndpointModeChat
+	rule := singleServiceRule(provider, "gpt-5.6-luna")
+	c, _ := testGinContext()
+	ph := &ProtocolHandler{}
+
+	attempts := 0
+	ph.DispatchWithPriorityFailover(c, rule, provider, "gpt-5.6-luna", func(p *typ.Provider, model string) {
+		attempts++
+		_, _ = ResolveOpenAIEndpointForRequest(c, p, model, typ.RuleFlags{}, IncomingAPIChat)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"message": "Internal server error"}})
+	})
+
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1: learning is gated on the declared mode", attempts)
+	}
+	if got := defaultEndpointMemory.Lookup(provider.UUID, "gpt-5.6-luna"); got != "" {
+		t.Errorf("learned %q on a mode that must never learn", got)
+	}
+}
+
+// TestDispatch_PerModel_CooldownStopsRepeatedRetries keeps a sick upstream
+// from doubling its own traffic: the second request inside the cooldown gets
+// one attempt, not two.
+func TestDispatch_PerModel_CooldownStopsRepeatedRetries(t *testing.T) {
+	defaultEndpointMemory = newEndpointMemory()
+	provider := perModelProvider()
+	rule := singleServiceRule(provider, "sick-model")
+	ph := &ProtocolHandler{}
+
+	run := func() int {
+		c, _ := testGinContext()
+		attempts := 0
+		ph.DispatchWithPriorityFailover(c, rule, provider, "sick-model", func(p *typ.Provider, model string) {
+			attempts++
+			_, _ = ResolveOpenAIEndpointForRequest(c, p, model, typ.RuleFlags{}, IncomingAPIChat)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"message": "Internal server error"}})
+		})
+		return attempts
+	}
+
+	if got := run(); got != 2 {
+		t.Errorf("first request attempts = %d, want 2 (guess + learning retry)", got)
+	}
+	if got := run(); got != 1 {
+		t.Errorf("second request attempts = %d, want 1 (cooldown)", got)
+	}
+}
+
+// ── the fixes from review ───────────────────────────────────────────────────
+
+// TestEffectiveEndpointMode_HostFallback covers the reason this is derived
+// rather than declared: ProviderTemplate.OpenAIEndpointMode never reaches a
+// provider created through the normal API (only the OAuth path copies it), so
+// a Zen provider in a real install carries no mode at all.
+func TestEffectiveEndpointMode_HostFallback(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *typ.Provider
+		want     ai.OpenAIEndpointMode
+	}{
+		{"zen with no declaration", &typ.Provider{APIBase: "https://opencode.ai/zen/go/v1"}, ai.EndpointModePerModel},
+		{"zen on the anthropic base", &typ.Provider{APIBase: "https://relay.example.com", APIBaseAnthropic: "https://opencode.ai/zen/go"}, ai.EndpointModePerModel},
+		{"declaration wins over the fallback", &typ.Provider{APIBase: "https://opencode.ai/zen/go/v1", OpenAIEndpointMode: ai.EndpointModeChat}, ai.EndpointModeChat},
+		{"unrelated provider", &typ.Provider{APIBase: "https://api.openai.com/v1"}, ai.EndpointModeUnknown},
+		{"nil", nil, ai.EndpointModeUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EffectiveEndpointMode(tt.provider); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDispatch_PerModel_FailedRetryStillFailsOver is the review's top finding:
+// a terminal status from the retry (404 on the other endpoint) must not mask
+// the retryable original, or the request dies on one service while a healthy
+// sibling sits idle.
+func TestDispatch_PerModel_FailedRetryStillFailsOver(t *testing.T) {
+	defaultEndpointMemory = newEndpointMemory()
+	zen := perModelProvider()
+	sibling := &typ.Provider{UUID: "p-sibling", Name: "sibling", APIStyle: protocol.APIStyleOpenAI, APIBase: "https://sibling.example.invalid/v1"}
+	ph, rule := perModelFailoverHandler(t, zen, sibling, "gpt-5.6-luna", "gpt-5.6-luna")
+	c, rec := testGinContext()
+
+	var seen []string
+	ph.DispatchWithPriorityFailover(c, rule, zen, "gpt-5.6-luna", func(p *typ.Provider, model string) {
+		target, _ := ResolveOpenAIEndpointForRequest(c, p, model, typ.RuleFlags{}, IncomingAPIChat)
+		seen = append(seen, p.UUID+":"+string(target))
+		switch {
+		case p.UUID != zen.UUID:
+			c.JSON(http.StatusOK, gin.H{"id": "from-sibling"})
+		case target == protocol.TypeOpenAIChat:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"message": "Internal server error"}})
+		default:
+			// Terminal on the retry: without the fix this ends the request.
+			c.JSON(http.StatusNotFound, gin.H{"error": gin.H{"message": "not found"}})
+		}
+	})
+
+	if len(seen) != 3 {
+		t.Fatalf("attempts = %v, want guess + retry + failover to the sibling", seen)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("client saw %d, want the sibling's 200", rec.Code)
+	}
+}
+
+// TestDispatch_PerModel_PinnedEndpointIsNotSecondGuessed: a rule that sets
+// openai_endpoint_override made the choice; learning must not overrule it.
+func TestDispatch_PerModel_PinnedEndpointIsNotSecondGuessed(t *testing.T) {
+	defaultEndpointMemory = newEndpointMemory()
+	provider := perModelProvider()
+	rule := singleServiceRule(provider, "gpt-5.6-luna")
+	c, _ := testGinContext()
+	ph := &ProtocolHandler{}
+
+	attempts := 0
+	ph.DispatchWithPriorityFailover(c, rule, provider, "gpt-5.6-luna", func(p *typ.Provider, model string) {
+		attempts++
+		flags := typ.RuleFlags{OpenAIEndpointOverride: "chat"}
+		target, _ := ResolveOpenAIEndpointForRequest(c, p, model, flags, IncomingAPIChat)
+		if target != protocol.TypeOpenAIChat {
+			t.Errorf("attempt used %q despite the override", target)
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"message": "Internal server error"}})
+	})
+
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1: a pinned endpoint is not retried elsewhere", attempts)
+	}
+}
+
+// TestDispatch_PerModel_SetupFailureIsNotAnUpstreamVerdict: a transform or
+// resolution failure is the gateway's own 500 and says nothing about which
+// endpoint the model speaks.
+func TestDispatch_PerModel_SetupFailureIsNotAnUpstreamVerdict(t *testing.T) {
+	defaultEndpointMemory = newEndpointMemory()
+	provider := perModelProvider()
+	rule := singleServiceRule(provider, "gpt-5.6-luna")
+	c, _ := testGinContext()
+	ph := &ProtocolHandler{}
+
+	attempts := 0
+	ph.DispatchWithPriorityFailover(c, rule, provider, "gpt-5.6-luna", func(p *typ.Provider, model string) {
+		attempts++
+		_, _ = ResolveOpenAIEndpointForRequest(c, p, model, typ.RuleFlags{}, IncomingAPIChat)
+		ph.FailAttemptSetup(c, errors.New("transform failed"))
+	})
+
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1: our own 500 is not an endpoint verdict", attempts)
+	}
+}
+
+// TestDispatch_PerModel_StaleDecisionDoesNotLeakAcrossAttempts: a later
+// attempt on a provider of another API style resolves no OpenAI endpoint, and
+// must not inherit the previous attempt's.
+func TestDispatch_PerModel_StaleDecisionDoesNotLeakAcrossAttempts(t *testing.T) {
+	defaultEndpointMemory = newEndpointMemory()
+	zen := perModelProvider()
+	sibling := &typ.Provider{UUID: "p-anthropic", Name: "claude", APIStyle: protocol.APIStyleAnthropic, APIBase: "https://anthropic.example.invalid"}
+	ph, rule := perModelFailoverHandler(t, zen, sibling, "gpt-5.6-luna", "claude-sonnet-5")
+	c, _ := testGinContext()
+
+	var seen []string
+	ph.DispatchWithPriorityFailover(c, rule, zen, "gpt-5.6-luna", func(p *typ.Provider, model string) {
+		seen = append(seen, p.UUID)
+		if p.APIStyle == protocol.APIStyleAnthropic {
+			// An Anthropic-style attempt never resolves an OpenAI endpoint.
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"message": "upstream down"}})
+			return
+		}
+		_, _ = ResolveOpenAIEndpointForRequest(c, p, model, typ.RuleFlags{}, IncomingAPIChat)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"message": "Internal server error"}})
+	})
+
+	// zen: guess + retry, then the sibling exactly once.
+	want := []string{zen.UUID, zen.UUID, sibling.UUID}
+	if len(seen) != len(want) {
+		t.Fatalf("attempts = %v, want %v", seen, want)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Fatalf("attempts = %v, want %v", seen, want)
+		}
+	}
+}
+
+// TestDispatch_PerModel_EmptyServiceListStillAttempts guards the hole the gate
+// installation opened: a rule with no active services (a probe pinning one by
+// header) must still dispatch, not answer an empty 200.
+func TestDispatch_PerModel_EmptyServiceListStillAttempts(t *testing.T) {
+	defaultEndpointMemory = newEndpointMemory()
+	provider := perModelProvider()
+	rule := &typ.Rule{UUID: "r1", Scenario: typ.ScenarioOpenAI, Active: true}
+	c, rec := testGinContext()
+	ph := &ProtocolHandler{}
+
+	attempts := 0
+	ph.DispatchWithPriorityFailover(c, rule, provider, "kimi-k3", func(p *typ.Provider, model string) {
+		attempts++
+		c.JSON(http.StatusOK, gin.H{"id": "ok"})
+	})
+
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+	if rec.Code != http.StatusOK || rec.Body.Len() == 0 {
+		t.Errorf("client saw %d with %d bytes, want the attempt's answer", rec.Code, rec.Body.Len())
+	}
+}

--- a/internal/protocolserver/endpoint_learning_test.go
+++ b/internal/protocolserver/endpoint_learning_test.go
@@ -2,6 +2,7 @@ package protocolserver
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/tingly-dev/tingly-box/ai"
+	"github.com/tingly-dev/tingly-box/internal/clock"
 	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 	"github.com/tingly-dev/tingly-box/internal/routing"
@@ -20,51 +22,53 @@ import (
 
 func TestEndpointMemory_LookupRememberExpiry(t *testing.T) {
 	now := time.Now()
+	restore := clock.SetClock(func() time.Time { return now })
+	defer restore()
 	m := newEndpointMemory()
-	m.now = func() time.Time { return now }
 
-	if got := m.Lookup("p1", "luna"); got != "" {
+	if got := m.Lookup(endpointMemoryKey("p1", "luna")); got != "" {
 		t.Fatalf("empty store returned %q", got)
 	}
 
-	m.Remember("p1", "luna", protocol.TypeOpenAIResponses)
-	if got := m.Lookup("p1", "luna"); got != protocol.TypeOpenAIResponses {
+	m.Remember(endpointMemoryKey("p1", "luna"), protocol.TypeOpenAIResponses)
+	if got := m.Lookup(endpointMemoryKey("p1", "luna")); got != protocol.TypeOpenAIResponses {
 		t.Errorf("learned value = %q, want responses", got)
 	}
 	// Keyed per model, not per provider.
-	if got := m.Lookup("p1", "kimi-k3"); got != "" {
+	if got := m.Lookup(endpointMemoryKey("p1", "kimi-k3")); got != "" {
 		t.Errorf("another model on the same provider returned %q", got)
 	}
 
 	now = now.Add(endpointMemoryTTL + time.Second)
-	if got := m.Lookup("p1", "luna"); got != "" {
+	if got := m.Lookup(endpointMemoryKey("p1", "luna")); got != "" {
 		t.Errorf("expired entry still returned %q", got)
 	}
 }
 
 func TestEndpointMemory_FailedRetryCooldown(t *testing.T) {
 	now := time.Now()
+	restore := clock.SetClock(func() time.Time { return now })
+	defer restore()
 	m := newEndpointMemory()
-	m.now = func() time.Time { return now }
 
-	if !m.ShouldRetry("p1", "luna") {
+	if !m.ShouldRetry(endpointMemoryKey("p1", "luna")) {
 		t.Fatal("first retry must be allowed")
 	}
-	m.MarkRetry("p1", "luna")
-	if m.ShouldRetry("p1", "luna") {
+	m.MarkRetry(endpointMemoryKey("p1", "luna"))
+	if m.ShouldRetry(endpointMemoryKey("p1", "luna")) {
 		t.Error("a second retry inside the cooldown must be refused")
 	}
 
 	now = now.Add(endpointRetryCooldown + time.Second)
-	if !m.ShouldRetry("p1", "luna") {
+	if !m.ShouldRetry(endpointMemoryKey("p1", "luna")) {
 		t.Error("retry must be allowed again after the cooldown")
 	}
 
 	// The cooldown gates failures only: a success clears it outright, and the
 	// learned mapping then means no failure arises to retry in the first place.
-	m.MarkRetry("p1", "luna")
-	m.Remember("p1", "luna", protocol.TypeOpenAIResponses)
-	if !m.ShouldRetry("p1", "luna") {
+	m.MarkRetry(endpointMemoryKey("p1", "luna"))
+	m.Remember(endpointMemoryKey("p1", "luna"), protocol.TypeOpenAIResponses)
+	if !m.ShouldRetry(endpointMemoryKey("p1", "luna")) {
 		t.Error("remembering an answer must clear the cooldown")
 	}
 }
@@ -115,6 +119,17 @@ func TestAlternateEndpoint(t *testing.T) {
 }
 
 // ── the loop ────────────────────────────────────────────────────────────────
+
+// resetEndpointMemory swaps in a fresh store for one test and restores the
+// process-wide one afterwards, so these tests neither inherit nor leak
+// learned state.
+func resetEndpointMemory(t *testing.T) *endpointMemory {
+	t.Helper()
+	previous := defaultEndpointMemory
+	defaultEndpointMemory = newEndpointMemory()
+	t.Cleanup(func() { defaultEndpointMemory = previous })
+	return defaultEndpointMemory
+}
 
 // perModelFailoverHandler builds a handler with the deps failover selection
 // needs (config-backed provider lookup, load balancer, health monitor), plus a
@@ -182,7 +197,7 @@ func testGinContext() (*gin.Context, *httptest.ResponseRecorder) {
 // retry the same service on Responses, serve that answer, and remember it so
 // the next request pays no extra round-trip.
 func TestDispatch_PerModel_LearnsResponsesOnlyModel(t *testing.T) {
-	defaultEndpointMemory = newEndpointMemory()
+	resetEndpointMemory(t)
 	provider := perModelProvider()
 	rule := singleServiceRule(provider, "gpt-5.6-luna")
 	c, rec := testGinContext()
@@ -214,7 +229,7 @@ func TestDispatch_PerModel_LearnsResponsesOnlyModel(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("client saw %d, want the retry's 200", rec.Code)
 	}
-	if got := defaultEndpointMemory.Lookup(provider.UUID, "gpt-5.6-luna"); got != protocol.TypeOpenAIResponses {
+	if got := defaultEndpointMemory.Lookup(endpointMemoryKey(provider.UUID, "gpt-5.6-luna")); got != protocol.TypeOpenAIResponses {
 		t.Errorf("learned = %q, want responses", got)
 	}
 }
@@ -222,9 +237,9 @@ func TestDispatch_PerModel_LearnsResponsesOnlyModel(t *testing.T) {
 // TestDispatch_PerModel_UsesLearnedEndpointWithoutRetry proves the learning is
 // worth having: once known, the right endpoint is used on the first attempt.
 func TestDispatch_PerModel_UsesLearnedEndpointWithoutRetry(t *testing.T) {
-	defaultEndpointMemory = newEndpointMemory()
+	resetEndpointMemory(t)
 	provider := perModelProvider()
-	defaultEndpointMemory.Remember(provider.UUID, "gpt-5.6-luna", protocol.TypeOpenAIResponses)
+	defaultEndpointMemory.Remember(endpointMemoryKey(provider.UUID, "gpt-5.6-luna"), protocol.TypeOpenAIResponses)
 	rule := singleServiceRule(provider, "gpt-5.6-luna")
 	c, rec := testGinContext()
 	ph := &ProtocolHandler{}
@@ -248,7 +263,7 @@ func TestDispatch_PerModel_UsesLearnedEndpointWithoutRetry(t *testing.T) {
 // narrow: a 401 that is a credential problem carries no format marker and
 // must not spend a round-trip on the other endpoint.
 func TestDispatch_PerModel_DoesNotRetryCredentialFailures(t *testing.T) {
-	defaultEndpointMemory = newEndpointMemory()
+	resetEndpointMemory(t)
 	provider := perModelProvider()
 	rule := singleServiceRule(provider, "kimi-k3")
 	c, _ := testGinContext()
@@ -264,7 +279,7 @@ func TestDispatch_PerModel_DoesNotRetryCredentialFailures(t *testing.T) {
 	if attempts != 1 {
 		t.Errorf("attempts = %d, want 1 (no endpoint retry for a credential failure)", attempts)
 	}
-	if got := defaultEndpointMemory.Lookup(provider.UUID, "kimi-k3"); got != "" {
+	if got := defaultEndpointMemory.Lookup(endpointMemoryKey(provider.UUID, "kimi-k3")); got != "" {
 		t.Errorf("nothing should have been learned, got %q", got)
 	}
 }
@@ -273,7 +288,7 @@ func TestDispatch_PerModel_DoesNotRetryCredentialFailures(t *testing.T) {
 // a provider that has not declared per-model variance behaves exactly as
 // before — one attempt, no buffering for a single-service rule, no learning.
 func TestDispatch_OtherModes_NeverRetryEndpoints(t *testing.T) {
-	defaultEndpointMemory = newEndpointMemory()
+	resetEndpointMemory(t)
 	provider := perModelProvider()
 	provider.OpenAIEndpointMode = ai.EndpointModeChat
 	rule := singleServiceRule(provider, "gpt-5.6-luna")
@@ -290,7 +305,7 @@ func TestDispatch_OtherModes_NeverRetryEndpoints(t *testing.T) {
 	if attempts != 1 {
 		t.Errorf("attempts = %d, want 1: learning is gated on the declared mode", attempts)
 	}
-	if got := defaultEndpointMemory.Lookup(provider.UUID, "gpt-5.6-luna"); got != "" {
+	if got := defaultEndpointMemory.Lookup(endpointMemoryKey(provider.UUID, "gpt-5.6-luna")); got != "" {
 		t.Errorf("learned %q on a mode that must never learn", got)
 	}
 }
@@ -299,7 +314,7 @@ func TestDispatch_OtherModes_NeverRetryEndpoints(t *testing.T) {
 // from doubling its own traffic: the second request inside the cooldown gets
 // one attempt, not two.
 func TestDispatch_PerModel_CooldownStopsRepeatedRetries(t *testing.T) {
-	defaultEndpointMemory = newEndpointMemory()
+	resetEndpointMemory(t)
 	provider := perModelProvider()
 	rule := singleServiceRule(provider, "sick-model")
 	ph := &ProtocolHandler{}
@@ -355,7 +370,7 @@ func TestEffectiveEndpointMode_HostFallback(t *testing.T) {
 // the retryable original, or the request dies on one service while a healthy
 // sibling sits idle.
 func TestDispatch_PerModel_FailedRetryStillFailsOver(t *testing.T) {
-	defaultEndpointMemory = newEndpointMemory()
+	resetEndpointMemory(t)
 	zen := perModelProvider()
 	sibling := &typ.Provider{UUID: "p-sibling", Name: "sibling", APIStyle: protocol.APIStyleOpenAI, APIBase: "https://sibling.example.invalid/v1"}
 	ph, rule := perModelFailoverHandler(t, zen, sibling, "gpt-5.6-luna", "gpt-5.6-luna")
@@ -387,7 +402,7 @@ func TestDispatch_PerModel_FailedRetryStillFailsOver(t *testing.T) {
 // TestDispatch_PerModel_PinnedEndpointIsNotSecondGuessed: a rule that sets
 // openai_endpoint_override made the choice; learning must not overrule it.
 func TestDispatch_PerModel_PinnedEndpointIsNotSecondGuessed(t *testing.T) {
-	defaultEndpointMemory = newEndpointMemory()
+	resetEndpointMemory(t)
 	provider := perModelProvider()
 	rule := singleServiceRule(provider, "gpt-5.6-luna")
 	c, _ := testGinContext()
@@ -413,7 +428,7 @@ func TestDispatch_PerModel_PinnedEndpointIsNotSecondGuessed(t *testing.T) {
 // resolution failure is the gateway's own 500 and says nothing about which
 // endpoint the model speaks.
 func TestDispatch_PerModel_SetupFailureIsNotAnUpstreamVerdict(t *testing.T) {
-	defaultEndpointMemory = newEndpointMemory()
+	resetEndpointMemory(t)
 	provider := perModelProvider()
 	rule := singleServiceRule(provider, "gpt-5.6-luna")
 	c, _ := testGinContext()
@@ -435,7 +450,7 @@ func TestDispatch_PerModel_SetupFailureIsNotAnUpstreamVerdict(t *testing.T) {
 // attempt on a provider of another API style resolves no OpenAI endpoint, and
 // must not inherit the previous attempt's.
 func TestDispatch_PerModel_StaleDecisionDoesNotLeakAcrossAttempts(t *testing.T) {
-	defaultEndpointMemory = newEndpointMemory()
+	resetEndpointMemory(t)
 	zen := perModelProvider()
 	sibling := &typ.Provider{UUID: "p-anthropic", Name: "claude", APIStyle: protocol.APIStyleAnthropic, APIBase: "https://anthropic.example.invalid"}
 	ph, rule := perModelFailoverHandler(t, zen, sibling, "gpt-5.6-luna", "claude-sonnet-5")
@@ -469,7 +484,7 @@ func TestDispatch_PerModel_StaleDecisionDoesNotLeakAcrossAttempts(t *testing.T) 
 // installation opened: a rule with no active services (a probe pinning one by
 // header) must still dispatch, not answer an empty 200.
 func TestDispatch_PerModel_EmptyServiceListStillAttempts(t *testing.T) {
-	defaultEndpointMemory = newEndpointMemory()
+	resetEndpointMemory(t)
 	provider := perModelProvider()
 	rule := &typ.Rule{UUID: "r1", Scenario: typ.ScenarioOpenAI, Active: true}
 	c, rec := testGinContext()
@@ -486,5 +501,92 @@ func TestDispatch_PerModel_EmptyServiceListStillAttempts(t *testing.T) {
 	}
 	if rec.Code != http.StatusOK || rec.Body.Len() == 0 {
 		t.Errorf("client saw %d with %d bytes, want the attempt's answer", rec.Code, rec.Body.Len())
+	}
+}
+
+// TestDispatchMayRetry_StopsBufferingOnceLearned: the response buffer and the
+// pristine-request snapshot exist to make a second attempt possible. Once the
+// endpoint is known there is no second attempt, and a per-model provider
+// should stop paying for one on every request.
+func TestDispatchMayRetry_StopsBufferingOnceLearned(t *testing.T) {
+	memory := resetEndpointMemory(t)
+	zen := perModelProvider()
+	rule := singleServiceRule(zen, "gpt-5.6-luna")
+
+	if !DispatchMayRetry(rule, zen, "gpt-5.6-luna") {
+		t.Error("with nothing learned a retry is still possible")
+	}
+
+	memory.Remember(endpointMemoryKey(zen.UUID, "gpt-5.6-luna"), protocol.TypeOpenAIResponses)
+	if DispatchMayRetry(rule, zen, "gpt-5.6-luna") {
+		t.Error("once learned there is nothing to retry, so nothing to buffer")
+	}
+	// Another model on the same provider is still unknown.
+	if !DispatchMayRetry(rule, zen, "kimi-k3") {
+		t.Error("learning one model must not silence another")
+	}
+	// A multi-service rule always retries, learned or not.
+	multi := &typ.Rule{UUID: "r-multi", Scenario: typ.ScenarioOpenAI, Active: true,
+		Services: []*loadbalance.Service{
+			{Provider: zen.UUID, Model: "gpt-5.6-luna", Active: true},
+			{Provider: "p-other", Model: "gpt-5.6-luna", Active: true},
+		}}
+	if !DispatchMayRetry(multi, zen, "gpt-5.6-luna") {
+		t.Error("a fallback tier is reason enough to buffer")
+	}
+}
+
+// TestDispatch_PerModel_ForgetsAnEndpointThatStopsWorking closes the loop the
+// previous test opens: with no buffer installed, a learned mapping that goes
+// stale must not pin the model to a dead endpoint for the rest of the TTL.
+func TestDispatch_PerModel_ForgetsAnEndpointThatStopsWorking(t *testing.T) {
+	memory := resetEndpointMemory(t)
+	zen := perModelProvider()
+	serviceID := endpointMemoryKey(zen.UUID, "gpt-5.6-luna")
+	memory.Remember(serviceID, protocol.TypeOpenAIResponses)
+	rule := singleServiceRule(zen, "gpt-5.6-luna")
+	ph := &ProtocolHandler{}
+
+	c, _ := testGinContext()
+	attempts := 0
+	ph.DispatchWithPriorityFailover(c, rule, zen, "gpt-5.6-luna", func(p *typ.Provider, model string) {
+		attempts++
+		_, _ = ResolveOpenAIEndpointForRequest(c, p, model, typ.RuleFlags{}, IncomingAPIChat)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"message": "Internal server error"}})
+	})
+
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1: a known endpoint is not retried, only forgotten", attempts)
+	}
+	if got := memory.Lookup(serviceID); got != "" {
+		t.Errorf("stale mapping survived as %q; the next request would fail the same way", got)
+	}
+	// And the next request may learn again.
+	if !DispatchMayRetry(rule, zen, "gpt-5.6-luna") {
+		t.Error("after forgetting, the next request must be able to retry")
+	}
+}
+
+// TestEndpointMemory_SweepsDeadEntries guards the one map against unbounded
+// growth: model names come from the request.
+func TestEndpointMemory_SweepsDeadEntries(t *testing.T) {
+	now := time.Now()
+	restore := clock.SetClock(func() time.Time { return now })
+	defer restore()
+	m := newEndpointMemory()
+
+	for i := range endpointMemorySweepAt + 1 {
+		m.MarkRetry(endpointMemoryKey("p1", fmt.Sprintf("model-%d", i)))
+	}
+	if got := len(m.entries); got <= endpointMemorySweepAt {
+		t.Fatalf("entries = %d, expected the map to have grown past the sweep threshold first", got)
+	}
+
+	// Past the cooldown every one of those entries is dead; the next write
+	// drops them.
+	now = now.Add(endpointRetryCooldown + time.Second)
+	m.MarkRetry(endpointMemoryKey("p1", "fresh"))
+	if got := len(m.entries); got != 1 {
+		t.Errorf("entries after sweep = %d, want only the fresh one", got)
 	}
 }

--- a/internal/protocolserver/endpoint_memory.go
+++ b/internal/protocolserver/endpoint_memory.go
@@ -4,33 +4,36 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tingly-dev/tingly-box/internal/clock"
+	"github.com/tingly-dev/tingly-box/internal/loadbalance"
 	"github.com/tingly-dev/tingly-box/internal/protocol"
 )
 
-// endpointMemoryTTL is how long a learned (provider, model) → endpoint
-// mapping is trusted. Long enough that a busy gateway learns each model once
-// a day rather than once an hour; short enough that a vendor moving a model
-// between formats corrects itself without a restart.
+// endpointMemoryTTL is how long a learned service → endpoint mapping is
+// trusted. Long enough that a busy gateway learns each model once a day
+// rather than once an hour; short enough that a vendor moving a model between
+// formats corrects itself without a restart.
 const endpointMemoryTTL = 8 * time.Hour
 
-// endpointRetryCooldown throttles learning retries that did NOT work. It has
-// nothing to do with successful ones: a retry that succeeds is remembered for
-// endpointMemoryTTL and clears the cooldown, and subsequent requests then use
-// the learned endpoint directly — there is no failure left to retry.
-//
-// So the cooldown answers one question only: after we spent a round-trip on
-// the other endpoint and that failed too, how soon may we spend another? A
-// minute bounds the waste at one extra request per (provider, model) per
+// endpointRetryCooldown throttles learning retries that did NOT work. A retry
+// that succeeds is remembered for endpointMemoryTTL and clears the cooldown,
+// and later requests then use the learned endpoint directly — there is no
+// failure left to retry. So this answers one question only: after we spent a
+// round-trip on the other endpoint and that failed too, how soon may we spend
+// another? A minute bounds the waste at one extra request per service per
 // minute while an upstream is sick, and is deliberately far shorter than the
 // TTL — a learned mapping is a verified fact worth keeping for hours, while a
-// failed attempt usually just means the upstream was down, and pinning that
-// for eight hours would keep a genuinely Responses-only model broken long
-// after the outage ended.
+// failed attempt usually just means the upstream was down.
 const endpointRetryCooldown = time.Minute
 
+// endpointMemorySweepAt is the entry count past which a write also drops dead
+// entries. Model names come from the request, so without a sweep a client
+// sending varied names could grow the map without bound.
+const endpointMemorySweepAt = 1024
+
 // endpointMemory remembers which OpenAI endpoint a specific model on a
-// specific provider actually answers on, for providers that declare
-// ai.EndpointModePerModel.
+// specific provider actually answers on, for upstreams whose format varies by
+// model (ai.EndpointModePerModel).
 //
 // Deliberately in-memory and TTL'd, never persisted: this is a runtime
 // observation, not user configuration. Writing it into config.json would make
@@ -38,89 +41,118 @@ const endpointRetryCooldown = time.Minute
 // that made the old AdaptiveProbe (PR #976) impossible to reason about. A
 // restart simply re-learns, at the cost of one extra round-trip per model.
 //
-// Only *successful* outcomes are stored. A failed attempt records nothing but
+// Only successful outcomes are stored. A failed attempt records nothing but
 // its timestamp, so a sick upstream cannot poison routing.
 type endpointMemory struct {
-	mu      sync.RWMutex
-	learned map[string]endpointMemoryEntry
-	// retried holds when the last *unsuccessful* learning retry ran. A
-	// successful one is deleted from here and lives in learned instead.
-	retried map[string]time.Time
-	now     func() time.Time // injectable for tests
+	mu sync.RWMutex
+	// entries is keyed by loadbalance.FormatServiceID — the same service key
+	// the breaker, usage tracking and the failover loop use, so a learned
+	// endpoint can be correlated with the rest of a service's state in logs.
+	entries map[string]endpointMemoryEntry
 }
 
+// endpointMemoryEntry holds both halves of what is known about one service:
+// the verified endpoint (if any) and when the last unsuccessful retry ran.
+// One entry rather than two maps keeps "a success ends the cooldown"
+// structural instead of an invariant between two containers.
 type endpointMemoryEntry struct {
-	endpoint protocol.APIType
-	expires  time.Time
+	endpoint  protocol.APIType // "" = nothing learned
+	expires   time.Time
+	lastRetry time.Time // zero = no cooldown running
+}
+
+func (e endpointMemoryEntry) dead(now time.Time) bool {
+	return (e.endpoint == "" || now.After(e.expires)) &&
+		(e.lastRetry.IsZero() || now.Sub(e.lastRetry) >= endpointRetryCooldown)
 }
 
 func newEndpointMemory() *endpointMemory {
-	return &endpointMemory{
-		learned: map[string]endpointMemoryEntry{},
-		retried: map[string]time.Time{},
-		now:     time.Now,
-	}
+	return &endpointMemory{entries: map[string]endpointMemoryEntry{}}
 }
 
 // defaultEndpointMemory is the process-wide store. One per process is right:
 // the fact it holds is a property of the upstream, not of a request or a rule.
 var defaultEndpointMemory = newEndpointMemory()
 
-func endpointMemoryKey(providerUUID, model string) string {
-	return providerUUID + "\x00" + model
-}
-
-// Lookup returns the endpoint learned for this provider+model, or "" when
-// nothing is known (or what was known has expired).
-func (m *endpointMemory) Lookup(providerUUID, model string) protocol.APIType {
+// Lookup returns the endpoint learned for this service, or "" when nothing is
+// known (or what was known has expired).
+func (m *endpointMemory) Lookup(serviceID string) protocol.APIType {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	entry, ok := m.learned[endpointMemoryKey(providerUUID, model)]
-	if !ok || m.now().After(entry.expires) {
+	entry := m.entries[serviceID]
+	if entry.endpoint == "" || clock.Now().After(entry.expires) {
 		return ""
 	}
 	return entry.endpoint
 }
 
-// Remember records a verified outcome: this provider+model answered on this
-// endpoint.
-func (m *endpointMemory) Remember(providerUUID, model string, endpoint protocol.APIType) {
+// Remember records a verified outcome: this service answered on this endpoint.
+func (m *endpointMemory) Remember(serviceID string, endpoint protocol.APIType) {
 	if endpoint == "" {
 		return
 	}
+	now := clock.Now()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	key := endpointMemoryKey(providerUUID, model)
-	m.learned[key] = endpointMemoryEntry{endpoint: endpoint, expires: m.now().Add(endpointMemoryTTL)}
-	// Success ends the cooldown: there is nothing left to re-learn.
-	delete(m.retried, key)
+	// lastRetry is left zero: success ends the cooldown.
+	m.entries[serviceID] = endpointMemoryEntry{endpoint: endpoint, expires: now.Add(endpointMemoryTTL)}
+	m.sweepLocked(now)
+}
+
+// Forget drops a learned mapping. Called when the learned endpoint stops
+// working, so the next request re-learns instead of failing for the rest of
+// the TTL.
+func (m *endpointMemory) Forget(serviceID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.entries, serviceID)
 }
 
 // ShouldRetry reports whether a learning retry (one extra round-trip on the
 // other endpoint) may run now. False only while the cooldown from a previous
-// *failed* retry is still running.
-func (m *endpointMemory) ShouldRetry(providerUUID, model string) bool {
+// unsuccessful retry is still running.
+func (m *endpointMemory) ShouldRetry(serviceID string) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	last, ok := m.retried[endpointMemoryKey(providerUUID, model)]
-	return !ok || m.now().Sub(last) >= endpointRetryCooldown
+	last := m.entries[serviceID].lastRetry
+	return last.IsZero() || clock.Now().Sub(last) >= endpointRetryCooldown
 }
 
 // MarkRetry starts the cooldown. Called *before* the extra round-trip, not
 // after: a retry that hangs or panics must still hold the gate shut, or a
 // broken upstream turns into a loop.
-func (m *endpointMemory) MarkRetry(providerUUID, model string) {
+func (m *endpointMemory) MarkRetry(serviceID string) {
+	now := clock.Now()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.retried[endpointMemoryKey(providerUUID, model)] = m.now()
+	entry := m.entries[serviceID]
+	entry.lastRetry = now
+	m.entries[serviceID] = entry
+	m.sweepLocked(now)
 }
 
-// alternateEndpoint returns the other OpenAI endpoint, or "" when the input
-// is not one of the two.
+// sweepLocked drops entries that hold nothing live. Opportunistic and
+// amortized — the same shape internal/probe's endpoint cache uses — so no
+// background goroutine is needed.
+func (m *endpointMemory) sweepLocked(now time.Time) {
+	if len(m.entries) <= endpointMemorySweepAt {
+		return
+	}
+	for key, entry := range m.entries {
+		if entry.dead(now) {
+			delete(m.entries, key)
+		}
+	}
+}
+
+// alternateEndpoint returns the other OpenAI endpoint, or "" when the input is
+// not one of the two.
 func alternateEndpoint(endpoint protocol.APIType) protocol.APIType {
 	switch endpoint {
 	case protocol.TypeOpenAIChat:
@@ -130,4 +162,10 @@ func alternateEndpoint(endpoint protocol.APIType) protocol.APIType {
 	default:
 		return ""
 	}
+}
+
+// endpointMemoryKey is the service key this store uses, shared with the
+// breaker and usage tracking.
+func endpointMemoryKey(providerUUID, model string) string {
+	return loadbalance.FormatServiceID(providerUUID, model)
 }

--- a/internal/protocolserver/endpoint_memory.go
+++ b/internal/protocolserver/endpoint_memory.go
@@ -1,0 +1,133 @@
+package protocolserver
+
+import (
+	"sync"
+	"time"
+
+	"github.com/tingly-dev/tingly-box/internal/protocol"
+)
+
+// endpointMemoryTTL is how long a learned (provider, model) → endpoint
+// mapping is trusted. Long enough that a busy gateway learns each model once
+// a day rather than once an hour; short enough that a vendor moving a model
+// between formats corrects itself without a restart.
+const endpointMemoryTTL = 8 * time.Hour
+
+// endpointRetryCooldown throttles learning retries that did NOT work. It has
+// nothing to do with successful ones: a retry that succeeds is remembered for
+// endpointMemoryTTL and clears the cooldown, and subsequent requests then use
+// the learned endpoint directly — there is no failure left to retry.
+//
+// So the cooldown answers one question only: after we spent a round-trip on
+// the other endpoint and that failed too, how soon may we spend another? A
+// minute bounds the waste at one extra request per (provider, model) per
+// minute while an upstream is sick, and is deliberately far shorter than the
+// TTL — a learned mapping is a verified fact worth keeping for hours, while a
+// failed attempt usually just means the upstream was down, and pinning that
+// for eight hours would keep a genuinely Responses-only model broken long
+// after the outage ended.
+const endpointRetryCooldown = time.Minute
+
+// endpointMemory remembers which OpenAI endpoint a specific model on a
+// specific provider actually answers on, for providers that declare
+// ai.EndpointModePerModel.
+//
+// Deliberately in-memory and TTL'd, never persisted: this is a runtime
+// observation, not user configuration. Writing it into config.json would make
+// a transient upstream state look like a setting the user chose — the mistake
+// that made the old AdaptiveProbe (PR #976) impossible to reason about. A
+// restart simply re-learns, at the cost of one extra round-trip per model.
+//
+// Only *successful* outcomes are stored. A failed attempt records nothing but
+// its timestamp, so a sick upstream cannot poison routing.
+type endpointMemory struct {
+	mu      sync.RWMutex
+	learned map[string]endpointMemoryEntry
+	// retried holds when the last *unsuccessful* learning retry ran. A
+	// successful one is deleted from here and lives in learned instead.
+	retried map[string]time.Time
+	now     func() time.Time // injectable for tests
+}
+
+type endpointMemoryEntry struct {
+	endpoint protocol.APIType
+	expires  time.Time
+}
+
+func newEndpointMemory() *endpointMemory {
+	return &endpointMemory{
+		learned: map[string]endpointMemoryEntry{},
+		retried: map[string]time.Time{},
+		now:     time.Now,
+	}
+}
+
+// defaultEndpointMemory is the process-wide store. One per process is right:
+// the fact it holds is a property of the upstream, not of a request or a rule.
+var defaultEndpointMemory = newEndpointMemory()
+
+func endpointMemoryKey(providerUUID, model string) string {
+	return providerUUID + "\x00" + model
+}
+
+// Lookup returns the endpoint learned for this provider+model, or "" when
+// nothing is known (or what was known has expired).
+func (m *endpointMemory) Lookup(providerUUID, model string) protocol.APIType {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	entry, ok := m.learned[endpointMemoryKey(providerUUID, model)]
+	if !ok || m.now().After(entry.expires) {
+		return ""
+	}
+	return entry.endpoint
+}
+
+// Remember records a verified outcome: this provider+model answered on this
+// endpoint.
+func (m *endpointMemory) Remember(providerUUID, model string, endpoint protocol.APIType) {
+	if endpoint == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := endpointMemoryKey(providerUUID, model)
+	m.learned[key] = endpointMemoryEntry{endpoint: endpoint, expires: m.now().Add(endpointMemoryTTL)}
+	// Success ends the cooldown: there is nothing left to re-learn.
+	delete(m.retried, key)
+}
+
+// ShouldRetry reports whether a learning retry (one extra round-trip on the
+// other endpoint) may run now. False only while the cooldown from a previous
+// *failed* retry is still running.
+func (m *endpointMemory) ShouldRetry(providerUUID, model string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	last, ok := m.retried[endpointMemoryKey(providerUUID, model)]
+	return !ok || m.now().Sub(last) >= endpointRetryCooldown
+}
+
+// MarkRetry starts the cooldown. Called *before* the extra round-trip, not
+// after: a retry that hangs or panics must still hold the gate shut, or a
+// broken upstream turns into a loop.
+func (m *endpointMemory) MarkRetry(providerUUID, model string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.retried[endpointMemoryKey(providerUUID, model)] = m.now()
+}
+
+// alternateEndpoint returns the other OpenAI endpoint, or "" when the input
+// is not one of the two.
+func alternateEndpoint(endpoint protocol.APIType) protocol.APIType {
+	switch endpoint {
+	case protocol.TypeOpenAIChat:
+		return protocol.TypeOpenAIResponses
+	case protocol.TypeOpenAIResponses:
+		return protocol.TypeOpenAIChat
+	default:
+		return ""
+	}
+}

--- a/internal/protocolserver/failover_dispatch.go
+++ b/internal/protocolserver/failover_dispatch.go
@@ -62,6 +62,8 @@ func (ph *ProtocolHandler) handlePreStreamFailure(c *gin.Context, err error, rec
 // rejected in the prologue, before the gate is installed, so they remain
 // non-retryable and reach the client unchanged.
 func (ph *ProtocolHandler) FailAttemptSetup(c *gin.Context, err error) {
+	// The 500 below is ours, not the upstream's verdict on the endpoint.
+	MarkAttemptSetupFailed(c)
 	c.JSON(http.StatusInternalServerError, ErrorResponse{
 		Error: ErrorDetail{
 			Message: err.Error(),
@@ -214,6 +216,19 @@ func (g *firstChunkGate) Committed() bool {
 	return g.committed
 }
 
+// BufferedBody exposes the captured (not yet written) body so the
+// orchestrator can read *why* an attempt failed, not just its status.
+// Endpoint learning needs the upstream's message text: the same "wrong
+// endpoint for this model" condition arrives as 401, 500-with-marker, or
+// bare 500 depending on the vendor behind the model. Empty once committed —
+// there is nothing left to inspect and nothing left to retry.
+func (g *firstChunkGate) BufferedBody() []byte {
+	if g.committed {
+		return nil
+	}
+	return g.buf.Bytes()
+}
+
 // CommitFirstChunk is the producer's "first real chunk arrived" signal.
 // It flushes captured headers + status + buffered body to the real
 // writer and switches to pass-through. Idempotent.
@@ -363,7 +378,11 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 	attempt dispatchAttempt,
 ) {
 	activeServices := rule.GetActiveServices()
-	if len(activeServices) <= 1 {
+	// A single-service rule normally needs no buffer: with no fallback tier
+	// there is nothing to retry. A per-model provider is the exception — the
+	// endpoint retry below is a second attempt at the *same* service, so the
+	// buffer has to be in place for it too.
+	if len(activeServices) <= 1 && !endpointLearningEnabled(initialProvider) {
 		attempt(initialProvider, initialModel)
 		return
 	}
@@ -384,8 +403,16 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 	// breaker store gets fed the right serviceID on failure.
 	rec, _ := recording.GetRecorderFromContext(c)
 
-	for i := 0; i < len(activeServices); i++ {
+	// A rule can reach here with an empty service list (a probe pinning a
+	// service by header, for instance) once the gate is installed for endpoint
+	// learning. Bound the loop below by at least one so the request is still
+	// attempted — len(activeServices) alone would run zero attempts and answer
+	// an empty 200.
+	maxAttempts := max(len(activeServices), 1)
+
+	for i := 0; i < maxAttempts; i++ {
 		serviceID := loadbalance.FormatServiceID(provider.UUID, model)
+		ResetEndpointDecision(c)
 		tried[serviceID] = true
 
 		// Update context before logging/dispatch so request-scoped observability
@@ -426,6 +453,17 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 			return
 		}
 		status := gate.Status()
+
+		// Endpoint learning: on a per-model provider, a failure that looks
+		// like "wrong endpoint for this model" earns one retry on the other
+		// endpoint against the same service. It runs before any failure is
+		// charged to the service — the service is not sick, the endpoint
+		// guess was wrong — so it costs neither a failover tier nor a
+		// breaker strike.
+		if ph.retryOnAlternateEndpoint(c, gate, provider, model, status, i+1, attempt) {
+			status = statusAfterEndpointRetry(status, gate)
+		}
+
 		if !isRetryableStatus(status) {
 			fields := failoverLogFields(c, rule, provider, model, serviceID)
 			fields["stage"] = "failover_terminal"
@@ -512,6 +550,25 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 		provider = nextProvider
 		model = nextService.Model
 	}
+}
+
+// statusAfterEndpointRetry decides which status the failover loop judges after
+// an endpoint retry ran.
+//
+// The retry's own status wins when it says something new: it succeeded, or it
+// is itself retryable. What it must not do is *mask* a retryable original — a
+// terminal status from the second endpoint (say a 404 on /responses) would
+// otherwise end the request on a service whose first failure had earned a
+// fallback to a healthy sibling.
+func statusAfterEndpointRetry(original int, gate *firstChunkGate) int {
+	retried := gate.Status()
+	if gate.Committed() || isSuccessStatus(retried) || isRetryableStatus(retried) {
+		return retried
+	}
+	if isRetryableStatus(original) {
+		return original
+	}
+	return retried
 }
 
 func failoverLogFields(c *gin.Context, rule *typ.Rule, provider *typ.Provider, model, serviceID string) logrus.Fields {

--- a/internal/protocolserver/failover_dispatch.go
+++ b/internal/protocolserver/failover_dispatch.go
@@ -378,12 +378,12 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 	attempt dispatchAttempt,
 ) {
 	activeServices := rule.GetActiveServices()
-	// A single-service rule normally needs no buffer: with no fallback tier
-	// there is nothing to retry. A per-model provider is the exception — the
-	// endpoint retry below is a second attempt at the *same* service, so the
-	// buffer has to be in place for it too.
-	if len(activeServices) <= 1 && !endpointLearningEnabled(initialProvider) {
+	// Nothing to iterate and nothing to retry: dispatch once, unbuffered.
+	// (An empty service list reaches here from the probe paths that pin a
+	// service by header.)
+	if len(activeServices) == 0 || !DispatchMayRetry(rule, initialProvider, initialModel) {
 		attempt(initialProvider, initialModel)
+		forgetStaleEndpoint(c, initialProvider, initialModel, c.Writer.Status())
 		return
 	}
 
@@ -403,16 +403,9 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 	// breaker store gets fed the right serviceID on failure.
 	rec, _ := recording.GetRecorderFromContext(c)
 
-	// A rule can reach here with an empty service list (a probe pinning a
-	// service by header, for instance) once the gate is installed for endpoint
-	// learning. Bound the loop below by at least one so the request is still
-	// attempted — len(activeServices) alone would run zero attempts and answer
-	// an empty 200.
-	maxAttempts := max(len(activeServices), 1)
-
-	for i := 0; i < maxAttempts; i++ {
+	for i := 0; i < len(activeServices); i++ {
 		serviceID := loadbalance.FormatServiceID(provider.UUID, model)
-		ResetEndpointDecision(c)
+		endpointDecisionFor(c).reset()
 		tried[serviceID] = true
 
 		// Update context before logging/dispatch so request-scoped observability
@@ -460,9 +453,7 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 		// charged to the service — the service is not sick, the endpoint
 		// guess was wrong — so it costs neither a failover tier nor a
 		// breaker strike.
-		if ph.retryOnAlternateEndpoint(c, gate, provider, model, status, i+1, attempt) {
-			status = statusAfterEndpointRetry(status, gate)
-		}
+		status = ph.retryOnAlternateEndpoint(c, gate, provider, model, status, i+1, attempt)
 
 		if !isRetryableStatus(status) {
 			fields := failoverLogFields(c, rule, provider, model, serviceID)
@@ -550,25 +541,6 @@ func (ph *ProtocolHandler) DispatchWithPriorityFailover(
 		provider = nextProvider
 		model = nextService.Model
 	}
-}
-
-// statusAfterEndpointRetry decides which status the failover loop judges after
-// an endpoint retry ran.
-//
-// The retry's own status wins when it says something new: it succeeded, or it
-// is itself retryable. What it must not do is *mask* a retryable original — a
-// terminal status from the second endpoint (say a 404 on /responses) would
-// otherwise end the request on a service whose first failure had earned a
-// fallback to a healthy sibling.
-func statusAfterEndpointRetry(original int, gate *firstChunkGate) int {
-	retried := gate.Status()
-	if gate.Committed() || isSuccessStatus(retried) || isRetryableStatus(retried) {
-		return retried
-	}
-	if isRetryableStatus(original) {
-		return original
-	}
-	return retried
 }
 
 func failoverLogFields(c *gin.Context, rule *typ.Rule, provider *typ.Provider, model, serviceID string) logrus.Fields {

--- a/internal/protocolserver/openai_chat.go
+++ b/internal/protocolserver/openai_chat.go
@@ -151,10 +151,7 @@ func (ph *ProtocolHandler) OpenAIChatCompletion(c *gin.Context, req *protocol.Op
 	SetTrackingContext(c, rule, provider, actualModel, responseModel, isStreaming)
 
 	// Snapshot a pristine template only when failover is possible.
-	// "Possible" includes the endpoint-learning retry, which re-enters this
-	// pipeline as a second attempt on the *same* service: without a snapshot it
-	// would re-transform the request object the first attempt already mutated.
-	multi := len(rule.GetActiveServices()) > 1 || endpointLearningEnabled(provider)
+	multi := DispatchMayRetry(rule, provider, actualModel)
 	var template []byte
 	if multi {
 		bs, err := req.MarshalJSON()

--- a/internal/protocolserver/openai_chat.go
+++ b/internal/protocolserver/openai_chat.go
@@ -151,7 +151,10 @@ func (ph *ProtocolHandler) OpenAIChatCompletion(c *gin.Context, req *protocol.Op
 	SetTrackingContext(c, rule, provider, actualModel, responseModel, isStreaming)
 
 	// Snapshot a pristine template only when failover is possible.
-	multi := len(rule.GetActiveServices()) > 1
+	// "Possible" includes the endpoint-learning retry, which re-enters this
+	// pipeline as a second attempt on the *same* service: without a snapshot it
+	// would re-transform the request object the first attempt already mutated.
+	multi := len(rule.GetActiveServices()) > 1 || endpointLearningEnabled(provider)
 	var template []byte
 	if multi {
 		bs, err := req.MarshalJSON()
@@ -213,7 +216,7 @@ func (ph *ProtocolHandler) runOpenAIChatAttempt(c *gin.Context, req *protocol.Op
 	case protocol.APIStyleOpenAI:
 		// Need flags for endpoint resolution, but we'll re-resolve with scenario after target is determined
 		tempFlags := ResolveRuleFlags(c, rule)
-		resolvedTarget, routeErr := ResolveOpenAIEndpoint(provider, tempFlags, IncomingAPIChat)
+		resolvedTarget, routeErr := ResolveOpenAIEndpointForRequest(c, provider, actualModel, tempFlags, IncomingAPIChat)
 		if routeErr != nil {
 			ph.FailAttemptSetup(c, routeErr)
 			return

--- a/internal/protocolserver/openai_responses.go
+++ b/internal/protocolserver/openai_responses.go
@@ -168,10 +168,7 @@ func (ph *ProtocolHandler) ResponsesCreate(c *gin.Context, scenarioType typ.Rule
 	// Snapshot a pristine template only when failover is possible. The template
 	// is the typed ResponseNewParams (post-vision-proxy — cloned per attempt so
 	// PreprocessInputData and vision proxy are not re-run).
-	// "Possible" includes the endpoint-learning retry, which re-enters this
-	// pipeline as a second attempt on the *same* service: without a snapshot it
-	// would re-transform the request object the first attempt already mutated.
-	multi := len(rule.GetActiveServices()) > 1 || endpointLearningEnabled(provider)
+	multi := DispatchMayRetry(rule, provider, actualModel)
 
 	// ── Per-attempt pipeline (provider-dependent) ──
 	ph.DispatchWithPriorityFailover(c, rule, provider, actualModel,

--- a/internal/protocolserver/openai_responses.go
+++ b/internal/protocolserver/openai_responses.go
@@ -168,7 +168,10 @@ func (ph *ProtocolHandler) ResponsesCreate(c *gin.Context, scenarioType typ.Rule
 	// Snapshot a pristine template only when failover is possible. The template
 	// is the typed ResponseNewParams (post-vision-proxy — cloned per attempt so
 	// PreprocessInputData and vision proxy are not re-run).
-	multi := len(rule.GetActiveServices()) > 1
+	// "Possible" includes the endpoint-learning retry, which re-enters this
+	// pipeline as a second attempt on the *same* service: without a snapshot it
+	// would re-transform the request object the first attempt already mutated.
+	multi := len(rule.GetActiveServices()) > 1 || endpointLearningEnabled(provider)
 
 	// ── Per-attempt pipeline (provider-dependent) ──
 	ph.DispatchWithPriorityFailover(c, rule, provider, actualModel,
@@ -210,7 +213,7 @@ func (ph *ProtocolHandler) runOpenAIResponsesAttempt(c *gin.Context, req *protoc
 		ph.FailAttemptSetup(c, fmt.Errorf("Responses API does not support Google-style providers yet. Provider: %s", provider.Name))
 		return
 	case protocol.APIStyleOpenAI:
-		resolvedTarget, routeErr := ResolveOpenAIEndpoint(provider, ResolveRuleFlags(c, rule), IncomingAPIResponses)
+		resolvedTarget, routeErr := ResolveOpenAIEndpointForRequest(c, provider, actualModel, ResolveRuleFlags(c, rule), IncomingAPIResponses)
 		if routeErr != nil {
 			ph.FailAttemptSetup(c, routeErr)
 			return

--- a/internal/protocolserver/protocol_endpoint.go
+++ b/internal/protocolserver/protocol_endpoint.go
@@ -31,6 +31,13 @@ const (
 //     EndpointModeChat                 → Chat
 //     EndpointModeResponses            → Responses
 //     EndpointModeBoth                 → mirror incoming
+//     EndpointModePerModel             → learned, else Chat
+//
+// learned carries what the dispatch loop has observed for this exact
+// provider+model (see endpointMemory); "" means nothing is known. It is
+// consulted only under EndpointModePerModel, where per-model variance is the
+// declared reality — no other mode can produce an extra round-trip, learned or
+// not. Passing it in keeps this function pure: the caller owns the lookup.
 //
 // Rule override is honored unconditionally (per design intent). When an override
 // conflicts with the provider's declared mode, a warning is logged but the override
@@ -46,12 +53,12 @@ const (
 // Anthropic→Chat downgrades. The user accepts this by declaring the mode.
 //
 // Pure function: no Server state, no probe lookups, no I/O.
-func ResolveOpenAIEndpoint(provider *typ.Provider, flags typ.RuleFlags, incoming IncomingAPIType) (protocol.APIType, error) {
+func ResolveOpenAIEndpoint(provider *typ.Provider, flags typ.RuleFlags, incoming IncomingAPIType, learned protocol.APIType) (protocol.APIType, error) {
 	if provider == nil {
 		return "", fmt.Errorf("provider is required for endpoint selection")
 	}
 
-	mode := provider.OpenAIEndpointMode
+	mode := EffectiveEndpointMode(provider)
 
 	// Rule override takes first priority (per design intent from .design/openai-endpoint-routing.md)
 	// Log warning when override conflicts with provider's declared mode
@@ -76,6 +83,17 @@ func ResolveOpenAIEndpoint(provider *typ.Provider, flags typ.RuleFlags, incoming
 	case ai.EndpointModeBoth:
 		if incoming == IncomingAPIResponses {
 			return protocol.TypeOpenAIResponses, nil
+		}
+		return protocol.TypeOpenAIChat, nil
+	case ai.EndpointModePerModel:
+		// A verified observation beats the guess; with none, guess Chat
+		// rather than mirroring the client. Mirroring would send every
+		// Anthropic-shaped request (which this gateway treats as Responses
+		// incoming) to /responses, and on a relay like OpenCode Zen most
+		// models are Chat-only — the common case would pay a failed
+		// round-trip to learn what the safe default already gets right.
+		if learned != "" {
+			return learned, nil
 		}
 		return protocol.TypeOpenAIChat, nil
 	default: // EndpointModeChat / zero value

--- a/internal/protocolserver/protocol_endpoint_test.go
+++ b/internal/protocolserver/protocol_endpoint_test.go
@@ -18,6 +18,7 @@ func TestResolveOpenAIEndpoint(t *testing.T) {
 		provider *typ.Provider
 		flags    typ.RuleFlags
 		incoming IncomingAPIType
+		learned  protocol.APIType
 		want     protocol.APIType
 	}{
 		// Default mode (chat) — provider ignores client's incoming API
@@ -101,6 +102,34 @@ func TestResolveOpenAIEndpoint(t *testing.T) {
 			want:     protocol.TypeOpenAIChat,
 		},
 		{
+			name:     "per_model with nothing learned guesses chat",
+			provider: &typ.Provider{UUID: "p-permodel", OpenAIEndpointMode: ai.EndpointModePerModel},
+			incoming: IncomingAPIResponses,
+			want:     protocol.TypeOpenAIChat,
+		},
+		{
+			name:     "per_model honors what was learned",
+			provider: &typ.Provider{UUID: "p-permodel", OpenAIEndpointMode: ai.EndpointModePerModel},
+			incoming: IncomingAPIChat,
+			learned:  protocol.TypeOpenAIResponses,
+			want:     protocol.TypeOpenAIResponses,
+		},
+		{
+			name:     "rule override still beats what was learned",
+			provider: &typ.Provider{UUID: "p-permodel", OpenAIEndpointMode: ai.EndpointModePerModel},
+			flags:    typ.RuleFlags{OpenAIEndpointOverride: "chat"},
+			incoming: IncomingAPIChat,
+			learned:  protocol.TypeOpenAIResponses,
+			want:     protocol.TypeOpenAIChat,
+		},
+		{
+			name:     "learned value is ignored outside per_model",
+			provider: &typ.Provider{UUID: "p-chat", OpenAIEndpointMode: ai.EndpointModeChat},
+			incoming: IncomingAPIChat,
+			learned:  protocol.TypeOpenAIResponses,
+			want:     protocol.TypeOpenAIChat,
+		},
+		{
 			name:     "unknown flag value treated as no override",
 			provider: both,
 			flags:    typ.RuleFlags{OpenAIEndpointOverride: "bogus"},
@@ -111,7 +140,7 @@ func TestResolveOpenAIEndpoint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ResolveOpenAIEndpoint(tt.provider, tt.flags, tt.incoming)
+			got, err := ResolveOpenAIEndpoint(tt.provider, tt.flags, tt.incoming, tt.learned)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -123,7 +152,7 @@ func TestResolveOpenAIEndpoint(t *testing.T) {
 }
 
 func TestResolveOpenAIEndpointNilProviderErrors(t *testing.T) {
-	if _, err := ResolveOpenAIEndpoint(nil, typ.RuleFlags{}, IncomingAPIChat); err == nil {
+	if _, err := ResolveOpenAIEndpoint(nil, typ.RuleFlags{}, IncomingAPIChat, ""); err == nil {
 		t.Error("expected error for nil provider")
 	}
 }
@@ -138,7 +167,7 @@ func TestResolveOpenAIEndpointCodexOAuthSnapshot(t *testing.T) {
 		OAuthDetail:        &typ.OAuthDetail{Issuer: ai.IssuerCodex},
 		OpenAIEndpointMode: ai.EndpointModeResponses,
 	}
-	got, err := ResolveOpenAIEndpoint(codex, typ.RuleFlags{}, IncomingAPIChat)
+	got, err := ResolveOpenAIEndpoint(codex, typ.RuleFlags{}, IncomingAPIChat, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

OpenCode Zen decides the wire format per model: 32 of its 35 models answer only on `/chat/completions`, while `gpt-5.6-luna`, `grok-4.5` and `grok-4.6` answer only on `/responses`. `OpenAIEndpointMode` is a per-provider fact and cannot say that, so a Codex client asking for luna was downgraded to Chat and got a bare 500.

## Key Changes

- **A fourth mode, `per_model`**: declares "both endpoints exist, but each model picks one" — not `both`, where mirroring the client's protocol is always safe.
- **Reactive learning**: guess Chat, and on a format-mismatch rejection retry the same service once on the other endpoint, remembering the answer for 8h in memory.
- **Bounded by the declaration**: providers that have not declared `per_model` cannot spend an extra round-trip, reach the mismatch matcher, or write to the memory — the containment the old `AdaptiveProbe` lacked.
- **Retry is free of failover semantics**: it runs before the failure is charged, so it costs no failover tier and no breaker strike, and it reuses the existing `firstChunkGate` (nesting a second buffer would break the first-chunk signal).
- **Existing providers are migrated**: `normalizeOpenCodeEndpointMode` sets the mode on every Zen provider, matching on API base so hand-added and old-snapshot providers are covered too.

## Notes

- Tolerating a bare 5xx as a mismatch signal is load-bearing — Zen reports one condition three ways and luna's carries no marker — and is only safe under the mode gate. The 4xx path still requires an explicit marker, so a credential 401 is never retried.
- Verified live (`endpoint_learning_e2e_test.go`, skipped without `OPENCODE_API_KEY`): luna 500/200, kimi-k3 200/401, both rejections recognized by the matcher. Rationale and the Adaptive comparison are in `.design/openai-endpoint-routing.md` §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LS5eJDtN9bfnVXPde2CNwk