### PR TITLE
ci(npm): accept 201 from the OIDC token exchange preflight

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -206,12 +206,17 @@ jobs:
               "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$escaped")
             code=${body##*$'\n'}
             resp=${body%$'\n'*}
-            if [ "$code" = "200" ]; then
-              echo "✅ $pkg: exchange OK"
-            else
-              echo "❌ $pkg: exchange HTTP $code: $(printf '%s' "$resp" | jq -r '.message // .error // .' 2>/dev/null || printf '%s' "$resp")"
-              FAIL=1
-            fi
+            # The registry answers 201 Created (not 200) when it mints a token;
+            # accept any 2xx. Never echo the body on success: it carries the token.
+            case "$code" in
+              2??)
+                echo "✅ $pkg: exchange OK (HTTP $code)"
+                ;;
+              *)
+                echo "❌ $pkg: exchange HTTP $code: $(printf '%s' "$resp" | jq -r '.message // .error // "(no message)"' 2>/dev/null || echo "(unparseable response)")"
+                FAIL=1
+                ;;
+            esac
           done
           [ "$FAIL" -eq 0 ] || {
             echo "The registry has no Trusted Publisher on that package that matches this run AND allows 'npm publish'."
@@ -561,12 +566,17 @@ jobs:
               "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$escaped")
             code=${body##*$'\n'}
             resp=${body%$'\n'*}
-            if [ "$code" = "200" ]; then
-              echo "✅ $pkg: exchange OK"
-            else
-              echo "❌ $pkg: exchange HTTP $code: $(printf '%s' "$resp" | jq -r '.message // .error // .' 2>/dev/null || printf '%s' "$resp")"
-              FAIL=1
-            fi
+            # The registry answers 201 Created (not 200) when it mints a token;
+            # accept any 2xx. Never echo the body on success: it carries the token.
+            case "$code" in
+              2??)
+                echo "✅ $pkg: exchange OK (HTTP $code)"
+                ;;
+              *)
+                echo "❌ $pkg: exchange HTTP $code: $(printf '%s' "$resp" | jq -r '.message // .error // "(no message)"' 2>/dev/null || echo "(unparseable response)")"
+                FAIL=1
+                ;;
+            esac
           done
           [ "$FAIL" -eq 0 ] || {
             echo "The registry has no Trusted Publisher on that package that matches this run AND allows 'npm publish'."


### PR DESCRIPTION
## Summary
The trusted-publisher preflight only treated HTTP 200 as success, but the npm registry answers 201 Created when it mints a publish token, so run 34374081872 failed on all six packages even though every exchange succeeded.

## Key Changes

- **Publish preflight correctness**: accept any 2xx from the OIDC exchange in both publish jobs, so a minted token no longer fails the job.
- **Token hygiene in logs**: the failure path prints only the registry's `message` / `error` instead of the full body, which can carry the token.

## Notes

- The workflow runs from the tag's ref, so re-running the old run won't pick this up; re-tag (or move `v0.260910.0-rc2`) onto a commit that includes this fix before dispatching again.
