### PR TITLE
fix(imagegen): surface a failed run at once, and let a pending run be cancelled

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1689,6 +1689,8 @@ export default {
     "runFailed": "Generation failed",
     "interruptedByReload": "Interrupted by a page reload",
     "retry": "Retry",
+    "cancelRun": "Cancel",
+    "cancelled": "Cancelled",
     "removeRun": "Remove this generation",
     "submitShortcut": "⌘/Ctrl + Enter to generate",
     "closePreview": "Close image preview",

--- a/frontend/src/i18n/locales/ru.ts
+++ b/frontend/src/i18n/locales/ru.ts
@@ -1699,6 +1699,8 @@ export default {
     "runFailed": "Генерация не удалась",
     "interruptedByReload": "Прервано перезагрузкой страницы",
     "retry": "Повторить",
+    "cancelRun": "Отменить",
+    "cancelled": "Отменено",
     "removeRun": "Удалить эту генерацию",
     "submitShortcut": "⌘/Ctrl + Enter — сгенерировать",
     "closePreview": "Закрыть предпросмотр изображения",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1685,6 +1685,8 @@ export default {
     "runFailed": "生成失败",
     "interruptedByReload": "页面刷新时被中断",
     "retry": "重试",
+    "cancelRun": "取消",
+    "cancelled": "已取消",
     "removeRun": "移除这次生成",
     "submitShortcut": "⌘/Ctrl + Enter 直接生成",
     "closePreview": "关闭图像预览",

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2466,6 +2466,12 @@ export const handlers = [
             )
         }
 
+        // A prompt carrying `[slow]` answers after 30s, so the pending card's
+        // Cancel button is exercisable against the mock backend too.
+        if (/\[slow\]/i.test(promptText)) {
+            await new Promise((r) => setTimeout(r, 30_000))
+        }
+
         // A prompt that asks for an NxM grid gets a real grid back, so the
         // playground's slicer is exercisable against the mock backend.
         const sheet = /(\d+)\s*[x×]\s*(\d+)\s+grid/i.exec(promptText)

--- a/frontend/src/pages/scenario/components/ImageGenPlaygroundCard.tsx
+++ b/frontend/src/pages/scenario/components/ImageGenPlaygroundCard.tsx
@@ -329,6 +329,10 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
     const promptFileInputRef = useRef<HTMLInputElement>(null);
     const pendingCount = runs.filter((run) => run.status === 'pending').length;
     const { copied: promptCopied, copy: copyPrompt } = useCopyFeedback();
+    // The in-flight request behind each pending card, so its Cancel button
+    // can abort the fetch instead of leaving the user to wait out the
+    // gateway's timeout on a provider that has stopped answering.
+    const inFlightRef = useRef(new Map<string, AbortController>());
 
     const updateRuns = useCallback((updater: (currentRuns: GenerationRun[]) => GenerationRun[]) => {
         const nextRuns = updater(imageGenSessionRuns);
@@ -666,6 +670,8 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
         updateRuns((currentRuns) => (currentRuns.some((run) => run.id === runId)
             ? currentRuns.map((run) => (run.id === runId ? { ...pendingRun, createdAt: run.createdAt } : run))
             : [...currentRuns, pendingRun]));
+        const controller = new AbortController();
+        inFlightRef.current.set(runId, controller);
         try {
             const client = await getOpenAIClient(IMAGE_SCENARIO);
             const editFiles = request.sources.map((ref) => ref.file);
@@ -677,27 +683,43 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
                     n: request.count,
                     size: request.size as any,
                     quality: request.quality as any,
-                })
+                }, { signal: controller.signal })
                 : await client.images.generate({
                     model: request.model,
                     prompt: request.prompt,
                     n: request.count,
                     size: request.size as any,
                     quality: request.quality,
-                });
+                }, { signal: controller.signal });
             const images = response.data ?? [];
             updateRuns((currentRuns) => currentRuns.map((run) => (
                 run.id === runId ? { ...run, images, status: 'completed', error: undefined } : run
             )));
         } catch (error: any) {
+            if (controller.signal.aborted) {
+                // The user asked for this; the card records it so the request
+                // is still there to retry, and no toast second-guesses them.
+                updateRuns((currentRuns) => currentRuns.map((run) => (
+                    run.id === runId
+                        ? { ...run, status: 'failed', error: t('playground.cancelled', { defaultValue: 'Cancelled' }) }
+                        : run
+                )));
+                return;
+            }
             const status = error?.status ? `${error.status}: ` : '';
             const message = error?.error?.message || error?.message || t('playground.requestFailed', { defaultValue: 'Request failed' });
             updateRuns((currentRuns) => currentRuns.map((run) => (
                 run.id === runId ? { ...run, status: 'failed', error: `${status}${message}` } : run
             )));
             showNotification(`${status}${message}`, 'error');
+        } finally {
+            inFlightRef.current.delete(runId);
         }
     }, [showNotification, t, updateRuns]);
+
+    const handleCancelRun = useCallback((id: string) => {
+        inFlightRef.current.get(id)?.abort();
+    }, []);
 
     const canSubmit = Boolean(prompt.trim()) && Boolean(model);
 
@@ -1398,6 +1420,16 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
                                                     >
                                                         {run.model} · {run.size} · {run.quality} · images/{run.endpoint}
                                                     </Typography>
+                                                    <Button
+                                                        size="small"
+                                                        variant="outlined"
+                                                        color="inherit"
+                                                        startIcon={<Close fontSize="small" />}
+                                                        onClick={() => handleCancelRun(run.id)}
+                                                        data-testid="imagegen-cancel-run"
+                                                    >
+                                                        {t('playground.cancelRun', { defaultValue: 'Cancel' })}
+                                                    </Button>
                                                 </Stack>
                                             ) : run.status === 'failed' ? (
                                                 <Stack spacing={1} sx={{ height: '100%', minWidth: 0 }}>

--- a/frontend/src/services/modelApi.ts
+++ b/frontend/src/services/modelApi.ts
@@ -89,5 +89,11 @@ export const getOpenAIClient = async (scenario: string): Promise<OpenAI> => {
         baseURL: `${base}/tingly/${scenario}/v1`,
         apiKey,
         dangerouslyAllowBrowser: true,
+        // Retry and fallback across providers is the gateway's job (its own
+        // SDK clients run with retries off). The browser SDK would otherwise
+        // silently re-send a request that came back 5xx/429 or timed out two
+        // more times, so a failed image run sat as a spinner for three upstream
+        // round-trips before the error reached the page.
+        maxRetries: 0,
     });
 };


### PR DESCRIPTION
## Summary
A server-side error in the image playground showed nothing for a long time: the browser OpenAI client kept the SDK default of two retries, so a 5xx/429 or timeout was re-sent twice before the error reached the failed-run card and the notification. A provider that stops answering was worse: the card spun until the gateway's 30-minute timeout with nothing the user could do.

## Key Changes

- **Playground error feedback**: `getOpenAIClient` now runs with `maxRetries: 0`, so a failed run turns red and notifies after one round-trip instead of three.
- **Single retry owner**: retry and provider fallback stay with the gateway, whose own SDK clients already run with retries off.
- **Cancel a pending run**: the pending card has a Cancel button that aborts the request; the card records "Cancelled" and keeps Retry, with no toast.

## Notes
- Mock backend: a `[fail]` prompt gave three 502 requests before the fix and one after; a new `[slow]` prompt answers after 30s so Cancel is exercisable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Df2YNEgtE58vfUjFCrPDj1