### PR TITLE
feat(imagegen): export sliced tiles as an MP4, and type the frame duration

### DIFF
--- a/.design/image-slice.md
+++ b/.design/image-slice.md
@@ -158,6 +158,50 @@ local file header / central directory / EOCD,文件名带 UTF-8 flag(bit 11),
 GIF 只有一块画布。GIF 边长上限 480px——九格 1024 的表连成 GIF 是几十 MB,
 而贴纸动画不需要。
 
+### 4.2 帧长是一个可输入的数字,不是一份预设列表
+
+第一版的帧长是一个下拉框,六档固定值(80…800 ms)。它把"这段动画多快"变成了
+"这六个里选哪个",而用户手里往往有一个具体的数:平台要求 12 fps、原素材是
+每帧 150 ms。现在它是和行列同一种控件——步进器 + 可直接键入的输入框
+(`utils/imageSlice.ts` 的 `clampFrameDelay`):
+
+- 范围 20…5000 ms,步进 10 ms。10 是 GIF 能存的最小单位(百分之一秒),所以
+  键入 155 会落到 160,而不是让 GIF 悄悄存成别的值;
+- 输入框在失焦 / 回车时才吸附,否则输入 "12" 的第一个字符就会被夹成 20;
+- 旁边的 `9 frames · 6 fps` 仍然是同一个值的另一种读法(原则 5)。
+
+`NumberStepper` 因此从行列专用的 `AxisStepper` 泛化而来:min / max / step /
+clamp / 单位后缀都是参数,行列、帧长、视频循环次数三处共用一个控件。
+
+### 4.3 视频:同一组帧,第三件成品(`utils/video.ts`)
+
+GIF 是浏览器自己能造出来的东西,也是聊天软件和社交平台会重压、限体积、
+甚至拒收的东西。**H.264 MP4 是所有平台原样转发的那一种**,所以同一组帧再多
+一个出口:`Download MP4`。
+
+- **编码交给浏览器,封装交给库。** H.264 由 WebCodecs 的 `VideoEncoder` 编,
+  MP4 / WebM 封装用 `mediabunny`(`mp4-muxer` 的继任者)。这里**不**沿用
+  `gif.ts` / `zip.ts` 自写的先例:MP4 的 box 结构不是任何规范里"小的那一半",
+  而 mediabunny 顺带解决了编码器探测、时间戳和 `moov` 前置。它按需 `import()`,
+  只在第一次导出视频时进包。
+- **能力是浏览器的属性,先问再画按钮。** 打开对话框时 `probeVideoTarget` 问一次:
+  有 H.264 → 按钮写 `Download MP4`;只有 VP9/VP8 → 按钮写 `Download WebM`,
+  tooltip 说明部分聊天应用不收;连 WebCodecs 都没有 → 按钮禁用,tooltip 列出
+  能用的浏览器。点了才失败是最差的失败方式(原则 7:诊断要走真实路径)。
+  注意 Playwright 自带的开源 Chromium **没有 H.264 编码器**,`ui-preview` 沙盒里
+  只能验证到 WebM;MP4 成品必须在正式 Chrome / Edge / Safari 上收尾。
+- **`moov` 在前**(`fastStart: 'in-memory'`):不少平台上传时先读文件头,`moov`
+  在尾部的文件会被先转码或者直接拒收。
+- **时长:循环到能被当成一段视频。** 九帧 200 ms 只有 1.8 秒,平台对亚秒级视频
+  不友好。`planVideoLoops` 取能超过 3 秒的最小循环次数作为默认,用户可以改,
+  旁边永远显示算出来的具体秒数(`= 5.4 s`),而不是"短 / 中 / 长"(原则 5)。
+- **透明:视频没有 alpha。** 清背景之后的镂空、或原本就带 alpha 的 PNG,导出视频时
+  要铺一个底色。底色选择器**只在帧里确实有透明时出现**(`analyzeSheetBackground`
+  顺带返回 `hasAlpha`),不透明的图不需要看到它(原则 9)。默认白色。
+- **偶数尺寸。** yuv420 要求宽高为偶数,`evenSize` 把 341 补到 342——多一像素
+  的底色,而不是裁掉一像素的画面。
+- **分辨率上限 1024**,不沿用 GIF 的 480:H.264 把一个 1024 的循环压在几百 KB。
+
 ---
 
 ## 5. 清背景:模型画上来的"假透明"
@@ -336,6 +380,7 @@ prompt 往往不是在这个框里写出来的:它是一个反复打磨的 `.md`
 |------|------|
 | `frontend/src/utils/zip.ts` | store-only ZIP writer + CRC-32 |
 | `frontend/src/utils/gif.ts` | GIF89a writer:中位切分量化 + LZW + 循环块 |
+| `frontend/src/utils/video.ts` | MP4 / WebM 导出:WebCodecs 编码 + `mediabunny` 封装,能力探测、循环数、偶数尺寸 |
 | `frontend/src/utils/imageMatte.ts` | 背景检测(棋盘格/绿幕)与清除 |
 | `frontend/src/utils/playgroundSession.ts` | run / 导入图的 IndexedDB 持久化(尽力而为、写入合并) |
 | `frontend/src/utils/promptFile.ts` | 文本文件 → prompt:分拣、读取、上限 |
@@ -355,7 +400,8 @@ prompt 往往不是在这个框里写出来的:它是一个反复打磨的 `.md`
 常量——UI 不可能给出一个几何层会悄悄拒绝的值。
 
 几何、打包、编码、抠图逻辑都是纯函数:单测在 `zip.test.ts` /
-`imageSlice.test.ts` / `download.test.ts` / `gif.test.ts` / `imageMatte.test.ts`。
+`imageSlice.test.ts` / `download.test.ts` / `gif.test.ts` / `imageMatte.test.ts` /
+`video.test.ts`(视频只测循环规划、偶数尺寸、文件名——编码本身要浏览器)。
 `imageMatte` 的测试直接构造 RGBA 缓冲(结构化类型,不依赖 canvas);`gif` 的测试
 自带一个最小解码器,断言"写出去的码流能被解回同样的像素"。
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "devicons-react": "^1.5.0",
     "i18next": "^26.3.6",
     "i18next-browser-languagedetector": "^8.2.1",
+    "mediabunny": "^1.56.1",
     "openai": "^6.48.0",
     "openapi-fetch": "^0.17.0",
     "prism-react-renderer": "^2.4.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       i18next-browser-languagedetector:
         specifier: ^8.2.1
         version: 8.2.1
+      mediabunny:
+        specifier: ^1.56.1
+        version: 1.56.1
       openai:
         specifier: ^6.48.0
         version: 6.48.0(ws@8.21.1)(zod@4.4.3)
@@ -1250,6 +1253,12 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/dom-mediacapture-transform@0.1.12':
+    resolution: {integrity: sha512-d7/QsLRwF864A5mgIM/YrfiglHoYn7zgCcAoJgW404r+2DwnNr7EBbLnCWpmOMgH8y0te73L1AV6H1bmauaWFw==}
+
+  '@types/dom-webcodecs@0.1.13':
+    resolution: {integrity: sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -2174,6 +2183,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mediabunny@1.56.1:
+    resolution: {integrity: sha512-DNOm0bRBmeOxJgCK/g3LxNWbxY5morTauNdlychujGmJ9L37ezVezkNoI1WtO2Xdb4WlWWJlYfIKnOEzd5phRw==}
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -3829,6 +3841,12 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/dom-mediacapture-transform@0.1.12':
+    dependencies:
+      '@types/dom-webcodecs': 0.1.13
+
+  '@types/dom-webcodecs@0.1.13': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8':
@@ -4733,6 +4751,11 @@ snapshots:
   marked@15.0.12: {}
 
   mdn-data@2.27.1: {}
+
+  mediabunny@1.56.1:
+    dependencies:
+      '@types/dom-mediacapture-transform': 0.1.12
+      '@types/dom-webcodecs': 0.1.13
 
   min-indent@1.0.1: {}
 

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -36,6 +36,7 @@ import {
     IconPlayerPause,
     IconArrowsMaximize,
     IconGif,
+    IconMovie,
     IconWorld,
     IconEdit,
     IconFileDescription,
@@ -202,6 +203,7 @@ export const PlayArrow = tablerMui(IconPlayerPlay);
 export const Pause = tablerMui(IconPlayerPause);
 export const OpenInFull = tablerMui(IconArrowsMaximize);
 export const Gif = tablerMui(IconGif);
+export const Movie = tablerMui(IconMovie);
 export const Filter = tablerMui(IconFilter);
 export const FilterOff = tablerMui(IconFilterOff);
 export const Sort = tablerMui(IconArrowsSort);

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1811,7 +1811,19 @@ export default {
       "frameCount": "{{count}} frames · {{fps}} fps",
       "frameDelay": "Frame duration",
       "downloadGif": "Download GIF",
-      "gifFailed": "Could not build the animation"
+      "gifFailed": "Could not build the animation",
+      "shorterFrame": "Shorter frames",
+      "longerFrame": "Longer frames",
+      "loops": "Video loops",
+      "fewerLoops": "Fewer loops",
+      "moreLoops": "More loops",
+      "videoLength": "= {{seconds}} s",
+      "videoBackground": "Video backdrop",
+      "downloadMp4": "Download MP4",
+      "downloadWebm": "Download WebM",
+      "videoFailed": "Could not build the video",
+      "videoUnsupported": "This browser cannot encode video. Chrome, Edge, Safari 16.4+ and Firefox 130+ can.",
+      "videoWebmOnly": "This browser has no H.264 encoder, so the file will be a WebM — playable in browsers, but some chat apps refuse it."
     }
   },
   "agentSetup": {

--- a/frontend/src/i18n/locales/ru.ts
+++ b/frontend/src/i18n/locales/ru.ts
@@ -1821,7 +1821,19 @@ export default {
       "frameCount": "{{count}} кадров · {{fps}} fps",
       "frameDelay": "Длительность кадра",
       "downloadGif": "Скачать GIF",
-      "gifFailed": "Не удалось собрать анимацию"
+      "gifFailed": "Не удалось собрать анимацию",
+      "shorterFrame": "Короче кадры",
+      "longerFrame": "Длиннее кадры",
+      "loops": "Повторы видео",
+      "fewerLoops": "Меньше повторов",
+      "moreLoops": "Больше повторов",
+      "videoLength": "= {{seconds}} с",
+      "videoBackground": "Фон видео",
+      "downloadMp4": "Скачать MP4",
+      "downloadWebm": "Скачать WebM",
+      "videoFailed": "Не удалось собрать видео",
+      "videoUnsupported": "Этот браузер не умеет кодировать видео. Chrome, Edge, Safari 16.4+ и Firefox 130+ умеют.",
+      "videoWebmOnly": "В этом браузере нет кодировщика H.264, поэтому файл будет WebM — воспроизводится в браузерах, но некоторые мессенджеры его не принимают."
     }
   },
   "agentSetup": {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1807,7 +1807,19 @@ export default {
       "frameCount": "{{count}} 帧 · {{fps}} fps",
       "frameDelay": "每帧时长",
       "downloadGif": "下载 GIF",
-      "gifFailed": "无法生成动画"
+      "gifFailed": "无法生成动画",
+      "shorterFrame": "缩短每帧",
+      "longerFrame": "延长每帧",
+      "loops": "视频循环次数",
+      "fewerLoops": "减少循环",
+      "moreLoops": "增加循环",
+      "videoLength": "= {{seconds}} 秒",
+      "videoBackground": "视频底色",
+      "downloadMp4": "下载 MP4",
+      "downloadWebm": "下载 WebM",
+      "videoFailed": "无法生成视频",
+      "videoUnsupported": "当前浏览器无法编码视频。Chrome、Edge、Safari 16.4+ 和 Firefox 130+ 可以。",
+      "videoWebmOnly": "当前浏览器没有 H.264 编码器,只能导出 WebM——浏览器里能播放,但部分聊天应用不接受。"
     }
   },
   "agentSetup": {

--- a/frontend/src/pages/scenario/components/ImageGenPlaygroundCard.tsx
+++ b/frontend/src/pages/scenario/components/ImageGenPlaygroundCard.tsx
@@ -1295,7 +1295,7 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
                             </Stack>
                         ) : (
                             <Stack spacing={1.5} sx={{ width: '100%', minWidth: 0, height: '100%' }}>
-                                <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 1 }}>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                                     <Typography variant="subtitle2" sx={{ minWidth: 0 }}>
                                         {t('playground.sessionOutputs', { defaultValue: 'Session images' })}
                                     </Typography>
@@ -1305,6 +1305,7 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
                                             color: "text.secondary",
                                             flexShrink: 0,
                                             whiteSpace: 'nowrap',
+                                            ml: 'auto',
                                         }}
                                     >
                                         {[
@@ -1320,6 +1321,28 @@ const ImageGenPlaygroundCard: React.FC<ImageGenPlaygroundCardProps> = ({
                                             }),
                                         ].filter(Boolean).join(' · ')}
                                     </Typography>
+                                    {/* The same two ways in as the empty state offers: the
+                                        strip filling up must not take them away. */}
+                                    <Stack direction="row" spacing={0.5} sx={{ flexShrink: 0 }}>
+                                        <Button
+                                            size="small"
+                                            color="inherit"
+                                            startIcon={<FileUpload fontSize="small" />}
+                                            onClick={() => importFileInputRef.current?.click()}
+                                            sx={{ color: 'text.secondary', '&:hover': { color: 'primary.main' } }}
+                                        >
+                                            {t('playground.referenceBrowse', { defaultValue: 'Browse' })}
+                                        </Button>
+                                        <Button
+                                            size="small"
+                                            color="inherit"
+                                            startIcon={<ContentPaste fontSize="small" />}
+                                            onClick={() => { void handleImportFromClipboard(); }}
+                                            sx={{ color: 'text.secondary', '&:hover': { color: 'primary.main' } }}
+                                        >
+                                            {t('playground.referencePaste', { defaultValue: 'Paste' })}
+                                        </Button>
+                                    </Stack>
                                 </Box>
 
                                 <Box

--- a/frontend/src/pages/scenario/components/ImageSliceDialog.tsx
+++ b/frontend/src/pages/scenario/components/ImageSliceDialog.tsx
@@ -17,20 +17,33 @@ import {
     Slider,
     Stack,
     TextField,
+    Tooltip,
     Typography,
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { Add, Close, Download, Gif, GridView, Pause, PlayArrow, Remove } from '@/components/icons';
+import { Add, Close, Download, Gif, GridView, Movie, Pause, PlayArrow, Remove } from '@/components/icons';
 import { createZipBlob } from '@/utils/zip';
 import { downloadBlob, slugify } from '@/utils/download';
 import { encodeGif } from '@/utils/gif';
+import {
+    encodeVideo,
+    evenSize,
+    MAX_VIDEO_LOOPS,
+    planVideoLoops,
+    probeVideoTarget,
+    videoFileName,
+    type VideoTarget,
+} from '@/utils/video';
 import { DEFAULT_TOLERANCE, type BackgroundKind } from '@/utils/imageMatte';
 import {
     analyzeSheetBackground,
+    clampFrameDelay,
     computeTileRects,
     DEFAULT_FRAME_DELAY,
     DEFAULT_GRID,
-    FRAME_DELAYS,
+    FRAME_DELAY_MAX,
+    FRAME_DELAY_MIN,
+    FRAME_DELAY_STEP,
     FULL_CROP,
     GUTTER_MAX,
     isFullCrop,
@@ -45,59 +58,81 @@ import {
     type TileRect,
 } from '@/utils/imageSlice';
 
-// Rows and columns are a number you nudge while watching the overlay, so each
-// is a stepper with a typable field rather than a dropdown that hides the
-// image behind a menu on every change. The cap is generous enough for a
-// spritesheet; 3x3 is the shape a sticker sheet almost always comes back as.
+// Rows, columns, frame duration and loop count are all numbers you nudge
+// while watching the result, so each is a stepper with a typable field rather
+// than a dropdown that hides the image behind a menu on every change. The
+// grid cap is generous enough for a spritesheet; 3x3 is the shape a sticker
+// sheet almost always comes back as.
 const AXIS_MAX = 12;
-const clampAxis = (value: number): number => Math.min(AXIS_MAX, Math.max(1, Math.round(value) || 1));
 
-interface AxisStepperProps {
+interface NumberStepperProps {
     label: string;
     value: number;
     onChange: (value: number) => void;
     decreaseLabel: string;
     increaseLabel: string;
+    min?: number;
+    max?: number;
+    step?: number;
+    /** Snaps a typed or stepped value; defaults to rounding within [min, max]. */
+    clamp?: (value: number) => number;
+    /** Unit shown after the field, e.g. `ms`. */
+    unit?: string;
+    width?: number;
 }
 
-const AxisStepper: React.FC<AxisStepperProps> = ({ label, value, onChange, decreaseLabel, increaseLabel }) => (
-    <Stack direction="row" sx={{ alignItems: 'flex-start', flex: 1, minWidth: 0, '& > .MuiIconButton-root': { mt: 0.25 } }}>
-        <IconButton
-            size="small"
-            onClick={() => onChange(clampAxis(value - 1))}
-            disabled={value <= 1}
-            aria-label={decreaseLabel}
-        >
-            <Remove fontSize="small" />
-        </IconButton>
-        <TextField
-            size="small"
-            helperText={label}
-            value={value}
-            onChange={(event) => {
-                const next = Number(event.target.value);
-                if (Number.isFinite(next) && next >= 1) onChange(clampAxis(next));
-            }}
-            onKeyDown={(event) => {
-                if (event.key === 'ArrowUp') { event.preventDefault(); onChange(clampAxis(value + 1)); }
-                if (event.key === 'ArrowDown') { event.preventDefault(); onChange(clampAxis(value - 1)); }
-            }}
-            slotProps={{
-                htmlInput: { 'aria-label': label, inputMode: 'numeric', min: 1, max: AXIS_MAX, style: { textAlign: 'center', padding: '6px 4px' } },
-                formHelperText: { sx: { mx: 0, textAlign: 'center', mt: 0.25, lineHeight: 1.2 } },
-            }}
-            sx={{ width: 52, '& .MuiInputBase-root': { px: 0.5 } }}
-        />
-        <IconButton
-            size="small"
-            onClick={() => onChange(clampAxis(value + 1))}
-            disabled={value >= AXIS_MAX}
-            aria-label={increaseLabel}
-        >
-            <Add fontSize="small" />
-        </IconButton>
-    </Stack>
-);
+const NumberStepper: React.FC<NumberStepperProps> = ({
+    label, value, onChange, decreaseLabel, increaseLabel,
+    min = 1, max = AXIS_MAX, step = 1, clamp, unit, width = 52,
+}) => {
+    const snap = clamp ?? ((next: number) => Math.min(max, Math.max(min, Math.round(next) || min)));
+    // Typing is free-form until the field loses focus: snapping on every
+    // keystroke would turn "12" into "20" the moment "1" is typed.
+    const [draft, setDraft] = useState<string | null>(null);
+    const commit = (text: string) => {
+        setDraft(null);
+        const next = Number(text);
+        if (Number.isFinite(next) && text.trim() !== '') onChange(snap(next));
+    };
+    return (
+        <Stack direction="row" sx={{ alignItems: 'flex-start', flex: 1, minWidth: 0, '& > .MuiIconButton-root': { mt: 0.25 } }}>
+            <IconButton
+                size="small"
+                onClick={() => onChange(snap(value - step))}
+                disabled={value <= min}
+                aria-label={decreaseLabel}
+            >
+                <Remove fontSize="small" />
+            </IconButton>
+            <TextField
+                size="small"
+                helperText={label}
+                value={draft ?? value}
+                onChange={(event) => setDraft(event.target.value)}
+                onBlur={(event) => commit(event.target.value)}
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter') { event.preventDefault(); commit((event.target as HTMLInputElement).value); }
+                    if (event.key === 'ArrowUp') { event.preventDefault(); setDraft(null); onChange(snap(value + step)); }
+                    if (event.key === 'ArrowDown') { event.preventDefault(); setDraft(null); onChange(snap(value - step)); }
+                }}
+                slotProps={{
+                    htmlInput: { 'aria-label': label, inputMode: 'numeric', min, max, style: { textAlign: 'center', padding: '6px 4px' } },
+                    input: unit ? { endAdornment: <Typography variant="caption" sx={{ color: 'text.secondary', pr: 0.5 }}>{unit}</Typography> } : undefined,
+                    formHelperText: { sx: { mx: 0, textAlign: 'center', mt: 0.25, lineHeight: 1.2 } },
+                }}
+                sx={{ width, '& .MuiInputBase-root': { px: 0.5 } }}
+            />
+            <IconButton
+                size="small"
+                onClick={() => onChange(snap(value + step))}
+                disabled={value >= max}
+                aria-label={increaseLabel}
+            >
+                <Add fontSize="small" />
+            </IconButton>
+        </Stack>
+    );
+};
 
 // The conventional "transparent here" checkerboard.
 const CHECKERBOARD_IMAGE = [
@@ -114,6 +149,9 @@ const PREVIEW_BOX = { width: 128, height: 128 };
 // A GIF of nine 1024px tiles is tens of megabytes; nothing about a sticker
 // animation needs that, and the cap is invisible to the user in practice.
 const GIF_MAX_SIZE = 480;
+// Video does not share that cap: H.264 keeps a 1024px loop to a few hundred KB.
+const VIDEO_MAX_SIZE = 1024;
+const DEFAULT_VIDEO_BACKGROUND = '#ffffff';
 
 // Below this, a pointer gesture was a click on a tile rather than a drag that
 // redraws the frame — the two share the same surface on purpose.
@@ -258,6 +296,15 @@ const ImageSliceDialog: React.FC<ImageSliceDialogProps> = ({
     const [frameDelay, setFrameDelay] = useState(DEFAULT_FRAME_DELAY);
     const [playing, setPlaying] = useState(true);
     const [frame, setFrame] = useState(0);
+    // Video: how many times the sequence plays (null = as many as it takes to
+    // clear the minimum length), and what shows through where the tiles are
+    // transparent, since MP4 has no alpha.
+    const [loops, setLoops] = useState<number | null>(null);
+    const [videoBackground, setVideoBackground] = useState(DEFAULT_VIDEO_BACKGROUND);
+    const [sheetHasAlpha, setSheetHasAlpha] = useState(false);
+    // undefined while the browser is still being asked; null when it cannot
+    // encode video at all.
+    const [videoTarget, setVideoTarget] = useState<VideoTarget | null | undefined>(undefined);
 
     // Start from a clean grid whenever a new image is opened — the dialog is a
     // per-image work surface, not a sticky global setting.
@@ -322,12 +369,27 @@ const ImageSliceDialog: React.FC<ImageSliceDialogProps> = ({
             setDetected(analysis.kind);
             setDetectedColors(analysis.colors);
             setCleanKind(analysis.kind);
+            setSheetHasAlpha(analysis.hasAlpha);
         } catch {
             setDetected('none');
             setDetectedColors([]);
             setCleanKind('none');
+            setSheetHasAlpha(false);
         }
     }, [image]);
+
+    // Whether this browser can produce a video, and which kind, is a property
+    // of the browser — asked once per open, so the button can say "MP4" or
+    // "WebM" (or explain itself when disabled) before anyone clicks it.
+    useEffect(() => {
+        if (!open) return;
+        let cancelled = false;
+        setVideoTarget(undefined);
+        probeVideoTarget({ width: VIDEO_MAX_SIZE, height: VIDEO_MAX_SIZE })
+            .then((target) => { if (!cancelled) setVideoTarget(target); })
+            .catch(() => { if (!cancelled) setVideoTarget(null); });
+        return () => { cancelled = true; };
+    }, [open]);
 
     const matte = useMemo<MatteSpec | null>(
         () => (cleanKind === 'none' ? null : { kind: cleanKind, tolerance, colors: detectedColors }),
@@ -511,6 +573,52 @@ const ImageSliceDialog: React.FC<ImageSliceDialogProps> = ({
             setWorking(false);
         }
     }, [exportSize, frameDelay, image, matte, selectedRects, showNotification, stem, t]);
+
+    // Video has a backdrop only when something would otherwise be see-through:
+    // a matte always leaves holes, and a PNG may have arrived with them.
+    const videoNeedsBackground = Boolean(matte) || sheetHasAlpha;
+    const effectiveLoops = loops ?? planVideoLoops(selectedRects.length, frameDelay);
+    const videoSeconds = (effectiveLoops * selectedRects.length * frameDelay) / 1000;
+
+    // Same frames again, boxed as the one format every chat app and platform
+    // forwards untouched. MP4 wants even dimensions, so the box is padded by
+    // a pixel where needed rather than cropped.
+    const handleDownloadVideo = useCallback(async () => {
+        if (!image || !videoTarget || selectedRects.length < 2) return;
+        setWorking(true);
+        try {
+            const longest = Math.max(selectedRects[0].width, selectedRects[0].height);
+            const size = Math.min(exportSize ?? longest, VIDEO_MAX_SIZE);
+            const scale = size / longest;
+            const box = evenSize({
+                width: Math.max(1, Math.round(selectedRects[0].width * scale)),
+                height: Math.max(1, Math.round(selectedRects[0].height * scale)),
+            });
+            const { width, height, frames } = renderAnimationFrames(image, selectedRects, { box, matte });
+            downloadBlob(
+                await encodeVideo({
+                    width,
+                    height,
+                    frames,
+                    delayMs: frameDelay,
+                    loops: effectiveLoops,
+                    background: videoNeedsBackground ? videoBackground : DEFAULT_VIDEO_BACKGROUND,
+                    target: videoTarget,
+                }),
+                videoFileName(stem, selectedRects.length, videoTarget),
+            );
+        } catch {
+            showNotification(
+                t('playground.slice.videoFailed', { defaultValue: 'Could not build the video' }),
+                'error',
+            );
+        } finally {
+            setWorking(false);
+        }
+    }, [
+        effectiveLoops, exportSize, frameDelay, image, matte, selectedRects, showNotification, stem, t,
+        videoBackground, videoNeedsBackground, videoTarget,
+    ]);
 
     const naturalWidth = image?.naturalWidth ?? 1;
     const naturalHeight = image?.naturalHeight ?? 1;
@@ -743,7 +851,7 @@ const ImageSliceDialog: React.FC<ImageSliceDialogProps> = ({
                         </Typography>
 
                         <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
-                            <AxisStepper
+                            <NumberStepper
                                 label={t('playground.slice.rows', { defaultValue: 'Rows' })}
                                 value={rows}
                                 onChange={setRows}
@@ -751,7 +859,7 @@ const ImageSliceDialog: React.FC<ImageSliceDialogProps> = ({
                                 increaseLabel={t('playground.slice.moreRows', { defaultValue: 'More rows' })}
                             />
                             <Typography variant="body2" sx={{ color: 'text.disabled', mt: 1 }}>×</Typography>
-                            <AxisStepper
+                            <NumberStepper
                                 label={t('playground.slice.cols', { defaultValue: 'Columns' })}
                                 value={cols}
                                 onChange={setCols}
@@ -996,22 +1104,66 @@ const ImageSliceDialog: React.FC<ImageSliceDialogProps> = ({
                                             })}
                                         </Typography>
                                     </Stack>
-                                    <FormControl size="small" fullWidth>
-                                        <InputLabel id="slice-delay-label">
-                                            {t('playground.slice.frameDelay', { defaultValue: 'Frame duration' })}
-                                        </InputLabel>
-                                        <Select
-                                            labelId="slice-delay-label"
-                                            label={t('playground.slice.frameDelay', { defaultValue: 'Frame duration' })}
-                                            value={frameDelay}
-                                            onChange={(event) => setFrameDelay(Number(event.target.value))}
-                                        >
-                                            {FRAME_DELAYS.map((value) => (
-                                                <MenuItem key={value} value={value}>{value} ms</MenuItem>
-                                            ))}
-                                        </Select>
-                                    </FormControl>
+                                    <NumberStepper
+                                        label={t('playground.slice.frameDelay', { defaultValue: 'Frame duration' })}
+                                        value={frameDelay}
+                                        onChange={setFrameDelay}
+                                        min={FRAME_DELAY_MIN}
+                                        max={FRAME_DELAY_MAX}
+                                        step={FRAME_DELAY_STEP}
+                                        clamp={clampFrameDelay}
+                                        unit="ms"
+                                        width={96}
+                                        decreaseLabel={t('playground.slice.shorterFrame', { defaultValue: 'Shorter frames' })}
+                                        increaseLabel={t('playground.slice.longerFrame', { defaultValue: 'Longer frames' })}
+                                    />
                                 </Stack>
+                            </Stack>
+
+                            {/* The video is the same loop again, played enough
+                                times to be a clip platforms accept, over a
+                                backdrop only when the frames have holes. */}
+                            <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start', mt: 1.5 }}>
+                                <NumberStepper
+                                    label={t('playground.slice.loops', { defaultValue: 'Video loops' })}
+                                    value={effectiveLoops}
+                                    onChange={setLoops}
+                                    min={1}
+                                    max={MAX_VIDEO_LOOPS}
+                                    width={56}
+                                    decreaseLabel={t('playground.slice.fewerLoops', { defaultValue: 'Fewer loops' })}
+                                    increaseLabel={t('playground.slice.moreLoops', { defaultValue: 'More loops' })}
+                                />
+                                <Typography variant="caption" sx={{ color: 'text.secondary', mt: 1.25, whiteSpace: 'nowrap' }}>
+                                    {t('playground.slice.videoLength', {
+                                        defaultValue: '= {{seconds}} s',
+                                        seconds: videoSeconds.toFixed(1),
+                                    })}
+                                </Typography>
+                                {videoNeedsBackground && (
+                                    <Stack sx={{ alignItems: 'center', ml: 'auto !important' }}>
+                                        <Box
+                                            component="input"
+                                            type="color"
+                                            value={videoBackground}
+                                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => setVideoBackground(event.target.value)}
+                                            aria-label={t('playground.slice.videoBackground', { defaultValue: 'Video backdrop' })}
+                                            sx={{
+                                                width: 40,
+                                                height: 34,
+                                                p: 0.25,
+                                                border: 1,
+                                                borderColor: 'divider',
+                                                borderRadius: 1,
+                                                bgcolor: 'transparent',
+                                                cursor: 'pointer',
+                                            }}
+                                        />
+                                        <Typography variant="caption" sx={{ color: 'text.secondary', mt: 0.25, lineHeight: 1.2 }}>
+                                            {t('playground.slice.videoBackground', { defaultValue: 'Video backdrop' })}
+                                        </Typography>
+                                    </Stack>
+                                )}
                             </Stack>
                         </Box>
 
@@ -1030,6 +1182,30 @@ const ImageSliceDialog: React.FC<ImageSliceDialogProps> = ({
                 >
                     {t('playground.slice.downloadGif', { defaultValue: 'Download GIF' })}
                 </Button>
+                <Tooltip
+                    title={videoTarget === null
+                        ? t('playground.slice.videoUnsupported', {
+                            defaultValue: 'This browser cannot encode video. Chrome, Edge, Safari 16.4+ and Firefox 130+ can.',
+                        })
+                        : videoTarget?.container === 'webm'
+                            ? t('playground.slice.videoWebmOnly', {
+                                defaultValue: 'This browser has no H.264 encoder, so the file will be a WebM — playable in browsers, but some chat apps refuse it.',
+                            })
+                            : ''}
+                >
+                    <span>
+                        <Button
+                            variant="outlined"
+                            startIcon={<Movie />}
+                            disabled={!image || working || selectedRects.length < 2 || !videoTarget}
+                            onClick={() => void handleDownloadVideo()}
+                        >
+                            {videoTarget?.container === 'webm'
+                                ? t('playground.slice.downloadWebm', { defaultValue: 'Download WebM' })
+                                : t('playground.slice.downloadMp4', { defaultValue: 'Download MP4' })}
+                        </Button>
+                    </span>
+                </Tooltip>
                 <Button
                     variant="contained"
                     startIcon={working ? <CircularProgress size={16} color="inherit" /> : <Download />}

--- a/frontend/src/utils/imageSlice.test.ts
+++ b/frontend/src/utils/imageSlice.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { computeTileRects, FULL_CROP, normalizeCrop, tileFileName } from './imageSlice';
+import {
+    clampFrameDelay,
+    computeTileRects,
+    DEFAULT_FRAME_DELAY,
+    FRAME_DELAY_MAX,
+    FRAME_DELAY_MIN,
+    FULL_CROP,
+    imageHasAlpha,
+    normalizeCrop,
+    tileFileName,
+} from './imageSlice';
 
 describe('computeTileRects', () => {
     it('divides an image into rows x cols tiles covering the whole frame', () => {
@@ -74,5 +84,22 @@ describe('tileFileName', () => {
         expect(tileFileName('cat', 0, 9)).toBe('cat-1.png');
         expect(tileFileName('cat', 9, 16)).toBe('cat-10.png');
         expect(tileFileName('cat', 0, 16)).toBe('cat-01.png');
+    });
+});
+
+describe('clampFrameDelay', () => {
+    it('snaps to the 10 ms a GIF can store and stays inside the range', () => {
+        expect(clampFrameDelay(123)).toBe(120);
+        expect(clampFrameDelay(125)).toBe(130);
+        expect(clampFrameDelay(1)).toBe(FRAME_DELAY_MIN);
+        expect(clampFrameDelay(99999)).toBe(FRAME_DELAY_MAX);
+        expect(clampFrameDelay(Number.NaN)).toBe(DEFAULT_FRAME_DELAY);
+    });
+});
+
+describe('imageHasAlpha', () => {
+    it('spots a single see-through pixel', () => {
+        expect(imageHasAlpha(new Uint8ClampedArray([1, 2, 3, 255, 4, 5, 6, 255]))).toBe(false);
+        expect(imageHasAlpha(new Uint8ClampedArray([1, 2, 3, 255, 4, 5, 6, 254]))).toBe(true);
     });
 });

--- a/frontend/src/utils/imageSlice.ts
+++ b/frontend/src/utils/imageSlice.ts
@@ -249,14 +249,27 @@ export const renderAnimationFrames = (
     return { width: box.width, height: box.height, frames };
 };
 
-/** Reads the whole sheet's pixels, to decide what its background is. */
-export const analyzeSheetBackground = (image: HTMLImageElement): BackgroundAnalysis => {
+export interface SheetAnalysis extends BackgroundAnalysis {
+    /** Whether any pixel is see-through — a video export then needs a backdrop. */
+    hasAlpha: boolean;
+}
+
+/** Reads the whole sheet's pixels once, for its background and its alpha. */
+export const analyzeSheetBackground = (image: HTMLImageElement): SheetAnalysis => {
     const canvas = document.createElement('canvas');
     canvas.width = image.naturalWidth;
     canvas.height = image.naturalHeight;
     const context = context2d(canvas);
     context.drawImage(image, 0, 0);
-    return analyzeBackground(context.getImageData(0, 0, canvas.width, canvas.height));
+    const pixels = context.getImageData(0, 0, canvas.width, canvas.height);
+    return { ...analyzeBackground(pixels), hasAlpha: imageHasAlpha(pixels.data) };
+};
+
+export const imageHasAlpha = (data: Uint8ClampedArray): boolean => {
+    for (let i = 3; i < data.length; i += 4) {
+        if (data[i] < 255) return true;
+    }
+    return false;
 };
 
 export const tileFileName = (stem: string, index: number, total: number): string => {
@@ -264,6 +277,16 @@ export const tileFileName = (stem: string, index: number, total: number): string
     return `${stem}-${String(index + 1).padStart(width, '0')}.png`;
 };
 
-/** Frame durations offered by the animation controls, in milliseconds. */
-export const FRAME_DELAYS = [80, 120, 200, 320, 500, 800];
+// Frame duration is typed or stepped in milliseconds rather than picked from
+// a list. GIF stores it in hundredths of a second, so it snaps to 10 ms; the
+// floor is what browsers still honour (they clamp anything faster), and the
+// ceiling is long enough for a slideshow.
+export const FRAME_DELAY_MIN = 20;
+export const FRAME_DELAY_MAX = 5000;
+export const FRAME_DELAY_STEP = 10;
 export const DEFAULT_FRAME_DELAY = 200;
+export const clampFrameDelay = (value: number): number => {
+    if (!Number.isFinite(value)) return DEFAULT_FRAME_DELAY;
+    const snapped = Math.round(value / FRAME_DELAY_STEP) * FRAME_DELAY_STEP;
+    return Math.min(FRAME_DELAY_MAX, Math.max(FRAME_DELAY_MIN, snapped));
+};

--- a/frontend/src/utils/video.test.ts
+++ b/frontend/src/utils/video.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { evenSize, MAX_VIDEO_LOOPS, MIN_VIDEO_MS, planVideoLoops, videoFileName } from './video';
+
+describe('planVideoLoops', () => {
+    it('repeats a short sequence until it clears the minimum length', () => {
+        // 9 frames × 200 ms = 1.8 s → two loops reach 3.6 s
+        expect(planVideoLoops(9, 200)).toBe(2);
+        expect(planVideoLoops(9, 200) * 9 * 200).toBeGreaterThanOrEqual(MIN_VIDEO_MS);
+    });
+
+    it('plays a sequence that is already long enough exactly once', () => {
+        expect(planVideoLoops(16, 500)).toBe(1);
+    });
+
+    it('never asks for zero loops, and caps the count', () => {
+        expect(planVideoLoops(0, 200)).toBe(1);
+        expect(planVideoLoops(2, 1)).toBe(MAX_VIDEO_LOOPS);
+    });
+});
+
+describe('evenSize', () => {
+    it('pads odd dimensions up by one pixel, leaving even ones alone', () => {
+        expect(evenSize({ width: 341, height: 341 })).toEqual({ width: 342, height: 342 });
+        expect(evenSize({ width: 512, height: 341 })).toEqual({ width: 512, height: 342 });
+        expect(evenSize({ width: 512, height: 512 })).toEqual({ width: 512, height: 512 });
+    });
+});
+
+describe('videoFileName', () => {
+    it('takes the extension from the container the browser could produce', () => {
+        expect(videoFileName('cat', 9, { container: 'mp4', codec: 'avc', extension: 'mp4' })).toBe('cat-9.mp4');
+        expect(videoFileName('cat', 9, { container: 'webm', codec: 'vp9', extension: 'webm' })).toBe('cat-9.webm');
+    });
+});

--- a/frontend/src/utils/video.ts
+++ b/frontend/src/utils/video.ts
@@ -1,0 +1,148 @@
+// The sliced tiles, handed over as a video instead of a GIF.
+//
+// A GIF is what the browser can build alone, but it is also what chat apps
+// and social platforms re-compress, cap by size, or refuse outright. An H.264
+// MP4 is the one format all of them forward as-is. Encoding it is delegated to
+// the browser's own WebCodecs encoder, and boxing it into MP4 (or WebM, when
+// no H.264 encoder exists) to `mediabunny` — an MP4 muxer is not the small
+// half of any spec, so unlike `gif.ts` / `zip.ts` this is not hand-rolled.
+//
+// The `mediabunny` import stays dynamic: the library is only pulled into the
+// bundle the first time someone actually asks for a video.
+
+import type { GifFrame } from './gif';
+
+export interface VideoTarget {
+    container: 'mp4' | 'webm';
+    codec: 'avc' | 'vp9' | 'vp8';
+    extension: 'mp4' | 'webm';
+}
+
+export interface VideoOptions {
+    width: number;
+    height: number;
+    frames: GifFrame[];
+    /** Per-frame duration in milliseconds. */
+    delayMs: number;
+    /** How many times the sequence plays; `planVideoLoops` picks a default. */
+    loops: number;
+    /**
+     * Video has no alpha, so anything a matte left transparent lands on this
+     * colour. CSS colour string.
+     */
+    background: string;
+    target: VideoTarget;
+}
+
+// Sub-second clips get dropped or refused by the platforms people forward to,
+// and a sticker loop is often well under a second — so the sequence repeats
+// until the clip is at least this long.
+export const MIN_VIDEO_MS = 3000;
+export const MAX_VIDEO_LOOPS = 60;
+
+/** The smallest number of loops that gets one sequence past `MIN_VIDEO_MS`. */
+export const planVideoLoops = (frameCount: number, delayMs: number): number => {
+    const once = frameCount * delayMs;
+    if (once <= 0) return 1;
+    return Math.min(MAX_VIDEO_LOOPS, Math.max(1, Math.ceil(MIN_VIDEO_MS / once)));
+};
+
+/**
+ * 4:2:0 chroma subsampling needs even dimensions; an odd frame is padded by a
+ * pixel rather than cropped, so nothing the user selected is lost.
+ */
+export const evenSize = (size: { width: number; height: number }): { width: number; height: number } => ({
+    width: size.width + (size.width % 2),
+    height: size.height + (size.height % 2),
+});
+
+export const videoFileName = (stem: string, count: number, target: VideoTarget): string => (
+    `${stem}-${count}.${target.extension}`
+);
+
+/**
+ * Which container / codec this browser can produce, MP4 + H.264 first because
+ * it is the one that forwards everywhere. `null` when the browser has no
+ * WebCodecs at all — the button then says so instead of failing on click.
+ */
+export const probeVideoTarget = async (
+    size: { width: number; height: number },
+): Promise<VideoTarget | null> => {
+    if (typeof VideoEncoder === 'undefined') return null;
+    const { getFirstEncodableVideoCodec } = await import('mediabunny');
+    const even = evenSize(size);
+    if (await getFirstEncodableVideoCodec(['avc'], even)) {
+        return { container: 'mp4', codec: 'avc', extension: 'mp4' };
+    }
+    const fallback = await getFirstEncodableVideoCodec(['vp9', 'vp8'], even);
+    if (fallback === 'vp9' || fallback === 'vp8') {
+        return { container: 'webm', codec: fallback, extension: 'webm' };
+    }
+    return null;
+};
+
+const context2d = (canvas: HTMLCanvasElement): CanvasRenderingContext2D => {
+    const context = canvas.getContext('2d');
+    if (!context) throw new Error('canvas 2d context unavailable');
+    return context;
+};
+
+export const encodeVideo = async (options: VideoOptions): Promise<Blob> => {
+    const { frames, delayMs, loops, background, target } = options;
+    if (frames.length === 0) throw new Error('video needs at least one frame');
+    const {
+        BufferTarget, CanvasSource, Mp4OutputFormat, Output, QUALITY_HIGH, WebMOutputFormat,
+    } = await import('mediabunny');
+
+    const size = evenSize({ width: options.width, height: options.height });
+
+    // Frames are RGBA buffers; `putImageData` would carry their alpha straight
+    // through, so each one is composited over the background on a second
+    // canvas before the encoder sees it.
+    const frameCanvas = document.createElement('canvas');
+    frameCanvas.width = options.width;
+    frameCanvas.height = options.height;
+    const frameContext = context2d(frameCanvas);
+
+    const canvas = document.createElement('canvas');
+    canvas.width = size.width;
+    canvas.height = size.height;
+    const context = context2d(canvas);
+
+    const output = new Output({
+        // `in-memory` writes `moov` ahead of `mdat`, which is what lets a
+        // platform start playing (or accept) the file before it has all of it.
+        format: target.container === 'mp4'
+            ? new Mp4OutputFormat({ fastStart: 'in-memory' })
+            : new WebMOutputFormat(),
+        target: new BufferTarget(),
+    });
+    const source = new CanvasSource(canvas, {
+        codec: target.codec,
+        quality: QUALITY_HIGH,
+        // Every frame a key frame would bloat the file; one per loop keeps
+        // seeking snappy without that.
+        keyFrameInterval: Math.max(1, (frames.length * delayMs) / 1000),
+    });
+    output.addVideoTrack(source, { frameRate: 1000 / delayMs });
+    await output.start();
+
+    const delaySeconds = delayMs / 1000;
+    let index = 0;
+    for (let loop = 0; loop < loops; loop += 1) {
+        for (const frame of frames) {
+            const imageData = new ImageData(new Uint8ClampedArray(frame.data), options.width, options.height);
+            frameContext.putImageData(imageData, 0, 0);
+            context.fillStyle = background;
+            context.fillRect(0, 0, size.width, size.height);
+            context.drawImage(frameCanvas, 0, 0);
+            await source.add(index * delaySeconds, delaySeconds);
+            index += 1;
+        }
+    }
+    await output.finalize();
+
+    const buffer = (output.target as InstanceType<typeof BufferTarget>).buffer;
+    if (!buffer) throw new Error('encoder produced no output');
+    return new Blob([buffer], { type: target.container === 'mp4' ? 'video/mp4' : 'video/webm' });
+};


### PR DESCRIPTION
## Summary
A GIF is what the browser can build alone, but chat apps and social platforms re-compress, cap, or refuse it; the slicer's animation now also leaves as an H.264 MP4, the format they all forward untouched. Frame duration becomes a typed value instead of a six-entry list.

## Key Changes

- **Video export**: `Download MP4` next to `Download GIF`, same tiles, same order, same crop / exclusions / matte; WebCodecs encodes, `mediabunny` muxes (lazy-loaded).
- **Browser capability up front**: probed once per open — the button reads MP4 or WebM, or is disabled with a tooltip naming browsers that can.
- **Forwardable by construction**: `moov` first, even dimensions for 4:2:0, sequence looped to ≥3 s with the loop count editable and the resulting length shown.
- **Backdrop only when needed**: MP4 has no alpha, so a colour picker appears only when frames are see-through (after a matte, or a PNG with alpha).
- **Custom frame duration**: typable stepper, 20–5000 ms snapped to the 10 ms a GIF can store; rows, columns, delay and loops share one `NumberStepper`.

## Notes

- Verified end to end in headless Chromium (mock playground → slice → matte → download → decode: 4.32 s, 342×342, three loops, white backdrop). That build has no H.264 encoder, so only the WebM branch ran; please try `Download MP4` once in real Chrome / Edge / Safari and forward the file in WeChat.
- `.design/image-slice.md` §4.2 / §4.3 record the trade-offs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JboghrkCZzs3KLG932Bsec)_