### PR TITLE
security: stop leaking upstream provider name in /v1/models responses

### DIFF
--- a/internal/protocolserver/anthropic_model.go
+++ b/internal/protocolserver/anthropic_model.go
@@ -1,7 +1,6 @@
 package protocolserver
 
 import (
-	"fmt"
 	"net/http"
 	"sort"
 
@@ -119,29 +118,23 @@ func (ph *ProtocolHandler) anthropicListModelsWithScenario(c *gin.Context, scena
 			continue
 		}
 
-		// Build display name with provider info
+		// Display name is the request model name only — the backing
+		// provider is intentionally not disclosed here, since /v1/models is
+		// consumed by external clients and must not leak upstream vendor
+		// identity.
 		displayName := rule.RequestModel
 		services := rule.GetServices()
 
-		// Track provider for template lookup
+		// Track provider for template lookup only (not exposed in the response).
 		var primaryProvider *typ.Provider
 
-		if len(services) > 0 {
-			providerNames := make([]string, 0, len(services))
-			for i := range services {
-				svc := services[i]
-				if svc.Active {
-					provider, err := cfg.GetProviderByUUID(svc.Provider)
-					if err == nil {
-						if primaryProvider == nil {
-							primaryProvider = provider
-						}
-						providerNames = append(providerNames, provider.Name)
-					}
+		for i := range services {
+			svc := services[i]
+			if svc.Active && primaryProvider == nil {
+				provider, err := cfg.GetProviderByUUID(svc.Provider)
+				if err == nil {
+					primaryProvider = provider
 				}
-			}
-			if len(providerNames) > 0 {
-				displayName += fmt.Sprintf(" (via %v)", providerNames)
 			}
 		}
 

--- a/internal/protocolserver/openai_model.go
+++ b/internal/protocolserver/openai_model.go
@@ -71,9 +71,11 @@ func (ph *ProtocolHandler) openAIListModelsWithScenario(c *gin.Context, scenario
 		// Get timestamp from provider's LastUpdated field
 		var created int64
 		services := rule.GetServices()
-		providerDesc := make([]string, 0, len(services))
 
-		// Track provider for template lookup
+		// Track provider for template lookup only — the backing provider's
+		// identity is intentionally not disclosed in the response, since
+		// /v1/models is consumed by external clients and must not leak
+		// upstream vendor identity.
 		var primaryProvider *typ.Provider
 
 		for i := range services {
@@ -89,24 +91,19 @@ func (ph *ProtocolHandler) openAIListModelsWithScenario(c *gin.Context, scenario
 					if primaryProvider == nil {
 						primaryProvider = provider
 					}
-					providerDesc = append(providerDesc, provider.Name)
 					// Parse LastUpdated timestamp if available
 					if provider.LastUpdated != "" {
 						if t, err := time.Parse(time.RFC3339, provider.LastUpdated); err == nil {
 							created = t.Unix()
 						}
 					}
-				} else {
-					providerDesc = append(providerDesc, svc.Provider)
 				}
 			}
 		}
 
-		// Build owned_by field
+		// owned_by is always "tingly-box" — never disclose the upstream
+		// provider name here.
 		ownedBy := "tingly-box"
-		if len(providerDesc) > 0 {
-			ownedBy += " via " + fmt.Sprintf("%v", providerDesc)
-		}
 
 		// Get model description from template if available
 		var description string


### PR DESCRIPTION
## Summary
`/v1/models` (both OpenAI and Anthropic formats) exposed the backing provider's name to any client calling the endpoint, leaking which upstream vendor/account serves a given model.

## Key Changes

- **Model list privacy**: `owned_by` (OpenAI format) and `display_name` (Anthropic format) no longer append `via [ProviderName]`; provider lookup is still used internally to resolve template metadata (description/context/capabilities) but is never surfaced in the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123CQC6AAhMycryKre28z4Y