### PR TITLE
security: stop sharing-key callers from reading/pinning internal routing

### DIFF
--- a/internal/protocolserver/routes.go
+++ b/internal/protocolserver/routes.go
@@ -4,8 +4,46 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tingly-dev/tingly-box/internal/constant"
 	"github.com/tingly-dev/tingly-box/internal/middleware"
 )
+
+// debugRoutingHeaders are TB-internal diagnostic headers understood by the
+// dispatch/routing layer (see .design/probe.md): X-Tingly-Debug-Routing asks
+// for the resolved provider/upstream URL to be echoed back in response
+// headers, and X-Tingly-Probe-Service/-Rule let the caller pin routing to an
+// arbitrary provider+model, bypassing owner-configured load balancing. Both
+// are meant only for TB's own loopback probes, which authenticate with the
+// global model token — never for a sharing-key caller.
+var debugRoutingHeaders = []string{
+	"X-Tingly-Debug-Routing",
+	"X-Tingly-Probe-Service",
+	"X-Tingly-Probe-Rule",
+}
+
+// debugHeaderGuard strips the debug/probe routing headers above from any
+// request that did not authenticate with the global model token, so a
+// sharing-key holder can neither read back routing/provider internals nor
+// pin service selection. Must run after modelAuth, which sets
+// constant.CtxKeyAuthKind.
+func (ph *ProtocolHandler) debugHeaderGuard(c *gin.Context) {
+	if c.GetString(constant.CtxKeyAuthKind) != constant.AuthKindGlobalModelToken {
+		for _, h := range debugRoutingHeaders {
+			c.Request.Header.Del(h)
+		}
+	}
+	c.Next()
+}
+
+// modelAuthChain builds the standard per-route handler prefix: modelAuth
+// itself, then debugHeaderGuard (which depends on modelAuth having already
+// set the auth-kind context key), then any route-specific middleware.
+func (ph *ProtocolHandler) modelAuthChain(modelAuth gin.HandlerFunc, extra ...gin.HandlerFunc) []gin.HandlerFunc {
+	chain := make([]gin.HandlerFunc, 0, 2+len(extra))
+	chain = append(chain, modelAuth, ph.debugHeaderGuard)
+	chain = append(chain, extra...)
+	return chain
+}
 
 // RegisterRoutes mounts the LLM gateway surface (/tingly/:scenario[/v1]/...)
 // onto engine. modelAuth gates every model endpoint (model API-token trust
@@ -50,54 +88,54 @@ func (ph *ProtocolHandler) RegisterRoutes(engine *gin.Engine, modelAuth gin.Hand
 // Anthropic surfaces on one group), each gated by modelAuth.
 func (ph *ProtocolHandler) SetupMixinEndpoints(group *gin.RouterGroup, modelAuth gin.HandlerFunc) {
 	// Chat completions endpoint (OpenAI compatible)
-	group.POST("/chat/completions", modelAuth, ph.teamScopeMiddleware, ph.HandleOpenAIChatCompletions)
+	group.POST("/chat/completions", ph.modelAuthChain(modelAuth, ph.teamScopeMiddleware, ph.HandleOpenAIChatCompletions)...)
 
 	// Responses API endpoints (OpenAI compatible)
-	group.POST("/responses", modelAuth, ph.teamScopeMiddleware, ph.HandleResponsesCreate)
-	group.GET("/responses/:id", modelAuth, ph.teamScopeMiddleware, ph.HandleResponsesGet)
+	group.POST("/responses", ph.modelAuthChain(modelAuth, ph.teamScopeMiddleware, ph.HandleResponsesCreate)...)
+	group.GET("/responses/:id", ph.modelAuthChain(modelAuth, ph.teamScopeMiddleware, ph.HandleResponsesGet)...)
 
 	// Chat completions endpoint (Anthropic compatible)
-	group.POST("/messages", modelAuth, ph.teamScopeMiddleware, ph.HandleAnthropicMessages)
+	group.POST("/messages", ph.modelAuthChain(modelAuth, ph.teamScopeMiddleware, ph.HandleAnthropicMessages)...)
 	// Count tokens endpoint (Anthropic compatible)
-	group.POST("/messages/count_tokens", modelAuth, ph.teamScopeMiddleware, ph.AnthropicCountTokens)
+	group.POST("/messages/count_tokens", ph.modelAuthChain(modelAuth, ph.teamScopeMiddleware, ph.AnthropicCountTokens)...)
 
 	// Embeddings endpoint (OpenAI compatible)
-	group.POST("/embeddings", modelAuth, ph.teamScopeMiddleware, DeclareOperation("embeddings"), ph.HandleOpenAIEmbeddings)
+	group.POST("/embeddings", ph.modelAuthChain(modelAuth, ph.teamScopeMiddleware, DeclareOperation("embeddings"), ph.HandleOpenAIEmbeddings)...)
 
 	// Image generation endpoint (OpenAI compatible).
 	// Routed directly to upstream POST /v1/images/generations; the Responses API
 	// (POST /responses with the image_generation tool) is exposed in parallel via
 	// the same scenario, with the caller choosing which surface to use.
-	group.POST("/images/generations", modelAuth, ph.teamScopeMiddleware, DeclareOperation("image_generation"), ph.HandleOpenAIImageGeneration)
+	group.POST("/images/generations", ph.modelAuthChain(modelAuth, ph.teamScopeMiddleware, DeclareOperation("image_generation"), ph.HandleOpenAIImageGeneration)...)
 
 	// Image edit endpoint (OpenAI compatible). Accepts the standard multipart
 	// wire format plus a JSON mirror with inline base64/data-URL images; the
 	// client layer adapts per vendor (Codex uses its native JSON edits
 	// endpoint, everyone else gets the SDK's multipart /images/edits).
-	group.POST("/images/edits", modelAuth, ph.teamScopeMiddleware, DeclareOperation("image_edit"), ph.HandleOpenAIImageEdit)
+	group.POST("/images/edits", ph.modelAuthChain(modelAuth, ph.teamScopeMiddleware, DeclareOperation("image_edit"), ph.HandleOpenAIImageEdit)...)
 
 	// Models endpoint (routed by scenario: openai -> OpenAIListModels, anthropic/claude_code -> AnthropicListModels)
-	group.GET("/models", modelAuth, ph.teamScopeMiddleware, ph.ListModelsByScenario)
+	group.GET("/models", ph.modelAuthChain(modelAuth, ph.teamScopeMiddleware, ph.ListModelsByScenario)...)
 }
 
 // SetupOpenAIEndpoints registers the OpenAI-only endpoint set on group.
 func (ph *ProtocolHandler) SetupOpenAIEndpoints(group *gin.RouterGroup, modelAuth gin.HandlerFunc) {
 	// Chat completions endpoint (OpenAI compatible)
-	group.POST("/chat/completions", modelAuth, ph.HandleOpenAIChatCompletions)
+	group.POST("/chat/completions", ph.modelAuthChain(modelAuth, ph.HandleOpenAIChatCompletions)...)
 	// Models endpoint (OpenAI compatible)
-	group.GET("/models", modelAuth, ph.HandleOpenAIListModels)
+	group.GET("/models", ph.modelAuthChain(modelAuth, ph.HandleOpenAIListModels)...)
 
 	// Responses API endpoints (OpenAI compatible)
-	group.POST("/responses", modelAuth, ph.HandleResponsesCreate)
-	group.GET("/responses/:id", modelAuth, ph.HandleResponsesGet)
+	group.POST("/responses", ph.modelAuthChain(modelAuth, ph.HandleResponsesCreate)...)
+	group.GET("/responses/:id", ph.modelAuthChain(modelAuth, ph.HandleResponsesGet)...)
 }
 
 // SetupAnthropicEndpoints registers the Anthropic-only endpoint set on group.
 func (ph *ProtocolHandler) SetupAnthropicEndpoints(group *gin.RouterGroup, modelAuth gin.HandlerFunc) {
 	// Chat completions endpoint (Anthropic compatible)
-	group.POST("/messages", modelAuth, ph.HandleAnthropicMessages)
+	group.POST("/messages", ph.modelAuthChain(modelAuth, ph.HandleAnthropicMessages)...)
 	// Count tokens endpoint (Anthropic compatible)
-	group.POST("/messages/count_tokens", modelAuth, ph.AnthropicCountTokens)
+	group.POST("/messages/count_tokens", ph.modelAuthChain(modelAuth, ph.AnthropicCountTokens)...)
 	// Models endpoint (Anthropic compatible)
-	group.GET("/models", modelAuth, ph.HandleAnthropicListModels)
+	group.GET("/models", ph.modelAuthChain(modelAuth, ph.HandleAnthropicListModels)...)
 }


### PR DESCRIPTION
## Summary
`X-Tingly-Debug-Routing` and `X-Tingly-Probe-Service`/`-Rule` are internal diagnostic headers meant only for TB's own loopback probes, but the dispatch/routing layer honored them from any request that passed `modelAuth` — including sharing-key holders, not just the gateway owner.

## Key Changes

- **Debug/probe header authorization**: a sharing-key caller could read back the real provider name/UUID and upstream URL via response headers, and even pin routing to an arbitrary provider+model, bypassing owner-configured load balancing entirely. Added `debugHeaderGuard`, run right after `modelAuth` on every model-serving route, which strips these headers unless the caller authenticated with the global model token (the same identity TB's own probes use).

---
_Generated by [Claude Code](https://claude.ai/code/session_0123CQC6AAhMycryKre28z4Y)_