### PR TITLE
ci: dispatch npm publish from the tag release pipeline

### DIFF
--- a/.design/npm.md
+++ b/.design/npm.md
@@ -6,7 +6,10 @@ again.
 ## Architecture today
 
 Packages under `build/npx/`, published by `.github/workflows/npm.yml` on
-each GitHub release:
+each GitHub release (dispatched by the `trigger-npm-publish` job at the end of
+`release.yml`, since a release created with `GITHUB_TOKEN` does not fire the
+`release: published` event; the run then waits for the `production`
+environment approval):
 
 - **`tingly-box`** — thin shim (`bin.js` + `package.json`, ~1.4 MB published
   after esbuild bundling). It declares one `optionalDependency` per platform

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -8,6 +8,15 @@ run-name: >-
   docker=${{ github.event.inputs.build_docker || 'true' }}]
   by @${{ github.actor }}
 
+# Triggers:
+#   - release: published — fires only for releases created by a person or an
+#     app token. Releases cut by release.yml use GITHUB_TOKEN, and GitHub does
+#     not start workflow runs for events created with that token, so a tag
+#     push reaches this workflow via the `trigger-npm-publish` job in
+#     release.yml, which dispatches it with the inputs below (npm_tag inferred
+#     from the version). Either way the run parks at the `production`
+#     environment approval before anything is published.
+#   - workflow_dispatch — manual (re-)publish against any existing release.
 on:
   release:
     types: [published]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -530,3 +530,68 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # GitHub never starts workflow runs for events that a workflow creates with
+  # its own GITHUB_TOKEN, so the release published above does not fire the
+  # `release: published` trigger in npm.yml. Dispatch it explicitly instead.
+  # Nothing gets published by this: the npm run stops at the `production`
+  # environment approval gate before the first `npm publish`. This only
+  # removes the manual "Run workflow" step, not the human approval.
+  trigger-npm-publish:
+    needs: [setup, github-release]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') && needs.github-release.result == 'success'
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch NPX publish workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.setup.outputs.release_tag }}
+        run: |
+          # Same inference npm.yml applies on a release event: stable → latest,
+          # pre-release (v1.2.3-rc1) → rc.
+          VERSION="${RELEASE_TAG#v}"
+          if [[ "$VERSION" == *-* ]]; then
+            NPM_TAG=rc
+          else
+            NPM_TAG=latest
+          fi
+
+          echo "Dispatching npm.yml for $RELEASE_TAG (npm dist-tag: $NPM_TAG)"
+          gh workflow run npm.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$RELEASE_TAG" \
+            -f tag="$RELEASE_TAG" \
+            -f npm_tag="$NPM_TAG" \
+            -f publish_cli=true \
+            -f publish_gui=false \
+            -f build_docker=true
+
+          # Best effort: link the dispatched run so approvers can find it from here.
+          RUN_URL=""
+          for _ in 1 2 3 4 5 6; do
+            sleep 5
+            RUN_URL="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow npm.yml \
+              --event workflow_dispatch --branch "$RELEASE_TAG" --limit 1 \
+              --json url -q '.[0].url' 2>/dev/null || true)"
+            [ -n "$RUN_URL" ] && break
+          done
+
+          {
+            echo "## 📦 NPX publish dispatched"
+            echo ""
+            echo "| Item | Value |"
+            echo "| --- | --- |"
+            echo "| Release | \`$RELEASE_TAG\` |"
+            echo "| npm dist-tag | \`$NPM_TAG\` |"
+            echo "| Publish | cli=true, gui=false, docker=true |"
+            if [ -n "$RUN_URL" ]; then
+              echo "| Run | $RUN_URL |"
+            else
+              echo "| Run | see the [NPX Package Publish workflow](https://github.com/$GITHUB_REPOSITORY/actions/workflows/npm.yml) |"
+            fi
+            echo ""
+            echo "The run waits for approval of the \`production\` environment before publishing."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -167,11 +167,23 @@ If a release introduces issues:
 
 After a GitHub Release is created, publish NPX packages to npm for easy installation.
 
-### Workflow: gh-npx-publish.yml
+### Workflow: npm.yml
 
-This is a manual workflow that publishes npm packages based on an existing GitHub Release.
+Publishes npm packages based on an existing GitHub Release.
 
-### Steps to Publish NPX Packages
+For a tag push (`v*`), you do not start it by hand: the last job of
+`release.yml` (`trigger-npm-publish`) dispatches it as soon as the GitHub
+Release is created, with `publish_cli=true`, `publish_gui=false`,
+`build_docker=true` and the npm dist-tag inferred from the version
+(`v1.2.3` → `latest`, `v1.2.3-rc1` → `rc`). The run then waits at the
+`production` environment approval gate — approving it is the only manual step
+left. (The explicit dispatch is needed because releases created with the
+workflow's `GITHUB_TOKEN` do not fire the `release: published` trigger.)
+
+Run it manually only to re-publish, to publish the GUI package, or to override
+the defaults:
+
+### Steps to Publish NPX Packages Manually
 
 1. **Navigate to Actions tab** in GitHub
 2. **Select "NPX Package Publish from GitHub Release"** workflow
@@ -180,13 +192,15 @@ This is a manual workflow that publishes npm packages based on an existing GitHu
 
    | Input | Description | Example |
    |-------|-------------|---------|
-   | `release_tag` | GitHub Release tag to download assets from | `v0.20260403.2230-hotfix` |
-   | `npx_version` | NPX package version (defaults to tag without `v`) | `0.20260403.2230-hotfix` |
+   | `tag` | GitHub Release tag to download assets from | `v0.20260403.2230-hotfix` |
+   | `npm_tag` | npm dist-tag (`latest` / `rc`) | `rc` |
    | `publish_cli` | Publish the CLI package (`tingly-box`) and its platform packages | `true` |
    | `publish_gui` | Publish GUI package (`tingly-box-gui`) | `false` |
+   | `build_docker` | Build and push the Docker NPX image after the CLI publish | `true` |
 
-5. **Important**: The `release_tag` must match an existing GitHub Release tag
-6. **The `npx_version`** should match the `release_tag` (without the `v` prefix) for consistency
+5. **Important**: The `tag` must match an existing GitHub Release tag; the npm
+   version is always the tag without the `v` prefix
+6. **Approve** the `production` deployment when the run pauses on it
 
 ### Published Packages
 


### PR DESCRIPTION
## Summary
Releases cut by `release.yml` with `GITHUB_TOKEN` never fire npm.yml's `release: published` trigger, so every release needed a manual "Run workflow" before the approval gate.

## Key Changes

- **Release → npm hand-off**: `release.yml` gains a final `trigger-npm-publish` job (tag pushes only) that dispatches `npm.yml` with cli=true, gui=false, docker=true and the dist-tag inferred from the version.
- **Approval kept**: the dispatched run still parks at the `production` environment gate, so nothing publishes without a human.
- **Docs**: trigger chain documented in `npm.yml`, `.design/npm.md`, `docs/MAINTENANCE.md`; stale manual-input names fixed.

## Notes
- `verify-build.yml` has the same `release: published` gap and is not addressed here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SmAkJBCmnrZza69BwApVqi)_