### PR TITLE
agentboot: parse tool results, isolate child sessions, capture stderr

### DIFF
--- a/agentboot/claude/accumulator.go
+++ b/agentboot/claude/accumulator.go
@@ -3,7 +3,9 @@ package claude
 import (
 	"encoding/json"
 	"maps"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/tingly-dev/tingly-box/agentboot/protocol"
 )
@@ -67,9 +69,12 @@ func (a *MessageAccumulator) AddEvent(event protocol.Event) ([]Message, bool, bo
 		}
 
 	case SDKUserMessage:
-		if msg := a.parseUserMessage(event); msg != nil {
+		for _, msg := range a.parseUserMessages(event) {
 			a.messages = append(a.messages, msg)
 			newMessages = append(newMessages, msg)
+			if tr, ok := msg.(*ToolResultMessage); ok {
+				a.completePendingToolUse(tr)
+			}
 		}
 
 	case SDKToolUseMessage:
@@ -237,16 +242,86 @@ func (a *MessageAccumulator) parseAssistantMessage(event protocol.Event) *Assist
 	return &msg
 }
 
-// parseUserMessage parses a user message from an event
-func (a *MessageAccumulator) parseUserMessage(event protocol.Event) *UserMessage {
-	var msg UserMessage
-	if err := unmarshalEvent(event, &msg); err != nil {
+// parseUserMessages parses a user event. The CLI emits two shapes: the
+// plain {"message": "<text>"} and the SDK {"message": {"role": "user",
+// "content": ...}} whose content blocks carry the tool_result answers to
+// earlier tool_use calls. Tool results are returned as ToolResultMessages so
+// consumers see them exactly as they would a standalone tool_result event.
+func (a *MessageAccumulator) parseUserMessages(event protocol.Event) []Message {
+	var raw struct {
+		Type            string          `json:"type"`
+		Message         json.RawMessage `json:"message"`
+		ParentToolUseID *string         `json:"parent_tool_use_id,omitempty"`
+		SessionID       string          `json:"session_id,omitempty"`
+		Timestamp       time.Time       `json:"timestamp,omitempty"`
+	}
+	if err := unmarshalEvent(event, &raw); err != nil {
 		return nil
 	}
-	if msg.SessionID != "" && a.sessionID == "" {
-		a.sessionID = msg.SessionID
+	if raw.SessionID != "" && a.sessionID == "" {
+		a.sessionID = raw.SessionID
 	}
-	return &msg
+	base := &UserMessage{Type: raw.Type, ParentToolUseID: raw.ParentToolUseID, SessionID: raw.SessionID, Timestamp: raw.Timestamp}
+
+	var text string
+	if json.Unmarshal(raw.Message, &text) == nil {
+		base.Message = text
+		return []Message{base}
+	}
+	var obj struct {
+		Content json.RawMessage `json:"content"`
+	}
+	if json.Unmarshal(raw.Message, &obj) != nil || len(obj.Content) == 0 {
+		return []Message{base}
+	}
+	if json.Unmarshal(obj.Content, &text) == nil {
+		base.Message = text
+		return []Message{base}
+	}
+	var blocks []json.RawMessage
+	if json.Unmarshal(obj.Content, &blocks) != nil {
+		return []Message{base}
+	}
+	var results []Message
+	var texts []string
+	for _, b := range blocks {
+		var probe struct {
+			Type      string          `json:"type"`
+			Text      string          `json:"text"`
+			ToolUseID string          `json:"tool_use_id"`
+			IsError   bool            `json:"is_error"`
+			Content   json.RawMessage `json:"content"`
+		}
+		if json.Unmarshal(b, &probe) != nil {
+			continue
+		}
+		switch probe.Type {
+		case ContentBlockTypeText:
+			texts = append(texts, probe.Text)
+		case ContentBlockTypeToolResult:
+			tr := &ToolResultMessage{Type: SDKToolResultMessage, ToolUseID: probe.ToolUseID, IsError: probe.IsError,
+				SessionID: raw.SessionID, Timestamp: raw.Timestamp}
+			var out string
+			if json.Unmarshal(probe.Content, &out) == nil {
+				tr.Output = out
+			} else {
+				var parts []json.RawMessage
+				if json.Unmarshal(probe.Content, &parts) == nil {
+					for _, part := range parts {
+						if cb, err := UnmarshalContentBlock(part); err == nil {
+							tr.Content = append(tr.Content, cb)
+						}
+					}
+				}
+			}
+			results = append(results, tr)
+		}
+	}
+	if len(texts) == 0 {
+		return results
+	}
+	base.Message = strings.Join(texts, "\n")
+	return append([]Message{base}, results...)
 }
 
 // parseToolUseMessage parses a tool_use message from an event

--- a/agentboot/claude/accumulator_user_test.go
+++ b/agentboot/claude/accumulator_user_test.go
@@ -1,0 +1,43 @@
+package claude
+
+import (
+	"testing"
+
+	"github.com/tingly-dev/tingly-box/agentboot/protocol"
+)
+
+// The CLI's stream-json answers a tool_use with a `user` message whose
+// content is a tool_result block. That must surface as a ToolResultMessage.
+func TestAccumulator_UserMessageCarriesToolResults(t *testing.T) {
+	a := NewMessageAccumulator()
+	raw := `{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"probe-marker","is_error":false}]},"parent_tool_use_id":null,"session_id":"s1"}`
+	msgs, _, _ := a.AddEvent(protocol.Event{Type: SDKUserMessage, Raw: raw})
+	if len(msgs) != 1 {
+		t.Fatalf("want 1 message, got %d: %+v", len(msgs), msgs)
+	}
+	tr, ok := msgs[0].(*ToolResultMessage)
+	if !ok || tr.ToolUseID != "toolu_1" || tr.Output != "probe-marker" || tr.IsError {
+		t.Fatalf("unexpected message %#v", msgs[0])
+	}
+
+	// Structured content and an error flag.
+	raw = `{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_2","type":"tool_result","content":[{"type":"text","text":"boom"}],"is_error":true}]}}`
+	msgs, _, _ = a.AddEvent(protocol.Event{Type: SDKUserMessage, Raw: raw})
+	tr, ok = msgs[0].(*ToolResultMessage)
+	if !ok || !tr.IsError || len(tr.Content) != 1 {
+		t.Fatalf("unexpected message %#v", msgs[0])
+	}
+
+	// Plain text still comes through as a UserMessage, in both shapes.
+	for _, raw := range []string{
+		`{"type":"user","message":"hello"}`,
+		`{"type":"user","message":{"role":"user","content":"hello"}}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}`,
+	} {
+		msgs, _, _ = a.AddEvent(protocol.Event{Type: SDKUserMessage, Raw: raw})
+		um, ok := msgs[0].(*UserMessage)
+		if len(msgs) != 1 || !ok || um.Message != "hello" {
+			t.Fatalf("%s: unexpected %#v", raw, msgs)
+		}
+	}
+}

--- a/agentboot/claude/driver.go
+++ b/agentboot/claude/driver.go
@@ -170,6 +170,7 @@ func (d *Driver) Prepare(ctx context.Context, prompt string, opts agentboot.Exec
 		Env:          env,
 		WorkDir:      workDir,
 		InitialInput: initialInput,
+		Stderr:       opts.Stderr,
 	}, nil
 }
 

--- a/agentboot/claude/environment.go
+++ b/agentboot/claude/environment.go
@@ -16,7 +16,6 @@ const (
 	EnvNodePath    = "NODE_PATH"
 	EnvBunVersions = "BUN_VERSIONS"
 	EnvBunInstall  = "BUN_INSTALL"
-
 )
 
 // GetCleanEnv returns a clean environment for running Claude CLI.
@@ -54,6 +53,10 @@ func (d *CLIDiscovery) buildCleanEnv(ctx context.Context) ([]string, error) {
 		// Skip Bun-specific paths that might interfere
 		if strings.HasPrefix(e, EnvBunVersions+"=") ||
 			strings.HasPrefix(e, EnvBunInstall+"=") {
+			continue
+		}
+
+		if isInheritedSessionIdentity(e) {
 			continue
 		}
 
@@ -127,4 +130,59 @@ func MergeEnv(base []string, custom []string) []string {
 	}
 
 	return result
+}
+
+// inheritedSessionIdentityKeys are variables a running Claude Code session
+// exports to describe ITSELF: that it is a remote / host-managed session and
+// which identity it authenticates with. When the host running agentboot is
+// itself inside such a session (a `tb start` from a Claude Code terminal, a
+// Claude Code remote container), a child `claude` inheriting them adopts the
+// parent's provider and credentials and silently ignores the routing it was
+// launched with (ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN, --settings).
+//
+// Only identity is dropped. User configuration that legitimately lives in
+// the shell (CLAUDE_CONFIG_DIR, CLAUDE_CODE_MAX_OUTPUT_TOKENS, ...) passes
+// through unchanged.
+var inheritedSessionIdentityKeys = map[string]bool{
+	"CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST": true,
+	"CLAUDE_CODE_REMOTE":                   true,
+	"CLAUDE_SESSION_INGRESS_TOKEN_FILE":    true,
+	"SESSION_INGRESS_URL":                  true,
+	// The parent's own session: a child that inherits CLAUDE_CODE_SESSION_ID
+	// writes into the parent's transcript, and CLAUDECODE / the entrypoint
+	// make it behave as a nested session of the parent's kind.
+	"CLAUDE_CODE_SESSION_ID":                        true,
+	"CLAUDE_CODE_CHILD_SESSION":                     true,
+	"CLAUDE_CODE_ENTRYPOINT":                        true,
+	"CLAUDECODE":                                    true,
+	"CLAUDE_PID":                                    true,
+	"CLAUDE_CODE_ACCOUNT_UUID":                      true,
+	"CLAUDE_CODE_ORGANIZATION_UUID":                 true,
+	"CLAUDE_CODE_USER_EMAIL":                        true,
+	"CLAUDE_CODE_HOLD_UNANSWERED_PARKED_PERMISSION": true,
+}
+
+// Prefixes that only a running session exports about itself.
+var inheritedSessionIdentityPrefixes = []string{
+	"CLAUDE_CODE_REMOTE_",
+	"CLAUDE_CODE_MESSAGING_",
+	"CLAUDE_SESSION_INGRESS_",
+}
+
+// isInheritedSessionIdentity reports whether a KEY=VALUE entry names the
+// parent session's identity rather than user configuration.
+func isInheritedSessionIdentity(kv string) bool {
+	key := kv
+	if i := strings.IndexByte(kv, '='); i >= 0 {
+		key = kv[:i]
+	}
+	if inheritedSessionIdentityKeys[key] {
+		return true
+	}
+	for _, p := range inheritedSessionIdentityPrefixes {
+		if strings.HasPrefix(key, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/agentboot/claude/environment_identity_test.go
+++ b/agentboot/claude/environment_identity_test.go
@@ -1,0 +1,44 @@
+package claude
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestBuildCleanEnv_DropsInheritedSessionIdentity(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST", "1")
+	t.Setenv("CLAUDE_CODE_REMOTE", "1")
+	t.Setenv("CLAUDE_CODE_REMOTE_SESSION_ID", "abc")
+	t.Setenv("CLAUDE_SESSION_INGRESS_TOKEN_FILE", "/tmp/x")
+	t.Setenv("SESSION_INGRESS_URL", "https://x")
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "parent-session")
+	t.Setenv("CLAUDE_CODE_ENTRYPOINT", "remote_mobile")
+	t.Setenv("CLAUDECODE", "1")
+	t.Setenv("CLAUDE_CODE_MESSAGING_TOKEN", "tok")
+	// User configuration must survive.
+	t.Setenv("CLAUDE_CODE_MAX_OUTPUT_TOKENS", "32000")
+	t.Setenv("CLAUDE_CONFIG_DIR", "/tmp/cfg")
+	t.Setenv("ANTHROPIC_BASE_URL", "http://gateway")
+
+	d := NewCLIDiscovery()
+	env, err := d.buildCleanEnv(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := "\n" + strings.Join(env, "\n") + "\n"
+	for _, dropped := range []string{
+		"CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=", "CLAUDE_CODE_REMOTE=", "CLAUDE_CODE_REMOTE_SESSION_ID=",
+		"CLAUDE_SESSION_INGRESS_TOKEN_FILE=", "SESSION_INGRESS_URL=",
+		"CLAUDE_CODE_SESSION_ID=", "CLAUDE_CODE_ENTRYPOINT=", "CLAUDECODE=", "CLAUDE_CODE_MESSAGING_TOKEN=",
+	} {
+		if strings.Contains(joined, "\n"+dropped) {
+			t.Errorf("%s should have been dropped", dropped)
+		}
+	}
+	for _, kept := range []string{"CLAUDE_CODE_MAX_OUTPUT_TOKENS=32000", "CLAUDE_CONFIG_DIR=/tmp/cfg", "ANTHROPIC_BASE_URL=http://gateway"} {
+		if !strings.Contains(joined, "\n"+kept+"\n") {
+			t.Errorf("%s should have been kept", kept)
+		}
+	}
+}

--- a/agentboot/options.go
+++ b/agentboot/options.go
@@ -1,6 +1,7 @@
 package agentboot
 
 import (
+	"io"
 	"time"
 )
 
@@ -70,6 +71,10 @@ type ExecutionOptions struct {
 	// PermissionPromptTool specifies the tool for permission prompts (e.g., "stdio")
 	// When set to "stdio", permission requests are sent via stdin/stdout for callback handling
 	PermissionPromptTool string
+
+	// Stderr, if set, receives the agent process's stderr for this execution
+	// (see process.LaunchSpec.Stderr). nil keeps the factory default.
+	Stderr io.Writer
 
 	// Store, if set, receives session lifecycle events driven by the runner.
 	// When non-nil and SessionID is non-empty the runner calls:

--- a/agentboot/process/fake.go
+++ b/agentboot/process/fake.go
@@ -48,13 +48,13 @@ func (f *FakeFactory) Start(ctx context.Context, spec LaunchSpec) (Handle, error
 	stdoutR, stdoutW := io.Pipe()
 
 	h := &FakeHandle{
-		StdinR:    stdinR,
-		stdinW:    stdinW,
-		stdoutR:   stdoutR,
-		stdoutW:   stdoutW,
-		done:      make(chan struct{}),
-		exitErr:   nil,
-		spec:      spec,
+		StdinR:  stdinR,
+		stdinW:  stdinW,
+		stdoutR: stdoutR,
+		stdoutW: stdoutW,
+		done:    make(chan struct{}),
+		exitErr: nil,
+		spec:    spec,
 	}
 
 	f.mu.Lock()

--- a/agentboot/process/osexec.go
+++ b/agentboot/process/osexec.go
@@ -26,7 +26,10 @@ func (f *OSExecFactory) Start(ctx context.Context, spec LaunchSpec) (Handle, err
 		return nil, fmt.Errorf("empty launch command")
 	}
 	cmd := spec.BuildCmd(ctx)
-	cmd.Stderr = f.Stderr
+	cmd.Stderr = spec.Stderr
+	if cmd.Stderr == nil {
+		cmd.Stderr = f.Stderr
+	}
 	if cmd.Stderr == nil {
 		cmd.Stderr = os.Stderr
 	}

--- a/agentboot/process/osexec_stderr_test.go
+++ b/agentboot/process/osexec_stderr_test.go
@@ -1,0 +1,28 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestOSExecFactory_PerLaunchStderr(t *testing.T) {
+	f := NewOSExecFactory()
+	var buf bytes.Buffer
+	h, err := f.Start(context.Background(), LaunchSpec{
+		Command: []string{"sh", "-c", "echo boom >&2; exit 3"},
+		Stderr:  &buf,
+	})
+	if err != nil {
+		t.Skipf("sh not available: %v", err)
+	}
+	_, _ = io.ReadAll(h.Stdout())
+	if err := h.Wait(); err == nil {
+		t.Fatal("expected a non-zero exit")
+	}
+	if !strings.Contains(buf.String(), "boom") {
+		t.Fatalf("stderr not captured: %q", buf.String())
+	}
+}

--- a/agentboot/process/process.go
+++ b/agentboot/process/process.go
@@ -30,6 +30,13 @@ type LaunchSpec struct {
 	// InitialInput optionally feeds bootstrap messages to stdin after start.
 	// It is consumed by the Runner, not the process Factory.
 	InitialInput <-chan any
+
+	// Stderr, if non-nil, receives this launch's stderr stream instead of
+	// the factory-wide default. Callers use it to keep an agent's own
+	// diagnostics (an argument rejected by the CLI, an auth failure printed
+	// before any protocol output) attached to the execution that produced
+	// them.
+	Stderr io.Writer
 }
 
 // BuildCmd converts the specification into an exec.Cmd.

--- a/agentboot/protocol/decoder.go
+++ b/agentboot/protocol/decoder.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-
 )
 
 // Decoder reads a stream of JSON-encoded values from an io.Reader and emits

--- a/agentboot/result.go
+++ b/agentboot/result.go
@@ -14,7 +14,7 @@ type Result struct {
 	Error    string // Error message if failed
 	Duration time.Duration
 	Format   OutputFormat           // Output format used
-	Events   []protocol.Event         // Raw events (stream-json mode)
+	Events   []protocol.Event       // Raw events (stream-json mode)
 	Metadata map[string]interface{} // Additional metadata
 }
 


### PR DESCRIPTION
Three fixes in `agentboot` for driving the `claude` CLI.

- **Tool results were dropped.** The CLI reports a tool's result as a `user` message whose content is a `tool_result` block. `UserMessage` expected a string in `message`, so the unmarshal failed and the message was discarded. `parseUserMessages` now handles both shapes and emits `ToolResultMessage`s. Test: `accumulator_user_test.go`.
- **A child CLI inherited the parent session's identity.** When the host process itself runs inside a Claude Code session, the spawned `claude` picked up `CLAUDE_CODE_SESSION_ID`, `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, the messaging/ingress variables and account/org ids, and behaved as a nested session of the parent. These are now stripped; user configuration such as `CLAUDE_CONFIG_DIR` still passes through. Test: `environment_identity_test.go`.
- **Stderr on failure.** `LaunchSpec.Stderr` / `ExecutionOptions.Stderr` let a caller capture the CLI's stderr, so a rejected flag or a missing dependency is reported with the CLI's own message instead of `exit status 1`. Test: `osexec_stderr_test.go`.

`go build ./...`, `go vet ./agentboot/...`, `go test -race ./agentboot/... ./remote/control/remoteagent/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3uhZNuXaC3H7itM9i39tn